### PR TITLE
Add SampleHelpers.CreateScope

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -9,6 +9,9 @@ namespace Samples
     public class SampleHelpers
     {
         private static readonly Type NativeMethodsType = Type.GetType("Datadog.Trace.ClrProfiler.NativeMethods, Datadog.Trace");
+        private static readonly Type TracerType = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace");
+        private static readonly MethodInfo GetTracerInstance = TracerType.GetProperty("Instance").GetMethod;
+        private static readonly MethodInfo StartActiveMethod = TracerType.GetMethod("StartActive", types: new[] { typeof(string) });
 
         public static bool IsProfilerAttached()
         {
@@ -50,6 +53,12 @@ namespace Samples
                     }
                 }
             }
+        }
+
+        public static IDisposable CreateScope(string operationName)
+        {
+            var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
+            return (IDisposable) StartActiveMethod.Invoke(tracer, new object[] { operationName });
         }
 
         public static IEnumerable<KeyValuePair<string,string>> GetDatadogEnvironmentVariables()


### PR DESCRIPTION
Lets you create a Datadog Scope in integration tests without having to reference the Datadog.Trace library directly


@DataDog/apm-dotnet