### PR TITLE
[CIApp] - Ensure the Origin tag value on the public SpanContext .ctor

### DIFF
--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -5,6 +5,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using Datadog.Trace.Ci;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace
@@ -44,6 +45,14 @@ namespace Datadog.Trace
         {
             SpanId = spanId;
             SamplingPriority = (int?)samplingPriority;
+
+            // Because this ctor is part of the public api, we need to ensure new SpanContext created by this .ctor
+            // has the CI Visibility origin tag if the CI Visibility mode is running to ensure the correct propagation
+            // to children spans and distributed trace.
+            if (CIVisibility.IsRunning)
+            {
+                Origin = Ci.Tags.TestTags.CIAppTestOriginName;
+            }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -45,14 +45,6 @@ namespace Datadog.Trace
         {
             SpanId = spanId;
             SamplingPriority = (int?)samplingPriority;
-
-            // Because this ctor is part of the public api, we need to ensure new SpanContext created by this .ctor
-            // has the CI Visibility origin tag if the CI Visibility mode is running to ensure the correct propagation
-            // to children spans and distributed trace.
-            if (CIVisibility.IsRunning)
-            {
-                Origin = Ci.Tags.TestTags.CIAppTestOriginName;
-            }
         }
 
         /// <summary>
@@ -101,6 +93,15 @@ namespace Datadog.Trace
                           : SpanIdGenerator.ThreadInstance.CreateNew();
 
             ServiceName = serviceName;
+
+            // Because we have a ctor as part of the public api without accepting the origin tag,
+            // we need to ensure new SpanContext created by this .ctor has the CI Visibility origin
+            // tag if the CI Visibility mode is running to ensure the correct propagation
+            // to children spans and distributed trace.
+            if (CIVisibility.IsRunning)
+            {
+                Origin = Ci.Tags.TestTags.CIAppTestOriginName;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR ensures the Origin tag value on the public SpanContext .ctor when running in CI Visibility mode.

This issue was discovered with a customer using this public constructor, is important due the origin tag affects billing.

**Note:** A manual Test api for customers is being discussed to enable them to write custom test instrumentation without depending on all tracing concepts.

@DataDog/apm-dotnet