### PR TITLE
Add better handling of nullable type chaining

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -86,10 +86,7 @@ namespace Datadog.Trace.DuckTyping
                 // WARNING: If targetField.FieldType cannot be duck cast to proxyMemberReturnType
                 // this will throw an exception at runtime when accessing the member
                 // We call DuckType.CreateCache<>.Create()
-                MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
-                    .MakeGenericType(proxyMemberReturnType).GetMethod("Create");
-
-                il.Emit(OpCodes.Call, getProxyMethodInfo);
+                MethodIlHelper.AddIlToDuckChain(il, proxyMemberReturnType, targetField.FieldType);
             }
             else if (returnType != proxyMemberReturnType)
             {

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -78,10 +78,7 @@ namespace Datadog.Trace.DuckTyping
             // Check if the type can be converted or if we need to enable duck chaining
             if (NeedsDuckChaining(targetField.FieldType, proxyMemberReturnType))
             {
-                if (UseDirectAccessTo(proxyTypeBuilder, targetField.FieldType) && targetField.FieldType.IsValueType)
-                {
-                    il.Emit(OpCodes.Box, targetField.FieldType);
-                }
+                UseDirectAccessTo(proxyTypeBuilder, targetField.FieldType);
 
                 // WARNING: If targetField.FieldType cannot be duck cast to proxyMemberReturnType
                 // this will throw an exception at runtime when accessing the member

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -687,7 +687,7 @@ namespace Datadog.Trace.DuckTyping
                 MethodInfo outerMethod,
                 ParameterInfo[] outerMethodParameters,
                 Type[] outerMethodGenericArguments,
-                Func<LazyILGenerator, Type, Type> duckCastParameterFunc,
+                Func<LazyILGenerator, Type, Type, Type> duckCastParameterFunc,
                 Func<Type, Type, bool> needsDuckChaining)
             {
                 List<OutputAndRefParameterData> outputAndRefParameters = null;
@@ -802,7 +802,7 @@ namespace Datadog.Trace.DuckTyping
 
                                     // If this is a forward duck type, we need to cast to IDuckType and extract the original instance
                                     // If this is a reverse duck type, we need to create a duck type from the original instance
-                                    duckCastParameterFunc(il, innerParamTypeElementType);
+                                    duckCastParameterFunc(il, innerParamTypeElementType, outerParamTypeElementType);
 
                                     il.MarkLabel(lblAfterGetInstance);
                                 }
@@ -831,7 +831,7 @@ namespace Datadog.Trace.DuckTyping
 
                                 // If this is a forward duck type, we need to cast to IDuckType and extract the original instance
                                 // If this is a reverse duck type, we need to create a duck type from the original instance
-                                duckCastParameterFunc(il, innerParamType);
+                                duckCastParameterFunc(il, innerParamType, outerParamType);
                             }
                             else
                             {
@@ -930,7 +930,7 @@ namespace Datadog.Trace.DuckTyping
             internal static void AddIlToSetOutputAndRefParameters(
                 LazyILGenerator il,
                 List<OutputAndRefParameterData> outputAndRefParameters,
-                Func<LazyILGenerator, Type, Type> duckChainFunc,
+                Func<LazyILGenerator, Type, Type, Type> duckChainFunc,
                 Func<Type, Type, bool> needsDuckChaining)
             {
                 foreach (OutputAndRefParameterData outOrRefParameter in outputAndRefParameters)
@@ -952,7 +952,7 @@ namespace Datadog.Trace.DuckTyping
                             il.Emit(OpCodes.Box, localType);
                         }
 
-                        duckChainFunc(il, proxyArgumentType);
+                        duckChainFunc(il, proxyArgumentType, localType);
                     }
                     else
                     {
@@ -971,7 +971,7 @@ namespace Datadog.Trace.DuckTyping
                 Type innerMethodReturnType,
                 Type outerMethodReturnType,
                 Func<Type, Type, bool> needsDuckChainingFunc,
-                Func<LazyILGenerator, Type, Type> addDuckChainIlFunc)
+                Func<LazyILGenerator, Type, Type, Type> addDuckChainIlFunc)
             {
                 // Check if the target method returns something
 
@@ -993,7 +993,7 @@ namespace Datadog.Trace.DuckTyping
                         }
 
                         // We call DuckType.CreateCache<>.Create() or DuckType.CreateCache<>.CreateReverse()
