### PR TITLE
Refactor all EnumNgenModuleMethodsInliningThisMethod call sites

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -484,7 +484,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     {
         // We check if the Module contains NGEN images and added to the
         // rejit handler list to verify the inlines.
-        rejit_handler->AddNGenModule(module_id);
+        rejit_handler->AddNGenInlinerModule(module_id);
     }
 
     AppDomainID app_domain_id = module_info.assembly.app_domain_id;
@@ -2586,6 +2586,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
         Logger::Warn("JITCachedFunctionSearchStarted: Call to ICorProfilerInfo4.GetFunctionInfo() failed for ",
                      functionId);
         return S_OK;
+    }
+
+    // Call RequestRejit for register inliners and current NGEN module.
+    if (rejit_handler != nullptr)
+    {
+        // Process the current module to detect inliners.
+        rejit_handler->AddNGenInlinerModule(module_id);
     }
 
     // Verify that we have the metadata for this module

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -124,6 +124,8 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
 
         return true;
     }
+
+    return false;
 }
 
 //

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -49,24 +49,17 @@ void RejitHandlerModuleMethod::SetFunctionInfo(const FunctionInfo& functionInfo)
     m_functionInfo = std::make_unique<FunctionInfo>(functionInfo);
 }
 
-void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)
+bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
-    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule: ", moduleId);
-    std::lock_guard<std::mutex> guard(m_ngenModulesLock);
-
-    // We check first if we already processed this module to skip it.
-    auto find_res = m_ngenModules.find(moduleId);
-    if (find_res != m_ngenModules.end())
-    {
-        return;
-    }
-
     // Enumerate all inliners and request rejit
     ModuleID currentModuleId = m_module->GetModuleId();
     mdMethodDef currentMethodDef = m_methodDef;
+
+    Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule for ",
+                  "[ModuleInliner=", moduleId , ", ModuleId=", currentModuleId, ", MethodDef=", currentMethodDef, "]");
+
     RejitHandler* handler = m_module->GetHandler();
     ICorProfilerInfo7* pInfo = handler->GetCorProfilerInfo();
-
     if (pInfo != nullptr)
     {
         // Now we enumerate all methods that inline the current methodDef
@@ -100,13 +93,10 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
                              ",MethodDef=", currentMethodDef, "]");
             }
 
-            if (!incompleteData)
-            {
-                m_ngenModules[moduleId] = true;
-            }
-            else
+            if (incompleteData)
             {
                 Logger::Warn("NGen inliner data for module '", moduleId, "' is incomplete.");
+                return false;
             }
         }
         else if (hr == E_INVALIDARG)
@@ -118,6 +108,8 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
         {
             Logger::Info("NGEN:: Error Incomplete data in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef,
                          ", HR=", hexValue.str(), "]");
+
+            return false;
         }
         else if (hr == CORPROF_E_UNSUPPORTED_CALL_SEQUENCE)
         {
@@ -129,6 +121,8 @@ void RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
             Logger::Info("NGEN:: Error in [ModuleId=", currentModuleId, ",MethodDef=", currentMethodDef,
                          ", HR=", hexValue.str(), "]");
         }
+
+        return true;
     }
 }
 
@@ -222,33 +216,37 @@ bool RejitHandlerModule::ContainsMethod(mdMethodDef methodDef)
 
 void RejitHandlerModule::RequestRejitForInlinersInModule(ModuleID moduleId)
 {
-    std::lock_guard<std::mutex> guard(m_methods_lock);
+    std::lock_guard<std::mutex> moduleGuard(m_ngenProcessedInlinerModulesLock);
+
+    // We check first if we already processed this module to skip it.
+    auto find_res = m_ngenProcessedInlinerModules.find(moduleId);
+    if (find_res != m_ngenProcessedInlinerModules.end())
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> methodsGuard(m_methods_lock);
+    bool success = true;
     for (const auto& method : m_methods)
     {
-        method.second.get()->RequestRejitForInlinersInModule(moduleId);
+        success = success && method.second.get()->RequestRejitForInlinersInModule(moduleId);
+        // If we fail to process a method, we stop the processing and try again in another call.
+        if (!success)
+        {
+            break;
+        }
+    }
+
+    if (success)
+    {
+        // We mark module as processed.
+        m_ngenProcessedInlinerModules[moduleId] = true;
     }
 }
 
 //
 // RejitHandler
 //
