### PR TITLE
Make ProcessEnvironmentWindows more robust

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/ProcessEnvironmentWindows.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/ProcessEnvironmentWindows.cs
@@ -27,6 +27,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 
 namespace Datadog.Trace.Tools.Runner.Checks.Windows
 {
@@ -39,7 +40,7 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
 
         private static Dictionary<string, string> _ReadVariablesCore(IntPtr hProcess)
         {
-            int retryCount = 3;
+            int retryCount = 5;
             bool RetryPolicy() => --retryCount > 0;
 
             Again:
@@ -65,6 +66,7 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
                 // There may be a race condition in environment block initialization of a recently started process.
                 if (RetryPolicy())
                 {
+                    Thread.Sleep(100);
                     goto Again;
                 }
                 else


### PR DESCRIPTION
`ProcessEnvironmentWindows` works by extracting the pointer to the environment variables from the target process then reading the variables. 
Whenever the target process makes changes to its environment variables, if the new total length is bigger than the old one then a new zone of memory will be allocated. We therefore have the following race condition:

 - The CLI gets the pointer to the environment variables
 - The target process sets a new environment variable. A new block of memory is allocated and the pointer to the environment variable is replaced
 - The CLI keeps reading from the old pointer which may now contain garbage

I don't think it's possible to avoid the race condition, short of injecting code into the target process to acquire the PEB lock. Instead, this PR tries to make the race condition less likely by increasing the number of retries and adding a pause between them. If that doesn't solve it we can try making the pause significantly bigger, since this code is used only in an interactive context (so it's OK if we have to wait a few seconds).