### PR TITLE
Add IIS checks to the CLI

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -314,7 +314,7 @@ partial class Build : NukeBuild
         .After(CreateDistributionHome)
         .Executes(() =>
         {
-            var runtimes = new[] { "win-x64", "linux-x64", "linux-musl-x64", "osx-x64", "linux-arm64" };
+            var runtimes = new[] { "win-x86", "win-x64", "linux-x64", "linux-musl-x64", "osx-x64", "linux-arm64" };
             DotNetPublish(x => x
                 .SetProject(Solution.GetProject(Projects.Tool))
                 // Have to do a restore currently as we're specifying specific runtime

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -314,7 +314,7 @@ partial class Build : NukeBuild
         .After(CreateDistributionHome)
         .Executes(() =>
         {
-            var runtimes = new[] { "win-x86", "win-x64", "linux-x64", "linux-musl-x64", "osx-x64", "linux-arm64" };
+            var runtimes = new[] { "win-x64", "linux-x64", "linux-musl-x64", "osx-x64", "linux-arm64" };
             DotNetPublish(x => x
                 .SetProject(Solution.GetProject(Projects.Tool))
                 // Have to do a restore currently as we're specifying specific runtime

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tools.Runner
                 }
             }
 
-            var result = await AgentConnectivityCheck.Run(new ImmutableExporterSettings(configuration)).ConfigureAwait(false);
+            var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(configuration)).ConfigureAwait(false);
 
             if (!result)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -122,6 +122,12 @@ namespace Datadog.Trace.Tools.Runner
 
                 var process = ProcessInfo.GetProcessInfo(pid.Value, rootDirectory, appSettingsConfigurationSource);
 
+                if (process == null)
+                {
+                    Utils.WriteError("Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.");
+                    return 1;
+                }
+
                 if (!ProcessBasicCheck.Run(process))
                 {
                     return 1;

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -68,12 +68,12 @@ namespace Datadog.Trace.Tools.Runner
                 return 1;
             }
 
+            var pool = serverManager.ApplicationPools[application.ApplicationPoolName];
+
             // The WorkerProcess part of ServerManager doesn't seem to be compatible with IISExpress
             // so we skip this bit when launched from the tests
             if (pid == null)
             {
-                var pool = serverManager.ApplicationPools[application.ApplicationPoolName];
-
                 var workerProcesses = pool.WorkerProcesses;
 
                 if (workerProcesses.Count > 0)
@@ -116,6 +116,11 @@ namespace Datadog.Trace.Tools.Runner
                 {
                     Utils.WriteError(GetProcessError);
                     return 1;
+                }
+
+                if (process.DotnetRuntime.HasFlag(ProcessInfo.Runtime.NetCore) && !string.IsNullOrEmpty(pool.ManagedRuntimeVersion))
+                {
+                    Utils.WriteWarning(IisMixedRuntimes);
                 }
 
                 if (!ProcessBasicCheck.Run(process))

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -1,0 +1,122 @@
+// <copyright file="CheckIisCommand.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Runner.Checks;
+using Microsoft.Web.Administration;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Datadog.Trace.Tools.Runner
+{
+    internal class CheckIisCommand : AsyncCommand<CheckIisSettings>
+    {
+        public override async Task<int> ExecuteAsync(CommandContext context, CheckIisSettings settings)
+        {
+            var values = settings.SiteName.Split('/');
+
+            var siteName = values[0];
+            var applicationName = values.Length > 1 ? $"/{values[1]}" : "/";
+
+            AnsiConsole.WriteLine($"Fetching application {applicationName} from site {siteName}");
+
+            var serverManager = new ServerManager();
+
+            var site = serverManager.Sites[siteName];
+
+            if (site == null)
+            {
+                Utils.WriteError($"Could not find site {siteName}");
+                Utils.WriteError("Available sites:");
+
+                foreach (var s in serverManager.Sites)
+                {
+                    Utils.WriteError($" - {s.Name}");
+                }
+
+                return 1;
+            }
+
+            var application = site.Applications[applicationName];
+
+            if (application == null)
+            {
+                Utils.WriteError($"Could not find application {applicationName} in site {siteName}");
+                Utils.WriteError("Available applications:");
+
+                foreach (var app in site.Applications)
+                {
+                    Utils.WriteError($" - {app.Path}");
+                }
+
+                return 1;
+            }
+
+            var pool = serverManager.ApplicationPools[application.ApplicationPoolName];
+
+            var workerProcesses = pool.WorkerProcesses;
+
+            if (workerProcesses.Count == 0)
+            {
+                Utils.WriteWarning("No worker process found, to perform additional checks make sure the application is active");
+            }
+            else
+            {
+                AnsiConsole.WriteLine($"Inspecting worker process {workerProcesses[0].ProcessId}");
+
+                var rootDirectory = application.VirtualDirectories.FirstOrDefault(d => d.Path == "/")?.PhysicalPath;
+
+                var config = application.GetWebConfiguration();
+                var appSettings = config.GetSection("appSettings");
+                var collection = appSettings.GetCollection();
+
+                var configurationSource = new DictionaryConfigurationSource(
+                    collection.ToDictionary(c => (string)c.Attributes["key"].Value, c => (string)c.Attributes["value"].Value));
+
+                var process = ProcessInfo.GetProcessInfo(workerProcesses[0].ProcessId, rootDirectory, configurationSource);
+
+                if (!ProcessBasicCheck.Run(process))
+                {
+                    return 1;
+                }
+
+                if (!await AgentConnectivityCheck.RunAsync(process).ConfigureAwait(false))
+                {
+                    return 1;
+                }
+            }
+
+            if (!GacCheck.Run())
+            {
+                return 1;
+            }
+
+            Utils.WriteSuccess("No issue found with the IIS site.");
+
+            return 0;
+        }
+
+        public override ValidationResult Validate(CommandContext context, CheckIisSettings settings)
+        {
+            var result = base.Validate(context, settings);
+
+            if (result.Successful)
+            {
+                // Perform additional validation
+                if (settings.SiteName.Count(c => c == '/') > 1)
+                {
+                    return ValidationResult.Error($"IIS site names can't have multiple / in their name: {settings.SiteName}");
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
@@ -1,0 +1,20 @@
+// <copyright file="CheckIisSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Spectre.Console.Cli;
+
+namespace Datadog.Trace.Tools.Runner
+{
+    internal class CheckIisSettings : CommandSettings
+    {
+        [CommandArgument(0, "<siteName>")]
+        public string SiteName { get; set; }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckProcessCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckProcessCommand.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Tools.Runner
                 return 1;
             }
 
-            foundIssue = !await AgentConnectivityCheck.Run(process).ConfigureAwait(false);
+            foundIssue = !await AgentConnectivityCheck.RunAsync(process).ConfigureAwait(false);
 
             if (foundIssue)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static async Task<bool> RunAsync(ImmutableExporterSettings settings)
         {
-            var payload = Vendors.MessagePack.MessagePackSerializer.Serialize(Array.Empty<Span[][]>());
+            var payload = Vendors.MessagePack.MessagePackSerializer.Serialize(Array.Empty<Span[]>());
 
             var requestFactory = TracesTransportStrategy.Get(settings);
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 {
     internal class AgentConnectivityCheck
     {
-        public static Task<bool> Run(ProcessInfo process)
+        public static Task<bool> RunAsync(ProcessInfo process)
         {
             var settings = new ExporterSettings(process.Configuration);
 
@@ -27,12 +27,12 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             AnsiConsole.WriteLine(DetectedAgentUrlFormat(url));
 
-            return Run(new ImmutableExporterSettings(settings));
+            return RunAsync(new ImmutableExporterSettings(settings));
         }
 
-        public static async Task<bool> Run(ImmutableExporterSettings settings)
+        public static async Task<bool> RunAsync(ImmutableExporterSettings settings)
         {
-            var payload = Vendors.MessagePack.MessagePackSerializer.Serialize(Array.Empty<Span[]>());
+            var payload = Vendors.MessagePack.MessagePackSerializer.Serialize(Array.Empty<Span[][]>());
 
             var requestFactory = TracesTransportStrategy.Get(settings);
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/GacCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/GacCheck.cs
@@ -1,0 +1,61 @@
+// <copyright file="GacCheck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+using static Datadog.Trace.Tools.Runner.Checks.Resources;
+
+namespace Datadog.Trace.Tools.Runner.Checks
+{
+    internal class GacCheck
+    {
+        public static bool Run()
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return true;
+            }
+
+            var gacFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), "Microsoft.NET", "assembly", "GAC_MSIL", "Datadog.Trace");
+
+            if (!Directory.Exists(gacFolder))
+            {
+                Utils.WriteError(MissingGac);
+                return false;
+            }
+
+            bool foundVersions = false;
+
+            foreach (var folder in Directory.GetDirectories(gacFolder))
+            {
+                if (!File.Exists(Path.Combine(folder, "Datadog.Trace.dll")))
+                {
+                    continue;
+                }
+
+                var name = new DirectoryInfo(folder).Name;
+
+                // Format: v4.0_2.3.0.0__def86d061d0d2eeb
+                var match = Regex.Match(name, @"v4.0_(?<version>\d+\.\d+\.\d+\.\d+)__def86d061d0d2eeb");
+
+                var version = match.Success ? match.Groups["version"].Value : name;
+
+                AnsiConsole.WriteLine(GacVersionFormat(version));
+                foundVersions = true;
+            }
+
+            if (!foundVersions)
+            {
+                Utils.WriteError(MissingGac);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -7,8 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
-using Microsoft.Win32;
 using Spectre.Console;
 
 using static Datadog.Trace.Tools.Runner.Checks.Resources;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
             }
             else
             {
-                Utils.WriteWarning(RuntimeDetectionFailed);
+                Utils.WriteWarning(runtime == ProcessInfo.Runtime.Mixed ? BothRuntimesDetected : RuntimeDetectionFailed);
                 runtime = ProcessInfo.Runtime.NetFx;
             }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessEnvironment.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessEnvironment.cs
@@ -33,15 +33,23 @@ namespace Datadog.Trace.Tools.Runner.Checks
         {
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
             {
-                // On Linux, Process.Modules does not list dynamically loaded assemblues: https://github.com/dotnet/runtime/issues/64042
+                // On Linux, Process.Modules does not list dynamically loaded assemblies: https://github.com/dotnet/runtime/issues/64042
                 return Linux.ProcessEnvironmentLinux.ReadModules(process);
             }
 
-            return process.Modules
+            var modules = process.Modules
                 .OfType<ProcessModule>()
                 .Select(p => p.FileName)
                 .Where(p => p != null)
                 .ToArray()!;
+
+            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                // On Windows, Process.Modules misses some dynamically loaded assemblies
+                return modules.Union(Windows.OpenFiles.GetOpenFiles(process.Id)).Distinct().ToArray()!;
+            }
+
+            return modules!;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -4,7 +4,9 @@
 // </copyright>
 #nullable enable
 
+using System.Collections.Generic;
 using System.Net;
+using System.Text;
 
 namespace Datadog.Trace.Tools.Runner.Checks
 {
@@ -19,6 +21,9 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
         public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
         public const string MissingGac = "The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
+        public const string NoWorkerProcess = "No worker process found, to perform additional checks make sure the application is active";
+        public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
+        public const string IisNoIssue = "No issue found with the IIS site.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
@@ -39,6 +44,42 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public static string SuspiciousRegistryKey(string key) => $@"The registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
 
         public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
+
+        public static string FetchingApplication(string site, string application) => $"Fetching application {application} from site {site}";
+
+        public static string InspectingWorkerProcess(int pid) => $"Inspecting worker process {pid}";
+
+        public static string ErrorExtractingConfiguration(string error) => $"Could not extract configuration from site: {error}";
+
+        public static string CouldNotFindSite(string site, IEnumerable<string> availableSites)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"Could not find site {site}");
+            sb.AppendLine("Available sites:");
+
+            foreach (var s in availableSites)
+            {
+                sb.AppendLine($" - {s}");
+            }
+
+            return sb.ToString();
+        }
+
+        public static string CouldNotFindApplication(string site, string application, IEnumerable<string> availableApplications)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine($"Could not find application {application} in site {site}");
+            sb.AppendLine("Available applications:");
+
+            foreach (var app in availableApplications)
+            {
+                sb.AppendLine($" - {app}");
+            }
+
+            return sb.ToString();
+        }
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";
     }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string TracerHomeNotSet = "The environment variable DD_DOTNET_TRACER_HOME is not set";
         public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
         public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
+        public const string MissingGac = "The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
@@ -36,6 +37,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public static string ErrorCheckingRegistry(string error) => $"Error trying to read the registry: {error}";
 
         public static string SuspiciousRegistryKey(string key) => $@"The registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
+
+        public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";
     }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string NetFrameworkRuntime = "Target process is running with .NET Framework";
         public const string NetCoreRuntime = "Target process is running with .NET Core";
         public const string RuntimeDetectionFailed = "Failed to detect target process runtime, assuming .NET Framework";
+        public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
         public const string ProfilerNotLoaded = "Profiler is not loaded into the process";
         public const string TracerNotLoaded = "Tracer is not loaded into the process";
         public const string TracerHomeNotSet = "The environment variable DD_DOTNET_TRACER_HOME is not set";
@@ -24,6 +25,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string NoWorkerProcess = "No worker process found, to perform additional checks make sure the application is active";
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
+        public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
@@ -171,10 +171,13 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
 
             try
             {
-                if (DuplicateHandle(handle, processHandle, out duplicatedHandle))
+                if (!DuplicateHandle(handle, processHandle, out duplicatedHandle))
                 {
-                    handle = duplicatedHandle.DangerousGetHandle();
+                    fileName = null;
+                    return false;
                 }
+
+                handle = duplicatedHandle.DangerousGetHandle();
 
                 if (GetHandleType(handle, out var handleType) && handleType == SystemHandleType.OB_TYPE_FILE)
                 {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
@@ -1,0 +1,502 @@
+// <copyright file="OpenFiles.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// Original code taken from https://github.com/urosjovanovic/MceController/blob/master/VmcServices/DetectOpenFiles.cs
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+// ReSharper disable InconsistentNaming
+
+namespace Datadog.Trace.Tools.Runner.Checks.Windows
+{
+    internal class OpenFiles
+    {
+        private const string NetworkDevicePrefix = "\\Device\\LanmanRedirector\\";
+        private const int MaxPath = 260;
+        private const int HandleTypeTokenCount = 27;
+
+        private static readonly string[] HandleTypeTokens =
+        {
+            string.Empty, string.Empty, "Directory", "SymbolicLink", "Token",
+            "Process", "Thread", "Unknown7", "Event", "EventPair", "Mutant",
+            "Unknown11", "Semaphore", "Timer", "Profile", "WindowStation",
+            "Desktop", "Section", "Key", "Port", "WaitablePort",
+            "Unknown21", "Unknown22", "Unknown23", "Unknown24",
+            "IoCompletion", "File"
+        };
+
+        private static Dictionary<string, string> _deviceMap;
+
+        internal enum NT_STATUS
+        {
+            STATUS_SUCCESS = 0x00000000,
+            STATUS_BUFFER_OVERFLOW = unchecked((int)0x80000005L),
+            STATUS_INFO_LENGTH_MISMATCH = unchecked((int)0xC0000004L)
+        }
+
+        internal enum SYSTEM_INFORMATION_CLASS
+        {
+            SystemBasicInformation = 0,
+            SystemPerformanceInformation = 2,
+            SystemTimeOfDayInformation = 3,
+            SystemProcessInformation = 5,
+            SystemProcessorPerformanceInformation = 8,
+            SystemHandleInformation = 16,
+            SystemInterruptInformation = 23,
+            SystemExceptionInformation = 33,
+            SystemRegistryQuotaInformation = 37,
+            SystemLookasideInformation = 45
+        }
+
+        internal enum OBJECT_INFORMATION_CLASS
+        {
+            ObjectBasicInformation = 0,
+            ObjectNameInformation = 1,
+            ObjectTypeInformation = 2,
+            ObjectAllTypesInformation = 3,
+            ObjectHandleInformation = 4
+        }
+
+        [Flags]
+        internal enum ProcessAccessRights
+        {
+            PROCESS_DUP_HANDLE = 0x00000040
+        }
+
+        [Flags]
+        internal enum DuplicateHandleOptions
+        {
+            DUPLICATE_CLOSE_SOURCE = 0x1,
+            DUPLICATE_SAME_ACCESS = 0x2
+        }
+
+        private enum SystemHandleType
+        {
+            OB_TYPE_UNKNOWN = 0,
+            OB_TYPE_TYPE = 1,
+            OB_TYPE_DIRECTORY,
+            OB_TYPE_SYMBOLIC_LINK,
+            OB_TYPE_TOKEN,
+            OB_TYPE_PROCESS,
+            OB_TYPE_THREAD,
+            OB_TYPE_UNKNOWN_7,
+            OB_TYPE_EVENT,
+            OB_TYPE_EVENT_PAIR,
+            OB_TYPE_MUTANT,
+            OB_TYPE_UNKNOWN_11,
+            OB_TYPE_SEMAPHORE,
+            OB_TYPE_TIMER,
+            OB_TYPE_PROFILE,
+            OB_TYPE_WINDOW_STATION,
+            OB_TYPE_DESKTOP,
+            OB_TYPE_SECTION,
+            OB_TYPE_KEY,
+            OB_TYPE_PORT,
+            OB_TYPE_WAITABLE_PORT,
+            OB_TYPE_UNKNOWN_21,
+            OB_TYPE_UNKNOWN_22,
+            OB_TYPE_UNKNOWN_23,
+            OB_TYPE_UNKNOWN_24,
+            // OB_TYPE_CONTROLLER,
+            // OB_TYPE_DEVICE,
+            // OB_TYPE_DRIVER,
+            OB_TYPE_IO_COMPLETION,
+            OB_TYPE_FILE
+        }
+
+        public static IEnumerable<string> GetOpenFiles(int processId)
+        {
+            NT_STATUS ret;
+            int length = 0x10000;
+
+            do
+            {
+                var ptr = IntPtr.Zero;
+
+                try
+                {
+                    ptr = Marshal.AllocHGlobal(length);
+
+                    ret = NativeMethods.NtQuerySystemInformation(SYSTEM_INFORMATION_CLASS.SystemHandleInformation, ptr, length, out var returnLength);
+
+                    if (ret == NT_STATUS.STATUS_INFO_LENGTH_MISMATCH)
+                    {
+                        // Round required memory up to the nearest 64KB boundary.
+                        length = ((returnLength + 0xffff) & ~0xffff);
+                    }
+                    else if (ret == NT_STATUS.STATUS_SUCCESS)
+                    {
+                        int handleCount = Marshal.ReadInt32(ptr);
+                        int offset = sizeof(int);
+                        int size = Marshal.SizeOf(typeof(SYSTEM_HANDLE_ENTRY));
+
+                        for (int i = 0; i < handleCount; i++)
+                        {
+                            var handleEntry = (SYSTEM_HANDLE_ENTRY)Marshal.PtrToStructure(IntPtrAdd(ptr, offset), typeof(SYSTEM_HANDLE_ENTRY));
+                            int ownerProcessId = GetProcessId(handleEntry.OwnerPid);
+                            if (ownerProcessId == processId)
+                            {
+                                var handle = (IntPtr)handleEntry.HandleValue;
+
+                                if (GetHandleType(handle, ownerProcessId, out var handleType) && handleType == SystemHandleType.OB_TYPE_FILE)
+                                {
+                                    if (GetFileNameFromHandle(handle, ownerProcessId, out var devicePath))
+                                    {
+                                        if (ConvertDevicePathToDosPath(devicePath, out var dosPath))
+                                        {
+                                            yield return dosPath;
+                                        }
+                                    }
+                                }
+                            }
+
+                            offset += size;
+                        }
+                    }
+                }
+                finally
+                {
+                    Marshal.FreeHGlobal(ptr);
+                }
+            }
+            while (ret == NT_STATUS.STATUS_INFO_LENGTH_MISMATCH);
+        }
+
+        private static IntPtr IntPtrAdd(IntPtr ptr, int offset)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return (IntPtr)((int)ptr + offset);
+            }
+
+            return (IntPtr)((long)ptr + offset);
+        }
+
+        private static int GetProcessId(IntPtr processId)
+        {
+            if (IntPtr.Size == 4)
+            {
+                return (int)processId;
+            }
+
+            return (int)((long)processId >> 32);
+        }
+
+        private static bool GetFileNameFromHandle(IntPtr handle, int processId, out string fileName)
+        {
+            var currentProcess = NativeMethods.GetCurrentProcess();
+
+            SafeProcessHandle processHandle = null;
+            SafeObjectHandle objectHandle = null;
+
+            try
+            {
+                processHandle = NativeMethods.OpenProcess(ProcessAccessRights.PROCESS_DUP_HANDLE, true, processId);
+
+                if (NativeMethods.DuplicateHandle(processHandle.DangerousGetHandle(), handle, currentProcess, out objectHandle, 0, false, DuplicateHandleOptions.DUPLICATE_SAME_ACCESS))
+                {
+                    handle = objectHandle.DangerousGetHandle();
+                }
+
+                return GetFileNameFromHandle(handle, out fileName);
+            }
+            finally
+            {
+                processHandle?.Close();
+                objectHandle?.Close();
+            }
+        }
+
+        private static bool GetFileNameFromHandle(IntPtr handle, out string fileName)
+        {
+            var ptr = IntPtr.Zero;
+
+            try
+            {
+                int length = 0x200;  // 512 bytes
+
+                ptr = Marshal.AllocHGlobal(length);
+
+                var ret = NativeMethods.NtQueryObject(handle, OBJECT_INFORMATION_CLASS.ObjectNameInformation, ptr, length, out length);
+
+                if (ret == NT_STATUS.STATUS_BUFFER_OVERFLOW)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                    ptr = Marshal.AllocHGlobal(length);
+
+                    ret = NativeMethods.NtQueryObject(handle, OBJECT_INFORMATION_CLASS.ObjectNameInformation, ptr, length, out length);
+                }
+
+                if (ret == NT_STATUS.STATUS_SUCCESS)
+                {
+                    var objNameInfo = (OBJECT_NAME_INFORMATION)Marshal.PtrToStructure(ptr, typeof(OBJECT_NAME_INFORMATION));
+                    fileName = objNameInfo.Name.Buffer;
+                    return fileName.Length != 0;
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+
+            fileName = string.Empty;
+            return false;
+        }
+
+        private static bool GetHandleType(IntPtr handle, int processId, out SystemHandleType handleType)
+        {
+            var token = GetHandleTypeToken(handle, processId);
+            return GetHandleTypeFromToken(token, out handleType);
+        }
+
+        private static bool GetHandleTypeFromToken(string token, out SystemHandleType handleType)
+        {
+            for (int i = 1; i < HandleTypeTokenCount; i++)
+            {
+                if (HandleTypeTokens[i] == token)
+                {
+                    handleType = (SystemHandleType)i;
+                    return true;
+                }
+            }
+
+            handleType = SystemHandleType.OB_TYPE_UNKNOWN;
+            return false;
+        }
+
+        private static string GetHandleTypeToken(IntPtr handle, int processId)
+        {
+            var currentProcess = NativeMethods.GetCurrentProcess();
+            SafeProcessHandle processHandle = null;
+            SafeObjectHandle objectHandle = null;
+
+            try
+            {
+                processHandle = NativeMethods.OpenProcess(ProcessAccessRights.PROCESS_DUP_HANDLE, true, processId);
+
+                if (NativeMethods.DuplicateHandle(processHandle.DangerousGetHandle(), handle, currentProcess, out objectHandle, 0, false, DuplicateHandleOptions.DUPLICATE_SAME_ACCESS))
+                {
+                    handle = objectHandle.DangerousGetHandle();
+                }
+
+                return GetHandleTypeToken(handle);
+            }
+            finally
+            {
+                processHandle?.Close();
+                objectHandle?.Close();
+            }
+        }
+
+        private static string GetHandleTypeToken(IntPtr handle)
+        {
+            NativeMethods.NtQueryObject(handle, OBJECT_INFORMATION_CLASS.ObjectTypeInformation, IntPtr.Zero, 0, out var length);
+            var ptr = IntPtr.Zero;
+
+            try
+            {
+                ptr = Marshal.AllocHGlobal(length);
+
+                if (NativeMethods.NtQueryObject(handle, OBJECT_INFORMATION_CLASS.ObjectTypeInformation, ptr, length, out length) == NT_STATUS.STATUS_SUCCESS)
+                {
+                    var objTypeInfo = (OBJECT_TYPE_INFORMATION)Marshal.PtrToStructure(ptr, typeof(OBJECT_TYPE_INFORMATION));
+                    return objTypeInfo.TypeName.Buffer;
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+
+            return string.Empty;
+        }
+
+        private static bool ConvertDevicePathToDosPath(string devicePath, out string dosPath)
+        {
+            EnsureDeviceMap();
+            int i = devicePath.Length;
+
+            while (i > 0 && (i = devicePath.LastIndexOf('\\', i - 1)) != -1)
+            {
+                if (_deviceMap.TryGetValue(devicePath.Substring(0, i), out var drive))
+                {
+                    dosPath = string.Concat(drive, devicePath.Substring(i));
+                    return dosPath.Length != 0;
+                }
+            }
+
+            dosPath = string.Empty;
+            return false;
+        }
+
+        private static void EnsureDeviceMap()
+        {
+            if (_deviceMap == null)
+            {
+                var localDeviceMap = BuildDeviceMap();
+                Interlocked.CompareExchange(ref _deviceMap, localDeviceMap, null);
+            }
+        }
+
+        private static Dictionary<string, string> BuildDeviceMap()
+        {
+            var logicalDrives = Environment.GetLogicalDrives();
+            var localDeviceMap = new Dictionary<string, string>(logicalDrives.Length);
+            var lpTargetPath = new StringBuilder(MaxPath);
+
+            foreach (var drive in logicalDrives)
+            {
+                var lpDeviceName = drive.Substring(0, 2);
+                NativeMethods.QueryDosDevice(lpDeviceName, lpTargetPath, MaxPath);
+                localDeviceMap.Add(NormalizeDeviceName(lpTargetPath.ToString()), lpDeviceName);
+            }
+
+            localDeviceMap.Add(NetworkDevicePrefix.Substring(0, NetworkDevicePrefix.Length - 1), "\\");
+            return localDeviceMap;
+        }
+
+        private static string NormalizeDeviceName(string deviceName)
+        {
+            if (string.Compare(deviceName, 0, NetworkDevicePrefix, 0, NetworkDevicePrefix.Length, StringComparison.InvariantCulture) == 0)
+            {
+                var shareName = deviceName.Substring(deviceName.IndexOf('\\', NetworkDevicePrefix.Length) + 1);
+                return NetworkDevicePrefix + shareName;
+            }
+
+            return deviceName;
+        }
+
+        // Modified from original solution based on https://stackoverflow.com/a/9995536
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct SYSTEM_HANDLE_ENTRY
+        {
+            public IntPtr OwnerPid;
+            public byte ObjectType;
+            public byte HandleFlags;
+            public short HandleValue;
+            public IntPtr ObjectPointer;
+            public int AccessMask;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct UNICODE_STRING
+        {
+            public ushort Length;
+            public ushort MaximumLength;
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string Buffer;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct OBJECT_TYPE_INFORMATION
+        {
+            public UNICODE_STRING TypeName;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 22)]
+            public ulong[] Reserved;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        private struct OBJECT_NAME_INFORMATION
+        {
+            public UNICODE_STRING Name;
+            public IntPtr NameBuffer;
+        }
+
+        internal static class NativeMethods
+        {
+            [DllImport("ntdll.dll")]
+            internal static extern NT_STATUS NtQuerySystemInformation(
+                [In] SYSTEM_INFORMATION_CLASS SystemInformationClass,
+                [In] IntPtr SystemInformation,
+                [In] int SystemInformationLength,
+                [Out] out int ReturnLength);
+
+            [DllImport("ntdll.dll")]
+            internal static extern NT_STATUS NtQueryObject(
+                [In] IntPtr Handle,
+                [In] OBJECT_INFORMATION_CLASS ObjectInformationClass,
+                [In] IntPtr ObjectInformation,
+                [In] int ObjectInformationLength,
+                [Out] out int ReturnLength);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern SafeProcessHandle OpenProcess(
+                [In] ProcessAccessRights dwDesiredAccess,
+                [In, MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+                [In] int dwProcessId);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool DuplicateHandle(
+                [In] IntPtr hSourceProcessHandle,
+                [In] IntPtr hSourceHandle,
+                [In] IntPtr hTargetProcessHandle,
+                [Out] out SafeObjectHandle lpTargetHandle,
+                [In] int dwDesiredAccess,
+                [In, MarshalAs(UnmanagedType.Bool)] bool bInheritHandle,
+                [In] DuplicateHandleOptions dwOptions);
+
+            [DllImport("kernel32.dll")]
+            internal static extern IntPtr GetCurrentProcess();
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern int GetProcessId(
+                [In] IntPtr Process);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            internal static extern bool CloseHandle(
+                [In] IntPtr hObject);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern int QueryDosDevice(
+                [In] string lpDeviceName,
+                [Out] StringBuilder lpTargetPath,
+                [In] int ucchMax);
+        }
+
+        internal sealed class SafeObjectHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            private SafeObjectHandle()
+                : base(true)
+            {
+            }
+
+            internal SafeObjectHandle(IntPtr preexistingHandle, bool ownsHandle)
+                : base(ownsHandle)
+            {
+                SetHandle(preexistingHandle);
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return NativeMethods.CloseHandle(handle);
+            }
+        }
+
+        internal sealed class SafeProcessHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            private SafeProcessHandle()
+                : base(true)
+            {
+            }
+
+            internal SafeProcessHandle(IntPtr preexistingHandle, bool ownsHandle)
+                : base(ownsHandle)
+            {
+                SetHandle(preexistingHandle);
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return NativeMethods.CloseHandle(handle);
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/OpenFiles.cs
@@ -204,7 +204,16 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
                     handle = objectHandle.DangerousGetHandle();
                 }
 
-                return GetFileNameFromHandle(handle, out fileName);
+                var fileType = NativeMethods.GetFileType(handle);
+
+                if (fileType == 0x1)
+                {
+                    // FILE_TYPE_DISK
+                    return GetFileNameFromHandle(handle, out fileName);
+                }
+
+                fileName = null;
+                return false;
             }
             finally
             {
@@ -448,6 +457,10 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
             [DllImport("kernel32.dll", SetLastError = true)]
             internal static extern int GetProcessId(
                 [In] IntPtr Process);
+
+            [DllImport("kernel32.dll")]
+            internal static extern int GetFileType(
+                [In] IntPtr hFile);
 
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.43.0" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
+    <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -66,6 +66,8 @@
     <PackageReference Include="Spectre.Console" Version="0.43.0" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacySettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacySettings.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tools.Runner
         public bool SetEnvironmentVariables { get; set; }
 
         [CommandOption("--ci-visibility")]
-        [Description("RunAsync the command in CI Visibility Mode")]
+        [Description("Run the command in CI Visibility Mode")]
         public bool EnableCIVisibilityMode { get; set; }
 
         [CommandOption("--env-vars")]

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacySettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacySettings.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tools.Runner
         public bool SetEnvironmentVariables { get; set; }
 
         [CommandOption("--ci-visibility")]
-        [Description("Run the command in CI Visibility Mode")]
+        [Description("RunAsync the command in CI Visibility Mode")]
         public bool EnableCIVisibilityMode { get; set; }
 
         [CommandOption("--env-vars")]

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Tools.Runner
                         .WithDescription("Set the environment variables for the CI")
                         .WithExample("ci configure azp".Split(' '));
                     c.AddCommand<RunCiCommand>("run")
-                        .WithDescription("RunAsync a command and instrument the tests")
+                        .WithDescription("Run a command and instrument the tests")
                         .WithExample("ci run -- dotnet test".Split(' '));
                 });
 
@@ -139,7 +139,7 @@ namespace Datadog.Trace.Tools.Runner
                 });
 
             config.AddCommand<RunCommand>("run")
-                .WithDescription("RunAsync a command with the Datadog tracer enabled")
+                .WithDescription("Run a command with the Datadog tracer enabled")
                 .WithExample("run -- dotnet myApp.dll".Split(' '));
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Tools.Runner
                         .WithDescription("Set the environment variables for the CI")
                         .WithExample("ci configure azp".Split(' '));
                     c.AddCommand<RunCiCommand>("run")
-                        .WithDescription("Run a command and instrument the tests")
+                        .WithDescription("RunAsync a command and instrument the tests")
                         .WithExample("ci run -- dotnet test".Split(' '));
                 });
 
@@ -131,10 +131,15 @@ namespace Datadog.Trace.Tools.Runner
                 {
                     c.AddCommand<CheckProcessCommand>("process");
                     c.AddCommand<CheckAgentCommand>("agent");
+
+                    if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+                    {
+                        c.AddCommand<CheckIisCommand>("iis");
+                    }
                 });
 
             config.AddCommand<RunCommand>("run")
-                .WithDescription("Run a command with the Datadog tracer enabled")
+                .WithDescription("RunAsync a command with the Datadog tracer enabled")
                 .WithExample("run -- dotnet myApp.dll".Split(' '));
         }
 

--- a/tracer/src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
+++ b/tracer/src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="System.Diagnostics.CodeAnalysis.Attributes.cs" company="Datadog">
+// <copyright file="System.Diagnostics.CodeAnalysis.Attributes.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.TestHelpers
 {
     public sealed class IisFixture : GacFixture, IDisposable
     {
-        private (Process Process, string ConfigFile) _iisExpress;
+        public (Process Process, string ConfigFile) IisExpress { get; private set; }
 
         public MockTracerAgent Agent { get; private set; }
 
@@ -24,7 +24,7 @@ namespace Datadog.Trace.TestHelpers
         {
             lock (this)
             {
-                if (_iisExpress.Process == null)
+                if (IisExpress.Process == null)
                 {
                     AddAssembliesToGac();
 
@@ -32,7 +32,7 @@ namespace Datadog.Trace.TestHelpers
                     Agent = new MockTracerAgent(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
-                    _iisExpress = helper.StartIISExpress(Agent, HttpPort, appType);
+                    IisExpress = helper.StartIISExpress(Agent, HttpPort, appType);
                 }
             }
         }
@@ -49,18 +49,18 @@ namespace Datadog.Trace.TestHelpers
 
             lock (this)
             {
-                if (_iisExpress.Process != null)
+                if (IisExpress.Process != null)
                 {
                     try
                     {
-                        if (!_iisExpress.Process.HasExited)
+                        if (!IisExpress.Process.HasExited)
                         {
                             // sending "Q" to standard input does not work because
                             // iisexpress is scanning console key press, so just kill it.
                             // maybe try this in the future:
                             // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
-                            _iisExpress.Process.Kill();
-                            _iisExpress.Process.WaitForExit(8000);
+                            IisExpress.Process.Kill();
+                            IisExpress.Process.WaitForExit(8000);
                         }
                     }
                     catch
@@ -68,11 +68,11 @@ namespace Datadog.Trace.TestHelpers
                         // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
                     }
 
-                    _iisExpress.Process.Dispose();
+                    IisExpress.Process.Dispose();
 
                     try
                     {
-                        File.Delete(_iisExpress.ConfigFile);
+                        File.Delete(IisExpress.ConfigFile);
                     }
                     catch
                     {

--- a/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void Dispose()
         {
-            if (ShutdownPath != null)
+            if (IisExpress.Process != null && ShutdownPath != null)
             {
                 var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
                 request.GetResponse().Close();

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.Run(processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
 
             console.Output.Should().Contain(DetectedAgentUrlFormat("http://fakeurl:7777/"));
         }
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.Run(processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
 
             console.Output.Should().Contain(ConnectToEndpointFormat(url, "HTTP"));
         }
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.Run(processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
 
             console.Output.Should().Contain(ConnectToEndpointFormat(url, "domain sockets"));
         }
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             using var console = ConsoleHelper.Redirect();
 
-            var result = await AgentConnectivityCheck.Run(CreateSettings("http://fakeurl/"));
+            var result = await AgentConnectivityCheck.RunAsync(CreateSettings("http://fakeurl/"));
 
             result.Should().BeFalse();
 
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             agent.RequestReceived += (_, e) => e.Value.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
-            var result = await AgentConnectivityCheck.Run(CreateSettings($"http://localhost:{agent.Port}/"));
+            var result = await AgentConnectivityCheck.RunAsync(CreateSettings($"http://localhost:{agent.Port}/"));
 
             result.Should().BeFalse();
 
@@ -137,7 +137,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 Version = expectedVersion
             };
 
-            var result = await AgentConnectivityCheck.Run(CreateSettings($"http://localhost:{agent.Port}/"));
+            var result = await AgentConnectivityCheck.RunAsync(CreateSettings($"http://localhost:{agent.Port}/"));
 
             result.Should().BeTrue();
 
@@ -166,7 +166,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 TracesTransport = Agent.TracesTransportType.UnixDomainSocket
             };
 
-            var result = await AgentConnectivityCheck.Run(new ImmutableExporterSettings(settings));
+            var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(settings));
 
             result.Should().BeTrue();
 
@@ -184,7 +184,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 Version = null
             };
 
-            var result = await AgentConnectivityCheck.Run(CreateSettings($"http://localhost:{agent.Port}/"));
+            var result = await AgentConnectivityCheck.RunAsync(CreateSettings($"http://localhost:{agent.Port}/"));
 
             result.Should().BeTrue();
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync(processInfo!);
 
             console.Output.Should().Contain(DetectedAgentUrlFormat("http://fakeurl:7777/"));
         }
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync(processInfo!);
 
             console.Output.Should().Contain(ConnectToEndpointFormat(url, "HTTP"));
         }
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             processInfo.Should().NotBeNull();
 
-            _ = await AgentConnectivityCheck.RunAsync((ImmutableExporterSettings)processInfo!);
+            _ = await AgentConnectivityCheck.RunAsync(processInfo!);
 
             console.Output.Should().Contain(ConnectToEndpointFormat(url, "domain sockets"));
         }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -1,0 +1,55 @@
+// <copyright file="IisCheckTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_1
+
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
+{
+    [Collection(nameof(ConsoleTestsCollection))]
+    public class IisCheckTests : TestHelper, IClassFixture<IisFixture>
+    {
+        private readonly IisFixture _iisFixture;
+
+        public IisCheckTests(IisFixture iisFixture, ITestOutputHelper output)
+            : base("AspNetCoreMvc31", output)
+        {
+            _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/shutdown";
+        }
+
+        [SkippableFact]
+        public async Task CheckApp()
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                throw new SkipException();
+            }
+
+            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+
+            // Send a request to initialize the app
+            using var httpClient = new HttpClient();
+            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+
+            result.Should().Be(0);
+
+            console.Output.Should().Contain("No issue found with the IIS site.");
+        }
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -32,7 +32,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task CheckApp()
         {
-            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+                || System.IntPtr.Size == 4)
             {
                 throw new SkipException();
             }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tools.Runner.Checks;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -30,13 +31,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         }
 
         [SkippableFact]
-        public async Task CheckApp()
+        public async Task WorkingApp()
         {
-            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
-                || System.IntPtr.Size == 4)
-            {
-                throw new SkipException();
-            }
+            EnsureWindowsAndX64();
 
             var buildPs1 = Path.Combine(EnvironmentTools.GetSolutionDirectory(), "tracer", "build.ps1");
 
@@ -62,6 +59,75 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             finally
             {
                 Process.Start("powershell", $"{buildPs1} GacRemove --framework net461").WaitForExit();
+            }
+        }
+
+        [SkippableFact]
+        public async Task NoGac()
+        {
+            EnsureWindowsAndX64();
+
+            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+
+            // Send a request to initialize the app
+            using var httpClient = new HttpClient();
+            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+
+            result.Should().Be(1);
+
+            console.Output.Should().Contain(Resources.MissingGac);
+        }
+
+        [SkippableFact]
+        public async Task ListSites()
+        {
+            EnsureWindowsAndX64();
+
+            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+
+            // Send a request to initialize the app
+            using var httpClient = new HttpClient();
+            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "dummySite" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+
+            result.Should().Be(1);
+
+            console.Output.Should().Contain(Resources.CouldNotFindSite("dummySite", new[] { "sample" }));
+        }
+
+        [SkippableFact]
+        public async Task ListApplications()
+        {
+            EnsureWindowsAndX64();
+
+            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+
+            // Send a request to initialize the app
+            using var httpClient = new HttpClient();
+            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample/dummy" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+
+            result.Should().Be(1);
+
+            console.Output.Should().Contain(Resources.CouldNotFindApplication("sample", "/dummy", new[] { "/" }));
+        }
+
+        private static void EnsureWindowsAndX64()
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+                || System.IntPtr.Size != 8)
+            {
+                throw new SkipException();
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Datadog.Trace.Tools.Runner.IntegrationTests.csproj
@@ -6,6 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="applicationHost.config" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="applicationHost.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.Tools.Runner\Datadog.Trace.Tools.Runner.csproj" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
@@ -1,0 +1,1027 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    IIS configuration sections.
+
+    For schema documentation, see
+    %IIS_BIN%\config\schema\IIS_schema.xml.
+    
+    Please make a backup of this file before making any changes to it.
+
+    NOTE: The following environment variables are available to be used
+          within this file and are understood by the IIS Express.
+
+          %IIS_USER_HOME% - The IIS Express home directory for the user
+          %IIS_SITES_HOME% - The default home directory for sites
+          %IIS_BIN% - The location of the IIS Express binaries
+          %SYSTEMDRIVE% - The drive letter of %IIS_BIN%
+
+-->
+
+<configuration>
+
+  <!--
+
+        The <configSections> section controls the registration of sections.
+        Section is the basic unit of deployment, locking, searching and
+        containment for configuration settings.
+        
+        Every section belongs to one section group.
+        A section group is a container of logically-related sections.
+        
+        Sections cannot be nested.
+        Section groups may be nested.
+        
+        <section
+            name=""  [Required, Collection Key] [XML name of the section]
+            allowDefinition="Everywhere" [MachineOnly|MachineToApplication|AppHostOnly|Everywhere] [Level where it can be set]
+            overrideModeDefault="Allow"  [Allow|Deny] [Default delegation mode]
+            allowLocation="true"  [true|false] [Allowed in location tags]
+        />
+        
+        The recommended way to unlock sections is by using a location tag:
+        <location path="Default Web Site" overrideMode="Allow">
+            <system.webServer>
+                <asp />
+            </system.webServer>
+        </location>
+
+    -->
+  <configSections>
+    <sectionGroup name="system.applicationHost">
+      <section name="applicationPools" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="configHistory" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="customMetadata" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="listenerAdapters" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="log" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="serviceAutoStartProviders" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="sites" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="webLimits" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+    </sectionGroup>
+
+    <sectionGroup name="system.webServer">
+      <section name="asp" overrideModeDefault="Deny" />
+      <section name="caching" overrideModeDefault="Allow" />
+      <section name="cgi" overrideModeDefault="Deny" />
+      <section name="defaultDocument" overrideModeDefault="Allow" />
+      <section name="directoryBrowse" overrideModeDefault="Allow" />
+      <section name="fastCgi" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="globalModules" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+      <section name="handlers" overrideModeDefault="Deny" />
+      <section name="httpCompression" overrideModeDefault="Allow" allowDefinition="Everywhere" />
+      <section name="httpErrors" overrideModeDefault="Allow" />
+      <section name="httpLogging" overrideModeDefault="Deny" />
+      <section name="httpProtocol" overrideModeDefault="Allow" />
+      <section name="httpRedirect" overrideModeDefault="Allow" />
+      <section name="httpTracing" overrideModeDefault="Deny" />
+      <section name="isapiFilters" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+      <section name="modules" allowDefinition="MachineToApplication" overrideModeDefault="Deny" />
+      <section name="applicationInitialization" allowDefinition="MachineToApplication" overrideModeDefault="Allow" />
+      <section name="odbcLogging" overrideModeDefault="Deny" />
+      <sectionGroup name="security">
+        <section name="access" overrideModeDefault="Deny" />
+        <section name="applicationDependencies" overrideModeDefault="Deny" />
+        <sectionGroup name="authentication">
+          <section name="anonymousAuthentication" overrideModeDefault="Deny" />
+          <section name="basicAuthentication" overrideModeDefault="Deny" />
+          <section name="clientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+          <section name="digestAuthentication" overrideModeDefault="Deny" />
+          <section name="iisClientCertificateMappingAuthentication" overrideModeDefault="Deny" />
+          <section name="windowsAuthentication" overrideModeDefault="Deny" />
+        </sectionGroup>
+        <section name="authorization" overrideModeDefault="Allow" />
+        <section name="ipSecurity" overrideModeDefault="Deny" />
+        <section name="dynamicIpSecurity" overrideModeDefault="Deny" />
+        <section name="isapiCgiRestriction" allowDefinition="AppHostOnly" overrideModeDefault="Deny" />
+        <section name="requestFiltering" overrideModeDefault="Allow" />
+      </sectionGroup>
+      <section name="serverRuntime" overrideModeDefault="Deny" />
+      <section name="serverSideInclude" overrideModeDefault="Deny" />
+      <section name="staticContent" overrideModeDefault="Allow" />
+      <sectionGroup name="tracing">
+        <section name="traceFailedRequests" overrideModeDefault="Allow" />
+        <section name="traceProviderDefinitions" overrideModeDefault="Deny" />
+      </sectionGroup>
+      <section name="urlCompression" overrideModeDefault="Allow" />
+      <section name="validation" overrideModeDefault="Allow" />
+      <sectionGroup name="webdav">
+        <section name="globalSettings" overrideModeDefault="Deny" />
+        <section name="authoring" overrideModeDefault="Deny" />
+        <section name="authoringRules" overrideModeDefault="Deny" />
+      </sectionGroup>
+      <sectionGroup name="rewrite">
+        <section name="allowedServerVariables" overrideModeDefault="Deny" />
+        <section name="rules" overrideModeDefault="Allow" />
+        <section name="outboundRules" overrideModeDefault="Allow" />
+        <section name="globalRules" overrideModeDefault="Deny" allowDefinition="AppHostOnly" />
+        <section name="providers" overrideModeDefault="Allow" />
+        <section name="rewriteMaps" overrideModeDefault="Allow" />
+      </sectionGroup>
+      <section name="webSocket" overrideModeDefault="Deny" />
+      <section name="aspNetCore" overrideModeDefault="Allow" />
+    </sectionGroup>
+  </configSections>
+
+  <configProtectedData>
+    <providers>
+      <add name="IISWASOnlyRsaProvider" type="" description="Uses RsaCryptoServiceProvider to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useMachineContainer="true" useOAEP="false" />
+      <add name="AesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisConfigurationKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAA/HKxkz6alrlAPez0IUgujj/6k3WxCDriHp6jvpv3yEZmo7h6SMzGLxo4mTrIQVHSkB7tmElHKfUFTzE2BWF7nFWHY6Z6qmGBauFzwJMwESjril7Gjz69RBFH259HQ6aRDq9Xfx7U7H4HtdmnKNqGjgl/hwPQBGeIlWiDh+sYv3vKB0QU971tjX6H2B+9armlnC8UOuA6JYMDMI/VLLL16sng0fWAy5JYe0YVABVjiAWDW264RZW9Tr1Oax4qHZKg+SdjULxeOc2YmpX+d0yeITo1HkPF1hN1gHpIPIUDo05ilHUNfR3OkjVCIQK4cFKCq1s8NH+y+13MxUC4Fn1AlQ==" />
+      <add name="IISWASOnlyAesProvider" type="Microsoft.ApplicationHost.AesProtectedConfigurationProvider" description="Uses an AES session key to encrypt and decrypt" keyContainerName="iisWasKey" cspProviderName="" useOAEP="false" useMachineContainer="true" sessionKey="AQIAAA5mAAAApAAALmU8lTC+v2qtfQiiiquvvLpUQqKLEXs+jSKoWCM/uPhyB++k4dwug19mGidNK5FYiWK2KYE1yhjVJcbp12E98Q0R2nT7eBiCMY2JairxQ591rqABK7keGaIjwH7PwGzSpILl3RJ4YFvJ/7ZXEJxeDZIjW8ZxWVXx+/VyHs9U3WguLEkgMUX3jrxJi8LouxaIVPJAv/YQ1ZCWs8zImitxX/C/7o7yaIxznfsN5nGQzQfpUDPeby99aw2zPVTtZI2LaWIBON8guABvZ6JtJVDWmfdK6sodbnwdZkr6/Z2rfvamT1dC1SpQrGG7ulR/f9/GXvCaW10ZVKxekBF/CYlNMg==" />
+    </providers>
+  </configProtectedData>
+
+  <system.applicationHost>
+
+    <applicationPools>
+      <add name="Clr4IntegratedAppPool" managedRuntimeVersion="v4.0" managedPipelineMode="Integrated" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+      <add name="Clr4ClassicAppPool" managedRuntimeVersion="v4.0" managedPipelineMode="Classic" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+      <add name="Clr2IntegratedAppPool" managedRuntimeVersion="v2.0" managedPipelineMode="Integrated" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+      <add name="Clr2ClassicAppPool" managedRuntimeVersion="v2.0" managedPipelineMode="Classic" CLRConfigFile="%IIS_USER_HOME%\config\aspnet.config" autoStart="true" />
+      <add name="UnmanagedClassicAppPool" managedRuntimeVersion="" managedPipelineMode="Classic" autoStart="true" />
+      <applicationPoolDefaults managedRuntimeVersion="v4.0">
+        <processModel loadUserProfile="true" setProfileEnvironment="false" />
+      </applicationPoolDefaults>
+    </applicationPools>
+
+    <!--
+
+          The <listenerAdapters> section defines the protocols with which the
+          Windows Process Activation Service (WAS) binds.
+
+        -->
+    <listenerAdapters>
+      <add name="http" />
+    </listenerAdapters>
+
+    <sites>
+      <site name="sample" id="1">
+        <application path="/" applicationPool="[POOL]">
+          <virtualDirectory path="/" physicalPath="[PATH]" />
+        </application>
+        <bindings>
+          <binding protocol="http" bindingInformation="*:[PORT]:localhost" />
+        </bindings>
+      </site>
+      <siteDefaults>
+        <!-- To enable logging, please change the below attribute "enabled" to "true" -->
+        <logFile logFormat="W3C" directory="%AppData%\Microsoft\IISExpressLogs" enabled="false" />
+        <traceFailedRequestsLogging directory="%AppData%\Microsoft" enabled="false" maxLogFileSizeKB="1024" />
+      </siteDefaults>
+      <applicationDefaults applicationPool="Clr4IntegratedAppPool" />
+      <virtualDirectoryDefaults allowSubDirConfig="true" />
+    </sites>
+
+    <webLimits />
+
+  </system.applicationHost>
+
+  <system.webServer>
+
+    <serverRuntime />
+
+    <asp scriptErrorSentToBrowser="true">
+      <cache diskTemplateCacheDirectory="%TEMP%\iisexpress\ASP Compiled Templates" />
+      <limits />
+    </asp>
+
+    <caching enabled="true" enableKernelCache="true">
+    </caching>
+
+    <cgi />
+
+    <defaultDocument enabled="true">
+      <files>
+        <add value="Default.htm" />
+        <add value="Default.asp" />
+        <add value="index.htm" />
+        <add value="index.html" />
+        <add value="iisstart.htm" />
+        <add value="default.aspx" />
+      </files>
+    </defaultDocument>
+
+    <directoryBrowse enabled="false" />
+
+    <fastCgi />
+
+    <!--
+
+          The <globalModules> section defines all native-code modules.
+          To enable a module, specify it in the <modules> section.
+
+        -->
+    <globalModules>
+      <add name="HttpLoggingModule" image="%IIS_BIN%\loghttp.dll" />
+      <add name="UriCacheModule" image="%IIS_BIN%\cachuri.dll" />
+      <add name="TokenCacheModule" image="%IIS_BIN%\cachtokn.dll" />
+      <add name="DynamicCompressionModule" image="%IIS_BIN%\compdyn.dll" />
+      <add name="StaticCompressionModule" image="%IIS_BIN%\compstat.dll" />
+      <add name="DefaultDocumentModule" image="%IIS_BIN%\defdoc.dll" />
+      <add name="DirectoryListingModule" image="%IIS_BIN%\dirlist.dll" />
+      <add name="ProtocolSupportModule" image="%IIS_BIN%\protsup.dll" />
+      <add name="HttpRedirectionModule" image="%IIS_BIN%\redirect.dll" />
+      <add name="ServerSideIncludeModule" image="%IIS_BIN%\iis_ssi.dll" />
+      <add name="StaticFileModule" image="%IIS_BIN%\static.dll" />
+      <add name="AnonymousAuthenticationModule" image="%IIS_BIN%\authanon.dll" />
+      <add name="CertificateMappingAuthenticationModule" image="%IIS_BIN%\authcert.dll" />
+      <add name="UrlAuthorizationModule" image="%IIS_BIN%\urlauthz.dll" />
+      <add name="BasicAuthenticationModule" image="%IIS_BIN%\authbas.dll" />
+      <add name="WindowsAuthenticationModule" image="%IIS_BIN%\authsspi.dll" />
+      <add name="IISCertificateMappingAuthenticationModule" image="%IIS_BIN%\authmap.dll" />
+      <add name="IpRestrictionModule" image="%IIS_BIN%\iprestr.dll" />
+      <add name="DynamicIpRestrictionModule" image="%IIS_BIN%\diprestr.dll" />
+      <add name="RequestFilteringModule" image="%IIS_BIN%\modrqflt.dll" />
+      <add name="CustomLoggingModule" image="%IIS_BIN%\logcust.dll" />
+      <add name="CustomErrorModule" image="%IIS_BIN%\custerr.dll" />
+      <add name="FailedRequestsTracingModule" image="%IIS_BIN%\iisfreb.dll" />
+      <add name="RequestMonitorModule" image="%IIS_BIN%\iisreqs.dll" />
+      <add name="IsapiModule" image="%IIS_BIN%\isapi.dll" />
+      <add name="IsapiFilterModule" image="%IIS_BIN%\filter.dll" />
+      <add name="CgiModule" image="%IIS_BIN%\cgi.dll" />
+      <add name="FastCgiModule" image="%IIS_BIN%\iisfcgi.dll" />
+      <!--            <add name="WebDAVModule" image="%IIS_BIN%\webdav.dll" /> -->
+      <add name="RewriteModule" image="%IIS_BIN%\rewrite.dll" />
+      <add name="ConfigurationValidationModule" image="%IIS_BIN%\validcfg.dll" />
+      <add name="WebSocketModule" image="%IIS_BIN%\iiswsock.dll" />
+      <add name="WebMatrixSupportModule" image="%IIS_BIN%\webmatrixsup.dll" />
+      <add name="ManagedEngine" image="%windir%\Microsoft.NET\Framework\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness32" />
+      <add name="ManagedEngine64" image="%windir%\Microsoft.NET\Framework64\v2.0.50727\webengine.dll" preCondition="integratedMode,runtimeVersionv2.0,bitness64" />
+      <add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
+      <add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
+      <add name="ApplicationInitializationModule" image="%IIS_BIN%\warmup.dll" />
+      <add name="AspNetCoreModule" image="%IIS_BIN%\aspnetcore.dll" />
+      <add name="AspNetCoreModuleV2" image="%IIS_BIN%\ASP.NET Core Module\V2\aspnetcorev2.dll" />
+    </globalModules>
+
+    <httpCompression directory="%TEMP%">
+      <scheme name="gzip" dll="%IIS_BIN%\gzip.dll" />
+      <dynamicTypes>
+        <add mimeType="text/*" enabled="true" />
+        <add mimeType="message/*" enabled="true" />
+        <add mimeType="application/x-javascript" enabled="true" />
+        <add mimeType="application/javascript" enabled="true" />
+        <add mimeType="*/*" enabled="false" />
+      </dynamicTypes>
+      <staticTypes>
+        <add mimeType="text/*" enabled="true" />
+        <add mimeType="message/*" enabled="true" />
+        <add mimeType="application/javascript" enabled="true" />
+        <add mimeType="application/atom+xml" enabled="true" />
+        <add mimeType="application/xaml+xml" enabled="true" />
+        <add mimeType="image/svg+xml" enabled="true" />
+        <add mimeType="*/*" enabled="false" />
+      </staticTypes>
+    </httpCompression>
+
+    <httpErrors lockAttributes="allowAbsolutePathsWhenDelegated,defaultPath">
+      <error statusCode="401" prefixLanguageFilePath="%IIS_BIN%\custerr" path="401.htm" />
+      <error statusCode="403" prefixLanguageFilePath="%IIS_BIN%\custerr" path="403.htm" />
+      <error statusCode="404" prefixLanguageFilePath="%IIS_BIN%\custerr" path="404.htm" />
+      <error statusCode="405" prefixLanguageFilePath="%IIS_BIN%\custerr" path="405.htm" />
+      <error statusCode="406" prefixLanguageFilePath="%IIS_BIN%\custerr" path="406.htm" />
+      <error statusCode="412" prefixLanguageFilePath="%IIS_BIN%\custerr" path="412.htm" />
+      <error statusCode="500" prefixLanguageFilePath="%IIS_BIN%\custerr" path="500.htm" />
+      <error statusCode="501" prefixLanguageFilePath="%IIS_BIN%\custerr" path="501.htm" />
+      <error statusCode="502" prefixLanguageFilePath="%IIS_BIN%\custerr" path="502.htm" />
+    </httpErrors>
+
+    <httpLogging dontLog="false" />
+
+    <httpProtocol>
+      <customHeaders>
+        <clear />
+        <add name="X-Powered-By" value="ASP.NET" />
+      </customHeaders>
+      <redirectHeaders>
+        <clear />
+      </redirectHeaders>
+    </httpProtocol>
+
+    <httpRedirect enabled="false" />
+
+    <httpTracing />
+
+    <isapiFilters>
+      <filter name="ASP.Net_2.0.50727-64" path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="bitness64,runtimeVersionv2.0" />
+      <filter name="ASP.Net_2.0.50727.0" path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="bitness32,runtimeVersionv2.0" />
+      <filter name="ASP.Net_2.0_for_v1.1" path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_filter.dll" enableCache="true" preCondition="runtimeVersionv1.1" />
+      <filter name="ASP.Net_4.0_32bit" path="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="bitness32,runtimeVersionv4.0" />
+      <filter name="ASP.Net_4.0_64bit" path="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_filter.dll" enableCache="true" preCondition="bitness64,runtimeVersionv4.0" />
+    </isapiFilters>
+
+    <odbcLogging />
+
+    <security>
+
+      <access sslFlags="None" />
+
+      <applicationDependencies>
+        <application name="Active Server Pages" groupId="ASP" />
+      </applicationDependencies>
+
+      <authentication>
+
+        <anonymousAuthentication enabled="true" userName="" />
+
+        <basicAuthentication enabled="false" />
+
+        <clientCertificateMappingAuthentication enabled="false" />
+
+        <digestAuthentication enabled="false" />
+
+        <iisClientCertificateMappingAuthentication enabled="false">
+        </iisClientCertificateMappingAuthentication>
+
+        <windowsAuthentication enabled="false">
+          <providers>
+            <add value="Negotiate" />
+            <add value="NTLM" />
+          </providers>
+        </windowsAuthentication>
+
+      </authentication>
+
+      <authorization>
+        <add accessType="Allow" users="*" />
+      </authorization>
+
+      <ipSecurity allowUnlisted="true" />
+
+      <isapiCgiRestriction notListedIsapisAllowed="true" notListedCgisAllowed="true">
+        <add path="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" allowed="true" groupId="ASP.NET_v4.0" description="ASP.NET_v4.0" />
+        <add path="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" allowed="true" groupId="ASP.NET_v4.0" description="ASP.NET_v4.0" />
+        <add path="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+        <add path="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" allowed="true" groupId="ASP.NET v2.0.50727" description="ASP.NET v2.0.50727" />
+      </isapiCgiRestriction>
+
+      <requestFiltering>
+        <fileExtensions allowUnlisted="true" applyToWebDAV="true">
+          <add fileExtension=".asa" allowed="false" />
+          <add fileExtension=".asax" allowed="false" />
+          <add fileExtension=".ascx" allowed="false" />
+          <add fileExtension=".master" allowed="false" />
+          <add fileExtension=".skin" allowed="false" />
+          <add fileExtension=".browser" allowed="false" />
+          <add fileExtension=".sitemap" allowed="false" />
+          <add fileExtension=".config" allowed="false" />
+          <add fileExtension=".cs" allowed="false" />
+          <add fileExtension=".csproj" allowed="false" />
+          <add fileExtension=".vb" allowed="false" />
+          <add fileExtension=".vbproj" allowed="false" />
+          <add fileExtension=".webinfo" allowed="false" />
+          <add fileExtension=".licx" allowed="false" />
+          <add fileExtension=".resx" allowed="false" />
+          <add fileExtension=".resources" allowed="false" />
+          <add fileExtension=".mdb" allowed="false" />
+          <add fileExtension=".vjsproj" allowed="false" />
+          <add fileExtension=".java" allowed="false" />
+          <add fileExtension=".jsl" allowed="false" />
+          <add fileExtension=".ldb" allowed="false" />
+          <add fileExtension=".dsdgm" allowed="false" />
+          <add fileExtension=".ssdgm" allowed="false" />
+          <add fileExtension=".lsad" allowed="false" />
+          <add fileExtension=".ssmap" allowed="false" />
+          <add fileExtension=".cd" allowed="false" />
+          <add fileExtension=".dsprototype" allowed="false" />
+          <add fileExtension=".lsaprototype" allowed="false" />
+          <add fileExtension=".sdm" allowed="false" />
+          <add fileExtension=".sdmDocument" allowed="false" />
+          <add fileExtension=".mdf" allowed="false" />
+          <add fileExtension=".ldf" allowed="false" />
+          <add fileExtension=".ad" allowed="false" />
+          <add fileExtension=".dd" allowed="false" />
+          <add fileExtension=".ldd" allowed="false" />
+          <add fileExtension=".sd" allowed="false" />
+          <add fileExtension=".adprototype" allowed="false" />
+          <add fileExtension=".lddprototype" allowed="false" />
+          <add fileExtension=".exclude" allowed="false" />
+          <add fileExtension=".refresh" allowed="false" />
+          <add fileExtension=".compiled" allowed="false" />
+          <add fileExtension=".msgx" allowed="false" />
+          <add fileExtension=".vsdisco" allowed="false" />
+          <add fileExtension=".rules" allowed="false" />
+        </fileExtensions>
+        <verbs allowUnlisted="true" applyToWebDAV="true" />
+        <hiddenSegments applyToWebDAV="true">
+          <add segment="web.config" />
+          <add segment="bin" />
+          <add segment="App_code" />
+          <add segment="App_GlobalResources" />
+          <add segment="App_LocalResources" />
+          <add segment="App_WebReferences" />
+          <add segment="App_Data" />
+          <add segment="App_Browsers" />
+        </hiddenSegments>
+      </requestFiltering>
+
+    </security>
+
+    <serverSideInclude ssiExecDisable="false" />
+
+    <staticContent lockAttributes="isDocFooterFileName">
+      <mimeMap fileExtension=".323" mimeType="text/h323" />
+      <mimeMap fileExtension=".3g2" mimeType="video/3gpp2" />
+      <mimeMap fileExtension=".3gp2" mimeType="video/3gpp2" />
+      <mimeMap fileExtension=".3gp" mimeType="video/3gpp" />
+      <mimeMap fileExtension=".3gpp" mimeType="video/3gpp" />
+      <mimeMap fileExtension=".aac" mimeType="audio/aac" />
+      <mimeMap fileExtension=".aaf" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".aca" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".accdb" mimeType="application/msaccess" />
+      <mimeMap fileExtension=".accde" mimeType="application/msaccess" />
+      <mimeMap fileExtension=".accdt" mimeType="application/msaccess" />
+      <mimeMap fileExtension=".acx" mimeType="application/internet-property-stream" />
+      <mimeMap fileExtension=".adt" mimeType="audio/vnd.dlna.adts" />
+      <mimeMap fileExtension=".adts" mimeType="audio/vnd.dlna.adts" />
+      <mimeMap fileExtension=".afm" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".ai" mimeType="application/postscript" />
+      <mimeMap fileExtension=".aif" mimeType="audio/x-aiff" />
+      <mimeMap fileExtension=".aifc" mimeType="audio/aiff" />
+      <mimeMap fileExtension=".aiff" mimeType="audio/aiff" />
+      <mimeMap fileExtension=".appcache" mimeType="text/cache-manifest" />
+      <mimeMap fileExtension=".application" mimeType="application/x-ms-application" />
+      <mimeMap fileExtension=".art" mimeType="image/x-jg" />
+      <mimeMap fileExtension=".asd" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".asf" mimeType="video/x-ms-asf" />
+      <mimeMap fileExtension=".asi" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".asm" mimeType="text/plain" />
+      <mimeMap fileExtension=".asr" mimeType="video/x-ms-asf" />
+      <mimeMap fileExtension=".asx" mimeType="video/x-ms-asf" />
+      <mimeMap fileExtension=".atom" mimeType="application/atom+xml" />
+      <mimeMap fileExtension=".au" mimeType="audio/basic" />
+      <mimeMap fileExtension=".avi" mimeType="video/avi" />
+      <mimeMap fileExtension=".axs" mimeType="application/olescript" />
+      <mimeMap fileExtension=".bas" mimeType="text/plain" />
+      <mimeMap fileExtension=".bcpio" mimeType="application/x-bcpio" />
+      <mimeMap fileExtension=".bin" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".bmp" mimeType="image/bmp" />
+      <mimeMap fileExtension=".c" mimeType="text/plain" />
+      <mimeMap fileExtension=".cab" mimeType="application/vnd.ms-cab-compressed" />
+      <mimeMap fileExtension=".calx" mimeType="application/vnd.ms-office.calx" />
+      <mimeMap fileExtension=".cat" mimeType="application/vnd.ms-pki.seccat" />
+      <mimeMap fileExtension=".cdf" mimeType="application/x-cdf" />
+      <mimeMap fileExtension=".chm" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".class" mimeType="application/x-java-applet" />
+      <mimeMap fileExtension=".clp" mimeType="application/x-msclip" />
+      <mimeMap fileExtension=".cmx" mimeType="image/x-cmx" />
+      <mimeMap fileExtension=".cnf" mimeType="text/plain" />
+      <mimeMap fileExtension=".cod" mimeType="image/cis-cod" />
+      <mimeMap fileExtension=".cpio" mimeType="application/x-cpio" />
+      <mimeMap fileExtension=".cpp" mimeType="text/plain" />
+      <mimeMap fileExtension=".crd" mimeType="application/x-mscardfile" />
+      <mimeMap fileExtension=".crl" mimeType="application/pkix-crl" />
+      <mimeMap fileExtension=".crt" mimeType="application/x-x509-ca-cert" />
+      <mimeMap fileExtension=".csh" mimeType="application/x-csh" />
+      <mimeMap fileExtension=".css" mimeType="text/css" />
+      <mimeMap fileExtension=".csv" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".cur" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".dcr" mimeType="application/x-director" />
+      <mimeMap fileExtension=".deploy" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".der" mimeType="application/x-x509-ca-cert" />
+      <mimeMap fileExtension=".dib" mimeType="image/bmp" />
+      <mimeMap fileExtension=".dir" mimeType="application/x-director" />
+      <mimeMap fileExtension=".disco" mimeType="text/xml" />
+      <mimeMap fileExtension=".dll" mimeType="application/x-msdownload" />
+      <mimeMap fileExtension=".dll.config" mimeType="text/xml" />
+      <mimeMap fileExtension=".dlm" mimeType="text/dlm" />
+      <mimeMap fileExtension=".doc" mimeType="application/msword" />
+      <mimeMap fileExtension=".docm" mimeType="application/vnd.ms-word.document.macroEnabled.12" />
+      <mimeMap fileExtension=".docx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+      <mimeMap fileExtension=".dot" mimeType="application/msword" />
+      <mimeMap fileExtension=".dotm" mimeType="application/vnd.ms-word.template.macroEnabled.12" />
+      <mimeMap fileExtension=".dotx" mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.template" />
+      <mimeMap fileExtension=".dsp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".dtd" mimeType="text/xml" />
+      <mimeMap fileExtension=".dvi" mimeType="application/x-dvi" />
+      <mimeMap fileExtension=".dvr-ms" mimeType="video/x-ms-dvr" />
+      <mimeMap fileExtension=".dwf" mimeType="drawing/x-dwf" />
+      <mimeMap fileExtension=".dwp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".dxr" mimeType="application/x-director" />
+      <mimeMap fileExtension=".eml" mimeType="message/rfc822" />
+      <mimeMap fileExtension=".emz" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".eot" mimeType="application/vnd.ms-fontobject" />
+      <mimeMap fileExtension=".eps" mimeType="application/postscript" />
+      <mimeMap fileExtension=".esd" mimeType="application/vnd.ms-cab-compressed" />
+      <mimeMap fileExtension=".etx" mimeType="text/x-setext" />
+      <mimeMap fileExtension=".evy" mimeType="application/envoy" />
+      <mimeMap fileExtension=".exe" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".exe.config" mimeType="text/xml" />
+      <mimeMap fileExtension=".fdf" mimeType="application/vnd.fdf" />
+      <mimeMap fileExtension=".fif" mimeType="application/fractals" />
+      <mimeMap fileExtension=".fla" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".flr" mimeType="x-world/x-vrml" />
+      <mimeMap fileExtension=".flv" mimeType="video/x-flv" />
+      <mimeMap fileExtension=".gif" mimeType="image/gif" />
+      <mimeMap fileExtension=".glb" mimeType="model/gltf-binary" />
+      <mimeMap fileExtension=".gtar" mimeType="application/x-gtar" />
+      <mimeMap fileExtension=".gz" mimeType="application/x-gzip" />
+      <mimeMap fileExtension=".h" mimeType="text/plain" />
+      <mimeMap fileExtension=".hdf" mimeType="application/x-hdf" />
+      <mimeMap fileExtension=".hdml" mimeType="text/x-hdml" />
+      <mimeMap fileExtension=".hhc" mimeType="application/x-oleobject" />
+      <mimeMap fileExtension=".hhk" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".hhp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".hlp" mimeType="application/winhlp" />
+      <mimeMap fileExtension=".hqx" mimeType="application/mac-binhex40" />
+      <mimeMap fileExtension=".hta" mimeType="application/hta" />
+      <mimeMap fileExtension=".htc" mimeType="text/x-component" />
+      <mimeMap fileExtension=".htm" mimeType="text/html" />
+      <mimeMap fileExtension=".html" mimeType="text/html" />
+      <mimeMap fileExtension=".htt" mimeType="text/webviewhtml" />
+      <mimeMap fileExtension=".hxt" mimeType="text/html" />
+      <mimeMap fileExtension=".ico" mimeType="image/x-icon" />
+      <mimeMap fileExtension=".ics" mimeType="text/calendar" />
+      <mimeMap fileExtension=".ief" mimeType="image/ief" />
+      <mimeMap fileExtension=".iii" mimeType="application/x-iphone" />
+      <mimeMap fileExtension=".inf" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".ins" mimeType="application/x-internet-signup" />
+      <mimeMap fileExtension=".isp" mimeType="application/x-internet-signup" />
+      <mimeMap fileExtension=".IVF" mimeType="video/x-ivf" />
+      <mimeMap fileExtension=".jar" mimeType="application/java-archive" />
+      <mimeMap fileExtension=".java" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".jck" mimeType="application/liquidmotion" />
+      <mimeMap fileExtension=".jcz" mimeType="application/liquidmotion" />
+      <mimeMap fileExtension=".jfif" mimeType="image/pjpeg" />
+      <mimeMap fileExtension=".jpb" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".jpe" mimeType="image/jpeg" />
+      <mimeMap fileExtension=".jpeg" mimeType="image/jpeg" />
+      <mimeMap fileExtension=".jpg" mimeType="image/jpeg" />
+      <mimeMap fileExtension=".js" mimeType="application/javascript" />
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+      <mimeMap fileExtension=".jsonld" mimeType="application/ld+json" />
+      <mimeMap fileExtension=".jsx" mimeType="text/jscript" />
+      <mimeMap fileExtension=".latex" mimeType="application/x-latex" />
+      <mimeMap fileExtension=".less" mimeType="text/css" />
+      <mimeMap fileExtension=".lit" mimeType="application/x-ms-reader" />
+      <mimeMap fileExtension=".lpk" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".lsf" mimeType="video/x-la-asf" />
+      <mimeMap fileExtension=".lsx" mimeType="video/x-la-asf" />
+      <mimeMap fileExtension=".lzh" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".m13" mimeType="application/x-msmediaview" />
+      <mimeMap fileExtension=".m14" mimeType="application/x-msmediaview" />
+      <mimeMap fileExtension=".m1v" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".m2ts" mimeType="video/vnd.dlna.mpeg-tts" />
+      <mimeMap fileExtension=".m3u" mimeType="audio/x-mpegurl" />
+      <mimeMap fileExtension=".m4a" mimeType="audio/mp4" />
+      <mimeMap fileExtension=".m4v" mimeType="video/mp4" />
+      <mimeMap fileExtension=".man" mimeType="application/x-troff-man" />
+      <mimeMap fileExtension=".manifest" mimeType="application/x-ms-manifest" />
+      <mimeMap fileExtension=".map" mimeType="text/plain" />
+      <mimeMap fileExtension=".mdb" mimeType="application/x-msaccess" />
+      <mimeMap fileExtension=".mdp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".me" mimeType="application/x-troff-me" />
+      <mimeMap fileExtension=".mht" mimeType="message/rfc822" />
+      <mimeMap fileExtension=".mhtml" mimeType="message/rfc822" />
+      <mimeMap fileExtension=".mid" mimeType="audio/mid" />
+      <mimeMap fileExtension=".midi" mimeType="audio/mid" />
+      <mimeMap fileExtension=".mix" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".mmf" mimeType="application/x-smaf" />
+      <mimeMap fileExtension=".mno" mimeType="text/xml" />
+      <mimeMap fileExtension=".mny" mimeType="application/x-msmoney" />
+      <mimeMap fileExtension=".mov" mimeType="video/quicktime" />
+      <mimeMap fileExtension=".movie" mimeType="video/x-sgi-movie" />
+      <mimeMap fileExtension=".mp2" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".mp3" mimeType="audio/mpeg" />
+      <mimeMap fileExtension=".mp4" mimeType="video/mp4" />
+      <mimeMap fileExtension=".mp4v" mimeType="video/mp4" />
+      <mimeMap fileExtension=".mpa" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".mpe" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".mpeg" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".mpg" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".mpp" mimeType="application/vnd.ms-project" />
+      <mimeMap fileExtension=".mpv2" mimeType="video/mpeg" />
+      <mimeMap fileExtension=".ms" mimeType="application/x-troff-ms" />
+      <mimeMap fileExtension=".msi" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".mso" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".mvb" mimeType="application/x-msmediaview" />
+      <mimeMap fileExtension=".mvc" mimeType="application/x-miva-compiled" />
+      <mimeMap fileExtension=".nc" mimeType="application/x-netcdf" />
+      <mimeMap fileExtension=".nsc" mimeType="video/x-ms-asf" />
+      <mimeMap fileExtension=".nws" mimeType="message/rfc822" />
+      <mimeMap fileExtension=".ocx" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".oda" mimeType="application/oda" />
+      <mimeMap fileExtension=".odc" mimeType="text/x-ms-odc" />
+      <mimeMap fileExtension=".ods" mimeType="application/oleobject" />
+      <mimeMap fileExtension=".oga" mimeType="audio/ogg" />
+      <mimeMap fileExtension=".ogg" mimeType="video/ogg" />
+      <mimeMap fileExtension=".ogv" mimeType="video/ogg" />
+      <mimeMap fileExtension=".one" mimeType="application/onenote" />
+      <mimeMap fileExtension=".onea" mimeType="application/onenote" />
+      <mimeMap fileExtension=".onetoc" mimeType="application/onenote" />
+      <mimeMap fileExtension=".onetoc2" mimeType="application/onenote" />
+      <mimeMap fileExtension=".onetmp" mimeType="application/onenote" />
+      <mimeMap fileExtension=".onepkg" mimeType="application/onenote" />
+      <mimeMap fileExtension=".osdx" mimeType="application/opensearchdescription+xml" />
+      <mimeMap fileExtension=".otf" mimeType="font/otf" />
+      <mimeMap fileExtension=".p10" mimeType="application/pkcs10" />
+      <mimeMap fileExtension=".p12" mimeType="application/x-pkcs12" />
+      <mimeMap fileExtension=".p7b" mimeType="application/x-pkcs7-certificates" />
+      <mimeMap fileExtension=".p7c" mimeType="application/pkcs7-mime" />
+      <mimeMap fileExtension=".p7m" mimeType="application/pkcs7-mime" />
+      <mimeMap fileExtension=".p7r" mimeType="application/x-pkcs7-certreqresp" />
+      <mimeMap fileExtension=".p7s" mimeType="application/pkcs7-signature" />
+      <mimeMap fileExtension=".pbm" mimeType="image/x-portable-bitmap" />
+      <mimeMap fileExtension=".pcx" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".pcz" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".pdf" mimeType="application/pdf" />
+      <mimeMap fileExtension=".pfb" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".pfm" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".pfx" mimeType="application/x-pkcs12" />
+      <mimeMap fileExtension=".pgm" mimeType="image/x-portable-graymap" />
+      <mimeMap fileExtension=".pko" mimeType="application/vnd.ms-pki.pko" />
+      <mimeMap fileExtension=".pma" mimeType="application/x-perfmon" />
+      <mimeMap fileExtension=".pmc" mimeType="application/x-perfmon" />
+      <mimeMap fileExtension=".pml" mimeType="application/x-perfmon" />
+      <mimeMap fileExtension=".pmr" mimeType="application/x-perfmon" />
+      <mimeMap fileExtension=".pmw" mimeType="application/x-perfmon" />
+      <mimeMap fileExtension=".png" mimeType="image/png" />
+      <mimeMap fileExtension=".pnm" mimeType="image/x-portable-anymap" />
+      <mimeMap fileExtension=".pnz" mimeType="image/png" />
+      <mimeMap fileExtension=".pot" mimeType="application/vnd.ms-powerpoint" />
+      <mimeMap fileExtension=".potm" mimeType="application/vnd.ms-powerpoint.template.macroEnabled.12" />
+      <mimeMap fileExtension=".potx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.template" />
+      <mimeMap fileExtension=".ppam" mimeType="application/vnd.ms-powerpoint.addin.macroEnabled.12" />
+      <mimeMap fileExtension=".ppm" mimeType="image/x-portable-pixmap" />
+      <mimeMap fileExtension=".pps" mimeType="application/vnd.ms-powerpoint" />
+      <mimeMap fileExtension=".ppsm" mimeType="application/vnd.ms-powerpoint.slideshow.macroEnabled.12" />
+      <mimeMap fileExtension=".ppsx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slideshow" />
+      <mimeMap fileExtension=".ppt" mimeType="application/vnd.ms-powerpoint" />
+      <mimeMap fileExtension=".pptm" mimeType="application/vnd.ms-powerpoint.presentation.macroEnabled.12" />
+      <mimeMap fileExtension=".pptx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
+      <mimeMap fileExtension=".prf" mimeType="application/pics-rules" />
+      <mimeMap fileExtension=".prm" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".prx" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".ps" mimeType="application/postscript" />
+      <mimeMap fileExtension=".psd" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".psm" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".psp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".pub" mimeType="application/x-mspublisher" />
+      <mimeMap fileExtension=".qt" mimeType="video/quicktime" />
+      <mimeMap fileExtension=".qtl" mimeType="application/x-quicktimeplayer" />
+      <mimeMap fileExtension=".qxd" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".ra" mimeType="audio/x-pn-realaudio" />
+      <mimeMap fileExtension=".ram" mimeType="audio/x-pn-realaudio" />
+      <mimeMap fileExtension=".rar" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".ras" mimeType="image/x-cmu-raster" />
+      <mimeMap fileExtension=".rf" mimeType="image/vnd.rn-realflash" />
+      <mimeMap fileExtension=".rgb" mimeType="image/x-rgb" />
+      <mimeMap fileExtension=".rm" mimeType="application/vnd.rn-realmedia" />
+      <mimeMap fileExtension=".rmi" mimeType="audio/mid" />
+      <mimeMap fileExtension=".roff" mimeType="application/x-troff" />
+      <mimeMap fileExtension=".rpm" mimeType="audio/x-pn-realaudio-plugin" />
+      <mimeMap fileExtension=".rtf" mimeType="application/rtf" />
+      <mimeMap fileExtension=".rtx" mimeType="text/richtext" />
+      <mimeMap fileExtension=".scd" mimeType="application/x-msschedule" />
+      <mimeMap fileExtension=".sct" mimeType="text/scriptlet" />
+      <mimeMap fileExtension=".sea" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".setpay" mimeType="application/set-payment-initiation" />
+      <mimeMap fileExtension=".setreg" mimeType="application/set-registration-initiation" />
+      <mimeMap fileExtension=".sgml" mimeType="text/sgml" />
+      <mimeMap fileExtension=".sh" mimeType="application/x-sh" />
+      <mimeMap fileExtension=".shar" mimeType="application/x-shar" />
+      <mimeMap fileExtension=".sit" mimeType="application/x-stuffit" />
+      <mimeMap fileExtension=".sldm" mimeType="application/vnd.ms-powerpoint.slide.macroEnabled.12" />
+      <mimeMap fileExtension=".sldx" mimeType="application/vnd.openxmlformats-officedocument.presentationml.slide" />
+      <mimeMap fileExtension=".smd" mimeType="audio/x-smd" />
+      <mimeMap fileExtension=".smi" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".smx" mimeType="audio/x-smd" />
+      <mimeMap fileExtension=".smz" mimeType="audio/x-smd" />
+      <mimeMap fileExtension=".snd" mimeType="audio/basic" />
+      <mimeMap fileExtension=".snp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".spc" mimeType="application/x-pkcs7-certificates" />
+      <mimeMap fileExtension=".spl" mimeType="application/futuresplash" />
+      <mimeMap fileExtension=".spx" mimeType="audio/ogg" />
+      <mimeMap fileExtension=".src" mimeType="application/x-wais-source" />
+      <mimeMap fileExtension=".ssm" mimeType="application/streamingmedia" />
+      <mimeMap fileExtension=".sst" mimeType="application/vnd.ms-pki.certstore" />
+      <mimeMap fileExtension=".stl" mimeType="application/vnd.ms-pki.stl" />
+      <mimeMap fileExtension=".sv4cpio" mimeType="application/x-sv4cpio" />
+      <mimeMap fileExtension=".sv4crc" mimeType="application/x-sv4crc" />
+      <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+      <mimeMap fileExtension=".svgz" mimeType="image/svg+xml" />
+      <mimeMap fileExtension=".swf" mimeType="application/x-shockwave-flash" />
+      <mimeMap fileExtension=".t" mimeType="application/x-troff" />
+      <mimeMap fileExtension=".tar" mimeType="application/x-tar" />
+      <mimeMap fileExtension=".tcl" mimeType="application/x-tcl" />
+      <mimeMap fileExtension=".tex" mimeType="application/x-tex" />
+      <mimeMap fileExtension=".texi" mimeType="application/x-texinfo" />
+      <mimeMap fileExtension=".texinfo" mimeType="application/x-texinfo" />
+      <mimeMap fileExtension=".tgz" mimeType="application/x-compressed" />
+      <mimeMap fileExtension=".thmx" mimeType="application/vnd.ms-officetheme" />
+      <mimeMap fileExtension=".thn" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".tif" mimeType="image/tiff" />
+      <mimeMap fileExtension=".tiff" mimeType="image/tiff" />
+      <mimeMap fileExtension=".toc" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".tr" mimeType="application/x-troff" />
+      <mimeMap fileExtension=".trm" mimeType="application/x-msterminal" />
+      <mimeMap fileExtension=".ts" mimeType="video/vnd.dlna.mpeg-tts" />
+      <mimeMap fileExtension=".tsv" mimeType="text/tab-separated-values" />
+      <mimeMap fileExtension=".ttf" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".tts" mimeType="video/vnd.dlna.mpeg-tts" />
+      <mimeMap fileExtension=".txt" mimeType="text/plain" />
+      <mimeMap fileExtension=".u32" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".uls" mimeType="text/iuls" />
+      <mimeMap fileExtension=".ustar" mimeType="application/x-ustar" />
+      <mimeMap fileExtension=".vbs" mimeType="text/vbscript" />
+      <mimeMap fileExtension=".vcf" mimeType="text/x-vcard" />
+      <mimeMap fileExtension=".vcs" mimeType="text/plain" />
+      <mimeMap fileExtension=".vdx" mimeType="application/vnd.ms-visio.viewer" />
+      <mimeMap fileExtension=".vml" mimeType="text/xml" />
+      <mimeMap fileExtension=".vsd" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".vss" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".vst" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".vsto" mimeType="application/x-ms-vsto" />
+      <mimeMap fileExtension=".vsw" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".vsx" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".vtx" mimeType="application/vnd.visio" />
+      <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
+      <mimeMap fileExtension=".wav" mimeType="audio/wav" />
+      <mimeMap fileExtension=".wax" mimeType="audio/x-ms-wax" />
+      <mimeMap fileExtension=".wbmp" mimeType="image/vnd.wap.wbmp" />
+      <mimeMap fileExtension=".wcm" mimeType="application/vnd.ms-works" />
+      <mimeMap fileExtension=".wdb" mimeType="application/vnd.ms-works" />
+      <mimeMap fileExtension=".webm" mimeType="video/webm" />
+      <mimeMap fileExtension=".wks" mimeType="application/vnd.ms-works" />
+      <mimeMap fileExtension=".wm" mimeType="video/x-ms-wm" />
+      <mimeMap fileExtension=".wma" mimeType="audio/x-ms-wma" />
+      <mimeMap fileExtension=".wmd" mimeType="application/x-ms-wmd" />
+      <mimeMap fileExtension=".wmf" mimeType="application/x-msmetafile" />
+      <mimeMap fileExtension=".wml" mimeType="text/vnd.wap.wml" />
+      <mimeMap fileExtension=".wmlc" mimeType="application/vnd.wap.wmlc" />
+      <mimeMap fileExtension=".wmls" mimeType="text/vnd.wap.wmlscript" />
+      <mimeMap fileExtension=".wmlsc" mimeType="application/vnd.wap.wmlscriptc" />
+      <mimeMap fileExtension=".wmp" mimeType="video/x-ms-wmp" />
+      <mimeMap fileExtension=".wmv" mimeType="video/x-ms-wmv" />
+      <mimeMap fileExtension=".wmx" mimeType="video/x-ms-wmx" />
+      <mimeMap fileExtension=".wmz" mimeType="application/x-ms-wmz" />
+      <mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+      <mimeMap fileExtension=".wps" mimeType="application/vnd.ms-works" />
+      <mimeMap fileExtension=".wri" mimeType="application/x-mswrite" />
+      <mimeMap fileExtension=".wrl" mimeType="x-world/x-vrml" />
+      <mimeMap fileExtension=".wrz" mimeType="x-world/x-vrml" />
+      <mimeMap fileExtension=".wsdl" mimeType="text/xml" />
+      <mimeMap fileExtension=".wtv" mimeType="video/x-ms-wtv" />
+      <mimeMap fileExtension=".wvx" mimeType="video/x-ms-wvx" />
+      <mimeMap fileExtension=".x" mimeType="application/directx" />
+      <mimeMap fileExtension=".xaf" mimeType="x-world/x-vrml" />
+      <mimeMap fileExtension=".xaml" mimeType="application/xaml+xml" />
+      <mimeMap fileExtension=".xap" mimeType="application/x-silverlight-app" />
+      <mimeMap fileExtension=".xbap" mimeType="application/x-ms-xbap" />
+      <mimeMap fileExtension=".xbm" mimeType="image/x-xbitmap" />
+      <mimeMap fileExtension=".xdr" mimeType="text/plain" />
+      <mimeMap fileExtension=".xht" mimeType="application/xhtml+xml" />
+      <mimeMap fileExtension=".xhtml" mimeType="application/xhtml+xml" />
+      <mimeMap fileExtension=".xla" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xlam" mimeType="application/vnd.ms-excel.addin.macroEnabled.12" />
+      <mimeMap fileExtension=".xlc" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xlm" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xls" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xlsb" mimeType="application/vnd.ms-excel.sheet.binary.macroEnabled.12" />
+      <mimeMap fileExtension=".xlsm" mimeType="application/vnd.ms-excel.sheet.macroEnabled.12" />
+      <mimeMap fileExtension=".xlsx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+      <mimeMap fileExtension=".xlt" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xltm" mimeType="application/vnd.ms-excel.template.macroEnabled.12" />
+      <mimeMap fileExtension=".xltx" mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.template" />
+      <mimeMap fileExtension=".xlw" mimeType="application/vnd.ms-excel" />
+      <mimeMap fileExtension=".xml" mimeType="text/xml" />
+      <mimeMap fileExtension=".xof" mimeType="x-world/x-vrml" />
+      <mimeMap fileExtension=".xpm" mimeType="image/x-xpixmap" />
+      <mimeMap fileExtension=".xps" mimeType="application/vnd.ms-xpsdocument" />
+      <mimeMap fileExtension=".xsd" mimeType="text/xml" />
+      <mimeMap fileExtension=".xsf" mimeType="text/xml" />
+      <mimeMap fileExtension=".xsl" mimeType="text/xml" />
+      <mimeMap fileExtension=".xslt" mimeType="text/xml" />
+      <mimeMap fileExtension=".xsn" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".xtp" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".xwd" mimeType="image/x-xwindowdump" />
+      <mimeMap fileExtension=".z" mimeType="application/x-compress" />
+      <mimeMap fileExtension=".zip" mimeType="application/x-zip-compressed" />
+    </staticContent>
+
+    <tracing>
+
+      <traceFailedRequests>
+        <add path="*">
+          <traceAreas>
+            <add provider="ASP" verbosity="Verbose" />
+            <add provider="ASPNET" areas="Infrastructure,Module,Page,AppServices" verbosity="Verbose" />
+            <add provider="ISAPI Extension" verbosity="Verbose" />
+            <add provider="WWW Server" areas="Authentication,Security,Filter,StaticFile,CGI,Compression,Cache,RequestNotifications,Module,Rewrite,WebSocket" verbosity="Verbose" />
+          </traceAreas>
+          <failureDefinitions statusCodes="200-999" />
+        </add>
+      </traceFailedRequests>
+
+      <traceProviderDefinitions>
+        <add name="WWW Server" guid="{3a2a4e84-4c21-4981-ae10-3fda0d9b0f83}">
+          <areas>
+            <clear />
+            <add name="Authentication" value="2" />
+            <add name="Security" value="4" />
+            <add name="Filter" value="8" />
+            <add name="StaticFile" value="16" />
+            <add name="CGI" value="32" />
+            <add name="Compression" value="64" />
+            <add name="Cache" value="128" />
+            <add name="RequestNotifications" value="256" />
+            <add name="Module" value="512" />
+            <add name="Rewrite" value="1024" />
+            <add name="FastCGI" value="4096" />
+            <add name="WebSocket" value="16384" />
+          </areas>
+        </add>
+        <add name="ASP" guid="{06b94d9a-b15e-456e-a4ef-37c984a2cb4b}">
+          <areas>
+            <clear />
+          </areas>
+        </add>
+        <add name="ISAPI Extension" guid="{a1c2040e-8840-4c31-ba11-9871031a19ea}">
+          <areas>
+            <clear />
+          </areas>
+        </add>
+        <add name="ASPNET" guid="{AFF081FE-0247-4275-9C4E-021F3DC1DA35}">
+          <areas>
+            <add name="Infrastructure" value="1" />
+            <add name="Module" value="2" />
+            <add name="Page" value="4" />
+            <add name="AppServices" value="8" />
+          </areas>
+        </add>
+      </traceProviderDefinitions>
+
+    </tracing>
+
+    <urlCompression />
+
+    <validation />
+    <webdav>
+      <globalSettings>
+        <propertyStores>
+          <add name="webdav_simple_prop" image="%IIS_BIN%\webdav_simple_prop.dll" image32="%IIS_BIN%\webdav_simple_prop.dll" />
+        </propertyStores>
+        <lockStores>
+          <add name="webdav_simple_lock" image="%IIS_BIN%\webdav_simple_lock.dll" image32="%IIS_BIN%\webdav_simple_lock.dll" />
+        </lockStores>
+
+      </globalSettings>
+      <authoring>
+        <locks enabled="true" lockStore="webdav_simple_lock" />
+      </authoring>
+      <authoringRules />
+    </webdav>
+    <webSocket />
+    <applicationInitialization />
+
+  </system.webServer>
+  <location path="" overrideMode="Allow">
+    <system.webServer>
+      <modules>
+        <add name="IsapiFilterModule" lockItem="true" />
+        <add name="BasicAuthenticationModule" lockItem="true" />
+        <add name="IsapiModule" lockItem="true" />
+        <add name="HttpLoggingModule" lockItem="true" />
+        <add name="DynamicCompressionModule" lockItem="true" />
+        <add name="StaticCompressionModule" lockItem="true" />
+        <add name="DefaultDocumentModule" lockItem="true" />
+        <add name="DirectoryListingModule" lockItem="true" />
+        <add name="ProtocolSupportModule" lockItem="true" />
+        <add name="HttpRedirectionModule" lockItem="true" />
+        <add name="ServerSideIncludeModule" lockItem="true" />
+        <add name="StaticFileModule" lockItem="true" />
+        <add name="AnonymousAuthenticationModule" lockItem="true" />
+        <add name="CertificateMappingAuthenticationModule" lockItem="true" />
+        <add name="UrlAuthorizationModule" lockItem="true" />
+        <add name="WindowsAuthenticationModule" lockItem="true" />
+        <add name="IISCertificateMappingAuthenticationModule" lockItem="true" />
+        <add name="WebMatrixSupportModule" lockItem="true" />
+        <add name="IpRestrictionModule" lockItem="true" />
+        <add name="DynamicIpRestrictionModule" lockItem="true" />
+        <add name="RequestFilteringModule" lockItem="true" />
+        <add name="CustomLoggingModule" lockItem="true" />
+        <add name="CustomErrorModule" lockItem="true" />
+        <add name="FailedRequestsTracingModule" lockItem="true" />
+        <add name="CgiModule" lockItem="true" />
+        <add name="FastCgiModule" lockItem="true" />
+        <!--                <add name="WebDAVModule" /> -->
+        <add name="RewriteModule" />
+        <add name="OutputCache" type="System.Web.Caching.OutputCacheModule" preCondition="managedHandler" />
+        <add name="Session" type="System.Web.SessionState.SessionStateModule" preCondition="managedHandler" />
+        <add name="WindowsAuthentication" type="System.Web.Security.WindowsAuthenticationModule" preCondition="managedHandler" />
+        <add name="FormsAuthentication" type="System.Web.Security.FormsAuthenticationModule" preCondition="managedHandler" />
+        <add name="DefaultAuthentication" type="System.Web.Security.DefaultAuthenticationModule" preCondition="managedHandler" />
+        <add name="RoleManager" type="System.Web.Security.RoleManagerModule" preCondition="managedHandler" />
+        <add name="UrlAuthorization" type="System.Web.Security.UrlAuthorizationModule" preCondition="managedHandler" />
+        <add name="FileAuthorization" type="System.Web.Security.FileAuthorizationModule" preCondition="managedHandler" />
+        <add name="AnonymousIdentification" type="System.Web.Security.AnonymousIdentificationModule" preCondition="managedHandler" />
+        <add name="Profile" type="System.Web.Profile.ProfileModule" preCondition="managedHandler" />
+        <add name="UrlMappingsModule" type="System.Web.UrlMappingsModule" preCondition="managedHandler" />
+        <add name="ApplicationInitializationModule" lockItem="true" />
+        <add name="WebSocketModule" lockItem="true" />
+        <add name="ServiceModel-4.0" type="System.ServiceModel.Activation.ServiceHttpModule,System.ServiceModel.Activation,Version=4.0.0.0,Culture=neutral,PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+        <add name="ConfigurationValidationModule" lockItem="true" />
+        <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
+        <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
+        <add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
+        <add name="AspNetCoreModule" lockItem="true" />
+        <add name="AspNetCoreModuleV2" lockItem="true" />
+      </modules>
+      <handlers accessPolicy="Read, Script">
+        <!--                <add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" /> -->
+        <add name="AXD-ISAPI-4.0_64bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="PageHandlerFactory-ISAPI-4.0_64bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="SimpleHandlerFactory-ISAPI-4.0_64bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="WebServiceHandlerFactory-ISAPI-4.0_64bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_64bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_64bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="svc-ISAPI-4.0_64bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+        <add name="rules-ISAPI-4.0_64bit" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+        <add name="xoml-ISAPI-4.0_64bit" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+        <add name="xamlx-ISAPI-4.0_64bit" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" />
+        <add name="aspq-ISAPI-4.0_64bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="cshtm-ISAPI-4.0_64bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="cshtml-ISAPI-4.0_64bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="vbhtm-ISAPI-4.0_64bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="vbhtml-ISAPI-4.0_64bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="svc-Integrated" path="*.svc" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="svc-ISAPI-2.0" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+        <add name="xoml-Integrated" path="*.xoml" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="xoml-ISAPI-2.0" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+        <add name="rules-Integrated" path="*.rules" verb="*" type="System.ServiceModel.Activation.HttpHandler, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="rules-ISAPI-2.0" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" />
+        <add name="AXD-ISAPI-4.0_32bit" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="PageHandlerFactory-ISAPI-4.0_32bit" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="SimpleHandlerFactory-ISAPI-4.0_32bit" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="WebServiceHandlerFactory-ISAPI-4.0_32bit" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-rem-ISAPI-4.0_32bit" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-soap-ISAPI-4.0_32bit" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="svc-ISAPI-4.0_32bit" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+        <add name="rules-ISAPI-4.0_32bit" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+        <add name="xoml-ISAPI-4.0_32bit" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+        <add name="xamlx-ISAPI-4.0_32bit" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" />
+        <add name="aspq-ISAPI-4.0_32bit" path="*.aspq" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="cshtm-ISAPI-4.0_32bit" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="cshtml-ISAPI-4.0_32bit" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="vbhtm-ISAPI-4.0_32bit" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="vbhtml-ISAPI-4.0_32bit" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="TraceHandler-Integrated-4.0" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="WebAdminHandler-Integrated-4.0" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="AssemblyResourceLoader-Integrated-4.0" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="PageHandlerFactory-Integrated-4.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="SimpleHandlerFactory-Integrated-4.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="WebServiceHandlerFactory-Integrated-4.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="HttpRemotingHandlerFactory-rem-Integrated-4.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="HttpRemotingHandlerFactory-soap-Integrated-4.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory, System.Runtime.Remoting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="svc-Integrated-4.0" path="*.svc" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="rules-Integrated-4.0" path="*.rules" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="xoml-Integrated-4.0" path="*.xoml" verb="*" type="System.ServiceModel.Activation.ServiceHttpHandlerFactory, System.ServiceModel.Activation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="xamlx-Integrated-4.0" path="*.xamlx" verb="GET,HEAD,POST,DEBUG" type="System.Xaml.Hosting.XamlHttpHandlerFactory, System.Xaml.Hosting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="aspq-Integrated-4.0" path="*.aspq" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="cshtm-Integrated-4.0" path="*.cshtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="cshtml-Integrated-4.0" path="*.cshtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="vbhtm-Integrated-4.0" path="*.vbhtm" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="vbhtml-Integrated-4.0" path="*.vbhtml" verb="GET,HEAD,POST,DEBUG" type="System.Web.HttpForbiddenHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="ScriptHandlerFactoryAppServices-Integrated-4.0" path="*_AppService.axd" verb="*" type="System.Web.Script.Services.ScriptHandlerFactory, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="ScriptResourceIntegrated-4.0" path="*ScriptResource.axd" verb="GET,HEAD" type="System.Web.Handlers.ScriptResourceHandler, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" preCondition="integratedMode,runtimeVersionv4.0" />
+        <add name="ASPClassic" path="*.asp" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%IIS_BIN%\asp.dll" resourceType="File" />
+        <add name="SecurityCertificate" path="*.cer" verb="GET,HEAD,POST" modules="IsapiModule" scriptProcessor="%IIS_BIN%\asp.dll" resourceType="File" />
+        <add name="ISAPI-dll" path="*.dll" verb="*" modules="IsapiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+        <add name="TraceHandler-Integrated" path="trace.axd" verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TraceHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="WebAdminHandler-Integrated" path="WebAdmin.axd" verb="GET,DEBUG" type="System.Web.Handlers.WebAdminHandler" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="AssemblyResourceLoader-Integrated" path="WebResource.axd" verb="GET,DEBUG" type="System.Web.Handlers.AssemblyResourceLoader" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="PageHandlerFactory-Integrated" path="*.aspx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.PageHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="SimpleHandlerFactory-Integrated" path="*.ashx" verb="GET,HEAD,POST,DEBUG" type="System.Web.UI.SimpleHandlerFactory" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="WebServiceHandlerFactory-Integrated" path="*.asmx" verb="GET,HEAD,POST,DEBUG" type="System.Web.Services.Protocols.WebServiceHandlerFactory,System.Web.Services,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b03f5f7f11d50a3a" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="HttpRemotingHandlerFactory-rem-Integrated" path="*.rem" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory,System.Runtime.Remoting,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="HttpRemotingHandlerFactory-soap-Integrated" path="*.soap" verb="GET,HEAD,POST,DEBUG" type="System.Runtime.Remoting.Channels.Http.HttpRemotingHandlerFactory,System.Runtime.Remoting,Version=2.0.0.0,Culture=neutral,PublicKeyToken=b77a5c561934e089" preCondition="integratedMode,runtimeVersionv2.0" />
+        <add name="AXD-ISAPI-2.0" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="PageHandlerFactory-ISAPI-2.0" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="SimpleHandlerFactory-ISAPI-2.0" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="WebServiceHandlerFactory-ISAPI-2.0" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness32" responseBufferLimit="0" />
+        <add name="svc-ISAPI-2.0-64" path="*.svc" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+        <add name="AXD-ISAPI-2.0-64" path="*.axd" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="PageHandlerFactory-ISAPI-2.0-64" path="*.aspx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="SimpleHandlerFactory-ISAPI-2.0-64" path="*.ashx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="WebServiceHandlerFactory-ISAPI-2.0-64" path="*.asmx" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-rem-ISAPI-2.0-64" path="*.rem" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="HttpRemotingHandlerFactory-soap-ISAPI-2.0-64" path="*.soap" verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" responseBufferLimit="0" />
+        <add name="rules-64-ISAPI-2.0" path="*.rules" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+        <add name="xoml-64-ISAPI-2.0" path="*.xoml" verb="*" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v2.0.50727\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv2.0,bitness64" />
+        <add name="CGI-exe" path="*.exe" verb="*" modules="CgiModule" resourceType="File" requireAccess="Execute" allowPathInfo="true" />
+        <add name="SSINC-stm" path="*.stm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+        <add name="SSINC-shtm" path="*.shtm" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+        <add name="SSINC-shtml" path="*.shtml" verb="GET,HEAD,POST" modules="ServerSideIncludeModule" resourceType="File" />
+        <add name="TRACEVerbHandler" path="*" verb="TRACE" modules="ProtocolSupportModule" requireAccess="None" />
+        <add name="OPTIONSVerbHandler" path="*" verb="OPTIONS" modules="ProtocolSupportModule" requireAccess="None" />
+        <add name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness32" responseBufferLimit="0" />
+        <add name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" path="*." verb="GET,HEAD,POST,DEBUG" modules="IsapiModule" scriptProcessor="%windir%\Microsoft.NET\Framework64\v4.0.30319\aspnet_isapi.dll" preCondition="classicMode,runtimeVersionv4.0,bitness64" responseBufferLimit="0" />
+        <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" responseBufferLimit="0" />
+        <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
+      </handlers>
+      <aspNetCore processPath="[DOTNET]" arguments="[RELATIVE_SAMPLE_PATH]" stdoutLogEnabled="false" stdoutLogFile=".\stdout" hostingModel="[HOSTING_MODEL]" />
+    </system.webServer>
+  </location>
+</configuration>

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
@@ -158,10 +158,14 @@
         <application path="/" applicationPool="[POOL]">
           <virtualDirectory path="/" physicalPath="[PATH]" />
         </application>
+        <application path="/mixed" applicationPool="Clr4IntegratedAppPool">
+          <virtualDirectory path="/" physicalPath="[PATH]" />
+        </application>
         <bindings>
           <binding protocol="http" bindingInformation="*:[PORT]:localhost" />
         </bindings>
       </site>
+
       <siteDefaults>
         <!-- To enable logging, please change the below attribute "enabled" to "true" -->
         <logFile logFormat="W3C" directory="%AppData%\Microsoft\IISExpressLogs" enabled="false" />

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/ProcessInfoTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/ProcessInfoTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Tools.Runner.Checks;
 using FluentAssertions;
@@ -39,6 +40,19 @@ namespace Datadog.Trace.Tools.Runner.Tests
                 GetModulesForNetCore());
 
             process.DotnetRuntime.Should().Be(ProcessInfo.Runtime.NetCore);
+        }
+
+        [Fact]
+        public void DetectMixedRuntimes()
+        {
+            var process = new ProcessInfo(
+                "app.exe",
+                1,
+                new Dictionary<string, string>(),
+                mainModule: "app.exe",
+                GetModulesForNetFramework().Concat(GetModulesForNetCore()).ToArray());
+
+            process.DotnetRuntime.Should().Be(ProcessInfo.Runtime.Mixed);
         }
 
         [Fact]


### PR DESCRIPTION
```
dd-trace check iis <siteName>
```

This command will try to validate the tracer configuration for an IIS site.

When used, it:

- Extracts the configuration (web.config)
- Finds the worker process and run the process checks on it
- Detects if .NET Core is running in a pool that has managed code enabled
- Runs the agent connectivity checks
- Checks that the Datadog.Trace.dll assembly is present in the GAC