### PR TITLE
Second attempt to fix flakiness caused by TcpPortProvider.GetOpenPort

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
@@ -71,12 +71,12 @@ namespace Datadog.Trace.TestHelpers
             // Use process and threads ids to try and minimize the chance of collision
             const int startPort = 49152;
             const int endPort = 65535;
-            const int poolSize = 1000; 
+            const int poolSize = 1000;
             int potentialPools = (endPort - startPort) / poolSize;
-            int selectedPool = (Process.GetCurrentProcess().Id.GetHashCode() + 
-                                Thread.CurrentThread.ManagedThreadId.GetHashCode()) 
+            int selectedPool = (Process.GetCurrentProcess().Id.GetHashCode() +
+                                Thread.CurrentThread.ManagedThreadId.GetHashCode())
                                % potentialPools;
-            
+
             return new PortRange() { MinPort = startPort + (poolSize * selectedPool), RangeLength = poolSize };
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
@@ -62,6 +62,10 @@ namespace Datadog.Trace.TestHelpers
                                               .GetActiveTcpListeners()
                                               .Select(ipEndPoint => ipEndPoint.Port);
 
+            usedPorts.Concat(IPGlobalProperties.GetIPGlobalProperties()
+                                               .GetActiveTcpConnections()
+                                               .Select(information => information.LocalEndPoint.Port));
+
             return new HashSet<int>(usedPorts);
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
@@ -69,21 +69,15 @@ namespace Datadog.Trace.TestHelpers
         {
             // Pick an arbitrary segment from the ephemeral port range (49152 – 65535)
             // Use process and threads ids to try and minimize the chance of collision
-            // https://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
             const int startPort = 49152;
             const int endPort = 65535;
-            const int poolSize = endPort - startPort;
-            int hash = 17;
-
-            unchecked
-            {
-                hash = (hash * 23) + Process.GetCurrentProcess().Id.GetHashCode();
-                hash = (hash * 23) + Thread.CurrentThread.ManagedThreadId.GetHashCode();
-            }
-
-            int offset = hash % poolSize;
-            int minPort = startPort + offset;
-            return new PortRange() { MinPort = minPort, RangeLength = endPort - minPort };
+            const int poolSize = 1000; 
+            int potentialPools = (endPort - startPort) / poolSize;
+            int selectedPool = (Process.GetCurrentProcess().Id.GetHashCode() + 
+                                Thread.CurrentThread.ManagedThreadId.GetHashCode()) 
+                               % potentialPools;
+            
+            return new PortRange() { MinPort = startPort + (poolSize * selectedPool), RangeLength = poolSize };
         }
 
         private class PortRange


### PR DESCRIPTION
This is a follow up https://github.com/DataDog/dd-trace-dotnet/pull/2438 . That PR attempted to bring back an old implementation of `TcpPortProvider.GetOpenPort` that was removed as part of #700 (following [several iterations and attempted fixes](https://github.com/DataDog/dd-trace-dotnet/commits/53094f53279a43687c14eb543bf68a99e6ba9a49/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs))

It turns out that implementation was still flakey, as it had a bug where it may decide to select ports from a pool that is too small compared to the large amount of tests that need to run, and so [the pool would be exhausted and an exception was thrown](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=90684&view=logs&j=5a8df16d-5c09-59d6-8b56-ce3e36871bff&t=c41af82a-a4b9-557d-4d8a-38d0d6466d9c). 

This PR attempts to address this issue by hard-coding the size of the pool.