### PR TITLE
[CIApp] - Add support for XUnit LogsDirectSubmission

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -91,6 +91,7 @@ namespace Datadog.Trace.Ci
                     // So the last spans in buffer aren't send to the agent.
                     Log.Debug("Integration flushing spans.");
                     await Tracer.Instance.FlushAsync().ConfigureAwait(false);
+                    await Tracer.Instance.TracerManager.DirectLogSubmission.Sink.FlushAsync().ConfigureAwait(false);
                     Log.Debug("Integration flushed.");
                 }
                 catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -90,8 +90,18 @@ namespace Datadog.Trace.Ci
                     // For some reason, sometimes when all test are finished none of the callbacks to handling the tracer disposal is triggered.
                     // So the last spans in buffer aren't send to the agent.
                     Log.Debug("Integration flushing spans.");
-                    await Tracer.Instance.FlushAsync().ConfigureAwait(false);
-                    await Tracer.Instance.TracerManager.DirectLogSubmission.Sink.FlushAsync().ConfigureAwait(false);
+                    if (_settings.Logs)
+                    {
+                        await Task.WhenAll(
+                            Tracer.Instance.FlushAsync(),
+                            Tracer.Instance.TracerManager.DirectLogSubmission.Sink.FlushAsync())
+                                  .ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await Tracer.Instance.FlushAsync().ConfigureAwait(false);
+                    }
+
                     Log.Debug("Integration flushed.");
                 }
                 catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.Ci.Configuration
         {
             Enabled = source?.GetBool(ConfigurationKeys.CIVisibility.Enabled) ?? false;
             Agentless = source?.GetBool(ConfigurationKeys.CIVisibility.AgentlessEnabled) ?? false;
+            Logs = source?.GetBool(ConfigurationKeys.CIVisibility.Logs) ?? false;
             ApiKey = source?.GetString(ConfigurationKeys.ApiKey);
             Site = source?.GetString(ConfigurationKeys.Site) ?? "datadoghq.com";
 
@@ -25,6 +26,13 @@ namespace Datadog.Trace.Ci.Configuration
             ProxyNoProxy = proxyNoProxy.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             TracerSettings = new TracerSettings(source);
+
+            if (Logs)
+            {
+                // On agentless we also enable the direct log submission
+                TracerSettings.LogSubmissionSettings.DirectLogSubmissionEnabledIntegrations.Add("XUnit,Serilog,ILogger,Log4Net,NLog");
+                TracerSettings.LogSubmissionSettings.DirectLogSubmissionBatchPeriod = TimeSpan.FromSeconds(1);
+            }
         }
 
         /// <summary>
@@ -61,6 +69,11 @@ namespace Datadog.Trace.Ci.Configuration
         /// Gets the no proxy list
         /// </summary>
         public string[] ProxyNoProxy { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the Logs submission is going to be used.
+        /// </summary>
+        public bool Logs { get; }
 
         /// <summary>
         /// Gets the tracer settings

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Ci.Configuration
             if (Logs)
             {
                 // Enable the direct log submission
-                TracerSettings.LogSubmissionSettings.DirectLogSubmissionEnabledIntegrations.Add("XUnit,Serilog,ILogger,Log4Net,NLog");
+                TracerSettings.LogSubmissionSettings.DirectLogSubmissionEnabledIntegrations.Add("XUnit");
                 TracerSettings.LogSubmissionSettings.DirectLogSubmissionBatchPeriod = TimeSpan.FromSeconds(1);
             }
         }

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Ci.Configuration
 
             if (Logs)
             {
-                // On agentless we also enable the direct log submission
+                // Enable the direct log submission
                 TracerSettings.LogSubmissionSettings.DirectLogSubmissionEnabledIntegrations.Add("XUnit,Serilog,ILogger,Log4Net,NLog");
                 TracerSettings.LogSubmissionSettings.DirectLogSubmissionBatchPeriod = TimeSpan.FromSeconds(1);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -6,15 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
-using Datadog.Trace.Logging.DirectSubmission;
-using Datadog.Trace.Logging.DirectSubmission.Formatting;
-using Datadog.Trace.Logging.DirectSubmission.Sink;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 {
@@ -101,13 +96,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                 return null;
             }
 
-            var sink = Tracer.Instance.TracerManager.DirectLogSubmission.Sink;
-            for (var i = 0; i < 10; i++)
-            {
-                sink.EnqueueLog(new XUnitLogEvent("Hello", span));
-                sink.EnqueueLog(new XUnitLogEvent("World", span));
-            }
-
             span.ResetStartTime();
             return scope;
         }
@@ -135,38 +123,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             }
 
             scope.Dispose();
