### PR TITLE
Log a message when the process is killed

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -177,6 +177,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     if (!process.WaitForExit(5000))
                     {
+                        Output.WriteLine("The process didn't exit in time. Killing it.");
                         process.Kill();
                     }
                 }


### PR DESCRIPTION
There is at least one occurrence of the GraphQL test failing because the last telemetry span is missing. Add a message to see if we just timed out when waiting for the process to exit gracefully or if it's something more serious.