### PR TITLE
Fix missing `http.status_code` tag on ASP.NET Core spans with errors

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -48,6 +48,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             { "/ping", 200 },
             { "/branch/ping", 200 },
             { "/branch/not-found", 404 },
+            { "/handled-exception", 500 },
         };
 
         protected string GetTestName(string testName)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -63,6 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             { "/ping", 200 },
             { "/branch/ping", 200 },
             { "/branch/not-found", 404 },
+            { "/handled-exception", 500 },
         };
 
         public void Dispose()

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,55 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,37 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,60 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,37 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,59 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,37 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,60 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,37 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,0 +1,60 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet_core.action: handledexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: Exception of type 'System.Exception' was thrown.,
+      error.stack:
+System.Exception: Exception of type 'System.Exception' was thrown.
+,
+      error.type: System.Exception,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /handled-exception,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.HandledException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: handled-exception,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/handled-exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21/Controllers/HomeController.cs
@@ -75,6 +75,21 @@ namespace Samples.AspNetCoreMvc.Controllers
             }
         }
 
+        [Route("handled-exception")]
+        public IActionResult HandledException(string input)
+        {
+            AddCorrelationIdentifierToResponse();
+            try
+            {
+                throw new Exception("Exception thrown and caught");
+            }
+            catch (Exception ex)
+            {
+                SampleHelpers.TrySetExceptionOnActiveScope(ex);
+                return StatusCode(500, new { user_message = "There was an error, returning 500: " + ex.Message });
+            }
+        }
+
         [Route("alive-check")]
         public string IsAlive()
         {


### PR DESCRIPTION
## Summary of changes

- Ensure that we always set the `http.status_code` flag on ASP.NET Core spans
- Small sample helper for setting an exception on the active span using reflection.

## Reason for change

If the customer marks the root aspnetcore request `Span` as an error (e.g. using `Tracer.ActiveScope.Span.SetException(ex)`), currently we _don't_ record the HTTP status code on response end. As a 200 response is assumed in these cases, we have error spans with the wrong status code.

This is especially likely to occur when the customer is _not_ using `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` (i.e. the default in v1.x), as in these cases we only create a single aspnetcore span. When the feature flag is enabled (the default in v2.x), calling `Tracer.ActiveScope.Span.SetException(ex)` sets the error on the _inner_ span, and so we record the final status code correctly.

> As part of the fix, spotted #2460

## Implementation details

If an exception occurs in the pipeline and isn't handled, the `OnHostingUnhandledException` handler will record an appropriate status code. It needs to do some inferring of the final status code, as Kestrel may change the result _after_ the pipeline has finished. Previously, we were using the presence of an error on the span to control whether to set the HTTP status code, to avoid overwriting with the wrong value.

Instead, we now check to see if the status code has been set at all. If it hasn't, we set it. This fixes the bug, without requiring any significant changes.

## Test coverage

Added an additional endpoint for testing this situation. Created snapshots for the _expected_ results, confirmed they were missing the status code, then made the fix and confirmed it resolved. 

## Other details
Fixes APMS-6804

@DataDog/apm-dotnet 
