### PR TITLE
Fix incorrect timeout in BatchingSinkTests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -132,14 +132,16 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             // Initial success ensures we don't permanently disable the sink
             _output.WriteLine("Queueing first event and waiting for sink");
             sink.EnqueueLog(evt);
-            WaitForBatches(sink, batchCount: 1);
+            var batches = WaitForBatches(sink, batchCount: 1);
+            _output.WriteLine($"Found {batches.Count} batches");
 
             // Put the sink in a broken status (temporary)
             for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
             {
                 _output.WriteLine($"Queueing broken event {i + 1}");
                 sink.EnqueueLog(evt);
-                WaitForBatches(sink, batchCount: i + 2);
+                batches = WaitForBatches(sink, batchCount: i + 2);
+                _output.WriteLine($"Found {batches.Count} batches");
             }
 
             // initial enqueue should be ignored
@@ -153,7 +155,8 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             // queue another log now circuit is partially open
             _output.WriteLine($"Queueing event in partially open sink");
             sink.EnqueueLog(evt);
-            WaitForBatches(sink, batchCount: BatchingSink.FailuresBeforeCircuitBreak + 2);
+            batches = WaitForBatches(sink, batchCount: BatchingSink.FailuresBeforeCircuitBreak + 2);
+            _output.WriteLine($"Found {batches.Count} batches");
         }
 
         private static ConcurrentStack<IList<DatadogLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -158,7 +158,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
 
         private static ConcurrentStack<IList<DatadogLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)
         {
-            var deadline = DateTime.UtcNow.AddSeconds(10_000);
+            var deadline = DateTime.UtcNow.AddSeconds(10);
             var batches = pbs.Batches;
             while (batches.Count < batchCount && DateTime.UtcNow < deadline)
             {


### PR DESCRIPTION
It should should be 10s not 3hrs

We've seen a couple of cases where it's apparently hanging in CI. There's obviously something flaky there (as the timeout _should_ be irrelevant if all is well). But I'm not sure what, and can't reproduce it, so will have to merge this for now so we can grab some real logs in the failing cases.