### PR TITLE
[Profiler] Add profiler in the automatic version bump process

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.AutoInstrumentation.Profiler.Native.Linux" VERSION 1.0.0)
+project("Datadog.AutoInstrumentation.Profiler.Native.Linux" VERSION 2.5.0)
 
 # ******************************************************
 # Compiler options

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
@@ -88,14 +88,9 @@ NETCOREAPP20_Datadog_AutoInstrumentation_ManagedLoader_pdb SYMBOLS          "net
 #endif    // not APSTUDIO_INVOKED
 
 // ------- version info -------------------------------------------------------
-// Alpha 1.0.2
-// Beta 1.1.1
-// Beta 2.?.?.x once integrated into Tracer repository (where x = beta version such as 1 or 2)
-// GA ???
-//
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION             2, 5, 0, 0
-PRODUCTVERSION          2, 5, 0, 0
+FILEVERSION             2,5,0,0
+PRODUCTVERSION          2,5,0,0
 FILEFLAGSMASK           VS_FF_PRERELEASE
 FILEOS                  VOS_NT
 FILETYPE                VFT_DLL

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -260,6 +260,7 @@
     <ClInclude Include="SynchronousOffThreadWorkerBase.h" />
     <ClInclude Include="ThreadCpuInfo.h" />
     <ClInclude Include="ThreadsCpuManager.h" />
+    <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ClrLifetime.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -130,6 +130,7 @@
     </ClInclude>
     <ClInclude Include="ClrLifetime.h" />
     <ClInclude Include="IClrLifetime.h" />
+    <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/version.h
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+constexpr auto PROFILER_VERSION = "2.5.0";

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <!-- Include this file into your project file using <Import Project="ProductVersion.props" /> or similar.                                 -->
   <!-- Follow the instructions in the comments to set the version and the version-date.                                                     -->
   <!-- This will make sure, your assmebly and file versions, as well as your NuGet package version are managed correctly.                   -->
@@ -9,7 +9,7 @@
     <!-- Beta 1.1.1                                                                                                                         -->
     <!-- GA 1.2.0                                                                                                                           -->
     <ProductVersion>2.5.0</ProductVersion>
-    <BetaVersion>0</BetaVersion>
+    <BetaVersion>1</BetaVersion>
 
     <!-- ProductVersionPrerelease format examples: alpha.1, alpha.2, beta.1, beta.2; EMPTY for stable releases.                             -->
     <ProductVersionPrerelease>beta.$(BetaVersion)</ProductVersionPrerelease>

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -5,15 +5,11 @@
 
   <!-- * * * * * * * * * * * INPUTS. Update this section EVERY time the component is shipped/released! * * * * * * * * * * *                -->
   <PropertyGroup>
-    <ProductVersionMajor>2</ProductVersionMajor>
-    <ProductVersionMinor>5</ProductVersionMinor>
-    <ProductVersionBuild>0</ProductVersionBuild>
-    <BetaVersion>0</BetaVersion>
     <!-- Alpha 1.0.2                                                                                                                        -->
     <!-- Beta 1.1.1                                                                                                                         -->
-    <!-- Beta 2.?.?.x once in Tracer repository (where x is the beta number ex: 1 or 2 when ready)                                          -->
-    <!-- GA ?.?.?                                                                                                                           -->
-    <ProductVersion>$(ProductVersionMajor).$(ProductVersionMinor).$(ProductVersionBuild)</ProductVersion>
+    <!-- GA 1.2.0                                                                                                                           -->
+    <ProductVersion>2.5.0</ProductVersion>
+    <BetaVersion>0</BetaVersion>
 
     <!-- ProductVersionPrerelease format examples: alpha.1, alpha.2, beta.1, beta.2; EMPTY for stable releases.                             -->
     <ProductVersionPrerelease>beta.$(BetaVersion)</ProductVersionPrerelease>

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -189,6 +189,7 @@ partial class Build
     Target UpdateVersion => _ => _
        .Description("Update the version number for the tracer")
        .Before(Clean, BuildTracerHome)
+       .Before(Clean, BuildProfilerHome)
        .Requires(() => Version)
        .Executes(() =>
         {

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -139,7 +139,7 @@ namespace PrepareRelease
                 "src/Datadog.Trace/TracerConstants.cs",
                 FourPartVersionReplace);
 
-            // Native profiler updates
+            // Native clr profiler updates
             SynchronizeVersion(
                 "src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
                 text => FullVersionReplace(text, ".", prefix: "VERSION "));
@@ -156,6 +156,29 @@ namespace PrepareRelease
             SynchronizeVersion(
                 "src/Datadog.Trace.ClrProfiler.Native/version.h",
                 text => FullVersionReplace(text, "."));
+
+            // .NET profiler
+
+            SynchronizeVersion(
+                "../profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc",
+                text =>
+                {
+                    text = FullVersionReplace(text, ",");
+                    text = FullVersionReplace(text, ".");
+                    return text;
+                });
+
+            SynchronizeVersion(
+                "../profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt",
+                text => FullVersionReplace(text, ".", prefix: "VERSION "));
+
+            SynchronizeVersion(
+                "../profiler/src/ProfilerEngine/Datadog.Profiler.Native/version.h",
+                text => FullVersionReplace(text, "."));
+
+            SynchronizeVersion(
+                "../profiler/src/ProfilerEngine/ProductVersion.props",
+                PropsVersionReplace);
 
             // Deployment updates
             SynchronizeVersion(
@@ -211,6 +234,11 @@ namespace PrepareRelease
         private string NuspecVersionReplace(string text)
         {
             return Regex.Replace(text, $"<version>{VersionPattern(withPrereleasePostfix: true)}</version>", $"<version>{VersionString(withPrereleasePostfix: true)}</version>", RegexOptions.Singleline);
+        }
+
+        private string PropsVersionReplace(string text)
+        {
+            return Regex.Replace(text, $"<ProductVersion>{VersionPattern(withPrereleasePostfix: false)}</ProductVersion>", $"<ProductVersion>{VersionString(withPrereleasePostfix: false)}</ProductVersion>", RegexOptions.Singleline);
         }
 
         private string WixProjReplace(string text)


### PR DESCRIPTION
## Summary of changes

Use the same version for the Tracer and the Profiler and add the profiler to the automatic version bumping process.

## Reason for change

Currently, the profiler has it's own versioning. We would like to have the same as the Tracer (to prevent for future headaches).
And in order to simplify the next releases, we add the profiler to the automatic version bumping process.

## Implementation details

Add the profiler files to replace version.

## Test coverage

Tested locally.

## Other details
<!-- Fixes #{issue} -->
