### PR TITLE
Add support for aspnetcore sites hosted out of process

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -135,28 +135,17 @@ namespace Datadog.Trace.Tools.Runner
 
                     var childProcesses = process.GetChildProcesses();
 
-                    int? aspnetCorePid = null;
-
-                    foreach (var childPid in childProcesses)
-                    {
-                        using var childProcess = Process.GetProcessById(childPid);
-
-                        if (childProcess.ProcessName.Equals("dotnet", StringComparison.OrdinalIgnoreCase))
-                        {
-                            aspnetCorePid = childPid;
-                            break;
-                        }
-                    }
-
-                    if (aspnetCorePid == null)
+                    if (childProcesses.Count == 0)
                     {
                         Utils.WriteError(AspNetCoreProcessNotFound);
                         return 1;
                     }
 
-                    AnsiConsole.WriteLine(AspNetCoreProcessFound(aspnetCorePid.Value));
+                    var aspnetCorePid = childProcesses[0];
 
-                    process = ProcessInfo.GetProcessInfo(aspnetCorePid.Value);
+                    AnsiConsole.WriteLine(AspNetCoreProcessFound(aspnetCorePid));
+
+                    process = ProcessInfo.GetProcessInfo(aspnetCorePid);
 
                     if (process == null)
                     {

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Tools.Runner
                 if (process.Modules.Any(m => Path.GetFileName(m).Equals("aspnetcorev2_outofprocess.dll", StringComparison.OrdinalIgnoreCase)))
                 {
                     // IIS site is hosting aspnetcore in out-of-process mode
-                    // Trying to locate the actual applicative process
+                    // Trying to locate the actual application process
                     AnsiConsole.WriteLine(OutOfProcess);
 
                     var childProcesses = process.GetChildProcesses();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -27,6 +27,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
         public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
+        public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
+        public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
@@ -54,6 +56,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public static string InspectingWorkerProcess(int pid) => $"Inspecting worker process {pid}";
 
         public static string ErrorExtractingConfiguration(string error) => $"Could not extract configuration from site: {error}";
+
+        public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
 
         public static string CouldNotFindSite(string site, IEnumerable<string> availableSites)
         {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -69,6 +69,7 @@
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
+    <PackageReference Include="System.Management" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -19,15 +19,11 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 {
     [Collection(nameof(ConsoleTestsCollection))]
-    public class IisCheckTests : TestHelper, IClassFixture<IisFixture>
+    public class IisCheckTests : TestHelper
     {
-        private readonly IisFixture _iisFixture;
-
-        public IisCheckTests(IisFixture iisFixture, ITestOutputHelper output)
+        public IisCheckTests(ITestOutputHelper output)
             : base("AspNetCoreMvc31", output)
         {
-            _iisFixture = iisFixture;
-            _iisFixture.ShutdownPath = "/shutdown";
         }
 
         [SkippableTheory]
@@ -46,15 +42,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 // GacFixture is not compatible with .NET Core, use the Nuke target instead
                 Process.Start("powershell", $"{buildPs1} GacAdd --framework net461").WaitForExit();
 
-                _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+                using var iisFixture = CreateIisFixture();
+
+                iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
 
                 // Send a request to initialize the app
                 using var httpClient = new HttpClient();
-                await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+                await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
 
                 using var console = ConsoleHelper.Redirect();
 
-                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = siteName }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = siteName }, iisFixture.IisExpress.ConfigFile, iisFixture.IisExpress.Process.Id);
 
                 result.Should().Be(0);
 
@@ -83,15 +81,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 // GacFixture is not compatible with .NET Core, use the Nuke target instead
                 Process.Start("powershell", $"{buildPs1} GacAdd --framework net461").WaitForExit();
 
-                _iisFixture.TryStartIis(this, IisAppType.AspNetCoreOutOfProcess);
+                using var iisFixture = CreateIisFixture();
+
+                iisFixture.TryStartIis(this, IisAppType.AspNetCoreOutOfProcess);
 
                 // Send a request to initialize the app
                 using var httpClient = new HttpClient();
-                await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+                await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
 
                 using var console = ConsoleHelper.Redirect();
 
-                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, iisFixture.IisExpress.ConfigFile, iisFixture.IisExpress.Process.Id);
 
                 result.Should().Be(0);
 
@@ -110,15 +110,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+            using var iisFixture = CreateIisFixture();
+
+            iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
 
             // Send a request to initialize the app
             using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, iisFixture.IisExpress.ConfigFile, iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 
@@ -130,15 +132,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+            using var iisFixture = CreateIisFixture();
+
+            iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
 
             // Send a request to initialize the app
             using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "dummySite" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "dummySite" }, iisFixture.IisExpress.ConfigFile, iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 