-
-void RejitHandler::RequestRejitForInlinersInModule(ModuleID moduleId)
-{
-    if (IsShutdownRequested())
-    {
-        return;
-    }
-
-    std::lock_guard<std::mutex> guard(m_modules_lock);
-    if (m_profilerInfo != nullptr)
-    {
-        for (const auto& mod : m_modules)
-        {
-            mod.second->RequestRejitForInlinersInModule(moduleId);
-        }
-    }
-}
 
 void RejitHandler::RequestRejit(std::vector<ModuleID>& modulesVector,
                                 std::vector<mdMethodDef>& modulesMethodDef)
@@ -360,16 +358,49 @@ void RejitHandler::RemoveModule(ModuleID moduleId)
     m_modules.erase(moduleId);
 }
 
-void RejitHandler::AddNGenModule(ModuleID moduleId)
+void RejitHandler::AddNGenInlinerModule(ModuleID moduleId)
 {
     if (IsShutdownRequested())
     {
         return;
     }
 
-    std::lock_guard<std::mutex> guard(m_ngenModules_lock);
-    m_ngenModules.push_back(moduleId);
-    RequestRejitForInlinersInModule(moduleId);
+    // Process the inliner module list ( to catch any incomplete data module )
+    // and also check if the module is already in the inliners list
+    std::lock_guard<std::mutex> guard(m_ngenInlinersModules_lock);
+    bool alreadyAdded = false;
+    if (m_profilerInfo != nullptr)
+    {
+        for (const auto& moduleInliner : m_ngenInlinersModules)
+        {
+            if (moduleInliner == moduleId)
+            {
+                alreadyAdded = true;
+            }
+            else
+            {
+                std::lock_guard<std::mutex> guard(m_modules_lock);
+                for (const auto& mod : m_modules)
+                {
+                    mod.second->RequestRejitForInlinersInModule(moduleInliner);
+                }
+            }
+        }
+    }
+
+    if (!alreadyAdded)
+    {
+        // Add the new module inliner
+        m_ngenInlinersModules.push_back(moduleId);
+        if (m_profilerInfo != nullptr)
+        {
+            std::lock_guard<std::mutex> guard(m_modules_lock);
+            for (const auto& mod : m_modules)
+            {
+                mod.second->RequestRejitForInlinersInModule(moduleId);
+            }
+        }
+    }
 }
 
 void RejitHandler::EnqueueForRejit(std::vector<ModuleID>& modulesVector, std::vector<mdMethodDef>& modulesMethodDef)
@@ -400,7 +431,7 @@ void RejitHandler::Shutdown()
     m_work_offloader->WaitForTermination();
 
     std::lock_guard<std::mutex> moduleGuard(m_modules_lock);
-    std::lock_guard<std::mutex> ngenModuleGuard(m_ngenModules_lock);
+    std::lock_guard<std::mutex> ngenModuleGuard(m_ngenInlinersModules_lock);
 
     WriteLock w_lock(m_shutdown_lock);
     m_shutdown.store(true);
