### PR TITLE
Add checks for the profiler path in the CLI

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tools.Runner
             return result;
         }
 
-        internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid)
+        internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid, IRegistryService registryService = null)
         {
             var values = settings.SiteName.Split('/');
 
@@ -172,7 +172,7 @@ namespace Datadog.Trace.Tools.Runner
                     }
                 }
 
-                if (!ProcessBasicCheck.Run(process))
+                if (!ProcessBasicCheck.Run(process, registryService))
                 {
                     return 1;
                 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/IRegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/IRegistryService.cs
@@ -11,6 +11,6 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         string[] GetLocalMachineValueNames(string key);
 
-        string? GetClsid(string key);
+        string? GetLocalMachineValue(string key);
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/IRegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/IRegistryService.cs
@@ -10,5 +10,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
     internal interface IRegistryService
     {
         string[] GetLocalMachineValueNames(string key);
+
+        string? GetClsid(string key);
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -178,18 +178,20 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         private static bool CheckProfilerPath(ProcessInfo process, string key, bool requiredOnLinux)
         {
+            bool ok = true;
+
             if (process.EnvironmentVariables.TryGetValue(key, out var profilerPath))
             {
                 if (!IsExpectedProfilerFile(profilerPath))
                 {
                     Utils.WriteError(WrongProfilerEnvironment(key, profilerPath));
-                    return false;
+                    ok = false;
                 }
 
                 if (!File.Exists(profilerPath))
                 {
                     Utils.WriteError(MissingProfilerEnvironment(key, profilerPath));
-                    return false;
+                    ok = false;
                 }
             }
             else if (requiredOnLinux)
@@ -197,11 +199,11 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 {
                     Utils.WriteError(EnvironmentVariableNotSet(key));
-                    return false;
+                    ok = false;
                 }
             }
 
-            return true;
+            return ok;
         }
 
         private static bool CheckClsid(IRegistryService registry, string registryKey)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         internal const string ClsidKey = @"CLSID\" + Utils.Profilerid + @"\InprocServer32";
 
-        public static bool Run(ProcessInfo process)
+        public static bool Run(ProcessInfo process, IRegistryService? registryService = null)
         {
             bool foundIssue = false;
             var runtime = process.DotnetRuntime;
@@ -140,7 +140,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
-                if (!CheckRegistry())
+                if (!CheckRegistry(registryService))
                 {
                     foundIssue = true;
                 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
                 if (!File.Exists(profilerPath))
                 {
-                    Utils.WriteError(MissingProfilerRegistry(profilerPath));
+                    Utils.WriteError(MissingProfilerRegistry(ClsidKey, profilerPath));
                     return false;
                 }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -4,9 +4,11 @@
 // </copyright>
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Datadog.Trace.Tools.Runner.Checks
@@ -66,6 +68,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
 
+        public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
+
         public static string CouldNotFindSite(string site, IEnumerable<string> availableSites)
         {
             var sb = new StringBuilder();
@@ -110,6 +114,14 @@ namespace Datadog.Trace.Tools.Runner.Checks
             }
 
             return sb.ToString();
+        }
+
+        public static string WrongProfilerEnvironment(string environmentVariable, string actualProfiler)
+        {
+            var expectedProfiler = RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+                ? "Datadog.Trace.ClrProfiler.Native.dll" : "Datadog.Trace.ClrProfiler.Native.so";
+
+            return $"The environment variable {environmentVariable} was set to '{actualProfiler}' but it should point to '{expectedProfiler}'";
         }
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -19,7 +19,6 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
         public const string ProfilerNotLoaded = "Profiler is not loaded into the process";
         public const string TracerNotLoaded = "Tracer is not loaded into the process";
-        public const string TracerHomeNotSet = "The environment variable DD_DOTNET_TRACER_HOME is not set";
         public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
         public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
         public const string MissingGac = "The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
@@ -30,6 +29,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+
+        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set";
 
         public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
@@ -48,6 +49,12 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public static string ErrorCheckingRegistry(string error) => $"Error trying to read the registry: {error}";
 
         public static string SuspiciousRegistryKey(string key) => $@"The registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
+
+        public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. Make sure the tracer has been properly installed with the MSI.";
+
+        public static string MissingProfilerRegistry(string path) => $@"The profiler was installed to the path {path} but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
+
+        public static string MissingProfilerEnvironment(string key, string path) => $@"The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
 
         public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. Make sure the tracer has been properly installed with the MSI.";
 
-        public static string MissingProfilerRegistry(string path) => $@"The profiler was installed to the path {path} but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
+        public static string MissingProfilerRegistry(string key, string path) => $@"The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
 
         public static string MissingProfilerEnvironment(string key, string path) => $@"The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/RegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/RegistryService.cs
@@ -30,14 +30,14 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
             return registryKey.GetValueNames();
         }
 
-        public string? GetClsid(string key)
+        public string? GetLocalMachineValue(string key)
         {
             if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 return null;
             }
 
-            var registryKey = Registry.ClassesRoot.OpenSubKey(key);
+            var registryKey = Registry.LocalMachine.OpenSubKey(key);
 
             return registryKey?.GetValue(null) as string;
         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/RegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/RegistryService.cs
@@ -29,5 +29,17 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
 
             return registryKey.GetValueNames();
         }