@@ -150,15 +154,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            _iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
+            using var iisFixture = CreateIisFixture();
+
+            iisFixture.TryStartIis(this, IisAppType.AspNetCoreInProcess);
 
             // Send a request to initialize the app
             using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{_iisFixture.HttpPort}/");
+            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample/dummy" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample/dummy" }, iisFixture.IisExpress.ConfigFile, iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 
@@ -172,6 +178,13 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             {
                 throw new SkipException();
             }
+        }
+
+        private static IisFixture CreateIisFixture()
+        {
+            var fixture = new IisFixture();
+            fixture.ShutdownPath = "/shutdown";
+            return fixture;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -43,11 +43,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 // GacFixture is not compatible with .NET Core, use the Nuke target instead
                 Process.Start("powershell", $"{buildPs1} GacAdd --framework net461").WaitForExit();
 
-                using var iisFixture = StartIis(IisAppType.AspNetCoreInProcess);
-
-                // Send a request to initialize the app
-                using var httpClient = new HttpClient();
-                await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
+                using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
 
                 using var console = ConsoleHelper.Redirect();
 
@@ -80,11 +76,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 // GacFixture is not compatible with .NET Core, use the Nuke target instead
                 Process.Start("powershell", $"{buildPs1} GacAdd --framework net461").WaitForExit();
 
-                using var iisFixture = StartIis(IisAppType.AspNetCoreOutOfProcess);
-
-                // Send a request to initialize the app
-                using var httpClient = new HttpClient();
-                await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
+                using var iisFixture = await StartIis(IisAppType.AspNetCoreOutOfProcess);
 
                 using var console = ConsoleHelper.Redirect();
 
@@ -107,11 +99,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            using var iisFixture = StartIis(IisAppType.AspNetCoreInProcess);
-
-            // Send a request to initialize the app
-            using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
+            using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
 
             using var console = ConsoleHelper.Redirect();
 
@@ -127,11 +115,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            using var iisFixture = StartIis(IisAppType.AspNetCoreInProcess);
-
-            // Send a request to initialize the app
-            using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
+            using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
 
             using var console = ConsoleHelper.Redirect();
 
@@ -147,11 +131,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             EnsureWindowsAndX64();
 
-            using var iisFixture = StartIis(IisAppType.AspNetCoreInProcess);
-
-            // Send a request to initialize the app
-            using var httpClient = new HttpClient();
-            await httpClient.GetAsync($"http://localhost:{iisFixture.HttpPort}/");
+            using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
 
             using var console = ConsoleHelper.Redirect();
 
@@ -165,13 +145,13 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         private static void EnsureWindowsAndX64()
         {
             if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
-                || System.IntPtr.Size != 8)
+                || IntPtr.Size != 8)
             {
                 throw new SkipException();
             }
         }
 
-        private IisFixture StartIis(IisAppType appType)
+        private async Task<IisFixture> StartIis(IisAppType appType)
         {
             var fixture = new IisFixture { ShutdownPath = "/shutdown" };
 
@@ -184,6 +164,10 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 fixture.Dispose();
                 throw;
             }
+
+            // Send a request to initialize the app
+            using var httpClient = new HttpClient();
+            await httpClient.GetAsync($"http://localhost:{fixture.HttpPort}/");
 
             return fixture;
         }


### PR DESCRIPTION
Without this change, the CLI would fail to detect the profiler/tracer in an aspnetcore site using out-of-process hosting, because they are loaded in the child process.