### PR TITLE
Fix CLI tool failing process checks when using Native Loader

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -237,11 +237,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
-                return "Datadog.Trace.ClrProfiler.Native.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase);
+                return "Datadog.Trace.ClrProfiler.Native.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase) ||
+                       "Datadog.AutoInstrumentation.NativeLoader.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase);
             }
 
             // Paths are case-sensitive on Linux
-            return "Datadog.Trace.ClrProfiler.Native.so".Equals(fileName, StringComparison.Ordinal);
+            return "Datadog.Trace.ClrProfiler.Native.so".Equals(fileName, StringComparison.Ordinal) ||
+                   "Datadog.AutoInstrumentation.NativeLoader.so".Equals(fileName, StringComparison.Ordinal);
         }
 
         private static string? FindProfilerModule(ProcessInfo process)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -238,7 +238,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 return "Datadog.Trace.ClrProfiler.Native.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase) ||
-                       "Datadog.AutoInstrumentation.NativeLoader.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase);
+                       "Datadog.AutoInstrumentation.NativeLoader.x64.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase) ||
+                       "Datadog.AutoInstrumentation.NativeLoader.x86.dll".Equals(fileName, StringComparison.OrdinalIgnoreCase);
             }
 
             // Paths are case-sensitive on Linux


### PR DESCRIPTION
Currently, the CLI's tool's basic process checks will fail if the `COR_PROFILER_PATH` or `CORECLR_PROFILER_PATH` env var is pointing to the Native Loader instead of the Tracer native library (`Datadog.Trace.ClrProfiler.Native.dll`). 

This causes the CLI tool's tests to fail when running with the native loader enabled (i.e. when the `use_native_loader` CI variable is set to true).

This PR changes it so that both paths are accepted.


**Note:** This PR does not change the error message the CLI tool prints out; it will still print out: 

> The environment variable CORECLR_PROFILER_PATH was set to '_...some incorrect path..._' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'

This should be changed to the Native Loader file name after the Native Loader is made the default in all environments.