### PR TITLE
Fix MongoDB integration when BsonDocument throws an exception

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -3,17 +3,27 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
+using FluentAssertions.Execution;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [UsesVerify]
     public class MongoDbTests : TestHelper
     {
+        private static readonly Regex OsRegex = new(@"""os"" : \{.*?\} ");
+        private static readonly Regex ObjectIdRegex = new(@"ObjectId\("".*?""\)");
+
         public MongoDbTests(ITestOutputHelper output)
             : base("MongoDB", output)
         {
@@ -23,55 +33,71 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MongoDB), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion)
+        public async Task SubmitsTraces(string packageVersion)
         {
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(3, 500);
-                spans.Count.Should().BeGreaterOrEqualTo(3);
 
-                var rootSpan = spans.Single(s => s.ParentId == null);
+                var version = string.IsNullOrEmpty(packageVersion) ? null : new Version(packageVersion);
+                var snapshotSuffix = version switch
+                    {
+                        null or { Major: >= 3 } or { Major: 2, Minor: >= 7 } => "2_7", // default is version 2.8.0
+                        { Major: 2, Minor: >= 5 } => "2_5", // version 2.5 + 2.6 include additional info on queries compared to 2.2
+                        { Major: 2, Minor: >= 2 } => "2_2",
+                        _ => "PRE_2_2"
+                    };
 
-                // Check for manual trace
-                rootSpan.Name.Should().Be("Main()");
-                rootSpan.Service.Should().Be("Samples.MongoDB");
-                rootSpan.Type.Should().BeNull();
+                var settings = VerifyHelper.GetSpanVerifierSettings();
+                // mongo stamps the current framework version, and OS so normalise those
+                settings.AddRegexScrubber(OsRegex, @"""os"" : {} ");
+                // v2.5.x records additional info in the insert query which is execution-specific
+                settings.AddRegexScrubber(ObjectIdRegex, @"ObjectId(""ABC123"")");
+                // normalise between running directly against localhost and against mongo container
+                settings.AddSimpleScrubber("out.host: localhost", "out.host: mongo");
+                settings.AddSimpleScrubber("out.host: mongo_arm64", "out.host: mongo");
+                // In some package versions, aggregate queries have an ID, others don't
+                settings.AddSimpleScrubber("\"$group\" : { \"_id\" : null, \"n\"", "\"$group\" : { \"_id\" : 1, \"n\"");
 
-                int spansWithResourceName = 0;
+                // The mongodb driver sends periodic monitors
+                var adminSpans = spans
+                                .Where(x => x.Resource is "buildInfo admin" or "getLastError admin")
+                                .ToList();
+                var nonAdminSpans = spans
+                                   .Where(x => !adminSpans.Contains(x))
+                                   .ToList();
 
-                foreach (var span in spans)
+                await VerifyHelper.VerifySpans(nonAdminSpans, settings)
+                                  .UseTextForParameters($"packageVersion={snapshotSuffix}")
+                                  .DisableRequireUniquePrefix();
+
+                telemetry.AssertIntegrationEnabled(IntegrationId.MongoDb);
+
+                // do some basic verification on the "admin" spans
+                using var scope = new AssertionScope();
+                adminSpans.Should().AllBeEquivalentTo(new { Service = "Samples.MongoDB-mongodb", Type = "mongodb", });
+                foreach (var adminSpan in adminSpans)
                 {
-                    if (span == rootSpan)
+                    adminSpan.Tags.Should().IntersectWith(new Dictionary<string, string>
                     {
-                        continue;
-                    }
+                        { "component", "MongoDb" },
+                        { "db.name", "admin" },
+                        { "env", "integration_tests" },
+                        { "mongodb.collection", "1" },
+                        { "span.kind", "client" },
+                    });
 
-                    if (span.Service == "Samples.MongoDB-mongodb")
+                    if (adminSpan.Resource == "buildInfo admin")
                     {
-                        span.Name.Should().Be("mongodb.query");
-                        span.Type.Should().Be(SpanTypes.MongoDb);
-                        span.Tags.Should().NotContainKey(Tags.Version, "external service span should not have service version tag.");
-
-                        if (span.Resource != null && span.Resource != "mongodb.query")
-                        {
-                            spansWithResourceName++;
-
-                            span.Tags.Should().ContainKey(Tags.MongoDbQuery);
-                            span.Resource.Should().NotStartWith("isMaster").And.NotStartWith("hello");
-                        }
+                        adminSpan.Tags.Should().Contain("mongodb.query", "{ \"buildInfo\" : 1 }");
                     }
                     else
                     {
-                        // These are manual traces
-                        span.Service.Should().Be("Samples.MongoDB");
-                        span.Tags[Tags.Version].Should().Be("1.0.0");
+                        adminSpan.Tags.Should().Contain("mongodb.query", "{ \"getLastError\" : 1 }");
                     }
                 }
-
-                spansWithResourceName.Should().BeGreaterThan(0, "extraction of the command failed on all spans");
-                telemetry.AssertIntegrationEnabled(IntegrationId.MongoDb);
             }
         }
     }

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.verified.txt
@@ -1,0 +1,307 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Main(),
+    Resource: Main(),
+    Service: Samples.MongoDB,
+    Tags: {
+      env: integration_tests,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: sync-calls,
+    Resource: sync-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: async-calls,
+    Resource: async-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: sync-calls-execute,
+    Resource: sync-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: async-calls-execute,
+    Resource: async-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: mongodb.query,
+    Resource: count test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "count" : "employees", "query" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: mongodb.query,
+    Resource: count test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "count" : "employees", "query" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_5,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_6,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.verified.txt
@@ -1,0 +1,311 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Main(),
+    Resource: Main(),
+    Service: Samples.MongoDB,
+    Tags: {
+      env: integration_tests,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: sync-calls,
+    Resource: sync-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: async-calls,
+    Resource: async-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: sync-calls-execute,
+    Resource: sync-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: async-calls-execute,
+    Resource: async-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "delete" : "employees", "ordered" : true, "deletes" : [{ "q" : { }, "limit" : 0 }] },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "insert" : "employees", "ordered" : true, "documents" : [{ "_id" : ObjectId("ABC123"), "name" : "MongoDB", "type" : "Database", "count" : 1, "info" : { "x" : 203, "y" : 102 } }] },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: mongodb.query,
+    Resource: count test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "count" : "employees", "query" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "delete" : "employees", "ordered" : true, "deletes" : [{ "q" : { }, "limit" : 0 }] },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "insert" : "employees", "ordered" : true, "documents" : [{ "_id" : ObjectId("ABC123"), "name" : "MongoDB", "type" : "Database", "count" : 1, "info" : { "x" : 203, "y" : 102 } }] },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: mongodb.query,
+    Resource: count test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "count" : "employees", "query" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_5,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_6,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.verified.txt
@@ -1,0 +1,311 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Main(),
+    Resource: Main(),
+    Service: Samples.MongoDB,
+    Tags: {
+      env: integration_tests,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: sync-calls,
+    Resource: sync-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: async-calls,
+    Resource: async-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: sync-calls-execute,
+    Resource: sync-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: async-calls-execute,
+    Resource: async-calls-execute,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "delete" : "employees", "ordered" : true },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "insert" : "employees", "ordered" : true },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: mongodb.query,
+    Resource: aggregate test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_3,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "delete" : "employees", "ordered" : true },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "insert" : "employees", "ordered" : true },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: mongodb.query,
+    Resource: aggregate test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: mongodb.query,
+    Resource: find test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "find" : "employees", "filter" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_5,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_6,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.verified.txt
@@ -1,0 +1,130 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Main(),
+    Resource: Main(),
+    Service: Samples.MongoDB,
+    Tags: {
+      env: integration_tests,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: sync-calls,
+    Resource: sync-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: async-calls,
+    Resource: async-calls,
+    Service: Samples.MongoDB,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: mongodb.query,
+    Resource: delete test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: mongodb.query,
+    Resource: insert test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: mongodb.query,
+    Resource: count test-db,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      db.name: test-db,
+      env: integration_tests,
+      mongodb.collection: employees,
+      mongodb.query: { "count" : "employees", "query" : { } },
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: mongodb.query,
+    Resource: mongodb.query,
+    Service: Samples.MongoDB-mongodb,
+    Type: mongodb,
+    ParentId: Id_4,
+    Tags: {
+      component: MongoDb,
+      env: integration_tests,
+      out.host: mongo,
+      out.port: 27017,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
@@ -38,7 +37,7 @@ namespace Samples.MongoDB
             };
 
 
-            using (var mainScope = Tracer.Instance.StartActive("Main()"))
+            using (var mainScope = SampleHelpers.CreateScope("Main()"))
             {
                 var connectionString = $"mongodb://{Host()}:27017";
                 var client = new MongoClient(connectionString);
@@ -59,7 +58,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var syncScope = Tracer.Instance.StartActive("sync-calls"))
+            using (var syncScope = SampleHelpers.CreateScope("sync-calls"))
             {
 #if MONGODB_2_2
                 collection.DeleteMany(allFilter);
@@ -100,7 +99,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var asyncScope = Tracer.Instance.StartActive("async-calls"))
+            using (var asyncScope = SampleHelpers.CreateScope("async-calls"))
             {
                 await collection.DeleteManyAsync(allFilter);
                 await collection.InsertOneAsync(newDocument);
@@ -122,14 +121,14 @@ namespace Samples.MongoDB
 
         public static void WireProtocolExecuteIntegrationTest(MongoClient client)
         {
-            using (var syncScope = Tracer.Instance.StartActive("sync-calls-execute"))
+            using (var syncScope = SampleHelpers.CreateScope("sync-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);
                 channel.KillCursors(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None);
             }
 
-            using (var asyncScope = Tracer.Instance.StartActive("async-calls-execute"))
+            using (var asyncScope = SampleHelpers.CreateScope("async-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR adds the try/catch we had before the integration rewrite to catch an exception calling `BsonDocument.ToString()`

Reference: https://groups.google.com/g/mongodb-user/c/-W36utrXflg/m/3f3kj1KFAgAJ

Also contains MongoDb snapshots, added in https://github.com/DataDog/dd-trace-dotnet/pull/2440

@DataDog/apm-dotnet