+
+        public string? GetClsid(string key)
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return null;
+            }
+
+            var registryKey = Registry.ClassesRoot.OpenSubKey(key);
+
+            return registryKey?.GetValue(null) as string;
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -177,7 +177,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             var registryService = new Mock<IRegistryService>();
             registryService.Setup(r => r.GetLocalMachineValueNames(It.Is(@"SOFTWARE\Microsoft\.NETFramework", StringComparer.Ordinal)))
                 .Returns(Array.Empty<string>());
-            registryService.Setup(r => r.GetClsid(It.Is(@"CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32", StringComparer.Ordinal)))
+            registryService.Setup(r => r.GetLocalMachineValue(It.Is<string>(s => s == ProcessBasicChecksTests.ClsidKey || s == ProcessBasicChecksTests.Clsid32Key)))
                 .Returns(EnvironmentHelper.GetProfilerPath());
 
             return registryService.Object;

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -181,7 +181,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             console.Output.Should().NotContainAny(ErrorCheckingRegistry(string.Empty), "is defined and could prevent the tracer from working properly");
             console.Output.Should().NotContain(MissingRegistryKey(ClsidKey));
-            console.Output.Should().NotContain(MissingProfilerRegistry(ProfilerPath));
+            console.Output.Should().NotContain(MissingProfilerRegistry(ClsidKey, ProfilerPath));
         }
 
         [SkippableFact]
@@ -224,7 +224,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             result.Should().BeFalse();
 
             console.Output.Should().NotContain(MissingRegistryKey(ClsidKey));
-            console.Output.Should().Contain(MissingProfilerRegistry("dummyPath/" + Path.GetFileName(ProfilerPath)));
+            console.Output.Should().Contain(MissingProfilerRegistry(ClsidKey, "dummyPath/" + Path.GetFileName(ProfilerPath)));
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -147,7 +147,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"),
                 MissingProfilerEnvironment(CorProfilerPathKey, "dummyPath"),
                 WrongProfilerEnvironment(CorProfilerPathKey, "dummyPath"),
+                MissingProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
                 WrongProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
+                MissingProfilerEnvironment(CorProfilerPath64Key, "dummyPath"),
                 WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"));
         }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            ProcessBasicCheck.Run(processInfo);
+            ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
 
 #if NET_FRAMEWORK
             const string expectedOutput = NetFrameworkRuntime;
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.Run(processInfo);
+            var result = ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
 
             result.Should().BeFalse();
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.Run(processInfo);
+            var result = ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
 
             result.Should().BeFalse();
 
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.Run(processInfo);
+            var result = ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
 
             result.Should().BeFalse();
 
