### PR TITLE
[Profiler] Activate checks in smoke tests for the new pipeline

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -74,10 +74,10 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
 
         if (errorCode == -1)
         {
-            Log::Error("LinuxStackFramesCollector::CollectStackSampleImplementation:"
-                       " Unable to send signal USR1 to thread with osThreadId=",
-                       osThreadId, ". Error code: ",
-                       strerror(errno));
+            Log::Warn("LinuxStackFramesCollector::CollectStackSampleImplementation:"
+                      " Unable to send signal USR1 to thread with osThreadId=",
+                      osThreadId, ". Error code: ",
+                      strerror(errno));
         }
         else
         {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -711,6 +711,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ModuleLoadFinished(ModuleID modul
         return S_OK;
     }
 
+    if (_pConfiguration->IsFFLibddprofEnabled())
+    {
+        return S_OK;
+    }
+
     return shared::Loader::GetSingletonInstance()->InjectLoaderToModuleInitializer(moduleId);
 }
 
@@ -769,6 +774,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::JITCachedFunctionSearchStarted(Fu
     if (false == _isInitialized.load())
     {
         // If this CorProfilerCallback has not yet initialized, or if it has already shut down, then this callback is a No-Op.
+        return S_OK;
+    }
+
+    if (_pConfiguration->IsFFLibddprofEnabled())
+    {
         return S_OK;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -51,6 +51,12 @@ public:
     }
 
     template <typename... Args>
+    static void Warn(const Args... args)
+    {
+        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Warn<Args...>(args...);
+    }
+
+    template <typename... Args>
     static void Error(const Args... args)
     {
         shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Error<Args...>(args...);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
@@ -141,7 +141,9 @@ namespace Datadog.Profiler.SmokeTests
         private void RunChecks(MockDatadogAgent agent, bool isRunningWithNewPipeline)
         {
             if (!isRunningWithNewPipeline)
+            {
                 return;
+            }
 
             CheckLogFiles();
             CheckPprofFiles();
@@ -151,17 +153,24 @@ namespace Datadog.Profiler.SmokeTests
         private void CheckLogFiles()
         {
             CheckLogFiles("DD-DotNet-Profiler-Native*.*");
-            //CheckLogFiles("DD-DotNet-Profiler-Managed*.*");
-            //CheckLogFiles("DD-DotNet-Common-ManagedLoader*.*");
+            CheckNoLogFiles("DD-DotNet-Profiler-Managed*.*");
+            CheckNoLogFiles("DD-DotNet-Common-ManagedLoader*.*");
+        }
+
+        private void CheckNoLogFiles(string filePattern)
+        {
+            var files = Directory.EnumerateFiles(_testLogDir, filePattern, SearchOption.AllDirectories).ToList();
+
+            Assert.Empty(files);
         }
 
         private void CheckLogFiles(string filePattern)
         {
-            List<string> managedLoaderLogFiles = Directory.EnumerateFiles(_testLogDir, filePattern, SearchOption.AllDirectories).ToList();
+            List<string> files = Directory.EnumerateFiles(_testLogDir, filePattern, SearchOption.AllDirectories).ToList();
 
-            Assert.NotEmpty(managedLoaderLogFiles);
+            Assert.NotEmpty(files);
 
-            foreach (string logFile in managedLoaderLogFiles)
+            foreach (string logFile in files)
             {
                 Assert.False(LogFileContainsErrorMessage(logFile), $"Found error message in the log file {logFile}");
             }


### PR DESCRIPTION
## Summary of changes

Activate checks in the smoke tests for the new pipeline.

## Reason for change

With the old pipeline, the checks were deactivated due to flakiness. We relied mainly on the rel. env. to ensure that there is nothing wrong.

With the new pipeline, we are in a different setup and we can now check few things (log files containing error, number of calls to the agent...)

## Implementation details

use a flag to determine if we run with the new pipeline or not.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
