### PR TITLE
Don't build and publish the native loader unless we are going to use it

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -77,6 +77,9 @@ partial class Build : NukeBuild
     [Parameter("Enables code coverage")]
     readonly bool CodeCoverage;
 
+    [Parameter("If true, uses the native loader for integration tests", List = false)]
+    readonly bool UseNativeLoader;
+
     [Parameter("The directory containing the tool .nupkg file")]
     readonly AbsolutePath ToolSource;
 
@@ -162,6 +165,7 @@ partial class Build : NukeBuild
     Target BuildNativeLoader => _ => _
         .Description("Builds the Native Loader, and publishes to the monitoring home directory")
         .After(Clean)
+        .OnlyWhenStatic(() => UseNativeLoader)
         .DependsOn(CompileNativeLoader)
         .DependsOn(PublishNativeLoader);
 


### PR DESCRIPTION
## Summary of changes
- Doesn't build the native loader  unless it's actually going to be used

## Reason for change
- We are at crippling low drive space levels in CI, and need all the help we can get

## Implementation details

PR #2358 added support for running integration tests using the native loader, but as this isn't the configuration we currently ship, we don't use it for integration tests by default (while the profiler and debugger will require it). #2358 ensured that the native loader is built for all the integration tests, but seeing as we don't use it currently, this is using extra time and drive space.

Whether or not the native loader is used is toggled in #2358 based on an environment variable. This PR simply checks that environment variable, and skips building the loader if it's not set.