### PR TITLE
add `process_id` tag to root span during serialization

### DIFF
--- a/tracer/src/Datadog.Trace/Metrics.cs
+++ b/tracer/src/Datadog.Trace/Metrics.cs
@@ -44,6 +44,11 @@ namespace Datadog.Trace
         internal const string TracesKeepRate = "_dd.tracer_kr";
 
         /// <summary>
+        /// The process id.
+        /// </summary>
+        internal const string ProcessId = "process_id";
+
+        /// <summary>
         /// Whether the libraries application security features are enabled.
         /// </summary>
         public const string AppSecEnabled = "_dd.appsec.enabled";

--- a/tracer/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagsList.cs
@@ -36,15 +36,8 @@ namespace Datadog.Trace.Tagging
 
         static TagsList()
         {
-            try
-            {
-                double processId = DomainMetadata.Instance.ProcessId;
-                ProcessIdValueBytes = MessagePackSerializer.Serialize(processId);
-            }
-            catch
-            {
-                ProcessIdValueBytes = null;
-            }
+            double processId = DomainMetadata.Instance.ProcessId;
+            ProcessIdValueBytes = processId > 0 ? MessagePackSerializer.Serialize(processId) : null;
         }
 
         protected List<KeyValuePair<string, double>> Metrics => Volatile.Read(ref _metrics);

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.TestHelpers
     {
         private static readonly Regex LocalhostRegex = new(@"localhost\:\d+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex KeepRateRegex = new(@"_dd.tracer_kr: \d\.\d+", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex ProcessIdRegex = new(@"process_id: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// With <see cref="Verify"/>, parameters are used as part of the filename.
@@ -58,6 +59,7 @@ namespace Datadog.Trace.TestHelpers
             });
             settings.AddRegexScrubber(LocalhostRegex, "localhost:00000");
             settings.AddRegexScrubber(KeepRateRegex, "_dd.tracer_kr: 1.0");
+            settings.AddRegexScrubber(ProcessIdRegex, "process_id: 0");
             return settings;
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -97,9 +97,10 @@ namespace Datadog.Trace.Tests.Tagging
             deserializedSpan.Tags.Should().Contain(Tags.Language, TracerConstants.Language);
             deserializedSpan.Tags.Should().Contain(Tags.RuntimeId, Tracer.RuntimeId);
 
-            deserializedSpan.Metrics.Count.Should().Be(customTagCount + 2);
+            deserializedSpan.Metrics.Count.Should().Be(customTagCount + 3);
             deserializedSpan.Metrics.Should().Contain(Metrics.SamplingLimitDecision, 0.75);
             deserializedSpan.Metrics.Should().Contain(Metrics.TopLevelSpan, 1);