-        }
-
-        private class XUnitLogEvent : DatadogLogEvent
-        {
-            private readonly string _message;
-            private readonly Span _span;
-
-            public XUnitLogEvent(string message, Span span)
-            {
-                _message = message;
-                _span = span;
-            }
-
-            public override void Format(StringBuilder sb, LogFormatter formatter)
-            {
-                formatter.FormatLog<Span>(
-                    sb,
-                    _span,
-                    DateTime.UtcNow,
-                    _message,
-                    null,
-                    DirectSubmissionLogLevelExtensions.Information,
-                    null,
-                    (JsonTextWriter writer, in Span state) =>
-                    {
-                        writer.WritePropertyName("dd.trace_id");
-                        writer.WriteValue($"{state.TraceId}");
-                        writer.WritePropertyName("dd.span_id");
-                        writer.WriteValue($"{state.SpanId}");
-                        return default;
-                    });
-            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -6,10 +6,15 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 {
@@ -96,6 +101,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                 return null;
             }
 
+            var sink = Tracer.Instance.TracerManager.DirectLogSubmission.Sink;
+            for (var i = 0; i < 10; i++)
+            {
+                sink.EnqueueLog(new XUnitLogEvent("Hello", span));
+                sink.EnqueueLog(new XUnitLogEvent("World", span));
+            }
+
             span.ResetStartTime();
             return scope;
         }
@@ -123,6 +135,38 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             }
 
             scope.Dispose();
