### PR TITLE
Make IntegrationRegistry and DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS case insensitive

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/IntegrationRegistry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationRegistry.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Configuration
         static IntegrationRegistry()
         {
             var values = Enum.GetValues(typeof(IntegrationId));
-            var ids = new Dictionary<string, int>(values.Length);
+            var ids = new Dictionary<string, int>(values.Length, StringComparer.OrdinalIgnoreCase);
 
             Names = new string[values.Cast<int>().Max() + 1];
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -140,25 +140,28 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             foreach (var integrationName in enabledLogShippingIntegrations)
             {
-                if (!IntegrationRegistry.Ids.TryGetValue(integrationName, out var integrationId))
+                if (!IntegrationRegistry.TryGetIntegrationId(integrationName, out var integrationId))
                 {
                     validationErrors.Add(
                         "Unknown integration: " + integrationName +
                         ". Use a valid logs integration name: " +
-                        string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.Names[(int)x])));
+                        string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.GetName(x))));
                     continue;
                 }
 
-                if (!SupportedIntegrations.Contains((IntegrationId)integrationId))
+                if (!SupportedIntegrations.Contains(integrationId))
                 {
                     validationErrors.Add(
                         "Integration: " + integrationName + " is not a supported direct log submission integration. " +
-                        "Use one of " + string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.Names[(int)x])));
+                        "Use one of " + string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.GetName(x))));
                     continue;
                 }
 
-                enabledIntegrationNames.Add(integrationName);
-                enabledIntegrations[integrationId] = true;
+                if (!enabledIntegrations[(int)integrationId])
+                {
+                    enabledIntegrationNames.Add(IntegrationRegistry.GetName(integrationId));
+                    enabledIntegrations[(int)integrationId] = true;
+                }
             }
 
             return new ImmutableDirectLogSubmissionSettings(

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsCollectionTests.cs
@@ -35,6 +35,7 @@ namespace Datadog.Trace.Tests.Configuration
                 { "DD_Wcf_ANALYTICS_ENABLED", "false" },
                 { "DD_Wcf_ANALYTICS_SAMPLE_RATE", "0.2" },
                 { "DD_Msmq_ENABLED", "true" },
+                { "DD_TRACE_stackexchangeredis_ENABLED", "false" },
             });
 
             var disabledIntegrations = new HashSet<string> { "foobar", "MongoDb", "Msmq" };
@@ -66,6 +67,36 @@ namespace Datadog.Trace.Tests.Configuration
 
             var consmos = final[IntegrationId.CosmosDb];
             consmos.Enabled.Should().BeNull();
+
+            var redis = final[IntegrationId.StackExchangeRedis];
+            redis.Enabled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ReturnsIntegrationWhenUsingIncorrectCasing()
+        {
+            var mutable = new IntegrationSettingsCollection(null);
+            var settings = new ImmutableIntegrationSettingsCollection(mutable, new HashSet<string>());
+
+            var log4NetByName = settings["LOG4NET"];
+            var log4NetById = settings[IntegrationId.Log4Net];
+
+            log4NetById.Should().Be(log4NetByName);
+        }
+
+        [Fact]
+        public void ReturnsDefaultSettingsForUnknownIntegration()
+        {
+            var mutable = new IntegrationSettingsCollection(null);
+            var settings = new ImmutableIntegrationSettingsCollection(mutable, new HashSet<string>());
+
+            var integrationName = "blobby";
+            var instance1 = settings[integrationName];
+            instance1.IntegrationName.Should().Be(integrationName);
+            instance1.Enabled.Should().BeNull();
+
+            var instance2 = settings[integrationName];
+            instance2.Should().NotBe(instance1);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationRegistryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationRegistryTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="IntegrationRegistryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class IntegrationRegistryTests
+    {
+        [Fact]
+        public void CanRoundTripIntegrationIds()
+        {
+            using var scope = new AssertionScope();
+            var values = IntegrationRegistry.Ids.Values;
+            values.Should().HaveCountGreaterThan(0);
+
+            foreach (var i in IntegrationRegistry.Ids.Values)
+            {
+                var integrationId = (IntegrationId)i;
+                var name = IntegrationRegistry.GetName(integrationId);
+                IntegrationRegistry.TryGetIntegrationId(name, out var parsedId1).Should().BeTrue();
+                IntegrationRegistry.TryGetIntegrationId(name.ToUpperInvariant(), out var parsedId2).Should().BeTrue();
+                IntegrationRegistry.TryGetIntegrationId(name.ToLowerInvariant(), out var parsedId3).Should().BeTrue();
+
+                parsedId1.Should().Be(integrationId);
+                parsedId2.Should().Be(integrationId);
+                parsedId3.Should().Be(integrationId);
+            }
+        }
+
+        [Fact]
+        public void TryGetIntegrationId_ReturnsFalseForUnknownIntegration()
+        {
+            IntegrationRegistry.TryGetIntegrationId("blobby", out _).Should().BeFalse();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsCollectionTests.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="IntegrationSettingsCollectionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class IntegrationSettingsCollectionTests
+    {
+        [Fact]
+        public void ReturnsIntegrationWhenUsingIncorrectCasing()
+        {
+            var settings = new IntegrationSettingsCollection(null);
+
+            var log4NetByName = settings["LOG4NET"];
+            var log4NetById = settings[nameof(IntegrationId.Log4Net)];
+
+            log4NetById.Should().Be(log4NetByName);
+        }
+
+        [Fact]
+        public void ReturnsDefaultSettingsForUnknownIntegration()
+        {
+            var settings = new IntegrationSettingsCollection(null);
+
+            var integrationName = "blobby";
+            var instance1 = settings[integrationName];
+
+            instance1.IntegrationName.Should().Be(integrationName);
+            instance1.Enabled.Should().BeNull();
+
+            instance1.Enabled = true;
+
+            var instance2 = settings[integrationName];
+            instance2.Should().NotBe(instance1);
+            instance2.IntegrationName.Should().Be(integrationName);
+            instance2.Enabled.Should().BeNull();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -152,5 +152,26 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             logSettings.ValidationErrors.Should().BeEmpty();
             logSettings.EnabledIntegrationNames.Should().Equal(enabledIntegrations);
         }
+
+        [Theory]
+        [InlineData("nlog")]
+        [InlineData("NLOG")]
+        [InlineData("nLog")]
+        [InlineData("Nlog")]
+        [InlineData("NLog")]
+        [InlineData("nLog;nlog;Nlog")]
+        public void EnabledIntegrationsAreCaseInsensitive(string integration)
+        {
+            var config = new NameValueCollection(Defaults);
+            config[ConfigurationKeys.DirectLogSubmission.EnabledIntegrations] = integration;
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(config));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings);
+
+            logSettings.IsEnabled.Should().BeTrue();
+            logSettings.ValidationErrors.Should().BeEmpty();
+            var expected = new List<string> { nameof(IntegrationId.NLog) };
+            logSettings.EnabledIntegrationNames.Should().BeEquivalentTo(expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- `IntegrationRegistry` is now case-insensitive
- Enabling logging frameworks with `DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS` is now case-insensitive

## Reason for change

Game day revealed the case sensitivity as a potential stumbling block for unboarding

## Implementation details

`StringComparer.OrdinalIgnoreCase` 🤷‍♂️ 

## Test coverage

Plenty 😄 

## Other details
Fixes AIT-767
