### PR TITLE
Support cleaning of filenames in HttpClient + ASP.NET

### DIFF
--- a/tracer/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/UriHelpers.cs
@@ -50,6 +50,7 @@ namespace Datadog.Trace.Util
             int previousIndex = 0;
             int index;
             int segmentLength;
+            int indexOfFileExtension = 0;
 
             do
             {
@@ -58,7 +59,18 @@ namespace Datadog.Trace.Util
                 if (index == -1)
                 {
                     // Last segment
-                    segmentLength = absolutePath.Length - previousIndex;
+                    // Is this a filename with an extension?
+                    if (absolutePath.Length > previousIndex
+                     && (indexOfFileExtension = absolutePath.LastIndexOf('.')) != -1
+                     && indexOfFileExtension > previousIndex)
+                    {
+                        // Only try and clean the filename, excluding the file extension
+                        segmentLength = indexOfFileExtension - previousIndex;
+                    }
+                    else
+                    {
+                        segmentLength = absolutePath.Length - previousIndex;
+                    }
                 }
                 else
                 {
@@ -74,7 +86,15 @@ namespace Datadog.Trace.Util
                     sb.Append(absolutePath, previousIndex, segmentLength);
                 }
 
-                if (index != -1)
+                if (index == -1)
+                {
+                    if (segmentLength > 0 && indexOfFileExtension > previousIndex)
+                    {
+                        // add the file extension
+                        sb.Append(absolutePath, indexOfFileExtension, absolutePath.Length - indexOfFileExtension);
+                    }
+                }
+                else
                 {
                     sb.Append('/');
                 }

--- a/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -29,6 +29,13 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs", "/DataDog/dd-trace-dotnet/blob/?/src/Datadog.Trace/Util/UriHelpers.cs")]
         [InlineData("/controller/action/2022", "/controller/action/?")]
         [InlineData("/controller/action/", "/controller/action/")]
+        [InlineData("/some-file/123/432/234.png", "/some-file/?/?/?.png")]
+        [InlineData("/some-file/1234.png", "/some-file/?.png")]
+        [InlineData("/some-file/123.456.png", "/some-file/123.456.png")]
+        [InlineData("/some-file/1234.", "/some-file/?.")]
+        [InlineData("/some-file/1234.c", "/some-file/?.c")]
+        [InlineData("/some-file/.12345", "/some-file/.12345")]
+        [InlineData("/some-file/123.12345/nada", "/some-file/123.12345/nada")]
         public void GetCleanUriPath_ShouldRemoveIdsFromPaths(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(url));
@@ -42,6 +49,7 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("https://localhost:5040/controller/action/2022", "/controller/action/?")]
         [InlineData("https://example.org/controller/action/2022", "/controller/action/?")]
         [InlineData("ftp://example.org/controller/action/2022", "/controller/action/?")]
+        [InlineData("ftp://example.org/controller/action/2022.png", "/controller/action/?.png")]
         public void GetCleanUriPath_ByUri_ShouldExtractThePathAndRemoveIds(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(new Uri(url)));


### PR DESCRIPTION
## Summary of changes

Adds cleaning of filenames to `UriHelpers.GetCleanUriPath()`

## Reason for change

The HttpClient integration (and the ASP.NET/ASP.NET Core integration when the feature flag is disabled) all do "cleaning" of URLs to try and reduce the cardinality introduced by number/guid route parameters. This works by examining each "segment" in a URL, and using heuristics to see if we should replace it with `?`.

This works as expected for the following paths:

- `/some/value/123` → `/some/value/?`
- `/some/value/123/123-456` → `/some/value/?/?`
- `/some/value/123/example.png` → `/some/value/?/example.png`

However, it treats the whole final segment as a single unit, which means filenames with extensions will never be obfuscated, e.g.

- `/some-filevalue/123.png`
- `/some-filevalue/123.456`
- `/some-filevalue/123.c`

That can lead to high cardinality, which in turn can cause problems for customers with too many endpoints in their account.

## Implementation details

When "cleaning" the final segment of a URL, we now check whether there's a `.` in the final segment. If there is, we only try and clean the "filename" section.

## Test coverage

The following positive test cases where the filename _is_ cleaned:

- `/some-file/123/432/234.png` → `/some-file/?/?/?.png`
- `/some-file/1234.png` → `/some-file/?.png`
- `/some-file/1234.` → `/some-file/?.` You could argue about this one, but didn't seem worth worrying about
- `/some-file/1234.c` → `/some-file/?.c`

The following negative test cases where the filename _is not_ cleaned:

- `/some-file/123.456.png` → `/some-file/123.456.png`
- `/some-file/.12345` → `/some-file/.12345`
- `/some-file/123.12345/nada` → `/some-file/123.12345/nada`

## Other details
Fixes APMS-6793
