### PR TITLE
Increase WAF timeout in tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -281,6 +281,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var executable = EnvironmentHelper.IsCoreClr() ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
             var args = EnvironmentHelper.IsCoreClr() ? $"{sampleAppPath} {arguments ?? string.Empty}" : arguments;
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_TRACE_RATE_LIMIT", traceRateLimit?.ToString());
+            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 1_000_000.ToString());
 
             int? aspNetCorePort = default;
             _process = ProfilerHelper.StartProcessWithProfiler(

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             using var waf = Waf.Create();
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
-            var result = context.Run(args, 100_000);
+            var result = context.Run(args, 1_000_000);
             result.ReturnCode.Should().Be(ReturnCode.Monitor);
             var resultData = JsonConvert.DeserializeObject<WafMatch[]>(result.Data).FirstOrDefault();
             resultData.Rule.Tags.Type.Should().Be(flow);


### PR DESCRIPTION
Should reduce flake, as a timeout would change the test results
