### PR TITLE
Support postfix time format for WAF timeout

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 
@@ -29,7 +30,8 @@ namespace Datadog.Trace.AppSec
 
             // Default timeout of 100 ms, only extreme conditions should cause timeout
             const int defaultWafTimeout = 100_000;
-            var wafTimeout = source?.GetInt32(ConfigurationKeys.AppSecWafTimeout) ?? defaultWafTimeout;
+            var wafTimeoutString = source?.GetString(ConfigurationKeys.AppSecWafTimeout);
+            var wafTimeout = ParseWafTimeout(wafTimeoutString);
             if (wafTimeout <= 0)
             {
                 wafTimeout = defaultWafTimeout;
@@ -74,6 +76,48 @@ namespace Datadog.Trace.AppSec
         {
             var source = GlobalSettings.CreateDefaultConfigurationSource();
             return new SecuritySettings(source);
+        }
+
+        private int ParseWafTimeout(string wafTimeoutString)
+        {
+            var numberStyles = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.Any;
+            if (int.TryParse(wafTimeoutString, numberStyles, CultureInfo.InvariantCulture, out var result))
+            {
+                return result;
+            }
+
+            wafTimeoutString = wafTimeoutString.Trim();
+
+            int multipler = 1;
+            string intPart = null;
+
+            if (wafTimeoutString.EndsWith("ms"))
+            {
+                multipler = 1_000;
+                intPart = wafTimeoutString.Substring(0, wafTimeoutString.Length - 2);
+            }
+            else if (wafTimeoutString.EndsWith("us"))
+            {
+                multipler = 1;
+                intPart = wafTimeoutString.Substring(0, wafTimeoutString.Length - 2);
+            }
+            else if (wafTimeoutString.EndsWith("s"))
+            {
+                multipler = 1_000_000;
+                intPart = wafTimeoutString.Substring(0, wafTimeoutString.Length - 1);
+            }
+
+            if (intPart == null)
+            {
+                return -1;
+            }
+
+            if (int.TryParse(intPart, numberStyles, CultureInfo.InvariantCulture, out result))
+            {
+                return result * multipler;
+            }
+
+            return -1;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -1,0 +1,73 @@
+// <copyright file="SecuritySettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Configuration;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests
+{
+    public class SecuritySettingsTests
+    {
+        [Fact]
+        public void NoPostFixShouldDefaultToMicroSeconds()
+        {
+            var target = CreateTestTarget("500");
+
+            Assert.Equal(500ul, target.WafTimeoutMicroSeconds);
+        }
+
+        [Fact]
+        public void UnknowPostfixShouldMeanDefaultValue()
+        {
+            var target = CreateTestTarget("500d");
+
+            Assert.Equal(100_000ul, target.WafTimeoutMicroSeconds);
+        }
+
+        [Fact]
+        public void JunkPostfixShouldMeanDefaultValue()
+        {
+            var target = CreateTestTarget("gibberish");
+
+            Assert.Equal(100_000ul, target.WafTimeoutMicroSeconds);
+        }
+
+        [Fact]
+        public void TestSecondsPostFix()
+        {
+            var target = CreateTestTarget("5s");
+
+            Assert.Equal(5_000_000ul, target.WafTimeoutMicroSeconds);
+        }
+
+        [Fact]
+        public void TestMillSecondsPostFix()
+        {
+            var target = CreateTestTarget("50ms");
+
+            Assert.Equal(50_000ul, target.WafTimeoutMicroSeconds);
+        }
+
+        [Fact]
+        public void TestMicroSecondsPostFix()
+        {
+            var target = CreateTestTarget("500us");
+
+            Assert.Equal(500ul, target.WafTimeoutMicroSeconds);
+        }
+
+        private static SecuritySettings CreateTestTarget(string stringToBeParsed)
+        {
+            var configurationSourceMock = new Mock<IConfigurationSource>();
+
+            configurationSourceMock.Setup(x => x.GetString(It.IsAny<string>())).Returns(stringToBeParsed);
+
+            var target = new SecuritySettings(configurationSourceMock.Object);
+            return target;
+        }
+    }
+}


### PR DESCRIPTION

## Summary of changes

The system tests set the timeout to '5s', and we don't currently support this format, meaning that we could timeout during the system tests.

## Reason for change

Errors that are probably caused timeouts have been observed.

## Implementation details

See changes.

## Test coverage

I wrote a unit test and it caught an error in my logic.

## Other details
<!-- Fixes #{issue} -->
