### PR TITLE
Ignore common test failures

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -169,6 +169,13 @@ namespace Datadog.Trace.TestHelpers
                 throw new SkipException("Segmentation fault on .NET Core 2.1");
             }
 #endif
+            if (exitCode == 134
+             && standardError?.Contains("System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex") == true
+             && standardError?.Contains("Coverlet.Core.Instrumentation.Tracker") == true)
+            {
+                // Coverlet occasionally throws AbandonedMutexException during clean up
+                throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
+            }
 
             Assert.True(exitCode >= 0, $"Process exited with code {exitCode}");
 


### PR DESCRIPTION
## Summary of changes

- Skips `NativeProfilerChecks` when there's a seg fault
- Skips the test when Coverlet throws an `AbandonedMutexException`

## Reason for change

These two symptoms regularly cause flakiness in the build. The former is somewhat concerning, but we have decided is not a priority to investigate at this point. 

The `AbandonedMutexException` is an error related to the Coverlet code coverage tool (which re-writes dlls to enable coverage). There have been some attempts to fix/work around this, but we still see them occasionally. This error is almost certainly benign.

## Implementation details

The Coverage approach is somewhat crude, looking for the presence of two strings that should appear in an exception message. But it should do the job ([see this build for an example of the failure](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=91152&view=logs&j=66fb5b47-c134-514a-33bf-1ca485953300&t=0da60a49-ad8b-5ec5-21e5-a82d653ea765))
