### PR TITLE
[Tracer] Use the native loader for Windows integration tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -132,7 +132,7 @@ stages:
   - job: generate_variables_job
     dependsOn: []
     pool:
-      vmImage: windows-2019 
+      vmImage: windows-2019
 
     steps:
     - template: steps/install-latest-dotnet-sdk.yml
@@ -532,6 +532,8 @@ stages:
 
     - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
+      env:
+        use_native_loader: true
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -585,7 +587,7 @@ stages:
       displayName: BuildWindowsIntegrationTests
 
     - script: |
-        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
+        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*profiler-beta.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
         docker-compose up -d IntegrationTests.IIS
       displayName: docker-compose start IntegrationTests.IIS
       retryCountOnTaskFailure: 5
@@ -795,10 +797,10 @@ stages:
 - stage: exploration_tests_windows
   condition: >
     and(
-      succeeded(), 
-      eq(variables['isScheduledBuild'], 'False'), 
+      succeeded(),
+      eq(variables['isScheduledBuild'], 'False'),
       or(
-        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.IsProfilerChanged'],'True'), 
+        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.IsProfilerChanged'],'True'),
         eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -507,6 +507,8 @@ stages:
     timeoutInMinutes: 100
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
+    variables:
+      use_native_loader: true
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -534,8 +536,6 @@ stages:
         Get-ChildItem env:
         tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
-      env:
-        use_native_loader: "true"
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -508,7 +508,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
     variables:
-      use_native_loader: true
+      USE_NATIVE_LOADER: true
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -532,9 +532,7 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
-    - powershell: |
-        Get-ChildItem env:
-        tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
+    - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -533,7 +533,7 @@ stages:
     - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
       env:
-        use_native_loader: true
+        use_native_loader: "true"
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -580,7 +580,7 @@ stages:
       displayName: Download MSI
       inputs:
         artifact: windows-msi-$(targetPlatform)
-        patterns: '**/*.msi'
+        patterns: '**/*profiler-beta.msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
     - script: tracer\build.cmd BuildWindowsIntegrationTests -Framework $(framework)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -530,7 +530,9 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
-    - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
+    - powershell: |
+        Get-ChildItem env:
+        tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
       env:
         use_native_loader: "true"

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.TestHelpers
 
             // The Tracer is not currently utilizing the Native Loader in production. It is only being used in the Continuous Profiler beta.
             // Because of that, we don't test it in the default pipeline.
-            bool useNativeLoader = string.Equals("true", Environment.GetEnvironmentVariable("use_native_loader"), StringComparison.InvariantCultureIgnoreCase);
+            bool useNativeLoader = string.Equals("true", Environment.GetEnvironmentVariable("USE_NATIVE_LOADER"), StringComparison.InvariantCultureIgnoreCase);
             ProfilerPath = useNativeLoader ? GetNativeLoaderPath() : GetTracerNativeDLLPath();
 
             var parts = _targetFramework.FrameworkName.Split(',');


### PR DESCRIPTION
## Summary of changes

For windows, we would like to run the tracer through the native proxy (aka native loader).
This PR makes sure that we run Windows Integration tests with it.

## Reason for change

- For non-IIS integration tests: just set the environment variable
- For IIS integratin tests: use the *profiler-beta.msi

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
