### PR TITLE
Add  `--overwrite true` to Azure upload

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1441,9 +1441,9 @@ stages:
           displayName: Write tracer version number to version.txt
 
         - bash: |
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt"
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt"
-            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "version.txt" --name "version.txt"
+            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt" --overwrite true
+            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt" --overwrite true
+            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "version.txt" --name "version.txt" --overwrite true
           displayName: Upload indexes to Azure
           condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:


### PR DESCRIPTION
## Summary of changes
- Adds `--overwrite true` to the index uploads to Azure (which describe the latest blob upload)

## Reason for change
Apparently MS decided to [change the defaults **in a patch release** for the Azure CLI](https://docs.microsoft.com/en-us/cli/azure/release-notes-azure-cli#storage) so our uploads started failing last week

## Semver refresher

Just in case anyone wondered:

```mermaid
flowchart TD
    A{Is this a major version change?} -->|Yes| B[Breaking changes allowed]
    A -->|No| C[Breaking changes not allowed]
```