### PR TITLE
[wip] track sampling mechanism and sampling rate

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Microsoft.Build.Framework;
 
@@ -102,7 +103,7 @@ namespace Datadog.Trace.MSBuild
 
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
                 _buildSpan.SetMetric(Tags.Analytics, 1.0d);
-                _buildSpan.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
+                _buildSpan.SetTraceSamplingDecision(SamplingPriorityValues.AutoKeep, SamplingMechanism.CiApp);
 
                 _buildSpan.Type = SpanTypes.Build;
                 _buildSpan.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
@@ -182,7 +183,7 @@ namespace Datadog.Trace.MSBuild
                 }
 
                 projectSpan.ResourceName = projectName;
-                projectSpan.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
+                projectSpan.SetTraceSamplingDecision(SamplingPriorityValues.AutoKeep, SamplingMechanism.CiApp);
                 projectSpan.Type = SpanTypes.Build;
 
                 foreach (KeyValuePair<string, string> prop in e.GlobalProperties)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Spectre.Console;
 
@@ -103,7 +104,6 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                         Span span = tracer.StartSpan("crank.test", startTime: minTimeStamp, serviceName: "crank");
 
-                        span.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
                         span.Type = SpanTypes.Test;
                         span.ResourceName = $"{fileName}/{jobItem.Key}";
                         CIEnvironmentValues.Instance.DecorateSpan(span);
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
                         span.SetTag(TestTags.Name, jobItem.Key);
                         span.SetTag(TestTags.Type, TestTags.TypeBenchmark);
                         span.SetTag(TestTags.Suite, $"Crank.{fileName}");
