### PR TITLE
CLI checks: consolidate IIS output messages when listing sites/apps

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Tools.Runner
 
         internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid, IRegistryService registryService = null)
         {
-            IEnumerable<string> GetAllApplicationNames(ServerManager sm)
+            static IEnumerable<string> GetAllApplicationNames(ServerManager sm)
             {
                 return from s in sm.Sites
                        from a in s.Applications

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.Tools.Runner
             if (result.Successful)
             {
                 // Perform additional validation
-                if (settings.SiteName.Count(c => c == '/') > 1)
+                if (settings.SiteName?.Count(c => c == '/') > 1)
                 {
                     return ValidationResult.Error($"IIS site names can't have multiple / in their name: {settings.SiteName}");
                 }
@@ -43,6 +44,25 @@ namespace Datadog.Trace.Tools.Runner
 
         internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid, IRegistryService registryService = null)
         {
+            IEnumerable<string> GetAllApplicationNames(ServerManager sm)
+            {
+                return from s in sm.Sites
+                       from a in s.Applications
+                       select $"{s.Name}{a.Path}";
+            }
+
+            var serverManager = new ServerManager(readOnly: true, applicationHostConfigurationPath);
+
+            if (settings.SiteName == null)
+            {
+                AnsiConsole.WriteLine(IisApplicationNotProvided());
+
+                var allApplicationNames = GetAllApplicationNames(serverManager);
+                AnsiConsole.WriteLine(ListAllIisApplications(allApplicationNames));
+
+                return 1;
+            }
+
             var values = settings.SiteName.Split('/');
 
             var siteName = values[0];
@@ -50,22 +70,15 @@ namespace Datadog.Trace.Tools.Runner
 
             AnsiConsole.WriteLine(FetchingApplication(siteName, applicationName));
 
-            var serverManager = new ServerManager(readOnly: true, applicationHostConfigurationPath);
-
             var site = serverManager.Sites[siteName];
+            var application = site?.Applications[applicationName];
 
-            if (site == null)
+            if (site == null || application == null)
             {
-                Utils.WriteError(CouldNotFindSite(siteName, serverManager.Sites.Select(s => s.Name)));
+                Utils.WriteError(CouldNotFindIisApplication(siteName, applicationName));
 
-                return 1;
-            }
-
-            var application = site.Applications[applicationName];
-
-            if (application == null)
-            {
-                Utils.WriteError(CouldNotFindApplication(siteName, applicationName, site.Applications.Select(a => a.Path)));
+                var allApplicationNames = GetAllApplicationNames(serverManager);
+                Utils.WriteError(ListAllIisApplications(allApplicationNames));
 
                 return 1;
             }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
@@ -3,18 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Spectre.Console.Cli;
 
 namespace Datadog.Trace.Tools.Runner
 {
     internal class CheckIisSettings : CommandSettings
     {
-        [CommandArgument(0, "<siteName>")]
+        [CommandArgument(0, "[siteName]")]
         public string SiteName { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Spectre.Console.Cli;
 
 namespace Datadog.Trace.Tools.Runner
@@ -10,6 +12,6 @@ namespace Datadog.Trace.Tools.Runner
     internal class CheckIisSettings : CommandSettings
     {
         [CommandArgument(0, "[siteName]")]
-        public string SiteName { get; set; }
+        public string? SiteName { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -68,9 +68,9 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
 
-        public static string IisApplicationNotProvided() => "IIS application not provided. ";
-
         public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
+
+        public static string IisApplicationNotProvided() => "IIS application not provided. ";
 
         public static string CouldNotFindIisApplication(string site, string application) => $"Could not find IIS application \"{site}{application}\". ";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -85,6 +85,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 sb.AppendLine($" - {app}");
             }
 
+            sb.AppendLine();
+            sb.AppendLine("USAGE:");
+            sb.AppendLine("    dd-trace check iis [siteName]");
+
             return sb.ToString();
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -80,9 +80,9 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             sb.AppendLine("Available IIS applications:");
 
-            foreach (var s in availableApplications)
+            foreach (var app in availableApplications)
             {
-                sb.AppendLine($" - {s}");
+                sb.AppendLine($" - {app}");
             }
 
             return sb.ToString();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
 
-        public static string FetchingApplication(string site, string application) => $"Fetching application {application} from site {site}";
+        public static string FetchingApplication(string site, string application) => $"Fetching IIS application \"{site}{application}\".";
 
         public static string InspectingWorkerProcess(int pid) => $"Inspecting worker process {pid}";
 
@@ -68,33 +68,21 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
 
+        public static string IisApplicationNotProvided() => "IIS application not provided. ";
+
         public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
 
-        public static string CouldNotFindSite(string site, IEnumerable<string> availableSites)
+        public static string CouldNotFindIisApplication(string site, string application) => $"Could not find IIS application \"{site}{application}\". ";
+
+        public static string ListAllIisApplications(IEnumerable<string> availableApplications)
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine($"Could not find site {site}");
-            sb.AppendLine("Available sites:");
+            sb.AppendLine("Available IIS applications:");
 
-            foreach (var s in availableSites)
+            foreach (var s in availableApplications)
             {
                 sb.AppendLine($" - {s}");
-            }
-
-            return sb.ToString();
-        }
-
-        public static string CouldNotFindApplication(string site, string application, IEnumerable<string> availableApplications)
-        {
-            var sb = new StringBuilder();
-
-            sb.AppendLine($"Could not find application {application} in site {site}");
-            sb.AppendLine("Available applications:");
-
-            foreach (var app in availableApplications)
-            {
-                sb.AppendLine($" - {app}");
             }
 
             return sb.ToString();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
 
-        public static string IisApplicationNotProvided() => "IIS application not provided. ";
+        public static string IisApplicationNotProvided() => "IIS application name not provided. ";
 
         public static string CouldNotFindIisApplication(string site, string application) => $"Could not find IIS application \"{site}{application}\". ";
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().Be(1);
 
-            console.Output.Should().Contain(Resources.CouldNotFindIisApplication("sample", "dummy"));
+            console.Output.Should().Contain(Resources.CouldNotFindIisApplication("sample", "/dummy"));
         }
 
         private static void EnsureWindowsAndX64()

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().Be(1);
 
-            console.Output.Should().Contain(Resources.CouldNotFindSite("dummySite", new[] { "sample" }));
+            console.Output.Should().Contain(Resources.CouldNotFindIisApplication("dummySite", "/"));
         }
 
         [SkippableFact]
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().Be(1);
 
-            console.Output.Should().Contain(Resources.CouldNotFindApplication("sample", "/dummy", new[] { "/", "/mixed" }));
+            console.Output.Should().Contain(Resources.CouldNotFindIisApplication("sample", "dummy"));
         }
 
         private static void EnsureWindowsAndX64()


### PR DESCRIPTION
## Summary of changes

Before:
- In the CLI command `dd-trace check iis <siteName>`, parameter `siteName` was required. If a value was provided and the `site` was not found in IIS, we listed all available sites. If the `site` was found but the `application` was not found in that site, we listed all available applications in that site.

After:
- CLI parameter `siteName` is now optional. If the user doesn't specify a value, we list all available site and applications in IIS.
- Consolidate all error messages to treat `site/application` as a single value and show all available `site/application` values. This list is displayed when a value is not provided (it's now optional), or if either the site or the application are not found.

Example output:

```
> dd-trace check iis

IIS application not provided.
Available IIS applications:
 - site1/
 - site1/app1
 - site2/app2

USAGE:
    dd-trace check iis [siteName]
```
```
> dd-trace check iis bad-site

Fetching IIS application "bad-site/".
Could not find IIS application "bad-site/".
Available IIS applications:
 - site1/
 - site1/app1
 - site2/app2

USAGE:
    dd-trace check iis [siteName]
```
```
> dd-trace check iis site1/bad-app

Fetching IIS application "site1/bad-app".
Could not find IIS application "site1/bad-app".
Available IIS applications:
 - site1/
 - site1/app1
 - site2/app2

USAGE:
    dd-trace check iis [siteName]
```

## Reason for change
Showing a consistent list when input is not valid makes is easier for users to find a valid value. All of these cases of invalid input now show the same consolidated site/application list:
- no input
- site not found
- site found, but application not found

## Implementation details
It's just console output...

## Test coverage
I tested this manually and observed the output. There are no changes to how the checks are actually performed.