@@ -510,23 +541,6 @@ void RejitHandler::SetCorAssemblyProfiler(AssemblyProperty* pCorAssemblyProfiler
 AssemblyProperty* RejitHandler::GetCorAssemblyProperty()
 {
     return m_pCorAssemblyProperty;
-}
-
-void RejitHandler::RequestRejitForNGenInliners()
-{
-    if (IsShutdownRequested())
-    {
-        return;
-    }
-
-    std::lock_guard<std::mutex> guard(m_ngenModules_lock);
-    if (m_profilerInfo != nullptr)
-    {
-        for (const auto& mod : m_ngenModules)
-        {
-            RequestRejitForInlinersInModule(mod);
-        }
-    }
 }
 
 void RejitHandler::SetEnableByRefInstrumentation(bool enableByRefInstrumentation)

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
@@ -381,7 +381,6 @@ ULONG RejitPreprocessor<RejitRequestDefinition>::RequestRejitForLoadedModules(
         else
         {
             m_rejit_handler->EnqueueForRejit(vtModules, vtMethodDefs);
-            m_rejit_handler->RequestRejitForNGenInliners();
         }
     }
 
@@ -424,7 +423,6 @@ void RejitPreprocessor<RejitRequestDefinition>::EnqueueRequestRejitForLoadedModu
 
     // Enqueue
     m_work_offloader->Enqueue(std::make_unique<RejitWorkItem>(std::move(action)));
-    m_rejit_handler->RequestRejitForNGenInliners();
 }
 
 // TraceIntegrationRejitPreprocessor


### PR DESCRIPTION
## Summary of changes
This PR refactors all `EnumNgenModuleMethodsInliningThisMethod` call sites and make sure it's only called from **two** `ICorProfilerCallBacks`: `ModuleLoadFinished` and `JITCachedFunctionSearchStarted`

## Reason for change
After the lastest change in #2442 we stopped calling the `EnumNgenModuleMethodsInliningThisMethod` from the background thread, and move the calls to `ICorProfilerCallback::ModuleLoadFinished`  and in the `P/Invoke call from the integrations definitions`.

This was working fine, but yesterday I saw this error in a local application:

```
02/17/22 10:23:14.743 PM [70716|52812] [info] InitializeProfiler: received id: FFAFA5168C4F4718B40CA8788875C2DA from managed side with 266 integrations.
02/17/22 10:23:14.745 PM [70716|52812] [info] Total number of modules to analyze: 2
02/17/22 10:23:14.748 PM [70716|16440] [info] ReJIT handler stored metadata for 1850347520 System AppDomain 9220072 ConsoleApp5.exe
02/17/22 10:23:14.748 PM [70716|16440] [info] Request ReJIT done for 6 methods
02/17/22 10:23:14.748 PM [70716|52812] [info] InitializeProfiler: Total integrations in profiler: 266
02/17/22 10:23:14.751 PM [70716|52812] [info] AddDerivedInstrumentations: received id: 61BF627FA9B5477F85595A9F0D68B29C from managed side with 9 integrations.
02/17/22 10:23:14.751 PM [70716|52812] [info] Total number of modules to analyze: 2
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665880, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665883, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665891, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665892, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665894, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100667125, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665880, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665883, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665891, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665892, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665894, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100667125, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665880, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665883, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665891, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665892, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665894, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100667125, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665880, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665883, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665891, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665892, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665894, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100667125, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665880, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665883, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665891, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665892, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100665894, HR=80131363]
02/17/22 10:23:14.751 PM [70716|52812] [info] NGEN:: Unsupported call sequence error in [ModuleId=1850347520,MethodDef=100667125, HR=80131363]
02/17/22 10:23:14.752 PM [70716|52812] [info] InitializeProfiler: Total integrations in profiler: 275
```

This ` Unsupported call sequence error` is happening from the `P/Invoke` call, 

Information of this error can be found here: https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/corprof-e-unsupported-call-sequence-hresult

To avoid this error this PR removes the call from the `P/Invoke`.

Also to ensure we don't miss any module that can be an inlineer of the methods we are rewriting a call was added at: `ICorProfilerCallBacks::JITCachedFunctionSearchStarted` 

The PR also removes methods related to the NGEN inlining that are not being used.