-                        span.SetTag(TestTags.Framework, $"Crank");
+                        span.SetTag(TestTags.Framework, "Crank");
                         span.SetTag(TestTags.Status, result.ReturnCode == 0 ? TestTags.StatusPass : TestTags.StatusFail);
 
                         if (result.JobResults.Properties?.Count > 0)

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -17,6 +17,7 @@ using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -283,7 +284,8 @@ namespace Datadog.Trace.AppSec
             {
                 // NOTE: DD_APPSEC_KEEP_TRACES=false means "drop all traces by setting AutoReject".
                 // It does _not_ mean "stop setting UserKeep (do nothing)". It should only be used for testing.
-                span.SetTraceSamplingPriority(_settings.KeepTraces ? SamplingPriorityValues.UserKeep : SamplingPriorityValues.AutoReject);
+                var samplingPriority = _settings.KeepTraces ? SamplingPriorityValues.UserKeep : SamplingPriorityValues.AutoReject;
+                span.SetTraceSamplingDecision(samplingPriority, SamplingMechanism.AppSec);
             }
             else
             {
@@ -291,7 +293,7 @@ namespace Datadog.Trace.AppSec
 
                 if (!_settings.KeepTraces)
                 {
-                    span.SetTraceSamplingPriority(SamplingPriorityValues.AutoReject);
+                    span.SetTraceSamplingDecision(SamplingPriorityValues.AutoReject, SamplingMechanism.AppSec);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
@@ -10,9 +10,9 @@ namespace Datadog.Trace.Ci.Sampling
 {
     internal class CISampler : ISampler
     {
-        public int GetSamplingPriority(Span span)
+        public SamplingDecision MakeSamplingDecision(Span span)
         {
-            return SamplingPriorityValues.UserKeep;
+            return new SamplingDecision(SamplingPriorityValues.UserKeep, SamplingMechanism.CiApp);
         }
 
         public void RegisterRule(ISamplingRule rule)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 {
@@ -76,14 +77,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                     if (scope is not null)
                     {
-                        if (setSamplingPriority && existingSpanContext?.SamplingPriority is not null)
+                        var span = scope.Span;
+
+                        if (setSamplingPriority)
                         {
-                            scope.Span.SetTraceSamplingPriority(existingSpanContext.SamplingPriority.Value);
+                            // TODO: figure out SamplingMechanism, do we propagate that as well for special cases like this?
+                            span.SetTraceSamplingDecision(existingSpanContext.SamplingPriority.Value, SamplingMechanism.Unknown);
                         }
 
                         if (returnValue is HttpWebResponse response)
                         {
-                            scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.Settings);
+                            span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.Settings);
                         }
 
                         scope.DisposeWithException(exception);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -9,6 +9,7 @@ using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 {
@@ -56,7 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority && spanContext?.SamplingPriority is not null)
                         {
-                            scope.Span.SetTraceSamplingPriority(spanContext.SamplingPriority.Value);
+                            // TODO: figure out SamplingMechanism, do we propagate that as well for special cases like this?
+                            scope.Span.SetTraceSamplingDecision(spanContext.SamplingPriority.Value, SamplingMechanism.Unknown);
                         }
 
                         // add distributed tracing headers to the HTTP request

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
 {
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
+            span.SetTraceSamplingDecision(SamplingPriorityValues.AutoKeep, SamplingMechanism.CiApp);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Bundle, testBundle);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 {
@@ -54,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
+            span.SetTraceSamplingDecision(SamplingPriorityValues.AutoKeep, SamplingMechanism.CiApp);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Bundle, testBundle);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 {
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
+            span.SetTraceSamplingDecision(SamplingPriorityValues.AutoKeep, SamplingMechanism.CiApp);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Bundle, testBundle);

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Sampling;
+
 namespace Datadog.Trace.ClrProfiler
 {
     /// <summary>
@@ -13,17 +15,13 @@ namespace Datadog.Trace.ClrProfiler
     {
         public int? GetSamplingPriority()
         {
-            return Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext?.SamplingPriority;
+            return Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext?.SamplingDecision?.Priority;
         }
 
         public void SetSamplingPriority(int? samplingPriority)
         {
-            var traceContext = Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext;
-
-            if (traceContext != null)
-            {
-                traceContext.SetSamplingPriority(samplingPriority, notifyDistributedTracer: false);
-            }
+            Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext
+                 ?.SetSamplingDecision(samplingPriority, SamplingMechanism.Unknown, notifyDistributedTracer: false);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -117,7 +117,8 @@ namespace Datadog.Trace.ClrProfiler
                 if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
                 {
                     // If we don't add the span to the trace context, then we need to manually call the sampler
-                    span.Context.TraceContext.SetSamplingPriority(tracer.TracerManager.Sampler?.GetSamplingPriority(span));
+                    var samplingDecision = tracer.TracerManager.Sampler?.MakeSamplingDecision(span);
+                    span.Context.TraceContext.SetSamplingPriority(samplingDecision?.Priority);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -114,11 +114,11 @@ namespace Datadog.Trace.ClrProfiler
 
                 tags.SetAnalyticsSampleRate(integrationId, tracer.Settings, enabledWithGlobalSetting: false);
 
-                if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
+                if (!addToTraceContext && span.Context.TraceContext.SamplingDecision == null)
                 {
                     // If we don't add the span to the trace context, then we need to manually call the sampler
                     var samplingDecision = tracer.TracerManager.Sampler?.MakeSamplingDecision(span);
-                    span.Context.TraceContext.SetSamplingPriority(samplingDecision?.Priority);
+                    span.Context.TraceContext.SetSamplingDecision(samplingDecision);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -34,11 +34,6 @@ namespace Datadog.Trace.ExtensionMethods
             SetTraceSamplingDecision(span, (int)samplingPriority, SamplingMechanism.Manual);
         }
 
-        internal static void SetTraceSamplingPriority(this ISpan span, int samplingPriority)
-        {
-            SetTraceSamplingDecision(span, samplingPriority, SamplingMechanism.Unknown);
-        }
-
         /// <summary>
         /// Sets the sampling priority for the trace that contains the specified <see cref="ISpan"/>.
         /// </summary>

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Sampling
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
@@ -24,18 +25,34 @@ namespace Datadog.Trace.ExtensionMethods
         /// </summary>
         /// <param name="span">A span that belongs to the trace.</param>
         /// <param name="samplingPriority">The new sampling priority for the trace.</param>
+        /// <remarks>
+        /// This public method is for SDK users only (aka custom instrumentation).
+        /// Internal Datadog calls should use SetTraceSamplingDecision(this ISpan, SamplingPriority, SamplingMechanism).
+        /// </remarks>
         public static void SetTraceSamplingPriority(this ISpan span, SamplingPriority samplingPriority)
         {
-            span.SetTraceSamplingPriority((int)samplingPriority);
+            SetTraceSamplingDecision(span, (int)samplingPriority, SamplingMechanism.Manual);
         }
 
         internal static void SetTraceSamplingPriority(this ISpan span, int samplingPriority)
         {
+            SetTraceSamplingDecision(span, samplingPriority, SamplingMechanism.Unknown);
+        }
+
+        /// <summary>
+        /// Sets the sampling priority for the trace that contains the specified <see cref="ISpan"/>.
+        /// </summary>
+        /// <param name="span">A span that belongs to the trace.</param>
+        /// <param name="priority">The new sampling priority for the trace.</param>
+        /// <param name="mechanism">The new sampling mechanism for the trace.</param>
+        /// <param name="rate">Optional. The sampling rate, if used.</param>
+        internal static void SetTraceSamplingDecision(this ISpan span, int priority, int mechanism, float? rate = null)
+        {
             if (span == null) { ThrowHelper.ThrowArgumentNullException(nameof(span)); }
 
-            if (span.Context is SpanContext spanContext && spanContext.TraceContext != null)
+            if (span.Context is SpanContext { TraceContext: { } traceContext })
             {
-                spanContext.TraceContext.SetSamplingPriority(samplingPriority);
+                traceContext.SetSamplingDecision(priority, mechanism, rate);
             }
         }
 

--- a/tracer/src/Datadog.Trace/HttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/HttpHeaderNames.cs
@@ -26,6 +26,18 @@ namespace Datadog.Trace
         public const string SamplingPriority = "x-datadog-sampling-priority";
 
         /// <summary>
+        /// Used to propagate sampling mechanism across tracer versions in the same process,
+        /// not for propagation across process boundaries.
+        /// </summary>
+        internal const string SamplingMechanism = "x-datadog-sampling-mechanism";
+
+        /// <summary>
+        /// Used to propagate sampling mechanism across tracer versions in the same process,
+        /// not for propagation across process boundaries.
+        /// </summary>
+        internal const string SamplingRate = "x-datadog-sampling-rate";
+
+        /// <summary>
         /// If header is set to "false", tracing is disabled for that http request.
         /// Tracing is enabled by default.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Sampling
         private readonly string _serviceNameRegex;
         private readonly string _operationNameRegex;
 
-        private bool _hasPoisonedRegex = false;
+        private bool _hasPoisonedRegex;
 
         public CustomSamplingRule(
             float rate,
@@ -36,6 +36,8 @@ namespace Datadog.Trace.Sampling
         }
 
         public string RuleName { get; }
+
+        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.Rule;
 
         /// <summary>
         /// Gets or sets the priority of the rule.

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -14,9 +14,11 @@ namespace Datadog.Trace.Sampling
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DefaultSamplingRule>();
 
-        private Dictionary<SampleRateKey, float> _sampleRates = new Dictionary<SampleRateKey, float>();
+        private Dictionary<SampleRateKey, float> _sampleRates = new();
 
         public string RuleName => "default-rule";
+
+        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.AgentRate;
 
         /// <summary>
         /// Gets the lowest possible priority

--- a/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Sampling
@@ -26,6 +24,8 @@ namespace Datadog.Trace.Sampling
         /// Gets the priority which is one beneath custom rules.
         /// </summary>
         public int Priority => 0;
+
+        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.Rule;
 
         public bool IsMatch(Span span)
         {

--- a/tracer/src/Datadog.Trace/Sampling/ISampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ISampler.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Sampling
     {
         void SetDefaultSampleRates(IEnumerable<KeyValuePair<string, float>> sampleRates);
 
-        int GetSamplingPriority(Span span);
+        SamplingDecision MakeSamplingDecision(Span span);
 
         void RegisterRule(ISamplingRule rule);
     }

--- a/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         int Priority { get; }
 
+        int SamplingMechanism { get; }
+
         bool IsMatch(Span span);
 
         float GetSamplingRate(Span span);

--- a/tracer/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Sampling
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RateLimiter>();
 
-        private readonly ConcurrentQueue<DateTime> _intervalQueue = new ConcurrentQueue<DateTime>();
+        private readonly ConcurrentQueue<DateTime> _intervalQueue = new();
 
         private readonly int _maxTracesPerInterval;
         private readonly int _intervalMilliseconds;

--- a/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Sampling
             _defaultRule.SetDefaultSampleRates(sampleRates);
         }
 
-        public int GetSamplingPriority(Span span)
+        public SamplingDecision MakeSamplingDecision(Span span)
         {
             var traceId = span.TraceId;
 
@@ -47,14 +47,13 @@ namespace Datadog.Trace.Sampling
                             sampleRate,
                             traceId);
 
-                        return GetSamplingPriority(span, sampleRate, agentSampling: rule is DefaultSamplingRule);
+                        return MakeSamplingDecision(span, sampleRate, rule.SamplingMechanism);
                     }
                 }
             }
 
             Log.Debug("No rules matched for trace {TraceId}", traceId);
-
-            return SamplingPriorityValues.AutoKeep;
+            return SamplingDecision.Default;
         }
 
         /// <summary>
@@ -77,21 +76,23 @@ namespace Datadog.Trace.Sampling
             _rules.Add(rule);
         }
 
-        private int GetSamplingPriority(Span span, float rate, bool agentSampling)
+        private SamplingDecision MakeSamplingDecision(Span span, float rate, int mechanism)
         {
             // make a sampling decision as a function of traceId and sampling rate
             var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
 
-            // legacy sampling based on data from agent
-            if (agentSampling)
-            {
-                return sample ? SamplingPriorityValues.AutoKeep : SamplingPriorityValues.AutoReject;
-            }
+            var priority = mechanism switch
+                           {
+                               // default sampling rule based on sampling rates from agent response.
+                               // if sampling decision was made automatically without any input from user, use AutoKeep/AutoReject.
+                               SamplingMechanism.AgentRate => sample ? SamplingPriorityValues.AutoKeep : SamplingPriorityValues.AutoReject,
 
-            // rules-based sampling + rate limiter
-            // NOTE: all tracers are changing this from AutoKeep/AutoReject to UserKeep/UserReject
-            // to prevent the agent from overriding user configuration
-            return sample && _limiter.Allowed(span) ? SamplingPriorityValues.UserKeep : SamplingPriorityValues.UserReject;
+                               // sampling rule based on user configuration (DD_TRACE_SAMPLE_RATE, DD_TRACE_SAMPLING_RULES).
+                               // if user influenced sampling decision in any way (manually, rules, rates, etc), use UserKeep/UserReject.
+                               _ => sample && _limiter.Allowed(span) ? SamplingPriorityValues.UserKeep : SamplingPriorityValues.UserReject
+                           };
+
+            return new SamplingDecision(priority, mechanism, rate);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/SamplingDecision.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingDecision.cs
@@ -1,0 +1,36 @@
+// <copyright file="SamplingDecision.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Sampling;
+
+internal readonly struct SamplingDecision
+{
+    /// <summary>
+    /// The default sampling decision used as a fall back when there are no matching sampling rates or rules.
+    /// </summary>
+    public static readonly SamplingDecision Default = new(SamplingPriorityValues.AutoKeep, SamplingMechanism.Default, rate: null);
+
+    public readonly int Priority;
+
+    public readonly int Mechanism;
+
+    public readonly double? Rate;
+
+    public SamplingDecision(int priority, int mechanism, double? rate = null)
+    {
+        Priority = priority;
+        Mechanism = mechanism;
+        Rate = rate;
+    }
+
+    public void Deconstruct(out int priority, out int mechanism, out double? rate)
+    {
+        priority = Priority;
+        mechanism = Mechanism;
+        rate = Rate;
+    }
+}

--- a/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
@@ -1,0 +1,83 @@
+﻿// <copyright file="SamplingMechanism.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Sampling;
+
+/// <summary>
+/// The mechanism used to make a trace sampling decision.
+/// </summary>
+internal static class SamplingMechanism
+{
+    /// <summary>
+    /// No sampling decision was made; or it was made with an unknown mechanism.
+    /// </summary>
+    public const int Unknown = -1;
+
+    /// <summary>
+    /// Sampling decision was made using the default mechanism.
+    /// The available sampling priorities are <see cref="SamplingPriority.AutoReject"/> (0)
+    /// and <see cref="SamplingPriority.AutoKeep"/> (1).
+    /// </summary>
+    public const int Default = 0;
+
+    /// <summary>
+    /// A sampling decision was made using a sampling rate computed automatically by the Agent.
+    /// The available sampling priorities are <see cref="SamplingPriority.AutoReject"/> (0)
+    /// and <see cref="SamplingPriority.AutoKeep"/> (1).
+    /// </summary>
+    public const int AgentRate = 1;
+
+    /// <summary>
+    /// A sampling decision was made using a sampling rate computed automatically by the backend.
+    /// The available sampling priorities are <see cref="SamplingPriority.AutoReject"/> (0)
+    /// and <see cref="SamplingPriority.AutoKeep"/> (1).
+    /// </summary>
+    public const int RemoteRateAuto = 2;
+
+    /// <summary>
+    /// A sampling decision was made using a sampling rule or
+    /// the global sampling rate configured by the user on the tracer.
+    /// The available sampling priorities are <see cref="SamplingPriority.UserReject"/> (-1)
+    /// and <see cref="SamplingPriority.UserKeep"/> (2).
+    /// </summary>
+    public const int Rule = 3;
+
+    /// <summary>
+    /// A sampling decision was made manually by the user.
+    /// The available sampling priorities are <see cref="SamplingPriority.UserReject"/> (-1)
+    /// and <see cref="SamplingPriority.UserKeep"/> (2).
+    /// </summary>
+    public const int Manual = 4;
+
+    /// <summary>
+    /// A sampling decision was made by AppSec; probably due to a security event.
+    /// The sampling priority is always <see cref="SamplingPriority.UserKeep"/> (2).
+    /// </summary>
+    public const int AppSec = 5;
+
+    /// <summary>
+    /// A sampling decision was made using a sampling rule configured remotely by the user.
+    /// The available sampling priorities are <see cref="SamplingPriority.UserReject"/> (-1)
+    /// and <see cref="SamplingPriority.UserKeep"/> (2).
+    /// </summary>
+    public const int RemoteRateUser = 6;
+
+    /// <summary>
+    /// A sampling decision was made using a sampling rule configured remotely by Datadog.
+    /// The available sampling priorities are [TBD].
+    /// </summary>
+    public const int RemoteRateDatadog = 7;
+
+    /// <summary>
+    /// CIApp does not have a defined mechanism value; so default to <see cref="Unknown"/> for now.
+    /// </summary>
+    public const int CiApp = Unknown;
+
+    /// <summary>
+    /// The sampling decision was made by an upstream service and propagated to this service.
+    /// The sampling mechanism is undefined and irrelevant in this case.
+    /// </summary>
+    public const int Propagated = Unknown;
+}

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -7,6 +7,7 @@ using System;
 using System.Globalization;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -177,11 +178,11 @@ namespace Datadog.Trace
                     // (e.g. "AutoKeep" or "1"), but try parsing as `int` first since it's much faster
                     if (int.TryParse(value, out var samplingPriorityInt32))
                     {
-                        Context.TraceContext.SetSamplingPriority(samplingPriorityInt32);
+                        Context.TraceContext.SetSamplingDecision(samplingPriorityInt32, SamplingMechanism.Manual);
                     }
                     else if (Enum.TryParse<SamplingPriority>(value, out var samplingPriorityEnum))
                     {
-                        Context.TraceContext.SetSamplingPriority((int?)samplingPriorityEnum);
+                        Context.TraceContext.SetSamplingDecision((int?)samplingPriorityEnum, SamplingMechanism.Manual);
                     }
 
                     break;
@@ -189,7 +190,7 @@ namespace Datadog.Trace
                     if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserKeep priority
-                        Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+                        Context.TraceContext.SetSamplingDecision(SamplingPriorityValues.UserKeep, SamplingMechanism.Manual);
                     }
 
                     break;
@@ -197,7 +198,7 @@ namespace Datadog.Trace
                     if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserReject priority
-                        Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
+                        Context.TraceContext.SetSamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
                     }
 
                     break;
@@ -325,8 +326,7 @@ namespace Datadog.Trace
             switch (key)
             {
                 case Trace.Tags.SamplingPriority:
-                    var samplingPriority = Context.TraceContext?.SamplingPriority ?? Context.SamplingPriority;
-                    return samplingPriority?.ToString();
+                    return Context.TraceContext?.SamplingDecision?.Priority.ToString();
                 case Trace.Tags.Origin:
                     return Context.Origin;
                 default:

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -70,7 +70,8 @@ namespace Datadog.Trace
                         {
                             // this is a local root span (i.e. not propagated).
                             // determine an initial sampling priority for this trace, but don't lock it yet
-                            _samplingPriority = Tracer.Sampler?.GetSamplingPriority(RootSpan);
+                            var samplingDecision = Tracer.Sampler?.MakeSamplingDecision(span);
+                            _samplingPriority = samplingDecision?.Priority;
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -40,11 +40,6 @@ namespace Datadog.Trace
         public TraceTagCollection Tags { get; }
 
         /// <summary>
-        /// Gets the trace's sampling priority.
-        /// </summary>
-        public int? SamplingPriority => _samplingDecision?.Priority;
-
-        /// <summary>
         /// Gets the trace's sampling decision, which includes
         /// priority, mechanism, and rate (if used).
         /// </summary>
@@ -143,11 +138,6 @@ namespace Datadog.Trace
             {
                 Tracer.Write(spansToWrite);
             }
-        }
-
-        public void SetSamplingPriority(int? samplingPriority, bool notifyDistributedTracer = true)
-        {
-            SetSamplingDecision(samplingPriority, SamplingMechanism.Unknown, rate: null, notifyDistributedTracer);
         }
 
         public void SetSamplingDecision(int? priority, int mechanism, double? rate = null, bool notifyDistributedTracer = true)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 
@@ -22,7 +23,7 @@ namespace Datadog.Trace
         private ArrayBuilder<Span> _spans;
 
         private int _openSpans;
-        private int? _samplingPriority;
+        private SamplingDecision? _samplingDecision;
 
         public TraceContext(IDatadogTracer tracer, TraceTagCollection tags = null)
         {
@@ -41,10 +42,13 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the trace's sampling priority.
         /// </summary>
-        public int? SamplingPriority
-        {
-            get => _samplingPriority;
-        }
+        public int? SamplingPriority => _samplingDecision?.Priority;
+
+        /// <summary>
+        /// Gets the trace's sampling decision, which includes
+        /// priority, mechanism, and rate (if used).
+        /// </summary>
+        public SamplingDecision? SamplingDecision => _samplingDecision;
 
         private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);
 
@@ -58,20 +62,19 @@ namespace Datadog.Trace
                     RootSpan = span;
                     DecorateRootSpan(span);
 
-                    if (_samplingPriority == null)
+                    if (_samplingDecision == null)
                     {
-                        if (span.Context.Parent is SpanContext context && context.SamplingPriority != null)
+                        if (span.Context.Parent is SpanContext { SamplingPriority: { } samplingPriority })
                         {
                             // this is a root span created from a propagated context that contains a sampling priority.
-                            // lock sampling priority when a span is started from a propagated trace.
-                            _samplingPriority = context.SamplingPriority;
+                            var decision = new SamplingDecision(samplingPriority, SamplingMechanism.Propagated);
+                            _samplingDecision = decision;
                         }
-                        else
+                        else if (Tracer.Sampler is not null)
                         {
                             // this is a local root span (i.e. not propagated).
                             // determine an initial sampling priority for this trace, but don't lock it yet
-                            var samplingDecision = Tracer.Sampler?.MakeSamplingDecision(span);
-                            _samplingPriority = samplingDecision?.Priority;
+                            _samplingDecision = Tracer.Sampler.MakeSamplingDecision(span);
                         }
                     }
                 }
@@ -86,13 +89,13 @@ namespace Datadog.Trace
 
             if (span == RootSpan)
             {
-                if (_samplingPriority == null)
+                if (_samplingDecision == null)
                 {
                     Log.Warning("Cannot set span metric for sampling priority before it has been set.");
                 }
                 else
                 {
-                    AddSamplingPriorityTags(span, _samplingPriority.Value);
+                    AddSamplingPriorityTags(span, _samplingDecision.Value.Priority);
                 }
             }
 
@@ -144,11 +147,27 @@ namespace Datadog.Trace
 
         public void SetSamplingPriority(int? samplingPriority, bool notifyDistributedTracer = true)
         {
-            _samplingPriority = samplingPriority;
+            SetSamplingDecision(samplingPriority, SamplingMechanism.Unknown, rate: null, notifyDistributedTracer);
+        }
+
+        public void SetSamplingDecision(int? priority, int mechanism, double? rate = null, bool notifyDistributedTracer = true)
+        {
+            if (priority == null)
+            {
+                SetSamplingDecision(null, notifyDistributedTracer);
+            }
+
+            var decision = new SamplingDecision(priority.Value, mechanism, rate);
+            SetSamplingDecision(decision, notifyDistributedTracer);
+        }
+
+        public void SetSamplingDecision(SamplingDecision? samplingDecision, bool notifyDistributedTracer = true)
+        {
+            _samplingDecision = samplingDecision;
 
             if (notifyDistributedTracer)
             {
-                DistributedTracer.Instance.SetSamplingPriority(samplingPriority);
+                DistributedTracer.Instance.SetSamplingPriority(samplingDecision?.Priority);
             }
         }
 
@@ -174,7 +193,7 @@ namespace Datadog.Trace
             // The agent looks for the sampling priority on the first span that has no parent
             // Finding those spans is not trivial, so instead we apply the priority to every span
 
-            var samplingPriority = _samplingPriority;
+            var samplingPriority = _samplingDecision?.Priority;
 
             if (samplingPriority == null)
             {

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -20,12 +21,14 @@ namespace Datadog.Trace.Tests.DistributedTracer
             var commonTracer = new CommonTracerImpl();
 
             var expectedSamplingPriority = SamplingPriorityValues.UserKeep;
+            var expectedSamplingDecision = new SamplingDecision(expectedSamplingPriority, SamplingMechanism.Unknown, rate: null);
 
             using var scope = (Scope)Tracer.Instance.StartActive("Test");
 
             commonTracer.SetSamplingPriority(expectedSamplingPriority);
 
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
+            var samplingDecision = scope.Span.Context.TraceContext.SamplingDecision;
+            samplingDecision?.Should().Be(expectedSamplingDecision, "SetSamplingPriority should have successfully set the active trace sampling priority");
         }
 
         private class CommonTracerImpl : CommonTracer

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             distributedTracer.Verify(t => t.GetSpanContext(), Times.Exactly(2));
             scope.Span.TraceId.Should().Be(spanContext.TraceId);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(spanContext.SamplingPriority);
+            scope.Span.Context.TraceContext.SamplingDecision?.Priority.Should().Be(spanContext.SamplingPriority);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -123,13 +123,13 @@ namespace Datadog.Trace.Tests.Sampling
             {
                 var traceId = idGenerator.CreateNew();
                 var span = GetMyServiceSpan(traceId);
-                var priority = sampler.GetSamplingPriority(span);
+                var decision = sampler.MakeSamplingDecision(span);
 
-                if (priority == SamplingPriorityValues.AutoKeep)
+                if (decision.Priority == SamplingPriorityValues.AutoKeep)
                 {
                     autoKeeps++;
                 }
-                else if (priority == SamplingPriorityValues.UserKeep)
+                else if (decision.Priority == SamplingPriorityValues.UserKeep)
                 {
                     userKeeps++;
                 }

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Util;
 using FluentAssertions;
 using Moq;
@@ -139,7 +140,7 @@ namespace Datadog.Trace.Tests
                   .Callback<ArraySegment<Span>>(s => spans = s);
 
             var traceContext = new TraceContext(tracer.Object);
-            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            traceContext.SetSamplingDecision(SamplingPriorityValues.UserKeep, SamplingMechanism.Unknown);
 
             var rootSpan = CreateSpan();
 
@@ -190,7 +191,7 @@ namespace Datadog.Trace.Tests
                   .Callback<ArraySegment<Span>>(s => spans = s);
 
             var traceContext = new TraceContext(tracer.Object);
-            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            traceContext.SetSamplingDecision(SamplingPriorityValues.UserKeep, SamplingMechanism.Unknown);
 
             var rootSpan = CreateSpan();
 

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -238,7 +238,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(parent, childSpan.Context.Parent);
             Assert.Equal(parentId, childSpan.Context.ParentId);
             Assert.NotNull(childSpan.Context.TraceContext);
-            Assert.Equal(samplingPriority, childSpan.Context.TraceContext.SamplingPriority);
+            Assert.Equal(samplingPriority, childSpan.Context.TraceContext.SamplingDecision?.Priority);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes
In this PR, we start tracking the sampling mechanism and sampling rate in addition to the sampling priority. In another PR, we will start propagating this information both vertically (as tags sent to the Agent) and horizontally (as upstream/downstream headers).

## Reason for change

## Implementation details
We introduce the `SamplingDecision`, which includes all the sampling information we need to track (priority, mechanism, and rate if used):
```csharp
struct SamplingDecision
{
   int Priority;
   int Mechanism;
   double? Rate;
}
```
In most places where we were using `SamplingPriority`, we now use `SamplingDecision` instead.

## Test coverage

## Other details
Note that while we now track sampling mechanism and rate, we're still not using this additional information in new ways. My next PR will combine this work and #2432 to add the new `_dd.p.upstream_services` trace-level tag. The first two PRs were independent of each other and could be merged in any order.

TODO:
- [ ] propagate sampling decision to "distributed tracer" (cross-version)