### PR TITLE
update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
-## What?
+## Summary of changes
 
-## Why?
+## Reason for change
 
-## How?
+## Implementation details
 
-## Testing?
+## Test coverage
 
-## Anything Else?
+## Other details
 <!-- Fixes #{issue} -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,30 @@
-Fixes #
+# Description
 
-Changes proposed in this pull request:
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
+<!-- Fixes #{issue} -->
 
+## Type of change
 
+<!-- Please delete options that are not relevant. -->
 
-@DataDog/apm-dotnet
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+<!-- Please describe the tests that you ran to verify your changes. -->
+
+- [ ] Test A
+- [ ] Test B
+
+# Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,9 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
+<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. "What? Why? How?" -->
 <!-- Fixes #{issue} -->
 
 ## Type of change
-
-<!-- Please delete options that are not relevant. -->
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -17,12 +14,8 @@ Please include a summary of the change and which issue is fixed. Please also inc
 
 <!-- Please describe the tests that you ran to verify your changes. -->
 
-- [ ] Test A
-- [ ] Test B
-
 # Checklist
 
-- [ ] My code follows the style guidelines of this project
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,10 @@
-# Description
+## What?
 
-<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. "What? Why? How?" -->
+## Why?
+
+## How?
+
+## Testing?
+
+## Anything Else?
 <!-- Fixes #{issue} -->
-
-## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-# How Has This Been Tested?
-
-<!-- Please describe the tests that you ran to verify your changes. -->
-
-# Checklist
-
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
## Summary of changes
Update the repository's pull request template

## Reason for change
Most PRs don't use the current template. Some people replace it entirely, some leave it empty. I hope this template motivates PR authors to write better PR descriptions. Also, every single PR has a `@DataDog/apm-dotnet` team mention, leading to notification fatigue.

## Implementation details
Ok, maybe this is a bad idea...

## Test coverage
Nope.

## Other details
I'm done. Maybe this is too much. I just wanted to get the conversation started 😅 