### PR TITLE
If the `int` status code is not valid, don't set it

### DIFF
--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -97,6 +97,12 @@ namespace Datadog.Trace.ExtensionMethods
 
         internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, ImmutableTracerSettings tracerSettings)
         {
+            if (statusCode < 100)
+            {
+                // not a valid status code. Likely the default integer value
+                return;
+            }
+
             string statusCodeString = ConvertStatusCodeToString(statusCode);
 
             if (span.Tags is IHasStatusCode statusCodeTags)

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ExtensionMethods
 
         internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, ImmutableTracerSettings tracerSettings)
         {
-            if (statusCode < 100)
+            if (statusCode < 100 || statusCode >= 600)
             {
                 // not a valid status code. Likely the default integer value
                 return;


### PR DESCRIPTION
## Summary of changes

- Short circuit if status code is invalid

## Reason for change

In some cases, notably timeouts, we may have a "default" status code in our integrations, and so would be setting the value as `0`. The tags normalizer will strip it anyway, but it messes up span integration tests apart from anything else