+        }
+
+        private class XUnitLogEvent : DatadogLogEvent
+        {
+            private readonly string _message;
+            private readonly Span _span;
+
+            public XUnitLogEvent(string message, Span span)
+            {
+                _message = message;
+                _span = span;
+            }
+
+            public override void Format(StringBuilder sb, LogFormatter formatter)
+            {
+                formatter.FormatLog<Span>(
+                    sb,
+                    _span,
+                    DateTime.UtcNow,
+                    _message,
+                    null,
+                    DirectSubmissionLogLevelExtensions.Information,
+                    null,
+                    (JsonTextWriter writer, in Span state) =>
+                    {
+                        writer.WritePropertyName("dd.trace_id");
+                        writer.WriteValue($"{state.TraceId}");
+                        writer.WritePropertyName("dd.span_id");
+                        writer.WriteValue($"{state.SpanId}");
+                        return default;
+                    });
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
@@ -1,0 +1,84 @@
+// <copyright file="XUnitTestOutputHelperQueueTestOutputIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.Text;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
+{
+    /// <summary>
+    /// Xunit.Sdk.TestOutputHelper.QueueTestOutput calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyNames = new[] { "xunit.execution.dotnet", "xunit.execution.desktop" },
+        TypeName = "Xunit.Sdk.TestOutputHelper",
+        MethodName = "QueueTestOutput",
+        ReturnTypeName = ClrNames.Void,
+        ParameterTypeNames = new[] { ClrNames.String },
+        MinimumVersion = "2.2.0",
+        MaximumVersion = "2.*.*",
+        IntegrationName = XUnitIntegration.IntegrationName)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class XUnitTestOutputHelperQueueTestOutputIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="output">Output string</param>
+        /// <returns>Calltarget state value</returns>
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string output)
+        {
+            var tracer = Tracer.Instance;
+            var span = tracer.ActiveScope?.Span as Span;
+            tracer.TracerManager.DirectLogSubmission.Sink.EnqueueLog(new XUnitLogEvent(output, span));
+            return CallTargetState.GetDefault();
+        }
+
+        private class XUnitLogEvent : DatadogLogEvent
+        {
+            private readonly string _message;
+            private readonly Span _span;
+
+            public XUnitLogEvent(string message, Span span)
+            {
+                _message = message;
+                _span = span;
+            }
+
+            public override void Format(StringBuilder sb, LogFormatter formatter)
+            {
+                formatter.FormatLog<Span>(
+                    sb,
+                    _span,
+                    DateTime.UtcNow,
+                    _message,
+                    null,
+                    DirectSubmissionLogLevelExtensions.Information,
+                    null,
+                    (JsonTextWriter writer, in Span state) =>
+                    {
+                        if (state is not null)
+                        {
+                            writer.WritePropertyName("dd.trace_id");
+                            writer.WriteValue($"{state.TraceId}");
+                            writer.WritePropertyName("dd.span_id");
+                            writer.WriteValue($"{state.SpanId}");
+                        }
+
+                        return default;
+                    });
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             public XUnitLogEvent(string message, Span span)
             {
                 _message = message;
-                _context = span is null ? null : new Context(span.TraceId, span.SpanId);
+                _context = span is null ? null : new Context(span.TraceId, span.SpanId, span.Context.Origin);
             }
 
             public override void Format(StringBuilder sb, LogFormatter formatter)
@@ -84,6 +84,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                             writer.WriteValue($"{state.Value.TraceId}");
                             writer.WritePropertyName("dd.span_id");
                             writer.WriteValue($"{state.Value.SpanId}");
+                            writer.WritePropertyName("_dd.origin");
+                            writer.WriteValue($"{state.Value.Origin}");
                         }
 
                         return default;
@@ -94,11 +96,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             {
                 public readonly ulong TraceId;
                 public readonly ulong SpanId;
+                public readonly string Origin;
 
-                public Context(ulong traceId, ulong spanId)
+                public Context(ulong traceId, ulong spanId, string origin)
                 {
                     TraceId = traceId;
                     SpanId = spanId;
+                    Origin = origin;
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                     _span,
                     DateTime.UtcNow,
                     _message,
-                    null,
+                    eventId: null,
                     DirectSubmissionLogLevelExtensions.Information,
                     null,
                     (JsonTextWriter writer, in Span state) =>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                     _message,
                     eventId: null,
                     DirectSubmissionLogLevelExtensions.Information,
-                    null,
+                    exception: null,
                     (JsonTextWriter writer, in Span state) =>
                     {
                         if (state is not null)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -323,6 +323,12 @@ namespace Datadog.Trace.Configuration
             /// Default is value is false (disabled).
             /// </summary>
             public const string AgentlessEnabled = "DD_CIVISIBILITY_AGENTLESS_ENABLED";
+
+            /// <summary>
+            /// Configuration key for enabling or disabling Logs direct submission.
+            /// Default is value is false (disabled).
+            /// </summary>
+            public const string Logs = "DD_CIVISIBILITY_LOGS_ENABLED";
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -332,10 +332,12 @@ namespace Datadog.Trace.ClrProfiler
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.desktop", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.dotnet", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
             };
 
@@ -552,10 +554,12 @@ namespace Datadog.Trace.ClrProfiler
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.XUnit,
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -316,10 +316,12 @@ namespace Datadog.Trace.ClrProfiler
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.desktop", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.dotnet", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
             };
 
@@ -523,10 +525,12 @@ namespace Datadog.Trace.ClrProfiler
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.XUnit,
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -316,10 +316,12 @@ namespace Datadog.Trace.ClrProfiler
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.desktop", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.desktop", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyFinished", ".ctor",  new[] { "System.Void", "_", "_", "_", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestAssemblyRunner`1", "RunTestCollectionAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "_", "_", "_" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestInvoker`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<System.Decimal>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"),
+                new("xunit.execution.dotnet", "Xunit.Sdk.TestOutputHelper", "QueueTestOutput",  new[] { "System.Void", "System.String" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"),
                 new("xunit.execution.dotnet", "Xunit.Sdk.TestRunner`1", "RunAsync",  new[] { "System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>" }, 2, 2, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"),
             };
 
@@ -523,10 +525,12 @@ namespace Datadog.Trace.ClrProfiler
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyFinishedCtorIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestInvokerRunAsyncIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestOutputHelperQueueTestOutputIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit.XUnitTestRunnerRunAsyncIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.XUnit,
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ImmutableDirectLogSubmissionSettings.cs" company="Datadog">
+// <copyright file="ImmutableDirectLogSubmissionSettings.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -24,6 +24,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             IntegrationId.ILogger,
             IntegrationId.Log4Net,
             IntegrationId.NLog,
+            IntegrationId.XUnit,
         };
 
         private readonly bool[] _enabledIntegrations;

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
@@ -1,10 +1,11 @@
-﻿// <copyright file="IDatadogSink.cs" company="Datadog">
+// <copyright file="IDatadogSink.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 #nullable enable
 
 using System;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
@@ -22,5 +23,10 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         /// Start the background process to send logs to the backend
         /// </summary>
         void Start();
+
+        /// <summary>
+        /// Flushes the sink
+        /// </summary>
+        Task FlushAsync();
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogsApi.cs" company="Datadog">
+// <copyright file="LogsApi.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
@@ -1,7 +1,10 @@
-﻿// <copyright file="NullDatadogSink.cs" company="Datadog">
+// <copyright file="NullDatadogSink.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+
+using System.Threading.Tasks;
+
 #nullable enable
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
@@ -18,6 +21,11 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 
         public void Start()
         {
+        }
+
+        public Task FlushAsync()
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -45,8 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 using var logsIntake = new MockLogsIntake();
                 EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));
-                SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds, "1");
-                SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.BatchSizeLimit, "10000");
+                SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Logs, "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Text;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission;
 using Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog;
