### PR TITLE
Update protobuf version to 3.19.4

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">


### PR DESCRIPTION
## Summary of changes

Update protobuf version.

## Reason for change

The dependabot tool in the dd-trace-dotnet repository reported an issue with version < 3.15.4 of protobuf
https://github.com/DataDog/dd-trace-dotnet/security/dependabot/2

## Implementation details

Update the version in the csprof file

## Test coverage

## Other details
<!-- Fixes #{issue} -->
