### PR TITLE
Add a warning to the CLI when a version conflict is detected

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -6,7 +6,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Spectre.Console;
 
 using static Datadog.Trace.Tools.Runner.Checks.Resources;
@@ -34,18 +36,44 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 runtime = ProcessInfo.Runtime.NetFx;
             }
 
-            var modules = FindTracerModules(process);
-
-            if (modules.Profiler == null)
+            if (FindProfilerModule(process) == null)
             {
                 Utils.WriteWarning(ProfilerNotLoaded);
                 foundIssue = true;
             }
 
-            if (modules.Tracer == null)
+            var tracerModules = FindTracerModules(process).ToArray();
+
+            if (tracerModules.Length == 0)
             {
                 Utils.WriteWarning(TracerNotLoaded);
                 foundIssue = true;
+            }
+            else if (tracerModules.Length > 1)
+            {
+                // There are too many tracers in there. Find out if it's bad or very bad
+                bool areAllVersion2 = true;
+                var versions = new HashSet<string>();
+
+                foreach (var tracer in tracerModules)
+                {
+                    var version = FileVersionInfo.GetVersionInfo(tracer);
+
+                    versions.Add(version.FileVersion ?? "{empty}");
+
+                    if (version.FileMajorPart < 2)
+                    {
+                        areAllVersion2 = false;
+                    }
+                }
+
+                Utils.WriteWarning(MultipleTracers(versions));
+
+                if (!areAllVersion2)
+                {
+                    Utils.WriteError(VersionConflict);
+                    foundIssue = true;
+                }
             }
 
             if (process.EnvironmentVariables.TryGetValue("DD_DOTNET_TRACER_HOME", out var tracerHome))
@@ -128,26 +156,33 @@ namespace Datadog.Trace.Tools.Runner.Checks
             }
         }
 