@@ -152,7 +152,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.Run(processInfo);
+            var result = ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
 
             using var scope = new AssertionScope();
             scope.AddReportable("Output", console.Output);

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Tools.Runner.Checks;
@@ -20,13 +21,18 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
     [Collection(nameof(ConsoleTestsCollection))]
     public class ProcessBasicChecksTests : ConsoleTestHelper
     {
+        private const string ClsidKey = @"CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32";
 #if NET_FRAMEWORK
         private const string CorProfilerKey = "COR_PROFILER";
+        private const string CorProfilerPathKey = "COR_PROFILER_PATH";
         private const string CorEnableKey = "COR_ENABLE_PROFILING";
 #else
         private const string CorProfilerKey = "CORECLR_PROFILER";
+        private const string CorProfilerPathKey = "CORECLR_PROFILER_PATH";
         private const string CorEnableKey = "CORECLR_ENABLE_PROFILING";
 #endif
+
+        private static readonly string FakeProfilerPath = typeof(ProcessBasicChecksTests).Assembly.Location;
 
         public ProcessBasicChecksTests(ITestOutputHelper output)
             : base(output)
@@ -91,9 +97,19 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             console.Output.Should().ContainAll(
                 ProfilerNotLoaded,
                 TracerNotLoaded,
-                TracerHomeNotSet,
+                EnvironmentVariableNotSet("DD_DOTNET_TRACER_HOME"),
                 WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, null),
                 WrongEnvironmentVariableFormat(CorEnableKey, "1", null));
+
+            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                // The variable is not required on Windows because the path is set through the registry
+                console.Output.Should().NotContain(EnvironmentVariableNotSet(CorProfilerPathKey));
+            }
+            else
+            {
+                console.Output.Should().Contain(EnvironmentVariableNotSet(CorProfilerPathKey));
+            }
         }
 
         [SkippableFact]
@@ -103,7 +119,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 enableProfiler: false,
                 ("DD_DOTNET_TRACER_HOME", "TheDirectoryDoesNotExist"),
                 (CorProfilerKey, Guid.Empty.ToString("B")),
-                (CorEnableKey, "0"));
+                (CorEnableKey, "0"),
+                (CorProfilerPathKey, "dummyPath"));
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 
             processInfo.Should().NotBeNull();
@@ -119,7 +136,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 TracerNotLoaded,
                 TracerHomeNotFoundFormat("TheDirectoryDoesNotExist"),
                 WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, Guid.Empty.ToString("B")),
-                WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"));
+                WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"),
+                MissingProfilerEnvironment(CorProfilerPathKey, "dummyPath"));
         }
 
         [SkippableFact]
@@ -148,33 +166,73 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         }
 
         [SkippableFact]
