### PR TITLE
Add missing `volatile` in Tracer creation

### DIFF
--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace
         private static int _liveTracerCount;
 
         private static Tracer _instance;
-        private static bool _globalInstanceInitialized;
+        private static volatile bool _globalInstanceInitialized;
 
         private readonly TracerManager _tracerManager;
 


### PR DESCRIPTION
## Summary of changes

- Add missing `volatile` to `Tracer._globalInstanceInitialized`

## Reason for change

This was missed in the change from `LazyInitializer.EnsureInitialized()` (which internally uses `Volatile.Read()` and `Volatile.Write()`). This could lead to a race condition during initialization due to code reordering, as described [here](https://github.com/signalfx/signalfx-dotnet-tracing/pull/400#discussion_r814199882).