-        private static (string? Profiler, string? Tracer) FindTracerModules(ProcessInfo process)
+        private static string? FindProfilerModule(ProcessInfo process)
         {
-            (string? Profiler, string? Tracer) result = default;
-
             foreach (var module in process.Modules)
             {
                 var fileName = Path.GetFileName(module);
 
-                if (fileName.Equals("datadog.trace.dll", StringComparison.OrdinalIgnoreCase))
-                {
-                    result.Tracer = fileName;
-                }
-                else if (fileName.Equals("Datadog.Trace.ClrProfiler.Native.dll", StringComparison.OrdinalIgnoreCase)
+                if (fileName.Equals("Datadog.Trace.ClrProfiler.Native.dll", StringComparison.OrdinalIgnoreCase)
                     || fileName.Equals("Datadog.Trace.ClrProfiler.Native.so", StringComparison.OrdinalIgnoreCase))
                 {
-                    result.Profiler = fileName;
+                    return module;
                 }
             }
 
-            return result;
+            return null;
+        }
+
+        private static IEnumerable<string> FindTracerModules(ProcessInfo process)
+        {
+            foreach (var module in process.Modules)
+            {
+                var fileName = Path.GetFileName(module);
+
+                if (fileName.Equals("Datadog.Trace.dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return module;
+                }
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessEnvironment.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessEnvironment.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 // On Windows, Process.Modules misses some dynamically loaded assemblies
-                return modules.Union(Windows.OpenFiles.GetOpenFiles(process.Id)).Distinct().ToArray()!;
+                return modules.Union(Windows.OpenFiles.GetOpenFiles(process.Id)).Distinct(StringComparer.OrdinalIgnoreCase).ToArray()!;
             }
 
             return modules!;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
         public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
-        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed MSI version.";
+        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Text;
 
@@ -26,6 +27,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
         public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
+        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace nuget version with the installed MSI version.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
@@ -78,6 +80,22 @@ namespace Datadog.Trace.Tools.Runner.Checks
             foreach (var app in availableApplications)
             {
                 sb.AppendLine($" - {app}");
+            }
+
+            return sb.ToString();
+        }
+
+        public static string MultipleTracers(IEnumerable<string> versions)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("Found multiple instances of Datadog.Trace.dll in the target process.");
+            sb.AppendLine("Detected versions:");
+
+            // The ordering is not required but makes the output consistent for tests
+            foreach (var version in versions.OrderBy(v => v))
+            {
+                sb.AppendLine($"- {version}");
             }
 
             return sb.ToString();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
         public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
-        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace nuget version with the installed MSI version.";
+        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed MSI version.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ConsoleTestHelper.cs
@@ -20,11 +20,16 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
         }
 
-        protected async Task<ProcessHelper> StartConsole(bool enableProfiler, params (string Key, string Value)[] environmentVariables)
+        protected Task<ProcessHelper> StartConsole(bool enableProfiler, params (string Key, string Value)[] environmentVariables)
         {
-            string sampleAppPath = EnvironmentHelper.GetSampleApplicationPath();
-            var executable = EnvironmentHelper.IsCoreClr() ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
-            var args = EnvironmentHelper.IsCoreClr() ? sampleAppPath : string.Empty;
+            return StartConsole(EnvironmentHelper, enableProfiler, environmentVariables);
+        }
+
+        protected async Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, params (string Key, string Value)[] environmentVariables)
+        {
+            string sampleAppPath = environmentHelper.GetSampleApplicationPath();
+            var executable = EnvironmentHelper.IsCoreClr() ? environmentHelper.GetSampleExecutionSource() : sampleAppPath;
+            var args = EnvironmentHelper.IsCoreClr() ? $"{sampleAppPath} wait" : "wait";
 
             var processStart = new ProcessStartInfo(executable, args)
             {
@@ -39,7 +44,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             {
                 agent = new MockTracerAgent();
 
-                EnvironmentHelper.SetEnvironmentVariables(
+                environmentHelper.SetEnvironmentVariables(
                     agent,
                     aspNetCorePort: 1000,
                     processStart.Environment);

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Tools.Runner.Checks;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -51,6 +52,26 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 #endif
 
             console.Output.Should().Contain(expectedOutput);
+        }
+
+        [Fact]
+        public async Task VersionConflict1X()
+        {
+            var environmentHelper = new EnvironmentHelper("VersionConflict.1x", typeof(TestHelper), Output);
+            using var helper = await StartConsole(environmentHelper, enableProfiler: true);
+            var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
+
+            processInfo.Should().NotBeNull();
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = ProcessBasicCheck.Run(processInfo);
+
+            result.Should().BeFalse();
+
+            console.Output.Should().Contain(VersionConflict);
+
+            console.Output.Should().Contain(MultipleTracers(new[] { "1.29.0.0", TracerConstants.AssemblyVersion }));
         }
 
         [Fact]

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Diagnostics;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
 
@@ -7,7 +9,7 @@ namespace Samples.VersionConflict_1x
 {
     class Program
     {
-        static async Task Main()
+        static async Task Main(string[] args)
         {
             using (WebServer.Start(out var url))
             {
@@ -28,6 +30,12 @@ namespace Samples.VersionConflict_1x
 
                         scope.Span.SetTag(Tags.SamplingPriority, "UserReject");
                     }
+                }
+
+                if (args.Length > 0 && args[0] == "wait")
+                {
+                    Console.WriteLine($"Waiting - PID: {Process.GetCurrentProcess().Id}");
+                    Thread.Sleep(Timeout.Infinite);
                 }
             }
         }

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
 
@@ -8,7 +10,7 @@ namespace Samples.VersionConflict_2x
 {
     class Program
     {
-        static async Task Main()
+        static async Task Main(string[] args)
         {
             using var server = WebServer.Start(out var url);
             
@@ -47,6 +49,12 @@ namespace Samples.VersionConflict_2x
 
                     _ = await client.GetStringAsync(url + "/b");
                 }
+            }
+
+            if (args.Length > 0 && args[0] == "wait")
+            {
+                Console.WriteLine($"Waiting - PID: {Process.GetCurrentProcess().Id}");
+                Thread.Sleep(Timeout.Infinite);
             }
         }
     }


### PR DESCRIPTION
With this change, the process check detects when the tracer is loaded multiple times and shows a warning. It also shows an error message if one of the Datadog.Trace.dll is version 1.x.