### PR TITLE
Reverse to protobuf 3.7.0 to avoid unexpected new dependency (System.Memory.dll)

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.19.4" />
+    <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">


### PR DESCRIPTION
## Summary of changes
Revert protobuf version 

## Reason for change
System.Memory.dll dependency is not found on customer site 
    
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
