### PR TITLE
Enable telemetry when sending directly to the intake by default

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -13,15 +13,16 @@ namespace Datadog.Trace.Telemetry
     {
         public TelemetrySettings(IConfigurationSource source, ImmutableTracerSettings tracerSettings)
         {
-            TelemetryEnabled = source?.GetBool(ConfigurationKeys.Telemetry.Enabled)
-                            ?? false; // disabled by default
+            var explicitlyEnabled = source?.GetBool(ConfigurationKeys.Telemetry.Enabled);
+            TelemetryEnabled = explicitlyEnabled ?? false;
 
             var apiKey = source?.GetString(ConfigurationKeys.ApiKey);
 
-            if (TelemetryEnabled && !string.IsNullOrEmpty(apiKey))
+            if (explicitlyEnabled != false && !string.IsNullOrEmpty(apiKey))
             {
                 // We have an API key, so try to send directly to intake
                 ApiKey = apiKey;
+                TelemetryEnabled = true;
 
                 var requestedTelemetryUri = source?.GetString(ConfigurationKeys.Telemetry.Uri);
                 if (!string.IsNullOrEmpty(requestedTelemetryUri)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Tests.Telemetry
 
         [Theory]
         [InlineData(null, null, false)]
-        [InlineData("SOMEKEY", null, false)]
+        [InlineData("SOMEKEY", null, true)]
         [InlineData(null, "0", false)]
         [InlineData("SOMEKEY", "0", false)]
         [InlineData(null, "1", true)]


### PR DESCRIPTION
The intake is going to be enabled to support the feature, so it's ok to be enabled

@DataDog/apm-dotnet 