### PR TITLE
Improve docs on Linux builds with Docker on Windows

### DIFF
--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -68,7 +68,7 @@ For example:
 
 ### Linux
 
-The recommended approach for Linux is to build using Docker. You can use this approach for both Windows and Linux hosts. The _build_in_docker.sh_ script automates building a Docker image with the required dependencies, and running the specified Nuke targets. For example:
+The recommended approach for Linux is to build using Docker. You can use this approach for both Windows and Linux hosts. The _build_in_docker.sh_ script automates building a Docker image with the required dependencies, and running the specified Nuke targets. For example, on Linux:
 
 ```bash
 # Clean and build the main tracer project
@@ -79,6 +79,11 @@ The recommended approach for Linux is to build using Docker. You can use this ap
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
 ./build_in_docker.sh BuildAndRunLinuxIntegrationTests
+```
+
+Alternatively, on Windows:
+```powershell
+./build_in_docker.ps1 BuildTracerHome BuildAndRunLinuxIntegrationTests
 ```
 
 ### macOS

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -1,0 +1,28 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+# in case we are being run from outside this directory
+Set-Location $PSScriptRoot
+
+$ROOT_DIR="$PSScriptRoot/.."
+$BUILD_DIR="$ROOT_DIR/tracer/build/_build"
+$IMAGE_NAME="dd-trace-dotnet/alpine-base"
+
+&docker build `
+   --build-arg DOTNETSDK_VERSION=6.0.100 `
+   --tag $IMAGE_NAME `
+   --file "$BUILD_DIR/docker/alpine.dockerfile" `
+   "$BUILD_DIR"
+
+&docker run -it --rm `
+    --mount type=bind,source="$ROOT_DIR",target=/project `
+    --env NugetPackageDirectory=/project/packages `
+    --env tracerHome=/project/shared/bin/monitoring-home/tracer `
+    --env artifacts=/project/tracer/bin/artifacts `
+    -p 5003:5003 `
+    -v /ddlogs:/var/log/datadog/dotnet `
+    $IMAGE_NAME `
+    dotnet /build/bin/Debug/_build.dll $BuildArguments


### PR DESCRIPTION
This PR is meant to make it easier to build and test in Linux using Docker Desktop on Windows.
Added `build_in_docker.ps1` which is an exact equivalent of `build_in_docker.sh`. Updated readme.md accordingly. 