### PR TITLE
add support for trace-level tags (vertical propagation)

### DIFF
--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace
                 setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority.Value.ToString(_invariantCulture));
             }
 
-            var datadogTags = context.TraceContext?.DatadogTags ?? context.DatadogTags;
+            var datadogTags = context.TraceContext?.Tags?.ToPropagationHeader() ?? context.DatadogTags;
 
             if (datadogTags != null)
             {

--- a/tracer/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagsList.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Tagging
             offset += MessagePackBinary.WriteMapHeaderForceMap32Block(ref bytes, offset, 0);
 
             // write "custom" span-level tags (from list of KVPs)
-            count += WriteTags(ref bytes, ref offset, Tags);
+            count += WriteSpanTags(ref bytes, ref offset, Tags);
 
             // write "well-known" span-level tags (from properties)
             count += WriteAdditionalTags(ref bytes, ref offset);
@@ -130,8 +130,8 @@ namespace Datadog.Trace.Tagging
             if (span.IsRootSpan)
             {
                 // write trace-level tags
-                var traceTags = span.Context.TraceContext?.Tags?.AsList();
-                count += WriteTags(ref bytes, ref offset, traceTags);
+                var traceTags = span.Context.TraceContext?.Tags;
+                count += WriteTraceTags(ref bytes, ref offset, traceTags);
             }
 
             if (span.IsTopLevel)
@@ -158,7 +158,7 @@ namespace Datadog.Trace.Tagging
             return offset - originalOffset;
         }
 
