### PR TITLE
Move EnumNgenModuleMethodsInliningThisMethod call from the background thread

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -295,9 +295,6 @@ void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector,
         {
             Logger::Warn("Error requesting ReJIT for ", modulesVector.size(), " methods");
         }
-
-        // Request for NGen Inliners
-        RequestRejitForNGenInliners();
     }
 }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
@@ -381,6 +381,7 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::RequestRejitForLoadedModules(
         else
         {
             m_rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
+            m_rejit_handler->RequestRejitForNGenInliners();
         }
     }
 
@@ -423,6 +424,7 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
 
     // Enqueue
     m_work_offloader->Enqueue(std::make_unique<RejitWorkItem>(std::move(action)));
+    m_rejit_handler->RequestRejitForNGenInliners();
 }
 
 // TraceIntegrationRejitPreprocessor


### PR DESCRIPTION
This PR moves `EnumNgenModuleMethodsInliningThisMethod` call from the background thread and use a CLR thread instead.

This may or may not solve the issue with NGEN and .NET Framework when the AppDomain pointer is null. Due the fact we are forcing running that fallback path inside a CLR thread.