### PR TITLE
Allow forcing releases from a specific commit sha

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -1,7 +1,11 @@
 name: Create draft release
 
 on:
-  workflow_dispatch:
+  workflow_dispatch:    
+    inputs:
+      forced_commit_id:
+        description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'.
+        required: false
 
 jobs:
   create_draft_release:
@@ -34,6 +38,7 @@ jobs:
         run: ./tracer/build.sh DownloadAzurePipelineAndGitlabArtifacts
         env:
           TargetBranch: ${{ github.event.ref }}
+          CommitSha: "${{ github.event.inputs.forced_commit_id }}"
 
       - name: "Generate release notes"
         id: release_notes


### PR DESCRIPTION
## Summary of changes

- Add ability to force a draft release for a specific commit

## Reason for change

This should not be the default approach, but it allows us to create releases without waiting for a full rebuild to occur, or where we have issues with temporary flake/capacity in CI.

This does some minimal verification of the provided sha (that it's on the branch provided) and checks that the artifacts are available, but does not require the build to have succeeded

> This is currently blocking me from doing the hotfix/2.4.2 release, I will port to `master` later
