### PR TITLE
Managed loader cache

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private static CachedAssembly[] _assemblies = Array.Empty<CachedAssembly>();
+        private static CachedAssembly[] _assemblies;
 
         internal static System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext { get; } = new ManagedProfilerAssemblyLoadContext();
 
@@ -61,7 +61,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
                 string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
             {
-                StartupLogger.Debug("Assembly {0} not found.", args.Name);
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -5,6 +5,7 @@
 
 #if NETCOREAPP
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
@@ -15,6 +16,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
+        private static readonly Dictionary<string, Assembly> CachedAssemblies = new();
+        private static CachedAssembly _fastPath = default;
+
         internal static System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext { get; } = new ManagedProfilerAssemblyLoadContext();
 
         private static string ResolveManagedProfilerDirectory()
@@ -35,36 +39,75 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
         private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
-            var assemblyName = new AssemblyName(args.Name);
-
-            // On .NET Framework, having a non-US locale can cause mscorlib
-            // to enter the AssemblyResolve event when searching for resources
-            // in its satellite assemblies. This seems to have been fixed in
-            // .NET Core in the 2.0 servicing branch, so we should not see this
-            // occur, but guard against it anyways. If we do see it, exit early
-            // so we don't cause infinite recursion.
-            if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
+            var fastPath = _fastPath;
+            if (fastPath.Name == args.Name)
             {
+                return fastPath.Assembly;
+            }
+
+            lock (CachedAssemblies)
+            {
+                if (CachedAssemblies.TryGetValue(args.Name, out Assembly assembly))
+                {
+                    return assembly;
+                }
+
+                var assemblyName = new AssemblyName(args.Name);
+
+                // On .NET Framework, having a non-US locale can cause mscorlib
+                // to enter the AssemblyResolve event when searching for resources
+                // in its satellite assemblies. This seems to have been fixed in
+                // .NET Core in the 2.0 servicing branch, so we should not see this
+                // occur, but guard against it anyways. If we do see it, exit early
+                // so we don't cause infinite recursion.
+                if (string.Equals(assemblyName.Name, "System.Private.CoreLib.resources", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
+                {
+                    StartupLogger.Debug("Assembly {0} not found.", args.Name);
+                    CachedAssemblies[args.Name] = null;
+                    return null;
+                }
+
+                var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+
+                // Only load the main profiler into the default Assembly Load Context.
+                // If Datadog.Trace or other libraries are provided by the NuGet package their loads are handled in the following two ways.
+                // 1) The AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
+                //    will load successfully and will not invoke this resolve event.
+                // 2) The AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
+                //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
+                //    load the originally referenced version
+                if (File.Exists(path))
+                {
+                    StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
+                    assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
+                    if (fastPath.Name == null)
+                    {
+                        _fastPath = new CachedAssembly(args.Name, assembly);
+                    }
+                    else
+                    {
+                        CachedAssemblies[args.Name] = assembly;
+                    }
+
+                    return assembly;
+                }
+
+                CachedAssemblies[args.Name] = null;
                 return null;
             }
+        }
 
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+        private readonly struct CachedAssembly
+        {
+            public readonly string Name;
+            public readonly Assembly Assembly;
 
-            // Only load the main profiler into the default Assembly Load Context.
-            // If Datadog.Trace or other libraries are provided by the NuGet package their loads are handled in the following two ways.
-            // 1) The AssemblyVersion is greater than or equal to the version used by Datadog.Trace, the assembly
-            //    will load successfully and will not invoke this resolve event.
-            // 2) The AssemblyVersion is lower than the version used by Datadog.Trace, the assembly will fail to load
-            //    and invoke this resolve event. It must be loaded in a separate AssemblyLoadContext since the application will only
-            //    load the originally referenced version
-            if (File.Exists(path))
+            public CachedAssembly(string name, Assembly assembly)
             {
-                StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
-                return DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
+                Name = name;
+                Assembly = assembly;
             }
-
-            return null;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
 
-            if (TryGetCachedAssembly(path, out var cachedAssembly))
+            if (IsDatadogAssembly(path, out var cachedAssembly))
             {
                 // The file exists in the Home folder...
                 if (cachedAssembly is not null)
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 //    load the originally referenced version
                 StartupLogger.Debug("Loading {0} with DependencyLoadContext.LoadFromAssemblyPath", path);
                 var assembly = DependencyLoadContext.LoadFromAssemblyPath(path); // Load unresolved framework and third-party dependencies into a custom Assembly Load Context
-                TrySetCachedAssembly(path, assembly);
+                SetDatadogAssembly(path, assembly);
                 return assembly;
             }
 
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             return null;
         }
 
-        private static bool TryGetCachedAssembly(string path, out Assembly cachedAssembly)
+        private static bool IsDatadogAssembly(string path, out Assembly cachedAssembly)
         {
             for (var i = 0; i < _assemblies.Length; i++)
             {
@@ -109,18 +109,16 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             return false;
         }
 
-        private static bool TrySetCachedAssembly(string path, Assembly cachedAssembly)
+        private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
         {
             for (var i = 0; i < _assemblies.Length; i++)
             {
                 if (_assemblies[i].Path == path)
                 {
                     _assemblies[i] = new CachedAssembly(path, cachedAssembly);
-                    return true;
+                    break;
                 }
             }
-
-            return false;
         }
 
         private readonly struct CachedAssembly

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                     {
                         using (var fileSink = new FileSink(StartupLogFilePath))
                         {
-                            fileSink.Info($"[{DateTime.UtcNow}] {message}{Environment.NewLine}", args);
+                            fileSink.Info($"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}", args);
                         }
 
                         return;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                     {
                         using (var fileSink = new FileSink(StartupLogFilePath))
                         {
-                            fileSink.Info($"[{DateTime.UtcNow:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}", args);
+                            fileSink.Info($"[{GetNow():yyyy-MM-dd HH:mm:ss.fff zzz}] {message}{Environment.NewLine}", args);
                         }
 
                         return;
@@ -169,6 +169,18 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             {
                 // Default to not enabled
                 return false;
+            }
+        }
+
+        private static DateTime GetNow()
+        {
+            try
+            {
+                return DateTime.Now;
+            }
+            catch
+            {
+                return DateTime.UtcNow;
             }
         }
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                     {
                         using (var fileSink = new FileSink(StartupLogFilePath))
                         {
-                            fileSink.Info($"[{GetNow():yyyy-MM-dd HH:mm:ss.fff zzz}] {message}{Environment.NewLine}", args);
+                            fileSink.Info($"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff zzz}] {message}{Environment.NewLine}", args);
                         }
 
                         return;
@@ -169,18 +169,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             {
                 // Default to not enabled
                 return false;
-            }
-        }
-
-        private static DateTime GetNow()
-        {
-            try
-            {
-                return DateTime.Now;
-            }
-            catch
-            {
-                return DateTime.UtcNow;
             }
         }
     }


### PR DESCRIPTION
This PR adds a cache layer into the managed loader to avoid multiple File.Exists and loading the assembly multiple times.
