### PR TITLE
New tags useful for throughput testing

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -21,6 +21,9 @@ namespace Datadog.Trace.Tools.Runner.Crank
 {
     internal class Importer
     {
+        public const string RateLimit = "rate-limit";
+        public const string PayloadSize = "payload-size";
+
         private static readonly IResultConverter[] Converters = new IResultConverter[]
         {
             new MsTimeResultConverter("benchmarks/start-time"),
@@ -147,11 +150,11 @@ namespace Datadog.Trace.Tools.Runner.Crank
                                 {
                                     arch = propItem.Value;
                                 }
-                                else if (propItem.Key == "rate_limit")
+                                else if (propItem.Key == RateLimit)
                                 {
                                     rateLimit = propItem.Value;
                                 }
-                                else if (propItem.Key == "payload_size")
+                                else if (propItem.Key == PayloadSize)
                                 {
                                     payloadSize = propItem.Value;
                                 }
@@ -178,12 +181,12 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                             if (rateLimit != string.Empty)
                             {
-                                span.SetTag(TestTags.RateLimit, rateLimit);
+                                span.SetTag(RateLimit, rateLimit);
                             }
 
                             if (payloadSize != string.Empty)
                             {
-                                span.SetTag(TestTags.PayloadSize, payloadSize);
+                                span.SetTag(PayloadSize, payloadSize);
                             }
 
                             span.ResourceName = $"{suite}/{testName}";

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -124,6 +124,8 @@ namespace Datadog.Trace.Tools.Runner.Crank
                             string scenario = string.Empty;
                             string profile = string.Empty;
                             string arch = string.Empty;
+                            string rateLimit = string.Empty;
+                            string payloadSize = string.Empty;
                             string testName = jobItem.Key;
                             foreach (var propItem in result.JobResults.Properties)
                             {
@@ -145,6 +147,14 @@ namespace Datadog.Trace.Tools.Runner.Crank
                                 {
                                     arch = propItem.Value;
                                 }
+                                else if (propItem.Key == "rate_limit")
+                                {
+                                    rateLimit = propItem.Value;
+                                }
+                                else if (propItem.Key == "payload_size")
+                                {
+                                    payloadSize = propItem.Value;
+                                }
                             }
 
                             string suite = fileName;
@@ -165,6 +175,17 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                             span.SetTag(TestTags.Suite, $"Crank.{suite}");
                             span.SetTag(TestTags.Name, testName);
+
+                            if (rateLimit != string.Empty)
+                            {
+                                span.SetTag(TestTags.RateLimit, rateLimit);
+                            }
+
+                            if (payloadSize != string.Empty)
+                            {
+                                span.SetTag(TestTags.PayloadSize, payloadSize);
+                            }
+
                             span.ResourceName = $"{suite}/{testName}";
                         }
 

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
@@ -104,5 +104,15 @@ namespace Datadog.Trace.Ci.Tags
         /// CI Visibility Library Version
         /// </summary>
         public const string CILibraryVersion = "ci_library.version";
+
+        /// <summary>
+        /// The rate limit set during a performance / throughput test
+        /// </summary>
+        public const string RateLimit = "rate-limit";
+
+        /// <summary>
+        /// The payload size for a test
+        /// </summary>
+        public const string PayloadSize = "payload-size";
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
@@ -104,15 +104,5 @@ namespace Datadog.Trace.Ci.Tags
         /// CI Visibility Library Version
         /// </summary>
         public const string CILibraryVersion = "ci_library.version";
-
-        /// <summary>
-        /// The rate limit set during a performance / throughput test
-        /// </summary>
-        public const string RateLimit = "rate-limit";
-
-        /// <summary>
-        /// The payload size for a test
-        /// </summary>
-        public const string PayloadSize = "payload-size";
     }
 }


### PR DESCRIPTION
## Summary of changes

Two extra test tags that allow users to specific a rate limit and payload size for a performance test.

## Reason for change

Applications can exhibit difference behaviours depending on request rate and payload size. These tags could be used to build a matrix that helps understand these behaviours. 