-        private int WriteTags(ref byte[] bytes, ref int offset, List<KeyValuePair<string, string>> tags)
+        private int WriteSpanTags(ref byte[] bytes, ref int offset, List<KeyValuePair<string, string>> tags)
         {
             int count = 0;
 
@@ -168,6 +168,27 @@ namespace Datadog.Trace.Tagging
                 {
                     count += tags.Count;
 
+                    foreach (var tag in tags)
+                    {
+                        WriteTag(ref bytes, ref offset, tag.Key, tag.Value);
+                    }
+                }
+            }
+
+            return count;
+        }
+
+        private int WriteTraceTags(ref byte[] bytes, ref int offset, TraceTagCollection tags)
+        {
+            int count = 0;
+
+            if (tags != null)
+            {
+                lock (tags)
+                {
+                    count += tags.Count;
+
+                    // don't cast to IEnumerable so we can use the struct enumerator from List<T>
                     foreach (var tag in tags)
                     {
                         WriteTag(ref bytes, ref offset, tag.Key, tag.Value);

--- a/tracer/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagsList.cs
@@ -121,22 +121,18 @@ namespace Datadog.Trace.Tagging
             var countOffset = offset;
             offset += MessagePackBinary.WriteMapHeaderForceMap32Block(ref bytes, offset, 0);
 
-            var tags = Tags;
+            // write "custom" span-level tags (from list of KVPs)
+            count += WriteTags(ref bytes, ref offset, Tags);
 
-            if (tags != null)
-            {
-                lock (tags)
-                {
-                    count += tags.Count;
-
-                    foreach (var pair in tags)
-                    {
-                        WriteTag(ref bytes, ref offset, pair.Key, pair.Value);
-                    }
-                }
-            }
-
+            // write "well-known" span-level tags (from properties)
             count += WriteAdditionalTags(ref bytes, ref offset);
+
+            if (span.IsRootSpan)
+            {
+                // write trace-level tags
+                var traceTags = span.Context.TraceContext?.Tags?.AsList();
+                count += WriteTags(ref bytes, ref offset, traceTags);
+            }
 
             if (span.IsTopLevel)
             {
@@ -160,6 +156,26 @@ namespace Datadog.Trace.Tagging
             }
 
             return offset - originalOffset;
+        }
+
+        private int WriteTags(ref byte[] bytes, ref int offset, List<KeyValuePair<string, string>> tags)
+        {
+            int count = 0;
+
+            if (tags != null)
+            {
+                lock (tags)
+                {
+                    count += tags.Count;
+
+                    foreach (var tag in tags)
+                    {
+                        WriteTag(ref bytes, ref offset, tag.Key, tag.Value);
+                    }
+                }
+            }
+
+            return count;
         }
 
         protected virtual int WriteAdditionalTags(ref byte[] bytes, ref int offset) => 0;

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -65,9 +65,9 @@ namespace Datadog.Trace.Tagging
                 // which uses '=' for padding
                 var separatorIndex = tag.IndexOf(KeyValueSeparator);
 
-                // there must be at least one char before and
-                // one char after the separator (e.g. "a=b")
-                if (separatorIndex > 0 && separatorIndex < tag.Length - 1)
+                // there must be at least one char before and one char after the separator (e.g. "a=b"),
+                // and each tag must being with "_dd.p.*"
+                if (separatorIndex > 0 && separatorIndex < tag.Length && tag.StartsWith(PropagatedTagPrefix))
                 {
                     var key = tag.Substring(0, separatorIndex);
                     var value = tag.Substring(separatorIndex + 1);

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -106,8 +106,6 @@ namespace Datadog.Trace.Tagging
             return traceTags;
         }
 
-        public List<KeyValuePair<string, string>> AsList() => _tags;
-
         public void SetTag(string key, string? value)
         {
             if (key is null)
@@ -115,24 +113,22 @@ namespace Datadog.Trace.Tagging
                 ThrowHelper.ThrowArgumentNullException(nameof(key));
             }
 
-            var tags = AsList();
-
-            lock (tags)
+            lock (_tags)
             {
                 bool tagsModified = false;
 
-                for (int i = 0; i < tags.Count; i++)
+                for (int i = 0; i < _tags.Count; i++)
                 {
-                    if (string.Equals(tags[i].Key, key, StringComparison.Ordinal))
+                    if (string.Equals(_tags[i].Key, key, StringComparison.Ordinal))
                     {
                         if (value == null)
                         {
-                            tags.RemoveAt(i);
+                            _tags.RemoveAt(i);
                             tagsModified = true;
                         }
-                        else if (!string.Equals(tags[i].Value, value, StringComparison.Ordinal))
+                        else if (!string.Equals(_tags[i].Value, value, StringComparison.Ordinal))
                         {
-                            tags[i] = new KeyValuePair<string, string>(key, value);
+                            _tags[i] = new KeyValuePair<string, string>(key, value);
                             tagsModified = true;
                         }
 
@@ -149,7 +145,7 @@ namespace Datadog.Trace.Tagging
                 // If we get there, the tag wasn't in the collection
                 if (value != null)
                 {
-                    tags.Add(new KeyValuePair<string, string>(key, value));
+                    _tags.Add(new KeyValuePair<string, string>(key, value));
 
                     // clear the cached header if we make any changes to a distributed tag
                     if (key.StartsWith(PropagatedTagPrefix, StringComparison.Ordinal))
@@ -162,15 +158,13 @@ namespace Datadog.Trace.Tagging
 
         public string? GetTag(string key)
         {
-            var tags = AsList();
-
-            lock (tags)
+            lock (_tags)
             {
-                for (int i = 0; i < tags.Count; i++)
+                for (int i = 0; i < _tags.Count; i++)
                 {
-                    if (string.Equals(tags[i].Key, key, StringComparison.Ordinal))
+                    if (string.Equals(_tags[i].Key, key, StringComparison.Ordinal))
                     {
-                        return tags[i].Value;
+                        return _tags[i].Value;
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -61,8 +61,8 @@ namespace Datadog.Trace.Tagging
                 var separatorIndex = tag.IndexOf(KeyValueSeparator);
 
                 // there must be at least one char before and
-                // one char after the separator ("a=b")
-                if (separatorIndex > 0 && separatorIndex < tag.Length - 2)
+                // one char after the separator (e.g. "a=b")
+                if (separatorIndex > 0 && separatorIndex < tag.Length - 1)
                 {
                     var key = tag.Substring(0, separatorIndex);
                     var value = tag.Substring(separatorIndex + 1);

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -64,7 +64,8 @@ namespace Datadog.Trace.Tagging
             foreach (var tag in tags)
             {
                 // the shortest tag has the "_dd.p." prefix, a 1-character key, and 1-character value (e.g. "_dd.p.a=b")
-                if (tag.Length >= MinimumPropagationHeaderLength)
+                if (tag.Length >= MinimumPropagationHeaderLength &&
+                    tag.StartsWith(PropagatedTagPrefix, StringComparison.Ordinal))
                 {
                     // NOTE: the first equals sign is the separator between key/value, but the tag value can contain
                     // additional equals signs, so make sure we only split on the _first_ one. For example,
@@ -75,8 +76,7 @@ namespace Datadog.Trace.Tagging
                     //         ⬆   separator must be at index 7 or higher and before the end of string
                     //  012345678
                     if (separatorIndex > PropagatedTagPrefixLength &&
-                        separatorIndex < tag.Length - 1 &&
-                        tag.StartsWith(PropagatedTagPrefix, StringComparison.Ordinal))
+                        separatorIndex < tag.Length - 1)
                     {
                         var key = tag.Substring(0, separatorIndex);
                         var value = tag.Substring(separatorIndex + 1);

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -1,0 +1,189 @@
+// <copyright file="TraceTagCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Tagging
+{
+    internal class TraceTagCollection
+    {
+        // key1=value1,key2=value2
+        private const char TagPairSeparator = ',';
+        private const char KeyValueSeparator = '=';
+
+        // tags with this prefix are propagated horizontally
+        // (i.e. from upstream services and to downstream services)
+        // using the `x-datadog-tags` header
+        private const string PropagatedTagPrefix = "_dd.p.";
+
+        // for now we only expect one trace-level tag:
+        // "_dd.p.upstream_services"
+        private const int DefaultCapacity = 1;
+
+        // "_dd.p.a=b"
+        public const int MinimumPropagationHeaderLength = 9;
+        public const int MaximumPropagationHeaderLength = 512;
+
+        private static readonly char[] TagPairSeparators = { TagPairSeparator };
+
+        private List<KeyValuePair<string, string>> _tags;
+        private string? _cachedPropagationHeader;
+
+        public TraceTagCollection()
+        {
+            _tags = new List<KeyValuePair<string, string>>(DefaultCapacity);
+        }
+
+        public TraceTagCollection(List<KeyValuePair<string, string>> tags)
+        {
+            _tags = tags;
+        }
+
+        public static TraceTagCollection ParseFromPropagationHeader(string? propagationHeader)
+        {
+            if (string.IsNullOrEmpty(propagationHeader))
+            {
+                return new TraceTagCollection();
+            }
+
+            var tags = propagationHeader!.Split(TagPairSeparators, StringSplitOptions.RemoveEmptyEntries);
+            var tagList = new List<KeyValuePair<string, string>>(tags.Length);
+
+            foreach (var tag in tags)
+            {
+                var separatorIndex = tag.IndexOf(KeyValueSeparator);
+
+                // there must be at least one char before and
+                // one char after the separator ("a=b")
+                if (separatorIndex > 0 && separatorIndex < tag.Length - 2)
+                {
+                    var key = tag.Substring(0, separatorIndex);
+                    var value = tag.Substring(separatorIndex + 1);
+                    tagList.Add(new KeyValuePair<string, string>(key, value));
+                }
+            }
+
+            return new TraceTagCollection(tagList)
+                   {
+                       // if the tags never change, we can reuse the same string we parsed
+                       _cachedPropagationHeader = propagationHeader
+                   };
+        }
+
+        public List<KeyValuePair<string, string>> AsList() => Volatile.Read(ref _tags);
+
+        public void SetTag(string key, string? value)
+        {
+            var tags = AsList();
+
+            lock (tags)
+            {
+                for (int i = 0; i < tags.Count; i++)
+                {
+                    if (string.Equals(tags[i].Key, key, StringComparison.Ordinal))
+                    {
+                        if (value == null)
+                        {
+                            tags.RemoveAt(i);
+                        }
+                        else
+                        {
+                            tags[i] = new KeyValuePair<string, string>(key, value);
+                        }
+
+                        // clear the cached value if we make any changes
+                        _cachedPropagationHeader = null;
+                        return;
+                    }
+                }
+
+                // If we get there, the tag wasn't in the collection
+                if (value != null)
+                {
+                    tags.Add(new KeyValuePair<string, string>(key, value));
+
+                    // clear the cached value if we make any changes
+                    _cachedPropagationHeader = null;
+                }
+            }
+        }
+
+        public string? GetTag(string key)
+        {
+            var tags = AsList();
+
+            lock (tags)
+            {
+                for (int i = 0; i < tags.Count; i++)
+                {
+                    if (string.Equals(tags[i].Key, key, StringComparison.Ordinal))
+                    {
+                        return tags[i].Value;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets a collection of propagated internal Datadog tags,
+        /// formatted as "key1=value1,key2=value2".
+        /// </summary>
+        public string ToPropagationHeader()
+        {
+            if (_cachedPropagationHeader == null)
+            {
+                // cache the propagated tags in a format ready
+                // for headers in case we need it multiple times
+                Interlocked.CompareExchange(ref _cachedPropagationHeader, FormatPropagationHeader(), null);
+            }
+
+            return _cachedPropagationHeader;
+        }
+
+        private string FormatPropagationHeader()
+        {
+            if (_tags.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+
+            foreach (var tag in _tags)
+            {
+                if (tag.Key.StartsWith(PropagatedTagPrefix) && !string.IsNullOrEmpty(tag.Value))
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.Append(TagPairSeparator);
+                    }
+
+                    sb.Append(tag.Key)
+                      .Append(KeyValueSeparator)
+                      .Append(tag.Value);
+                }
+
+                if (sb.Length > MaximumPropagationHeaderLength)
+                {
+                    // if combined tags are too long for propagation headers,
+                    // don't set the header and instead set special "_dd.propagation_error:max_size" span tag
+                    SetTag(TraceTagNames.Propagation.PropagationHeadersError, "max_size");
+                    _ = StringBuilderCache.GetStringAndRelease(sb);
+                    _cachedPropagationHeader = string.Empty;
+                    return string.Empty;
+                }
+            }
+
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -58,6 +58,11 @@ namespace Datadog.Trace.Tagging
 
             foreach (var tag in tags)
             {
+                // NOTE: the first equals sign is the separator between key/value,
+                // but the tag value can contain additional equals signs,
+                // so make sure we only split on the _first_ one.
+                // For example, the "_dd.p.upstream_services" tag will have base64-encoded strings
+                // which uses '=' for padding
                 var separatorIndex = tag.IndexOf(KeyValueSeparator);
 
                 // there must be at least one char before and

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tagging
                    };
         }
 
-        public List<KeyValuePair<string, string>> AsList() => Volatile.Read(ref _tags);
+        public List<KeyValuePair<string, string>> AsList() => _tags;
 
         public void SetTag(string key, string? value)
         {

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -182,7 +182,6 @@ namespace Datadog.Trace.Tagging
                     // if combined tags are too long for propagation headers,
                     // don't set the header and instead set special "_dd.propagation_error:max_size" span tag
                     SetTag(TraceTagNames.Propagation.PropagationHeadersError, "max_size");
-                    _ = StringBuilderCache.GetStringAndRelease(sb);
                     _cachedPropagationHeader = string.Empty;
                     return string.Empty;
                 }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -86,6 +86,7 @@ namespace Datadog.Trace.Tagging
                     if (separatorIndex > PropagatedTagPrefixLength &&
                         separatorIndex < tag.Length - 1)
                     {
+                        // TODO: implement something like StringSegment to avoid allocating new strings?
                         var key = tag.Substring(0, separatorIndex);
                         var value = tag.Substring(separatorIndex + 1);
                         tagList.Add(new KeyValuePair<string, string>(key, value));
@@ -245,6 +246,15 @@ namespace Datadog.Trace.Tagging
         public List<KeyValuePair<string, string>>.Enumerator GetEnumerator()
         {
             return _tags.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns the trace tags an <see cref="IEnumerable{T}"/>.
+        /// Use for testing only as it will allocate on the heap.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> ToEnumerable()
+        {
+            return _tags;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tagging
             _tags = new List<KeyValuePair<string, string>>(DefaultCapacity);
         }
 
-        public TraceTagCollection(List<KeyValuePair<string, string>> tags)
+        private TraceTagCollection(List<KeyValuePair<string, string>> tags)
         {
             _tags = tags;
         }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -173,21 +173,24 @@ namespace Datadog.Trace.Tagging
         }
 
         /// <summary>
-        /// Gets a collection of propagated internal Datadog tags,
-        /// formatted as "key1=value1,key2=value2".
+        /// Constructs a string that can be used for horizontal propagation using the "x-datadog-tags" header
+        /// in a "key1=value1,key2=value2" format. This header should only include tags with the "_dd.p.*" prefix.
+        /// The returned string is cached and reused if no relevant tags are changed between calls.
         /// </summary>
+        /// <returns>A string that can be used for horizontal propagation using the "x-datadog-tags" header.</returns>
+        /// <seealso cref="FormatPropagationHeader"/>
         public string ToPropagationHeader()
         {
             if (_cachedPropagationHeader == null)
             {
-                // cache the propagated tags in a format ready
-                // for headers in case we need it multiple times
+                // cache the header in case we need it multiple times
                 Interlocked.CompareExchange(ref _cachedPropagationHeader, FormatPropagationHeader(), null);
             }
 
             return _cachedPropagationHeader;
         }
 
+        /// <seealso cref="ToPropagationHeader"/>
         private string FormatPropagationHeader()
         {
             if (_tags.Count == 0)

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -180,8 +180,10 @@ namespace Datadog.Trace.Tagging
                 if (sb.Length > MaximumPropagationHeaderLength)
                 {
                     // if combined tags are too long for propagation headers,
-                    // don't set the header and instead set special "_dd.propagation_error:max_size" span tag
+                    // set tag "_dd.propagation_error:max_size"...
                     SetTag(TraceTagNames.Propagation.PropagationHeadersError, "max_size");
+
+                    // ... and don't set the header
                     _cachedPropagationHeader = string.Empty;
                     return string.Empty;
                 }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -6,13 +6,14 @@
 #nullable enable
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Tagging
 {
-    internal class TraceTagCollection
+    internal class TraceTagCollection : IEnumerable<KeyValuePair<string, string>>
     {
         // key1=value1,key2=value2
         private const char TagPairSeparator = ',';
@@ -46,6 +47,8 @@ namespace Datadog.Trace.Tagging
         {
             _tags = tags;
         }
+
+        public int Count => _tags.Count;
 
         public static TraceTagCollection ParseFromPropagationHeader(string? propagationHeader)
         {
@@ -229,6 +232,21 @@ namespace Datadog.Trace.Tagging
             }
 
             return StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        public List<KeyValuePair<string, string>>.Enumerator GetEnumerator()
+        {
+            return _tags.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
+        {
+            return _tags.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _tags.GetEnumerator();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -6,7 +6,6 @@
 #nullable enable
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.Util;
@@ -15,13 +14,13 @@ namespace Datadog.Trace.Tagging
 {
     internal class TraceTagCollection
     {
-        // key1=value1,key2=value2
+        // "x-datadog-tags" header format is "key1=value1,key2=value2"
         private const char TagPairSeparator = ',';
         private const char KeyValueSeparator = '=';
 
         // tags with this prefix are propagated horizontally
         // (i.e. from upstream services and to downstream services)
-        // using the `x-datadog-tags` header
+        // using the "x-datadog-tags" header
         private const string PropagatedTagPrefix = "_dd.p.";
         private const int PropagatedTagPrefixLength = 6; // "_dd.p.".Length
 
@@ -48,8 +47,17 @@ namespace Datadog.Trace.Tagging
             _tags = tags;
         }
 
+        /// <summary>
+        /// Gets the number of elements contained in the <see cref="TraceTagCollection"/>.
+        /// </summary>
         public int Count => _tags.Count;
 
+        /// <summary>
+        /// Parses the "x-datadog-tags" header value in "key1=value1,key2=value2" format.
+        /// Propagated tags require the an "_dd.p.*" prefix, so any other tags are ignored.
+        /// </summary>
+        /// <param name="propagationHeader">The header value to parse.</param>
+        /// <returns>A <see cref="TraceTagCollection"/> that contains the valid tags parsed from the specified header value.</returns>
         public static TraceTagCollection ParseFromPropagationHeader(string? propagationHeader)
         {
             if (string.IsNullOrEmpty(propagationHeader))

--- a/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TraceTagCollection.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Tagging
 {
-    internal class TraceTagCollection : IEnumerable<KeyValuePair<string, string>>
+    internal class TraceTagCollection
     {
         // key1=value1,key2=value2
         private const char TagPairSeparator = ',';
@@ -229,16 +229,6 @@ namespace Datadog.Trace.Tagging
         }
 
         public List<KeyValuePair<string, string>>.Enumerator GetEnumerator()
-        {
-            return _tags.GetEnumerator();
-        }
-
-        IEnumerator<KeyValuePair<string, string>> IEnumerable<KeyValuePair<string, string>>.GetEnumerator()
-        {
-            return _tags.GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
         {
             return _tags.GetEnumerator();
         }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -24,9 +24,10 @@ namespace Datadog.Trace
         private int _openSpans;
         private int? _samplingPriority;
 
-        public TraceContext(IDatadogTracer tracer)
+        public TraceContext(IDatadogTracer tracer, TraceTagCollection tags = null)
         {
             Tracer = tracer;
+            Tags = tags;
         }
 
         public Span RootSpan { get; private set; }
@@ -34,6 +35,8 @@ namespace Datadog.Trace
         public DateTimeOffset UtcNow => _utcStart.Add(Elapsed);
 
         public IDatadogTracer Tracer { get; }
+
+        public TraceTagCollection Tags { get; }
 
         /// <summary>
         /// Gets the trace's sampling priority.
@@ -44,16 +47,6 @@ namespace Datadog.Trace
         }
 
         private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);
-
-        /// <summary>
-        /// Gets or sets a collection of propagated internal Datadog tags,
-        /// formatted as "key1=value1,key2=value2".
-        /// </summary>
-        /// <remarks>
-        /// We're keeping this as the string representation to avoid having to parse.
-        /// For now, it's relatively easy to append new values when needed.
-        /// </remarks>
-        public string DatadogTags { get; set; }
 
         public void AddSpan(Span span)
         {
@@ -198,17 +191,17 @@ namespace Datadog.Trace
         {
             if (AzureAppServices.Metadata.IsRelevant)
             {
-                span.SetTag(Tags.AzureAppServicesSiteName, AzureAppServices.Metadata.SiteName);
-                span.SetTag(Tags.AzureAppServicesSiteKind, AzureAppServices.Metadata.SiteKind);
-                span.SetTag(Tags.AzureAppServicesSiteType, AzureAppServices.Metadata.SiteType);
-                span.SetTag(Tags.AzureAppServicesResourceGroup, AzureAppServices.Metadata.ResourceGroup);
-                span.SetTag(Tags.AzureAppServicesSubscriptionId, AzureAppServices.Metadata.SubscriptionId);
-                span.SetTag(Tags.AzureAppServicesResourceId, AzureAppServices.Metadata.ResourceId);
-                span.SetTag(Tags.AzureAppServicesInstanceId, AzureAppServices.Metadata.InstanceId);
-                span.SetTag(Tags.AzureAppServicesInstanceName, AzureAppServices.Metadata.InstanceName);
-                span.SetTag(Tags.AzureAppServicesOperatingSystem, AzureAppServices.Metadata.OperatingSystem);
-                span.SetTag(Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
-                span.SetTag(Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteName, AzureAppServices.Metadata.SiteName);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteKind, AzureAppServices.Metadata.SiteKind);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteType, AzureAppServices.Metadata.SiteType);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceGroup, AzureAppServices.Metadata.ResourceGroup);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSubscriptionId, AzureAppServices.Metadata.SubscriptionId);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceId, AzureAppServices.Metadata.ResourceId);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceId, AzureAppServices.Metadata.InstanceId);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceName, AzureAppServices.Metadata.InstanceName);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesOperatingSystem, AzureAppServices.Metadata.OperatingSystem);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
+                span.SetTag(Datadog.Trace.Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/TraceTagNames.cs
+++ b/tracer/src/Datadog.Trace/TraceTagNames.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="TraceTagNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace;
+
+/// <summary>
+/// Standard span tags used by integrations.
+/// </summary>
+internal static class TraceTagNames
+{
+    internal static class Propagation
+    {
+        internal const string PropagationHeadersError = "_dd.propagation_error";
+    }
+}

--- a/tracer/src/Datadog.Trace/TraceTagNames.cs
+++ b/tracer/src/Datadog.Trace/TraceTagNames.cs
@@ -6,7 +6,7 @@
 namespace Datadog.Trace;
 
 /// <summary>
-/// Standard span tags used by integrations.
+/// Tags names use for trace-level tags.
 /// </summary>
 internal static class TraceTagNames
 {

--- a/tracer/src/Datadog.Trace/TraceTagNames.cs
+++ b/tracer/src/Datadog.Trace/TraceTagNames.cs
@@ -6,7 +6,7 @@
 namespace Datadog.Trace;
 
 /// <summary>
-/// Tags names use for trace-level tags.
+/// Names used for trace-level tags.
 /// </summary>
 internal static class TraceTagNames
 {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -348,20 +348,19 @@ namespace Datadog.Trace
                 traceContext = parentSpanContext.TraceContext;
                 if (traceContext == null)
                 {
-                    traceContext = new TraceContext(this);
+                    var traceTags = TraceTagCollection.ParseFromPropagationHeader(parentSpanContext.DatadogTags);
+                    traceContext = new TraceContext(this, traceTags);
                     traceContext.SetSamplingPriority(parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority());
                 }
             }
             else
             {
-                traceContext = new TraceContext(this);
+                traceContext = new TraceContext(this, tags: null);
                 traceContext.SetSamplingPriority(DistributedTracer.Instance.GetSamplingPriority());
             }
 
             var finalServiceName = serviceName ?? DefaultServiceName;
-            var spanContext = new SpanContext(parent, traceContext, finalServiceName, traceId: traceId, spanId: spanId);
-
-            return spanContext;
+            return new SpanContext(parent, traceContext, finalServiceName, traceId: traceId, spanId: spanId);
         }
 
         internal Scope StartActiveInternal(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool finishOnClose = true, ITags tags = null)

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -1,0 +1,142 @@
+﻿// <copyright file="TraceTagsCollectionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Tagging;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Tagging;
+
+public class TraceTagsCollectionTests
+{
+    public static TheoryData<string, List<KeyValuePair<string, string>>> ParseData() => new()
+    {
+        {
+            null,
+            new List<KeyValuePair<string, string>>()
+        },
+        {
+            string.Empty,
+            new List<KeyValuePair<string, string>>()
+        },
+        {
+            "key1=value1",
+            new List<KeyValuePair<string, string>>
+            {
+                new("key1", "value1")
+            }
+        },
+        {
+            "key1=value1,key2=value2",
+            new List<KeyValuePair<string, string>>
+            {
+                new("key1", "value1"),
+                new("key2", "value2")
+            }
+        },
+        {
+            "key1=value1,key2=value2,key3=value3",
+            new List<KeyValuePair<string, string>>
+            {
+                new("key1", "value1"),
+                new("key2", "value2"),
+                new("key3", "value3")
+            }
+        },
+        {
+            "key1=,=value2,=,key3",
+            new List<KeyValuePair<string, string>>()
+        }
+    };
+
+    public static TheoryData<List<KeyValuePair<string, string>>, string> SerializeData() => new()
+    {
+        {
+            new List<KeyValuePair<string, string>>(),
+            string.Empty
+        },
+        {
+            new List<KeyValuePair<string, string>>
+            {
+                new("_dd.p.key1", "value1")
+            },
+            "_dd.p.key1=value1"
+        },
+        {
+            new List<KeyValuePair<string, string>>
+            {
+                new("_dd.p.key1", "value1"),
+                new("_dd.p.key2", "value2")
+            },
+            "_dd.p.key1=value1,_dd.p.key2=value2"
+        },
+        {
+            new List<KeyValuePair<string, string>>
+            {
+                new("key1", "value1"),
+                new("_dd.p.key2", "value2"),
+                new("key3", "value3")
+            },
+            "_dd.p.key2=value2"
+        }
+    };
+
+    [Fact]
+    public void ToPropagationHeaderValue_Empty()
+    {
+        var tags = new TraceTagCollection();
+        var header = tags.ToPropagationHeader();
+        header.Should().Be(string.Empty);
+    }
+
+    [Theory]
+    [MemberData(nameof(SerializeData))]
+    public void ToPropagationHeaderValue(List<KeyValuePair<string, string>> pairs, string expectedHeader)
+    {
+        var headerValue = new TraceTagCollection(pairs).ToPropagationHeader();
+        headerValue.Should().Be(expectedHeader);
+    }
+
+    [Theory]
+    [InlineData(8)]   // this produces "_dd.p.a=" which is too short and invalid
+    [InlineData(9)]   // this produces the shortest possible header, "_dd.p.a=b"
+    [InlineData(512)] // this produces the longest possible header
+    [InlineData(513)] // this produces a header that is too long
+    public void ToPropagationHeaderValue_Length(int totalHeaderLength)
+    {
+        // single tag with "_dd.p.a={...}", which has 8 chars plus the value's length
+        var pairs = new List<KeyValuePair<string, string>> { new("_dd.p.a", new string('b', totalHeaderLength - 8)) };
+        var traceTags = new TraceTagCollection(pairs);
+        var headerValue = traceTags.ToPropagationHeader();
+
+        if (totalHeaderLength < TraceTagCollection.MinimumPropagationHeaderLength)
+        {
+            // too short
+            headerValue.Should().BeNullOrEmpty();
+            traceTags.GetTag(TraceTagNames.Propagation.PropagationHeadersError).Should().BeNull();
+        }
+        else if (totalHeaderLength > TraceTagCollection.MaximumPropagationHeaderLength)
+        {
+            // too long
+            headerValue.Should().BeNullOrEmpty();
+            traceTags.GetTag(TraceTagNames.Propagation.PropagationHeadersError).Should().Be("max_size");
+        }
+        else
+        {
+            // valid length
+            headerValue.Should().NotBeNullOrEmpty();
+            traceTags.GetTag(TraceTagNames.Propagation.PropagationHeadersError).Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ParseData))]
+    public void ParseFromPropagationHeader(string header, List<KeyValuePair<string, string>> expectedPairs)
+    {
+        var tags = TraceTagCollection.ParseFromPropagationHeader(header).AsList();
+        tags.Should().BeEquivalentTo(expectedPairs);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -180,7 +180,7 @@ public class TraceTagsCollectionTests
     [MemberData(nameof(ParseData))]
     public void ParseFromPropagationHeader(string header, KeyValuePair<string, string>[] expectedPairs)
     {
-        var tags = TraceTagCollection.ParseFromPropagationHeader(header).AsList();
+        var tags = TraceTagCollection.ParseFromPropagationHeader(header);
         tags.Should().BeEquivalentTo(expectedPairs);
     }
 
@@ -189,7 +189,7 @@ public class TraceTagsCollectionTests
     {
         var tags = new TraceTagCollection();
         var header = tags.ToPropagationHeader();
-        tags.AsList().Should().BeEmpty();
+        tags.Should().BeEmpty();
         header.Should().BeEmpty();
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Tagging;
 using FluentAssertions;
@@ -12,70 +13,111 @@ namespace Datadog.Trace.Tests.Tagging;
 
 public class TraceTagsCollectionTests
 {
-    public static TheoryData<string, List<KeyValuePair<string, string>>> ParseData() => new()
+    private static readonly KeyValuePair<string, string>[] EmptyTags = Array.Empty<KeyValuePair<string, string>>();
+
+    public static TheoryData<string, KeyValuePair<string, string>[]> ParseData() => new()
     {
         {
             null,
-            new List<KeyValuePair<string, string>>()
+            EmptyTags
         },
         {
             string.Empty,
-            new List<KeyValuePair<string, string>>()
+            EmptyTags
         },
         {
-            "a=b",
-            new List<KeyValuePair<string, string>>
+            // multiple valid tags
+            "_dd.p.key1=value1,_dd.p.key2=value2,_dd.p.key3=value3",
+            new KeyValuePair<string, string>[]
             {
-                new("a", "b")
+                new("_dd.p.key1", "value1"),
+                new("_dd.p.key2", "value2"),
+                new("_dd.p.key3", "value3"),
             }
         },
         {
-            "key1=value1,key2=value2,key3=value3",
-            new List<KeyValuePair<string, string>>
-            {
-                new("key1", "value1"),
-                new("key2", "value2"),
-                new("key3", "value3")
-            }
+            // missing key prefix
+            "key1=value1",
+            EmptyTags
         },
         {
-            // invalid key/value pairs
-            "key1=,=value2,=,key3",
-            new List<KeyValuePair<string, string>>()
-        }
+            // no value
+            "_dd.p.key1=",
+            EmptyTags
+        },
+        {
+            // no key
+            "=value1",
+            EmptyTags
+        },
+        {
+            // no key or value
+            "=",
+            EmptyTags
+        },
+        {
+            // no separator
+            "_dd.p.key1",
+            EmptyTags
+        },
+        {
+            // key too short
+            "_dd.p.=value1",
+            EmptyTags
+        },
     };
 
-    public static TheoryData<List<KeyValuePair<string, string>>, string> SerializeData() => new()
+    public static TheoryData<KeyValuePair<string, string>[], string> SerializeData() => new()
     {
         {
-            new List<KeyValuePair<string, string>>(),
+            EmptyTags,
             string.Empty
         },
         {
-            new List<KeyValuePair<string, string>>
-            {
-                new("_dd.p.key1", "value1")
-            },
-            "_dd.p.key1=value1"
-        },
-        {
-            new List<KeyValuePair<string, string>>
+            new KeyValuePair<string, string>[]
             {
                 new("_dd.p.key1", "value1"),
-                new("_dd.p.key2", "value2")
+                new("_dd.p.key2", "value2"),
+                new("_dd.p.key3", "value3"),
             },
-            "_dd.p.key1=value1,_dd.p.key2=value2"
+            "_dd.p.key1=value1,_dd.p.key2=value2,_dd.p.key3=value3"
         },
         {
-            new List<KeyValuePair<string, string>>
+            // missing prefix
+            new KeyValuePair<string, string>[]
             {
-                new("key1", "value1"),
-                new("_dd.p.key2", "value2"),
-                new("key3", "value3")
+                new("key1", "value1")
             },
-            "_dd.p.key2=value2"
-        }
+            string.Empty
+        },
+        {
+            // missing key
+            new KeyValuePair<string, string>[]
+            {
+                new(string.Empty, "value1"),
+            },
+            string.Empty
+        },
+        {
+            // missing value
+            new KeyValuePair<string, string>[]
+            {
+                new("_dd.p.key1", null),
+                new("_dd.p.key2", string.Empty),
+            },
+            string.Empty
+        },
     };
+
+    [Fact]
+    public void ThrowsOnNullKey()
+    {
+        var tags = new TraceTagCollection();
+
+        tags.Invoking(t => t.SetTag(null!, "value"))
+            .Should()
+            .Throw<ArgumentNullException>();
+    }
 
     [Fact]
     public void ToPropagationHeaderValue_Empty()
@@ -87,7 +129,7 @@ public class TraceTagsCollectionTests
 
     [Theory]
     [MemberData(nameof(SerializeData))]
-    public void ToPropagationHeaderValue(List<KeyValuePair<string, string>> pairs, string expectedHeader)
+    public void ToPropagationHeaderValue(KeyValuePair<string, string>[] pairs, string expectedHeader)
     {
         var traceTags = new TraceTagCollection();
 
@@ -136,9 +178,94 @@ public class TraceTagsCollectionTests
 
     [Theory]
     [MemberData(nameof(ParseData))]
-    public void ParseFromPropagationHeader(string header, List<KeyValuePair<string, string>> expectedPairs)
+    public void ParseFromPropagationHeader(string header, KeyValuePair<string, string>[] expectedPairs)
     {
         var tags = TraceTagCollection.ParseFromPropagationHeader(header).AsList();
         tags.Should().BeEquivalentTo(expectedPairs);
+    }
+
+    [Fact]
+    public void NewCollectionIsEmpty()
+    {
+        var tags = new TraceTagCollection();
+        var header = tags.ToPropagationHeader();
+        tags.AsList().Should().BeEmpty();
+        header.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SetTag()
+    {
+        var tags = new TraceTagCollection();
+
+        // distributed tag is set...
+        tags.SetTag("_dd.p.key1", "value1");
+        var value1 = tags.GetTag("_dd.p.key1");
+        value1.Should().Be("value1");
+
+        // ...and added to the header
+        var header = tags.ToPropagationHeader();
+        header.Should().Be("_dd.p.key1=value1");
+
+        // non-distributed tag is set...
+        tags.SetTag("key2", "value2");
+        var value2 = tags.GetTag("key2");
+        value2.Should().Be("value2");
+
+        // ...but not added to the header
+        header = tags.ToPropagationHeader();
+        header.Should().Be("_dd.p.key1=value1");
+    }
+
+    [Fact]
+    public void SetTag_MultipleTimes()
+    {
+        var tags = new TraceTagCollection();
+        tags.SetTag("_dd.p.key1", "value1");
+        tags.SetTag("_dd.p.key1", "value1");
+
+        var value1 = tags.GetTag("_dd.p.key1");
+        value1.Should().Be("value1");
+
+        var header = tags.ToPropagationHeader();
+        header.Should().Be("_dd.p.key1=value1");
+    }
+
+    [Fact]
+    public void HeaderIsCached()
+    {
+        var header = "_dd.p.key1=value1";
+
+        // should cache original header
+        var tags = TraceTagCollection.ParseFromPropagationHeader(header);
+        var cachedHeader = tags.ToPropagationHeader();
+        cachedHeader.Should().BeSameAs(header);
+
+        // set tag to same value, should not invalidate the cached header
+        tags.SetTag("_dd.p.key1", "value1");
+        cachedHeader = tags.ToPropagationHeader();
+        cachedHeader.Should().BeSameAs(header);
+
+        // add valid non-distributed trace tag, should not invalidate the cached header
+        tags.SetTag("key2", "value2");
+        cachedHeader = tags.ToPropagationHeader();
+        cachedHeader.Should().BeSameAs(header);
+
+        // add valid distributed trace tag, invalidates the cached header
+        tags.SetTag("_dd.p.key3", "value3");
+        cachedHeader = tags.ToPropagationHeader();
+        cachedHeader.Should().NotBe(header);
+    }
+
+    [Fact]
+    public void HeaderIsNotCached()
+    {
+        // missing prefix, tag is ignored
+        var header = "key1=value1";
+
+        // should not cache original header
+        var tags = TraceTagCollection.ParseFromPropagationHeader(header);
+        var cachedHeader = tags.ToPropagationHeader();
+        cachedHeader.Should().NotBeSameAs(header);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -96,7 +96,14 @@ public class TraceTagsCollectionTests
     [MemberData(nameof(SerializeData))]
     public void ToPropagationHeaderValue(List<KeyValuePair<string, string>> pairs, string expectedHeader)
     {
-        var headerValue = new TraceTagCollection(pairs).ToPropagationHeader();
+        var traceTags = new TraceTagCollection();
+
+        foreach (var pair in pairs)
+        {
+            traceTags.SetTag(pair.Key, pair.Value);
+        }
+
+        var headerValue = traceTags.ToPropagationHeader();
         headerValue.Should().Be(expectedHeader);
     }
 
@@ -107,9 +114,11 @@ public class TraceTagsCollectionTests
     [InlineData(513)] // this produces a header that is too long
     public void ToPropagationHeaderValue_Length(int totalHeaderLength)
     {
+        var traceTags = new TraceTagCollection();
+
         // single tag with "_dd.p.a={...}", which has 8 chars plus the value's length
-        var pairs = new List<KeyValuePair<string, string>> { new("_dd.p.a", new string('b', totalHeaderLength - 8)) };
-        var traceTags = new TraceTagCollection(pairs);
+        traceTags.SetTag("_dd.p.a", new string('b', totalHeaderLength - 8));
+
         var headerValue = traceTags.ToPropagationHeader();
 
         if (totalHeaderLength < TraceTagCollection.MinimumPropagationHeaderLength)

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -181,15 +181,17 @@ public class TraceTagsCollectionTests
     public void ParseFromPropagationHeader(string header, KeyValuePair<string, string>[] expectedPairs)
     {
         var tags = TraceTagCollection.ParseFromPropagationHeader(header);
-        tags.Should().BeEquivalentTo(expectedPairs);
+        tags.ToEnumerable().Should().BeEquivalentTo(expectedPairs);
     }
 
     [Fact]
     public void NewCollectionIsEmpty()
     {
         var tags = new TraceTagCollection();
+        tags.Count.Should().Be(0);
+        tags.ToEnumerable().Should().BeEmpty();
+
         var header = tags.ToPropagationHeader();
-        tags.Should().BeEmpty();
         header.Should().BeEmpty();
     }
 
@@ -202,6 +204,7 @@ public class TraceTagsCollectionTests
         tags.SetTag("_dd.p.key1", "value1");
         var value1 = tags.GetTag("_dd.p.key1");
         value1.Should().Be("value1");
+        tags.Count.Should().Be(1);
 
         // ...and added to the header
         var header = tags.ToPropagationHeader();
@@ -211,6 +214,7 @@ public class TraceTagsCollectionTests
         tags.SetTag("key2", "value2");
         var value2 = tags.GetTag("key2");
         value2.Should().Be("value2");
+        tags.Count.Should().Be(2);
 
         // ...but not added to the header
         header = tags.ToPropagationHeader();
@@ -222,7 +226,10 @@ public class TraceTagsCollectionTests
     {
         var tags = new TraceTagCollection();
         tags.SetTag("_dd.p.key1", "value1");
+        tags.Count.Should().Be(1);
+
         tags.SetTag("_dd.p.key1", "value1");
+        tags.Count.Should().Be(1);
 
         var value1 = tags.GetTag("_dd.p.key1");
         value1.Should().Be("value1");

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -23,18 +23,10 @@ public class TraceTagsCollectionTests
             new List<KeyValuePair<string, string>>()
         },
         {
-            "key1=value1",
+            "a=b",
             new List<KeyValuePair<string, string>>
             {
-                new("key1", "value1")
-            }
-        },
-        {
-            "key1=value1,key2=value2",
-            new List<KeyValuePair<string, string>>
-            {
-                new("key1", "value1"),
-                new("key2", "value2")
+                new("a", "b")
             }
         },
         {

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TraceTagsCollectionTests.cs
@@ -39,6 +39,7 @@ public class TraceTagsCollectionTests
             }
         },
         {
+            // invalid key/value pairs
             "key1=,=value2,=,key3",
             new List<KeyValuePair<string, string>>()
         }


### PR DESCRIPTION
Continuation of #2178.

Add support for trace-level tags that are propagated via `x-datadog-tags` header. Trace-level tags are now sent to the Agent by adding them to root spans during serialization. (aka vertical propagation)
- add new `TraceTagNames` for well-known trace-level tags (leaving `Tags` for span-level tags)
  - add new trace-level tag `_dd.propagation_error` to denote propagation errors (e.g. header too long)
- add new class `TraceTagsCollection` with support for parsing from and serializing to the `x-datadog-tags` propagation header
- replace `string TraceContext.DatadogTags` with `TraceTagsCollection TraceContext.Tags`
  - during incoming calls from upstream services, parse the `x-datadog-tags` header to populate `TraceContext.Tags`
  - during outgoing calls to downstream services, inject the `x-datadog-tags` header with values from `TraceContext.Tags`
- during trace serialization, if a span is the root span, add the tags from `TraceContext.Tags`

Future work:
- next PRs
  - add the concept of "sampling mechanism", and track sampling priority, sampling mechanism, and sampling rate throughout so we can propagate this info later
  - add special support for the `_dd.p.upstream_services` trace-level tag
- handle adding trace tags to other spans besides root when the root is not present in the same tace chunk (find the first span with no parent?)
- someday: migrate existing trace-level tags to use this mechanism? (`_sampling_priority_v1`, `_dd.origin`, `_dd.tracer_kr`, and many more...)