### PR TITLE
Make check iis command more tolerant

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -30,9 +30,11 @@ namespace Datadog.Trace.Tools.Runner
             if (result.Successful)
             {
                 // Perform additional validation
-                if (settings.SiteName.Count(c => c == '/') > 1)
+                var siteName = string.Join(' ', settings.SiteName);
+
+                if (siteName.Count(c => c == '/') > 1)
                 {
-                    return ValidationResult.Error($"IIS site names can't have multiple / in their name: {settings.SiteName}");
+                    return ValidationResult.Error($"IIS site names can't have multiple / in their name: {siteName}");
                 }
             }
 
@@ -41,7 +43,8 @@ namespace Datadog.Trace.Tools.Runner
 
         internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid)
         {
-            var values = settings.SiteName.Split('/');
+            var fullSiteName = string.Join(' ', settings.SiteName);
+            var values = fullSiteName.Split('/');
 
             var siteName = values[0];
             var applicationName = values.Length > 1 ? $"/{values[1]}" : "/";

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
@@ -3,11 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Spectre.Console.Cli;
 
 namespace Datadog.Trace.Tools.Runner
@@ -15,6 +10,6 @@ namespace Datadog.Trace.Tools.Runner
     internal class CheckIisSettings : CommandSettings
     {
         [CommandArgument(0, "<siteName>")]
-        public string SiteName { get; set; }
+        public string[] SiteName { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
                 using var console = ConsoleHelper.Redirect();
 
-                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = siteName }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+                var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = new[] { siteName } }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
 
                 result.Should().Be(0);
 
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = new[] { "sample" } }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "dummySite" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = new[] { "dummySite" } }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 
@@ -124,7 +124,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = "sample/dummy" }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
+            var result = await CheckIisCommand.ExecuteAsync(new CheckIisSettings { SiteName = new[] { "sample/dummy" } }, _iisFixture.IisExpress.ConfigFile, _iisFixture.IisExpress.Process.Id);
 
             result.Should().Be(1);
 


### PR DESCRIPTION
Before this change, arguments must be wrapped in quotes when they have spaces in them. For instance:

```
dd-trace check iis "Default Web Site/WebApplication1"
```

It's likely that many customers are running apps in the default web site, so this change preventively makes the syntax more tolerant. This is now valid:

```
dd-trace check iis Default Web Site/WebApplication1
````