-        public void NoRegistry()
+        public void GoodRegistry()
         {
-            var registryService = new Mock<IRegistryService>();
-            registryService.Setup(r => r.GetLocalMachineValueNames(It.IsAny<string>())).Returns(Array.Empty<string>());
+            var registryService = MockRegistryService(Array.Empty<string>(), FakeProfilerPath);
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.CheckRegistry(registryService.Object);
+            var result = ProcessBasicCheck.CheckRegistry(registryService);
 
             result.Should().BeTrue();
 
             console.Output.Should().NotContainAny(ErrorCheckingRegistry(string.Empty), "is defined and could prevent the tracer from working properly");
+            console.Output.Should().NotContain(MissingRegistryKey(ClsidKey));
+            console.Output.Should().NotContain(MissingProfilerRegistry(FakeProfilerPath));
         }
 
         [SkippableFact]
         public void BadRegistryKey()
         {
-            var registryService = new Mock<IRegistryService>();
-            registryService.Setup(r => r.GetLocalMachineValueNames(It.IsAny<string>())).Returns(new[] { "cor_profiler" });
+            var registryService = MockRegistryService(new[] { "cor_profiler" }, FakeProfilerPath);
 
             using var console = ConsoleHelper.Redirect();
 
-            var result = ProcessBasicCheck.CheckRegistry(registryService.Object);
+            var result = ProcessBasicCheck.CheckRegistry(registryService);
 
             result.Should().BeFalse();
 
             console.Output.Should().Contain(SuspiciousRegistryKey("cor_profiler"));
+        }
+
+        [SkippableFact]
+        public void ProfilerNotRegistered()
+        {
+            var registryService = MockRegistryService(Array.Empty<string>(), null);
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = ProcessBasicCheck.CheckRegistry(registryService);
+
+            result.Should().BeFalse();
+
+            console.Output.Should().Contain(MissingRegistryKey(ClsidKey));
+        }
+
+        [SkippableFact]
+        public void ProfilerNotFound()
+        {
+            var registryService = MockRegistryService(Array.Empty<string>(), "dummyPath");
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = ProcessBasicCheck.CheckRegistry(registryService);
+
+            result.Should().BeFalse();
+
+            console.Output.Should().NotContain(MissingRegistryKey(ClsidKey));
+            console.Output.Should().Contain(MissingProfilerRegistry("dummyPath"));
+        }
+
+        private static IRegistryService MockRegistryService(string[] frameworkKeyValues, string profilerKeyValue)
+        {
+            var registryService = new Mock<IRegistryService>();
+            registryService.Setup(r => r.GetLocalMachineValueNames(It.Is(@"SOFTWARE\Microsoft\.NETFramework", StringComparer.Ordinal)))
+                .Returns(frameworkKeyValues);
+            registryService.Setup(r => r.GetClsid(It.Is(@"CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32", StringComparer.Ordinal)))
+                .Returns(profilerKeyValue);
+
+            return registryService.Object;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -22,14 +22,19 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
     [Collection(nameof(ConsoleTestsCollection))]
     public class ProcessBasicChecksTests : ConsoleTestHelper
     {
-        private const string ClsidKey = @"CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32";
+        internal const string ClsidKey = @"SOFTWARE\Classes\CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32";
+        internal const string Clsid32Key = @"SOFTWARE\Classes\Wow6432Node\CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32";
 #if NET_FRAMEWORK
         private const string CorProfilerKey = "COR_PROFILER";
         private const string CorProfilerPathKey = "COR_PROFILER_PATH";
+        private const string CorProfilerPath32Key = "COR_PROFILER_PATH_32";
+        private const string CorProfilerPath64Key = "COR_PROFILER_PATH_64";
         private const string CorEnableKey = "COR_ENABLE_PROFILING";
 #else
         private const string CorProfilerKey = "CORECLR_PROFILER";
         private const string CorProfilerPathKey = "CORECLR_PROFILER_PATH";
+        private const string CorProfilerPath32Key = "CORECLR_PROFILER_PATH_32";
+        private const string CorProfilerPath64Key = "CORECLR_PROFILER_PATH_64";
         private const string CorEnableKey = "CORECLR_ENABLE_PROFILING";
 #endif
 
@@ -121,7 +126,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 ("DD_DOTNET_TRACER_HOME", "TheDirectoryDoesNotExist"),
                 (CorProfilerKey, Guid.Empty.ToString("B")),
                 (CorEnableKey, "0"),
-                (CorProfilerPathKey, "dummyPath"));
+                (CorProfilerPathKey, "dummyPath"),
+                (CorProfilerPath32Key, "dummyPath"),
+                (CorProfilerPath64Key, "dummyPath"));
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 
             processInfo.Should().NotBeNull();
@@ -139,7 +146,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, Guid.Empty.ToString("B")),
                 WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"),
                 MissingProfilerEnvironment(CorProfilerPathKey, "dummyPath"),
-                WrongProfilerEnvironment(CorProfilerPathKey, "dummyPath"));
+                WrongProfilerEnvironment(CorProfilerPathKey, "dummyPath"),
+                WrongProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
+                WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"));
         }
 
         [SkippableFact]
@@ -165,7 +174,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 "DD_DOTNET_TRACER_HOME",
                 CorProfilerKey,
                 CorEnableKey,
-                CorProfilerPathKey);
+                CorProfilerPathKey,
+                CorProfilerPath32Key,
+                CorProfilerPath64Key);
         }
 
         [SkippableFact]
@@ -247,7 +258,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             var registryService = new Mock<IRegistryService>();
             registryService.Setup(r => r.GetLocalMachineValueNames(It.Is(@"SOFTWARE\Microsoft\.NETFramework", StringComparer.Ordinal)))
                 .Returns(frameworkKeyValues);
-            registryService.Setup(r => r.GetClsid(It.Is(@"CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\InprocServer32", StringComparer.Ordinal)))
+            registryService.Setup(r => r.GetLocalMachineValue(It.Is<string>(s => s == ClsidKey || s == Clsid32Key)))
                 .Returns(profilerKeyValue);
 
             return registryService.Object;


### PR DESCRIPTION
With this change, the CLI process check also validates that:
 - On Windows, the registry key `HKEY_CLASSES_ROOT\CLSID\{846F5F1C-F9AE-4B07-969E-05C26BC060D8}` is set with the correct path
 - On Linux, the environment variable `CORECLR_PROFILER_PATH` is set with the correct path
 - On Windows, the environment variable `COR_PROFILER_PATH` is either missing or set with a correct path