### PR TITLE
Disable runtime metrics tests for netcoreapp 3.1

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+// Disabled on .NET Core 3.1 as we were running into this issue: https://github.com/dotnet/runtime/issues/51579
 #if NET5_0_OR_GREATER
 using System;
 using System.Collections.Generic;

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NETCOREAPP3_1 || NET5_0
+#if NET5_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;


### PR DESCRIPTION
It looks like https://github.com/DataDog/dd-trace-dotnet/pull/2227 wasn't enough, the tests are still occasionally deadlocking. 