### PR TITLE
[CIApp] - Revert `ci_library.language` tag to `language`

### DIFF
--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.BenchmarkDotNet
                     span.SetTag(TestTags.Suite, report.BenchmarkCase.Descriptor.Type.FullName);
                     span.SetTag(TestTags.Framework, $"BenchmarkDotNet {summary.HostEnvironmentInfo.BenchmarkDotNetVersion}");
                     span.SetTag(TestTags.Status, report.Success ? TestTags.StatusPass : TestTags.StatusFail);
-                    span.SetTag(TestTags.CILibraryLanguage, TracerConstants.Language);
+                    span.SetTag(TestTags.Language, TracerConstants.Language);
                     span.SetTag(TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);
 
                     if (summary.HostEnvironmentInfo != null)

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.MSBuild
                 _buildSpan.SetTag(CommonTags.OSArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86");
                 _buildSpan.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
                 _buildSpan.SetTag(CommonTags.RuntimeArchitecture, Environment.Is64BitProcess ? "x64" : "x86");
-                _buildSpan.SetTag(TestTags.CILibraryLanguage, TracerConstants.Language);
+                _buildSpan.SetTag(TestTags.Language, TracerConstants.Language);
                 _buildSpan.SetTag(TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);
                 CIEnvironmentValues.Instance.DecorateSpan(_buildSpan);
             }

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
@@ -96,9 +96,9 @@ namespace Datadog.Trace.Ci.Tags
         public const string CIAppTestOriginName = "ciapp-test";
 
         /// <summary>
-        /// CI Visibility Library Language
+        /// Library Language
         /// </summary>
-        public const string CILibraryLanguage = "ci_library.language";
+        public const string Language = "language";
 
         /// <summary>
         /// CI Visibility Library Version

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             span.SetTag(TestTags.Framework, testFramework);
             span.SetTag(TestTags.FrameworkVersion, type.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
-            span.SetTag(TestTags.CILibraryLanguage, TracerConstants.Language);
+            span.SetTag(TestTags.Language, TracerConstants.Language);
             span.SetTag(TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);
             CIEnvironmentValues.Instance.DecorateSpan(span);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.SetTag(TestTags.Framework, testFramework);
             span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
-            span.SetTag(TestTags.CILibraryLanguage, TracerConstants.Language);
+            span.SetTag(TestTags.Language, TracerConstants.Language);
             span.SetTag(TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);
             CIEnvironmentValues.Instance.DecorateSpan(span);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.SetTag(TestTags.Framework, testFramework);
             span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
-            span.SetTag(TestTags.CILibraryLanguage, TracerConstants.Language);
+            span.SetTag(TestTags.Language, TracerConstants.Language);
             span.SetTag(TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);
             CIEnvironmentValues.Instance.DecorateSpan(span);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, Tags.Env, "integration_tests");
 
                         // CI Library Language
-                        AssertTargetSpanEqual(targetSpan, TestTags.CILibraryLanguage, TracerConstants.Language);
+                        AssertTargetSpanEqual(targetSpan, TestTags.Language, TracerConstants.Language);
 
                         // CI Library Language
                         AssertTargetSpanEqual(targetSpan, TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, Tags.Env, "integration_tests");
 
                         // CI Library Language
-                        AssertTargetSpanEqual(targetSpan, TestTags.CILibraryLanguage, TracerConstants.Language);
+                        AssertTargetSpanEqual(targetSpan, TestTags.Language, TracerConstants.Language);
 
                         // CI Library Language
                         AssertTargetSpanEqual(targetSpan, TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         AssertTargetSpanEqual(targetSpan, Tags.Env, "integration_tests");
 
                         // CI Library Language
-                        AssertTargetSpanEqual(targetSpan, TestTags.CILibraryLanguage, TracerConstants.Language);
+                        AssertTargetSpanEqual(targetSpan, TestTags.Language, TracerConstants.Language);
 
                         // CI Library Language
                         AssertTargetSpanEqual(targetSpan, TestTags.CILibraryVersion, TracerConstants.AssemblyVersion);

--- a/tracer/test/Datadog.Trace.Tests/Util/ModuleInitializer.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/ModuleInitializer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ModuleInitializer.cs" company="Datadog">
+// <copyright file="ModuleInitializer.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>


### PR DESCRIPTION
This PR reverts `ci_library.language` tag to `language` (as other integrations).


@DataDog/apm-dotnet