### PR TITLE
Add Auth header to HttpClient that downloads Azure DevOps build artifacts

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -813,14 +813,17 @@ partial class Build
         return (artifactBuild, artifact);
     }
 
-    static async Task DownloadAzureArtifact(AbsolutePath outputDirectory, BuildArtifact artifact)
+    async Task DownloadAzureArtifact(AbsolutePath outputDirectory, BuildArtifact artifact)
     {
         var zipPath = outputDirectory / $"{artifact.Name}.zip";
 
         Console.WriteLine($"Downloading artifacts from {artifact.Resource.DownloadUrl} to {zipPath}...");
 
-        // buildHttpClient.GetArtifactContentZipAsync doesn't seem to work
+        // buildHttpClient.GetArtifactContentZipAsync doesn't seem to work due to 'Redirect' response status.
+        // instead of downloading resources from https://dev.azure.com/ resource url starts with https://artprodcus3.artifacts.visualstudio.com
         var temporary = new HttpClient();
+        temporary.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{AzureDevopsToken}")));
+
         var resourceDownloadUrl = artifact.Resource.DownloadUrl;
         var response = await temporary.GetAsync(resourceDownloadUrl);
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -552,7 +552,7 @@ partial class Build
 
             Logger.Info("Release artifacts found, downloading...");
 
-            await DownloadAzureArtifact(OutputDirectory, artifact);
+            await DownloadAzureArtifact(OutputDirectory, artifact, AzureDevopsToken);
             var resourceDownloadUrl = artifact.Resource.DownloadUrl;
 
             Console.WriteLine("::set-output name=artifacts_link::" + resourceDownloadUrl);
@@ -809,11 +809,11 @@ partial class Build
             throw new Exception($"Error: no artifacts available for {branch}");
         }
 
-        await DownloadAzureArtifact(outputDirectory, artifact);
+        await DownloadAzureArtifact(outputDirectory, artifact, AzureDevopsToken);
         return (artifactBuild, artifact);
     }
 
-    async Task DownloadAzureArtifact(AbsolutePath outputDirectory, BuildArtifact artifact)
+    static async Task DownloadAzureArtifact(AbsolutePath outputDirectory, BuildArtifact artifact, string token)
     {
         var zipPath = outputDirectory / $"{artifact.Name}.zip";
 
@@ -822,7 +822,7 @@ partial class Build
         // buildHttpClient.GetArtifactContentZipAsync doesn't seem to work due to 'Redirect' response status.
         // instead of downloading resources from https://dev.azure.com/ resource url starts with https://artprodcus3.artifacts.visualstudio.com
         var temporary = new HttpClient();
-        temporary.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{AzureDevopsToken}")));
+        temporary.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{token}")));
 
         var resourceDownloadUrl = artifact.Resource.DownloadUrl;
         var response = await temporary.GetAsync(resourceDownloadUrl);


### PR DESCRIPTION
## Summary of changes
Add Auth header to HttpClient that downloads Azure DevOps build artifacts.

## Reason for change
On private Azure DevOps projects, it's impossible to download directly from Azure DevOps, without authorization.