### PR TITLE
Update the CLI tests to use the new EnvironmentHelper methods

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -178,7 +178,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             registryService.Setup(r => r.GetLocalMachineValueNames(It.Is(@"SOFTWARE\Microsoft\.NETFramework", StringComparer.Ordinal)))
                 .Returns(Array.Empty<string>());
             registryService.Setup(r => r.GetLocalMachineValue(It.Is<string>(s => s == ProcessBasicChecksTests.ClsidKey || s == ProcessBasicChecksTests.Clsid32Key)))
-                .Returns(EnvironmentHelper.GetProfilerPath());
+                .Returns(EnvironmentHelper.GetTracerNativeDLLPath());
 
             return registryService.Object;
         }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         private const string CorEnableKey = "CORECLR_ENABLE_PROFILING";
 #endif
 
-        private static readonly string ProfilerPath = EnvironmentHelper.GetProfilerPath();
+        private static readonly string ProfilerPath = EnvironmentHelper.GetTracerNativeDLLPath();
 
         public ProcessBasicChecksTests(ITestOutputHelper output)
             : base(output)


### PR DESCRIPTION
Update the CLI tests following the changes from https://github.com/DataDog/dd-trace-dotnet/pull/2358.