### PR TITLE
[Doc] Describe the best scenarios to upgrade from v1 to v2

### DIFF
--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -1,11 +1,11 @@
-# Migration to .Net Tracer v2
+# Migration to .NET Tracer v2
 
-## .Net Tracer v2.0 content
+## .NET Tracer v2.0 content
 
 The .NET Tracer v2.0:
 
 - Fixes a long standing bug where traces could be disconnected when automatic and custom tracing were using two different versions of the tracer.
-- Adds support to .Net 6 and drops the support of .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade in line with Microsoft's guidance.
+- Adds support to .NET 6 and drops the support of .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade in line with Microsoft's guidance.
 - Refactored our APIs for an easier and safer use.
 
 For a more complete overview, please refer to our [release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).
@@ -16,7 +16,7 @@ For a more complete overview, please refer to our [release notes on GitHub](http
 
 Most of our api changes do not require any changes to your code, but some patterns are no longer supported or recommended. Please refer to [Datadog.Trace documentation](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#upgrading-from-1x-to-20) for more information.
 
-### What if you are relying on .Net Framework lower than 4.6.0
+### What if you are relying on .NET Framework lower than 4.6.0
 
 If you are currently targeting version < 4.6.1, we suggest you upgrade in line with [Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework). On our end, we will support fixing major bugs on top of Tracer v1.31.
 
@@ -49,4 +49,4 @@ In that case, the migration will create disconnected traces one last time. **You
 
 #### .NET Framework
 
-If you rely on the .Net Framework, there are no scenarios where you could avoid disconnected traces between automatic and custome instrumentation. In that case, you should do what's easier for you.
+If you rely on the .NET Framework, there are no scenarios where you could avoid disconnected traces between automatic and custome instrumentation. In that case, you should do what's easier for you.

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -51,10 +51,8 @@ If your application uses both automatic and custom instrumentation, your applica
 
 On .NET Core, to avoid disconnected traces during the upgrade process:
 
-1. Upgrade the NuGet package to the latest version of the tracer
+1. Upgrade _Datadog.Trace_ NuGet package to the latest version of the tracer
 2. Upgrade the automatic instrumentation package to the matching version of the tracer
-
-> If you are targeting .NET Core/.NET 5+, and are unable to upgrade both the _Datadog.Trace_ NuGet package and MSI simultaneously, always prefer upgrading the NuGet package first.
 
 ##### If you were using v1.28.7 or lower
 

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -1,0 +1,52 @@
+# Migration to .Net Tracer v2
+
+## .Net Tracer v2.0 content
+
+The .NET Tracer v2.0:
+
+- Fixes a long standing bug where traces could be disconnected when automatic and custom tracing were using two different versions of the tracer.
+- Adds support to .Net 6 and drops the support of .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade in line with Microsoft's guidance.
+- Refactored our APIs for an easier and safer use.
+
+For a more complete overview, please refer to our [release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).
+
+## Upgrading from 1.x to 2.0
+
+### Code changes
+
+Most of our api changes do not require any changes to your code, but some patterns are no longer supported or recommended. Please refer to [Datadog.Trace documentation](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#upgrading-from-1x-to-20) for more information.
+
+### What if you are relying on .Net Framework lower than 4.6.0
+
+If you are currently targeting version < 4.6.1, we suggest you upgrade in line with [Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework). On our end, we will support fixing major bugs on top of Tracer v1.31.
+
+That said, automatic instrumentation relies only on the CLR (runtime) version, not the compile-time target. Even if an application is built for .NET Framework older than 4.6.1, as long as it runs on a supported CLR version, automatic instrumentation will work normally.
+
+Regarding custom instrumentation, NuGet package version 2.0 and above will no longer include binaries for versions of .NET Framework older than 4.6.1. The NuGet package will only work correctly with applications that target (at compile time):
+
+- .NET Framework 4.6.1 or above
+- .NET Core 3.1 or above
+- .NET Standard 2.0 or above (includes .NET Core 2.0 and above)
+
+### Rollout strategy when mixing automatic and custom instrumentation
+
+**Note that** even though you won't get disconnected traces when using two different v2 versions of the tracer, **you should aim at aligning the versions of the automatic and manual tracers**. Indeed, there's a bigger overhead when there's a version mismatch, so you should aim at making this situation temporary.
+
+#### .NET Core
+
+##### If you were using v1.28.8 or greater
+
+On .NET Core, to avoid disconnected traces during the upgrade process:
+
+- Upgrade the nuget package to the latest version of the tracer
+- Then upgrade serverside
+
+Indeed, on .NET Core, if the assembly version from the nuget package is newer, the CLR can load that one instead of the assembly from the tracer's home folder.
+
+##### If you were using v1.28.7 or lower
+
+In that case, the migration will create disconnected traces one last time. **You should update the Tracer Home (ie serverside) first though**, then the nuget.
+
+#### .NET Framework
+
+If you rely on the .Net Framework, there are no scenarios where you could avoid disconnected traces between automatic and custome instrumentation. In that case, you should do what's easier for you.

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -1,6 +1,6 @@
 # Migration to .NET Tracer v2
 
-## .NET Tracer v2.0 content
+## .NET Tracer v2.0 contents
 
 The .NET Tracer v2.0:
 
@@ -29,9 +29,11 @@ Regarding custom instrumentation, NuGet package version 2.0 and above will no lo
 - .NET 5 or above
 - .NET Standard 2.0 or above (includes .NET Core 2.0 and above)
 
-### Rollout strategy when mixing automatic and custom instrumentation
+### Rollout strategy when using automatic and custom instrumentation
 
-**Note that** even though you won't get disconnected traces when using two different v2 versions of the tracer, **you should aim at aligning the versions of the automatic and manual tracers**. Indeed, there's a bigger overhead when there's a version mismatch, so you should aim at making this situation temporary.
+If your application uses both automatic and custom instrumentation, your application traces may be disconnected until both components are upgraded to v2.x. Follow the steps below to upgrade the components in the recommended order.
+
+**Note:** To minimize application overhead, align the versions of the automatic and custom instrumentation. Using two different versions of the 2.x .NET Tracer will still result in complete traces but it requires additional overhead, so Datadog recommends minimizing the amount of time that the versions are mismatched.
 
 #### .NET Core and .NET 5+
 
@@ -39,8 +41,8 @@ Regarding custom instrumentation, NuGet package version 2.0 and above will no lo
 
 On .NET Core, to avoid disconnected traces during the upgrade process:
 
-- Upgrade the nuget package to the latest version of the tracer
-- Then upgrade serverside
+1. Upgrade the nuget package to the latest version of the tracer
+2. Upgrade the automatic instrumentation package to the matching version of the tracer
 
 Indeed, on .NET Core, if the assembly version from the nuget package is newer, the CLR can load that one instead of the assembly from the tracer's home folder.
 
@@ -50,4 +52,4 @@ In that case, the migration will create disconnected traces one last time. **You
 
 #### .NET Framework
 
-If you rely on the .NET Framework, there are no scenarios where you could avoid disconnected traces between automatic and custom instrumentation. In that case, you should do what's easier for you.
+On .NET Framework there will be disconnected traces between automatic and custom instrumentation until both packages are upgraded to 2.x. In this upgrade scenario, Datadog recommends upgrading the automatic and custom instrumentation in whichever order is easiest for your application.

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -14,7 +14,17 @@ For a more complete overview, please refer to our [release notes on GitHub](http
 
 ### Code changes
 
-Most of our api changes do not require any changes to your code, but some patterns are no longer supported or recommended. Please refer to [Datadog.Trace documentation](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#upgrading-from-1x-to-20) for more information.
+Most of our api changes do not require any changes to your code, but some patterns are no longer supported or recommended. Please refer to [Datadog.Trace documentation](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#upgrading-from-1x-to-20) for full details:
+- [Singleton `Tracer` instances](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#supported-net-versions)
+- [Immutable `Tracer.Settings`](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#immutable-tracersettings)
+- [Exporter settings](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#exporter-settings)
+- [Configure ADO.NET integrations individually](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#configure-adonet-integrations-individually)
+- [`ElasticsearchNet5` integration ID removed](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#elasticsearchnet5-integration-id-removed)
+- [Obsolete APIs have been removed](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#obsolete-apis-have-been-removed)
+- [Introduction of interfaces `ISpan`, `IScope`, and `ITracer`](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#elasticsearchnet5-integration-id-removed)
+- [Simplification of the tracer interface](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#simplification-of-the-tracer-interface)
+- [Incorrect integration names are ignored](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#incorrect-integration-names-are-ignored)
+- [Automatic instrumentation changes](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#automatic-instrumentation-changes)
 
 ### What if you are relying on .NET Framework lower than 4.6.1
 
@@ -41,15 +51,15 @@ If your application uses both automatic and custom instrumentation, your applica
 
 On .NET Core, to avoid disconnected traces during the upgrade process:
 
-1. Upgrade the nuget package to the latest version of the tracer
+1. Upgrade the NuGet package to the latest version of the tracer
 2. Upgrade the automatic instrumentation package to the matching version of the tracer
 
-Indeed, on .NET Core, if the assembly version from the nuget package is newer, the CLR can load that one instead of the assembly from the tracer's home folder.
+> If you are targeting .NET Core/.NET 5+, and are unable to upgrade both the _Datadog.Trace_ NuGet package and MSI simultaneously, always prefer upgrading the NuGet package first.
 
 ##### If you were using v1.28.7 or lower
 
-In that case, the migration will create disconnected traces one last time. **You should update the Tracer Home (ie serverside) first though**, then the nuget.
+In that case, the migration will create disconnected traces one last time. **You should update the Tracer Home (ie serverside) first though**, then the NuGet.
 
 #### .NET Framework
 
-On .NET Framework there will be disconnected traces between automatic and custom instrumentation until both packages are upgraded to 2.x. In this upgrade scenario, Datadog recommends upgrading the automatic and custom instrumentation in whichever order is easiest for your application.
+On .NET Framework there will be disconnected traces between automatic and custom instrumentation until both packages are upgraded to 2.x. In this upgrade scenario, Datadog recommends upgrading the MSI and NuGet package in whichever order is easiest for your application.

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -41,7 +41,7 @@ Regarding custom instrumentation, NuGet package version 2.0 and above will no lo
 
 ### Rollout strategy when using automatic and custom instrumentation
 
-If your application uses both automatic and custom instrumentation, your application traces may be disconnected until both components are upgraded to v2.x. Follow the steps below to upgrade the components in the recommended order.
+If your application uses both automatic and custom instrumentation, your application traces may be disconnected until both components are upgraded to v2.x. If you are unable to upgrade both components simultaneously, follow the steps below to upgrade the components in the recommended order.
 
 **Note:** To minimize application overhead, align the versions of the automatic and custom instrumentation. Using two different versions of the 2.x .NET Tracer will still result in complete traces but it requires additional overhead, so Datadog recommends minimizing the amount of time that the versions are mismatched.
 
@@ -58,7 +58,7 @@ On .NET Core, to avoid disconnected traces during the upgrade process:
 
 ##### If you were using v1.28.7 or lower
 
-In that case, the migration will create disconnected traces one last time. **You should update the Tracer Home (ie serverside) first though**, then the NuGet.
+In this upgrade scenario **you should upgrade the automatic instrumentation first** and then upgrade the _Datadog.Trace_ NuGet package. If the components are not upgraded in the correct order, the automatic instrumentation may fail to produce traces.
 
 #### .NET Framework
 

--- a/docs/migrations/v1_to_v2.md
+++ b/docs/migrations/v1_to_v2.md
@@ -5,7 +5,7 @@
 The .NET Tracer v2.0:
 
 - Fixes a long standing bug where traces could be disconnected when automatic and custom tracing were using two different versions of the tracer.
-- Adds support to .NET 6 and drops the support of .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade in line with Microsoft's guidance.
+- Adds support for .NET 6 and ends support of .NET Framework versions older than 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade in line with Microsoft's guidance.
 - Refactored our APIs for an easier and safer use.
 
 For a more complete overview, please refer to our [release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).
@@ -16,7 +16,7 @@ For a more complete overview, please refer to our [release notes on GitHub](http
 
 Most of our api changes do not require any changes to your code, but some patterns are no longer supported or recommended. Please refer to [Datadog.Trace documentation](https://github.com/DataDog/dd-trace-dotnet/tree/v2.0.1/docs/Datadog.Trace#upgrading-from-1x-to-20) for more information.
 
-### What if you are relying on .NET Framework lower than 4.6.0
+### What if you are relying on .NET Framework lower than 4.6.1
 
 If you are currently targeting version < 4.6.1, we suggest you upgrade in line with [Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework). On our end, we will support fixing major bugs on top of Tracer v1.31.
 
@@ -26,13 +26,14 @@ Regarding custom instrumentation, NuGet package version 2.0 and above will no lo
 
 - .NET Framework 4.6.1 or above
 - .NET Core 3.1 or above
+- .NET 5 or above
 - .NET Standard 2.0 or above (includes .NET Core 2.0 and above)
 
 ### Rollout strategy when mixing automatic and custom instrumentation
 
 **Note that** even though you won't get disconnected traces when using two different v2 versions of the tracer, **you should aim at aligning the versions of the automatic and manual tracers**. Indeed, there's a bigger overhead when there's a version mismatch, so you should aim at making this situation temporary.
 
-#### .NET Core
+#### .NET Core and .NET 5+
 
 ##### If you were using v1.28.8 or greater
 
@@ -49,4 +50,4 @@ In that case, the migration will create disconnected traces one last time. **You
 
 #### .NET Framework
 
-If you rely on the .NET Framework, there are no scenarios where you could avoid disconnected traces between automatic and custome instrumentation. In that case, you should do what's easier for you.
+If you rely on the .NET Framework, there are no scenarios where you could avoid disconnected traces between automatic and custom instrumentation. In that case, you should do what's easier for you.


### PR DESCRIPTION
Adding a document that aims at describing the rollout scenarios available for our customers when upgrading from v1 to v2

@DataDog/apm-dotnet