### PR TITLE
Fixes for the build related to hotfix releases

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -2,6 +2,10 @@ name: Create draft release
 
 on:
   workflow_dispatch:
+    inputs:
+      forced_commit_id:
+        description: 'Force using artifacts from specific commit? If provided, this will try and use the artifacts from the given commit, regardless of build status'
+        required: false
 
 jobs:
   create_draft_release:
@@ -34,6 +38,7 @@ jobs:
         run: ./tracer/build.sh DownloadAzurePipelineAndGitlabArtifacts
         env:
           TargetBranch: ${{ github.event.ref }}
+          CommitSha: "${{ github.event.inputs.forced_commit_id }}"
 
       - name: "Generate release notes"
         id: release_notes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,8 @@ build:
   only:
     - master
     - main
+    -/^hotfix.*$/
+    -/^release.*$/
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
@@ -35,6 +37,8 @@ publish:
   only:
     - master
     - main
+    -/^hotfix.*$/
+    -/^release.*$/
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: 


### PR DESCRIPTION
## Summary of changes

- Allow running the GitLab build for hotfix releases
- Allow forcing release from a specific SHA

## Reason for change

Ran into both these issues recently while trying to do hotfix releases. 

We solved the first issue (can't run the gitlab build on hotfix branches) in #2503 by removing the restriction entirely. The first attempt in #2502 didn't work because I didn't use the correct syntax to denote a regex match. The fix in this PR should work.

The second issue is that failures with the crank runner was preventing us from releasing. Fixed this in #2510, this is a cherry-pick of that PR.

> Note that the Git diff makes the changes introduced in #2510 look more dramatic than they are. Only the branch starting `if (!string.IsNullOrEmpty(CommitSha))` is new.