@@ -120,6 +121,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
 
             public void Start()
             {
+            }
+
+            public Task FlushAsync()
+            {
+                return Task.CompletedTask;
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -43,6 +44,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
 
             public void Start()
             {
+            }
+
+            public Task FlushAsync()
+            {
+                return Task.CompletedTask;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #if !NETCOREAPP
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
 using Datadog.Trace.DuckTyping;
@@ -58,6 +59,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
 
             public void Start()
             {
+            }
+
+            public Task FlushAsync()
+            {
+                return Task.CompletedTask;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
 using Datadog.Trace.Vendors.Serilog.Capturing;
 using Datadog.Trace.Vendors.Serilog.Core;
@@ -42,6 +43,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
 
             public void Start()
             {
+            }
+
+            public Task FlushAsync()
+            {
+                return Task.CompletedTask;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="MockLogsIntake.cs" company="Datadog">
+// <copyright file="MockLogsIntake.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -51,6 +51,7 @@ namespace Datadog.Trace.TestHelpers
                     _listener = listener;
 
                     _listenerThread = new Thread(HandleHttpRequests);
+                    _listenerThread.IsBackground = true;
                     _listenerThread.Start();
 
                     return;
@@ -248,7 +249,8 @@ namespace Datadog.Trace.TestHelpers
             public static List<Log> DeserializeFromStream(Stream stream)
             {
                 using var sr = new StreamReader(stream);
-                using var jsonTextReader = new JsonTextReader(sr);
+                var json = sr.ReadToEnd();
+                using var jsonTextReader = new JsonTextReader(new StringReader(json));
                 return JsonSerializer.Deserialize<List<Log>>(jsonTextReader);
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
@@ -249,8 +249,7 @@ namespace Datadog.Trace.TestHelpers
             public static List<Log> DeserializeFromStream(Stream stream)
             {
                 using var sr = new StreamReader(stream);
-                var json = sr.ReadToEnd();
-                using var jsonTextReader = new JsonTextReader(new StringReader(json));
+                using var jsonTextReader = new JsonTextReader(sr);
                 return JsonSerializer.Deserialize<List<Log>>(jsonTextReader);
             }
         }

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
@@ -8,6 +8,8 @@ namespace Samples.XUnitTests
 {
     public class TestSuite
     {
+        private ITestOutputHelper _output;
+
         public TestSuite(ITestOutputHelper output)
         {
             output.WriteLine($"Pid: {Process.GetCurrentProcess().Id}");
@@ -17,11 +19,13 @@ namespace Samples.XUnitTests
                 output.WriteLine($"  {entry.Key} = {entry.Value}");
             }
             output.WriteLine(string.Empty);
+            _output = output;
         }
 
         [Fact]
         public void SimplePassTest()
         {
+            _output.WriteLine("Test:SimplePassTest");
         }
 
         [Fact(Skip = "Simple skip reason")]
@@ -32,6 +36,7 @@ namespace Samples.XUnitTests
         [Fact]
         public void SimpleErrorTest()
         {
+            _output.WriteLine("Test:SimpleErrorTest");
             int i = 0;
             int z = 0 / i;
         }
@@ -44,6 +49,7 @@ namespace Samples.XUnitTests
         [Trait("Compatibility", "Linux")]
         public void TraitPassTest()
         {
+            _output.WriteLine("Test:TraitPassTest");
         }
 
         [Fact(Skip = "Simple skip reason")]
@@ -60,6 +66,7 @@ namespace Samples.XUnitTests
         [Trait("Compatibility", "Linux")]
         public void TraitErrorTest()
         {
+            _output.WriteLine("Test:TraitErrorTest");
             int i = 0;
             int z = 0 / i;
         }
@@ -72,6 +79,7 @@ namespace Samples.XUnitTests
         [InlineData(3, 3, 6)]
         public void SimpleParameterizedTest(int xValue, int yValue, int expectedResult)
         {
+            _output.WriteLine("Test:SimpleParameterizedTest");
             Assert.Equal(expectedResult, xValue + yValue);
         }
 
@@ -91,6 +99,7 @@ namespace Samples.XUnitTests
         [InlineData(3, 0, 6)]
         public void SimpleErrorParameterizedTest(int xValue, int yValue, int expectedResult)
         {
+            _output.WriteLine("Test:SimpleErrorParameterizedTest");
             Assert.Equal(expectedResult, xValue / yValue);
         }
     }


### PR DESCRIPTION
This PR adds support for send xUnit `ITestOutputHelper` logs through the DirectSubmission 
#### Changes:
- Add support for XUnit integration id in DirectLogSubmission.
- Add Flush support in DirectLogSubmission.
- Add CI Visibility configuration settings for logs.
- Add `TestOutputHelper.QueueTestOutput` integration.

#### Example:
![image](https://user-images.githubusercontent.com/69803/156572237-beb862ab-abe9-47fa-ba9f-f7d1485264c1.png)

![image](https://user-images.githubusercontent.com/69803/156572282-eb5b5029-c74b-4333-bf84-f184208bfea7.png)
