### PR TITLE
Update README badges

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,13 +10,13 @@ This repository contains the sources for the client-side components of the Datad
 
 | Package                      | Download                                                                                                                                                  |
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Windows and Linux Installers | [See releases](https://github.com/DataDog/dd-trace-dotnet/releases)                                                                                       |
+| Windows and Linux Installers | [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/DataDog/dd-trace-dotnet)](https://github.com/DataDog/dd-trace-dotnet/releases)                                                                                       |
 | `Datadog.Trace`              | [![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)                                     |
 | `Datadog.Trace.OpenTracing`  | [![Datadog.Trace.OpenTracing](https://img.shields.io/nuget/vpre/Datadog.Trace.OpenTracing.svg)](https://www.nuget.org/packages/Datadog.Trace.OpenTracing) |
 
 ## Build status
 
-Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
+Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows_tracer)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
 
 ## Get in touch
 


### PR DESCRIPTION
- add missing badge for latest GitHub release (sorted by SemVer, ignore pre-releases)
- fix Azure DevOps badge after build stage was renamed

[Preview](https://github.com/DataDog/dd-trace-dotnet/blob/cb213f7c84ed518d286668e49b220a5df012866b/docs/README.md)