+            deserializedSpan.Metrics.Should().Contain(Metrics.ProcessId, DomainMetadata.Instance.ProcessId);
 
             for (int i = 0; i < customTagCount; i++)
             {

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Util;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -87,6 +88,7 @@ namespace Datadog.Trace.Tests.Tagging
             var tracer = new Mock<IDatadogTracer>();
             var traceContext = new TraceContext(tracer.Object);
             var span = new Span(new SpanContext(SpanContext.None, traceContext, "service1"), start: null);
+            traceContext.AddSpan(span);
 
             const int customTagCount = 15;
             SetupForSerializationTest(span, customTagCount);
@@ -114,8 +116,11 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var tracer = new Mock<IDatadogTracer>();
             var traceContext = new TraceContext(tracer.Object);
+
             var rootSpan = new Span(new SpanContext(SpanContext.None, traceContext, "service1"), start: null);
+            traceContext.AddSpan(rootSpan);
             var childSpan = new Span(new SpanContext(rootSpan.Context, traceContext, "service2"), start: null);
+            traceContext.AddSpan(childSpan);
 
             const int customTagCount = 15;
             SetupForSerializationTest(childSpan, customTagCount);
@@ -142,8 +147,11 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var tracer = new Mock<IDatadogTracer>();
             var traceContext = new TraceContext(tracer.Object);
+
             var rootSpan = new Span(new SpanContext(SpanContext.None, traceContext, "service1"), start: null);
+            traceContext.AddSpan(rootSpan);
             var childSpan = new Span(new SpanContext(rootSpan.Context, traceContext, "service1"), start: null);
+            traceContext.AddSpan(childSpan);
 
             const int customTagCount = 15;
             SetupForSerializationTest(childSpan, customTagCount);

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -39,6 +39,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -45,6 +45,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -39,6 +39,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -47,6 +47,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -45,6 +45,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -39,6 +39,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -25,6 +25,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -21,6 +21,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -48,6 +48,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -19,6 +19,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -46,6 +46,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -29,6 +29,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -52,6 +52,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=__statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -29,6 +29,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=__statusCode=200.verified.txt
@@ -43,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -43,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -51,6 +51,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -48,6 +48,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -43,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -45,6 +45,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -45,6 +45,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21WrongMethodTests.__path=_.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21WrongMethodTests.__path=_.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc21WrongMethodTests.__path=_delay_0.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc21WrongMethodTests.__path=_delay_0.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=__statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -29,6 +29,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=__statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -52,6 +52,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30WrongMethodTests.__path=_.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30WrongMethodTests.__path=_.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc30WrongMethodTests.__path=_delay_0.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc30WrongMethodTests.__path=_delay_0.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=__statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -29,6 +29,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -28,6 +28,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -23,6 +23,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -25,6 +25,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=__statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_handled-exception_statusCode=500.verified.txt
@@ -52,6 +52,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code-string_[200]_statusCode=500.verified.txt
@@ -49,6 +49,7 @@ at Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTestString(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31Tests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -46,6 +46,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31WrongMethodTests.__path=_.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31WrongMethodTests.__path=_.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetCoreMvc31WrongMethodTests.__path=_delay_0.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMvc31WrongMethodTests.__path=_delay_0.verified.txt
@@ -18,6 +18,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Classic.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Admin_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_Home_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Admin_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_identifier_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithExpansion.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_Index_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_Home_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Admin_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=401&TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequestWithStatusCode-statuscode=503&TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_BadRequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_BadValue_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_OptionalIdentifier_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_StatusCode-value=503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc4.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_123_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_BadValue_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_identifier_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc4Tests.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Classic.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_DataDog_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_badrequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.NoFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_DataDog_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Get_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_badrequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-async_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay-optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithExpansion.__path=_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -65,6 +65,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -41,6 +41,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -63,6 +63,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -69,6 +69,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_TransferRequest_401_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_TransferRequest_401_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_TransferRequest_503_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_TransferRequest_503_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_TransferRequest_401_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_TransferRequest_401_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_TransferRequest_503_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_TransferRequest_503_statusCode=500.verified.txt
@@ -24,6 +24,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Classic.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
@@ -63,6 +63,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
@@ -67,6 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_TransferRequest_401_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_TransferRequest_401_statusCode=401.verified.txt
@@ -63,6 +63,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_TransferRequest_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_TransferRequest_503_statusCode=503.verified.txt
@@ -67,6 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_constraints_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_delay_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_environment_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithExpansion.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -44,6 +44,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -40,6 +40,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
@@ -63,6 +63,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
@@ -67,6 +67,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTrans
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -42,6 +42,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -38,6 +38,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -38,6 +38,7 @@ at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(H
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.verified.txt
@@ -12,6 +12,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.verified.txt
@@ -11,6 +11,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.verified.txt
@@ -12,6 +12,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.verified.txt
@@ -12,6 +12,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.verified.txt
@@ -11,6 +11,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -24,6 +24,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -46,6 +47,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_environment_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -44,6 +45,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_optional_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -24,6 +24,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -46,6 +47,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_constraints_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_delay_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_environment_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -44,6 +45,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -24,6 +24,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -27,6 +27,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -46,6 +47,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -22,6 +22,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -25,6 +25,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -44,6 +45,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -20,6 +20,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -19,6 +19,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -44,6 +45,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -69,6 +71,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -94,6 +97,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -119,6 +123,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -19,6 +19,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -44,6 +45,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -69,6 +71,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -94,6 +97,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -119,6 +123,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -30,6 +30,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -67,6 +68,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -104,6 +106,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -141,6 +144,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -178,6 +182,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -30,6 +30,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -67,6 +68,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -104,6 +106,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -141,6 +144,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -178,6 +182,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
@@ -30,6 +30,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -67,6 +68,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -104,6 +106,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -141,6 +144,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -178,6 +182,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=404_url=_Health_login.php.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore2.__enableSecurity=True_expectedStatusCode=404_url=_Health_login.php.verified.txt
@@ -27,6 +27,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -61,6 +62,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -95,6 +97,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -129,6 +132,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -163,6 +167,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -20,6 +20,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -46,6 +47,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -72,6 +74,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -98,6 +101,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -124,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -20,6 +20,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -46,6 +47,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -72,6 +74,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -98,6 +101,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -124,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_expectedStatusCode=404_url=_waf_login.php.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=False_expectedStatusCode=404_url=_waf_login.php.verified.txt
@@ -31,6 +31,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -69,6 +70,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -107,6 +109,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -145,6 +148,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -183,6 +187,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_enableBlocking=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -31,6 +31,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -69,6 +70,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -107,6 +109,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -145,6 +148,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -183,6 +187,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=200_url=_Health_-arg=[$slice].verified.txt
@@ -31,6 +31,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -69,6 +70,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -107,6 +109,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -145,6 +148,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -183,6 +187,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=200_url=_Health_-test&[$slice].verified.txt
@@ -31,6 +31,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -69,6 +70,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -107,6 +109,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -145,6 +148,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -183,6 +187,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=404_url=_Health_login.php.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.__enableSecurity=True_expectedStatusCode=404_url=_Health_login.php.verified.txt
@@ -27,6 +27,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -61,6 +62,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -95,6 +97,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -129,6 +132,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -163,6 +167,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetCore5ExternalRules._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5ExternalRules._.verified.txt
@@ -31,6 +31,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -69,6 +70,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -107,6 +109,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -145,6 +148,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -183,6 +187,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_-arg=[$slice].verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_-test&[$slice].verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=False.__url=_Health_wp-config.verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_-arg=[$slice].verified.txt
@@ -46,6 +46,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -99,6 +100,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -152,6 +154,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -205,6 +208,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -258,6 +262,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_-test&[$slice].verified.txt
@@ -46,6 +46,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -99,6 +100,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -152,6 +154,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -205,6 +208,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -258,6 +262,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__url=_Health_wp-config.verified.txt
@@ -39,6 +39,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -85,6 +86,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -131,6 +133,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -177,6 +180,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -223,6 +227,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
@@ -46,6 +46,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -99,6 +100,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -152,6 +154,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -205,6 +208,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -258,6 +262,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
@@ -46,6 +46,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -99,6 +100,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -152,6 +154,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -205,6 +208,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -258,6 +262,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.blockingEnabled=True.__url=_Health_wp-config.verified.txt
@@ -39,6 +39,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -85,6 +86,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -131,6 +133,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -177,6 +180,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -223,6 +227,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_-arg=[$slice].verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_-test&[$slice].verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=False.__url=_Health_wp-config.verified.txt
@@ -38,6 +38,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -82,6 +83,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -126,6 +128,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -170,6 +173,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -214,6 +218,7 @@
       span.kind: server
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_-arg=[$slice].verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_-test&[$slice].verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__url=_Health_wp-config.verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-arg=[$slice].verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_-test&[$slice].verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_wp-config.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.blockingEnabled=True.__url=_Health_wp-config.verified.txt
@@ -47,6 +47,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -101,6 +102,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -155,6 +157,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -209,6 +212,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
@@ -263,6 +267,7 @@
       _dd.runtime_family: dotnet
     },
     Metrics: {
+      process_id: 0,
       _dd.appsec.enabled: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,

--- a/tracer/test/snapshots/TraceAnnotationsTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsTests._.verified.txt
@@ -13,6 +13,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -42,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -66,6 +68,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -90,6 +93,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -114,6 +118,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -138,6 +143,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=BasicHttpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -42,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -66,6 +68,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -90,6 +93,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -114,6 +118,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -138,6 +143,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -15,6 +15,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -36,6 +37,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -57,6 +59,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -78,6 +81,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -99,6 +103,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -120,6 +125,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=NetTcpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -15,6 +15,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -36,6 +37,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -57,6 +59,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -78,6 +81,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -99,6 +103,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -120,6 +125,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=False.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=False.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -42,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -66,6 +68,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -90,6 +93,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -114,6 +118,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -138,6 +143,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=True.verified.txt
+++ b/tracer/test/snapshots/WcfTests.__binding=WSHttpBinding_enableNewWcfInstrumentation=True.verified.txt
@@ -18,6 +18,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -42,6 +43,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -66,6 +68,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -90,6 +93,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -114,6 +118,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -138,6 +143,7 @@
       version: 1.0.0
     },
     Metrics: {
+      process_id: 0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0


### PR DESCRIPTION
## Summary of changes
Add a new `process_id` numeric tag to root spans.

## Reason for change
The tag is required for correlation between Live Process and APM.

## Implementation details
Inject the tag into the `metrics` dictionary of root spans during serialization. Tag value is constant (for the lifetime of a process), so the UTF-8 bytes can be cached.

## Test coverage

Tests for `TagsList` serialization were modified to check for this tag when expected.

## Other details

These changes are built on top of #2542. Merge that PR first.
Resolves AIT-776.