-                        addDuckChainIlFunc(il, outerMethodReturnType);
+                        addDuckChainIlFunc(il, outerMethodReturnType, innerMethodReturnType);
                     }
                     else if (currentReturnType != outerMethodReturnType)
                     {
@@ -1010,17 +1010,18 @@ namespace Datadog.Trace.DuckTyping
             internal static bool NeedsDuckChainingReverse(Type targetType, Type proxyType)
                 => NeedsDuckChaining(targetType: proxyType, proxyType: targetType);
 
-            internal static Type AddIlToDuckChain(LazyILGenerator il, Type genericType)
+            internal static Type AddIlToDuckChain(LazyILGenerator il, Type genericType, Type fromType)
             {
                 var getProxyMethodInfo = typeof(CreateCache<>)
                                         .MakeGenericType(genericType)
-                                        .GetMethod("Create");
+                                        .GetMethod("CreateFrom")
+                                        .MakeGenericMethod(fromType);
 
                 il.Emit(OpCodes.Call, getProxyMethodInfo);
                 return genericType;
             }
 
-            internal static Type AddIlToDuckChainReverse(LazyILGenerator il, Type genericType)
+            internal static Type AddIlToDuckChainReverse(LazyILGenerator il, Type genericType, Type originalType)
             {
                 var getProxyMethodInfo = typeof(CreateCache<>)
                                         .MakeGenericType(genericType)
@@ -1030,7 +1031,7 @@ namespace Datadog.Trace.DuckTyping
                 return genericType;
             }
 
-            internal static Type AddIlToExtractDuckType(LazyILGenerator il, Type toType)
+            internal static Type AddIlToExtractDuckType(LazyILGenerator il, Type toType, Type fromType)
             {
                 // outer is a duck type, so extract it
                 // Call IDuckType.Instance property to get the actual value

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -152,10 +152,7 @@ namespace Datadog.Trace.DuckTyping
             // Check if the type can be converted or if we need to enable duck chaining
             if (needsDuckChaining(targetProperty.PropertyType, proxyMemberReturnType))
             {
-                if (UseDirectAccessTo(proxyTypeBuilder, targetProperty.PropertyType) && targetProperty.PropertyType.IsValueType)
-                {
-                    il.Emit(OpCodes.Box, targetProperty.PropertyType);
-                }
+                UseDirectAccessTo(proxyTypeBuilder, targetProperty.PropertyType);
 
                 // If this is a forward duck type, we need to create a duck type from the original instance
                 // If this is a reverse duck type, we need to cast to IDuckType and extract the original instance

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DuckTyping
             MemberInfo proxyMember,
             PropertyInfo targetProperty,
             FieldInfo instanceField,
-            Func<LazyILGenerator, Type, Type> duckCastInnerToOuterFunc,
+            Func<LazyILGenerator, Type, Type, Type> duckCastInnerToOuterFunc,
             Func<Type, Type, bool> needsDuckChaining)
         {
             string proxyMemberName = proxyMember.Name;
@@ -159,7 +159,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // If this is a forward duck type, we need to create a duck type from the original instance
                 // If this is a reverse duck type, we need to cast to IDuckType and extract the original instance
-                duckCastInnerToOuterFunc(il, proxyMemberReturnType);
+                duckCastInnerToOuterFunc(il, proxyMemberReturnType, targetProperty.PropertyType);
             }
             else if (returnType != proxyMemberReturnType)
             {
@@ -179,7 +179,7 @@ namespace Datadog.Trace.DuckTyping
             MemberInfo proxyMember,
             PropertyInfo targetProperty,
             FieldInfo instanceField,
-            Func<LazyILGenerator, Type, Type> duckCastOuterToInner,
+            Func<LazyILGenerator, Type, Type, Type> duckCastOuterToInner,
             Func<Type, Type, bool> needsDuckChaining)
         {
             string proxyMemberName = null;
@@ -236,7 +236,7 @@ namespace Datadog.Trace.DuckTyping
                     // If this is a forward duck type, we need to cast to IDuckType and extract the original instance
                     // and set the targetParamType to object
                     // If this is a reverse duck type, we need to create a duck type from the original instance
-                    targetParamType = duckCastOuterToInner(il, targetParamType);
+                    targetParamType = duckCastOuterToInner(il, targetParamType, proxyParamType);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -965,6 +965,19 @@ namespace Datadog.Trace.DuckTyping
             }
 
             /// <summary>
+            /// Create a new proxy instance from a target instance
+            /// </summary>
+            /// <typeparam name="T">Type of the return value</typeparam>
+            /// <typeparam name="TOriginal">Type of the original value</typeparam>
+            /// <param name="instance">Target instance value</param>
+            /// <returns>Proxy instance</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public T CreateInstance<T, TOriginal>(TOriginal instance)
+            {
+                return ((CreateProxyInstance<T>)_activator)(instance);
+            }
+
+            /// <summary>
             /// Get if the proxy instance can be created
             /// </summary>
             /// <returns>true if the proxy can be created; otherwise, false.</returns>
@@ -1041,6 +1054,23 @@ namespace Datadog.Trace.DuckTyping
                 }
 
                 return GetProxy(instance.GetType()).CreateInstance<T>(instance);
+            }
+
+            /// <summary>
+            /// Create a new instance of a proxy type for a target instance using the T proxy definition
+            /// </summary>
+            /// <typeparam name="TOriginal">The original instance's type </typeparam>
+            /// <param name="instance">Object instance</param>
+            /// <returns>Proxy instance</returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static T CreateFrom<TOriginal>(TOriginal instance)
+            {
+                if (instance is null)
+                {
+                    return default;
+                }
+
+                return GetProxy(typeof(TOriginal)).CreateInstance<T, TOriginal>(instance);
             }
 
             /// <summary>

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/DuckChainingNullableTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/DuckChainingNullableTests.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="DuckChainingNullableTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckChainingNullableTests
+    {
+        [Fact]
+        public void CanDuckChainNullableDirectly_WithNullNullable()
+        {
+            var instance = new GenericTestClass();
+            var proxy = instance.DuckCast<GenericProxyStruct>();
+        }
+
+        [Fact]
+        public void CanDuckChainNullableDirectlyWithNonNullNullable()
+        {
+            var instance = new GenericTestClass { MyTestStruct = new TestStruct() };
+            var proxy = instance.DuckCast<GenericProxyStruct>();
+        }
+
+        [Fact]
+        public void CanDuckChainNullableDirectly()
+        {
+            TestStruct? instance = new TestStruct();
+            var proxy = DuckType.CreateCache<NullableProxyTestStruct>.CreateFrom(instance);
+        }
+
+        // Proxies
+        [DuckCopy]
+        public struct GenericProxyStruct
+        {
+            public NullableProxyTestStruct MyTestStruct;
+        }
+
+        [DuckCopy]
+        public struct NullableProxyTestStruct
+        {
+            public ProxyTestStruct Value;
+        }
+
+        [DuckCopy]
+        public struct ProxyTestStruct
+        {
+        }
+
+        // Originals
+        public struct TestStruct
+        {
+        }
+
+        public class GenericTestClass
+        {
+            public TestStruct? MyTestStruct { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Currently, when doing duck chaining, we call `CreateCache<T>.Create(object instance)` to do the conversion. Note that this is a boxing operation. Inside this method, we then call `instance.GetType()` to determine the type to convert from. However, [doing a boxing operation on a non-`null` `Nullable<T>` type converts it to the type `T` itself](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-value-types#how-to-identify-a-nullable-value-type). The end result is that we create the incorrect proxy mapping.

## An example of the problem

For example, consider this type hierarchy:

```csharp
public class GenericTestClass
{
    public TestStruct? MyTestStruct { get; set; }
}

public struct TestStruct { }
```

Which we want to create a proxy for:

```csharp
[DuckCopy]
public struct GenericProxyStruct
{
    public NullableProxyTestStruct MyTestStruct;
}

[DuckCopy]
public struct NullableProxyTestStruct
{
    public ProxyTestStruct Value;
}

[DuckCopy]
public struct ProxyTestStruct { }
```

Running the following before this PR would throw, as it tries to proxy `TestStruct` to `NullableProxyTestStruct` _not_ `TestStruct?`

```csharp
var instance = new GenericTestClass { MyTestStruct = new TestStruct() };
var proxy = instance.DuckCast<GenericProxyStruct>();
```

> Note that we currently require an "intermediate" proxy to handle the nullable. It would be nice to handle this implicitly in the future, which incidentally would also solve this issue

The biggest problem is that the behaviour is _different_ depending on whether the proxied property is `null` at runtime, or it has a value, so there's no "safe" way to create a proxy heirarchy that works in all cases.

## The fix

The source of this problem is that the `CreateCache<T>.Create(object instance)` call that is part of `DuckChaining` boxes the source field. To work around the issue, I created a new, generic, method `CreateCache<T>.CreateFrom<T>(T instance)` which avoids the boxing. This then creates a proxy between the nullable type as expected, and the above hierarchy works as expected.

This fix only helps with the duck-chaining case, but this is the main case in which errors can occur - in most cases, _directly_ duck typing a nullable isn't something we'll need to do (hopefully!)

> ~This change is giving `System.InvalidProgramException: Common Language Runtime detected an invalid program.` in the new tests, in .NET 6 only. If anyone can help me pin down why, it would be much appreciated 😬~ Tony found the reason-we no longer need to box value types before calling `CreateFrom()`. Fixed in https://github.com/DataDog/dd-trace-dotnet/pull/2424/commits/d5c645311a178e52bb7af9cf9a14ff9c7de28b69

@DataDog/apm-dotnet