### PR TITLE
Add DD_TRACE_RATE_LIMIT parameter

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -147,11 +147,19 @@ namespace Datadog.Trace.Configuration
         public const string LogsInjectionEnabled = "DD_LOGS_INJECTION";
 
         /// <summary>
+        /// This parameter is obsolete and should be replaced by `DD_TRACE_RATE_LIMIT`.
         /// Configuration key for setting the number of traces allowed
         /// to be submitted per second.
         /// </summary>
         /// <seealso cref="TracerSettings.MaxTracesSubmittedPerSecond"/>
         public const string MaxTracesSubmittedPerSecond = "DD_MAX_TRACES_PER_SECOND";
+
+        /// <summary>
+        /// Configuration key for setting the number of traces allowed
+        /// to be submitted per second.
+        /// </summary>
+        /// <seealso cref="TracerSettings.MaxTracesSubmittedPerSecond"/>
+        public const string TraceRateLimit = "DD_TRACE_RATE_LIMIT";
 
         /// <summary>
         /// Configuration key for enabling or disabling the diagnostic log at startup

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -147,11 +147,11 @@ namespace Datadog.Trace.Configuration
         public const string LogsInjectionEnabled = "DD_LOGS_INJECTION";
 
         /// <summary>
-        /// This parameter is obsolete and should be replaced by `DD_TRACE_RATE_LIMIT`.
         /// Configuration key for setting the number of traces allowed
         /// to be submitted per second.
         /// </summary>
         /// <seealso cref="TracerSettings.MaxTracesSubmittedPerSecond"/>
+        [Obsolete("This parameter is obsolete and should be replaced by `DD_TRACE_RATE_LIMIT`")]
         public const string MaxTracesSubmittedPerSecond = "DD_MAX_TRACES_PER_SECOND";
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating the maximum number of traces set to AutoKeep (p1) per second.
         /// Default is <c>100</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.MaxTracesSubmittedPerSecond"/>
+        /// <seealso cref="ConfigurationKeys.TraceRateLimit"/>
         public int MaxTracesSubmittedPerSecond { get; }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -85,7 +85,8 @@ namespace Datadog.Trace.Configuration
                                    // default value
                                    false;
 
-            MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
+            MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.TraceRateLimit) ??
+                                          source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
                                           // default value
                                           100;
 
@@ -232,7 +233,7 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating the maximum number of traces set to AutoKeep (p1) per second.
         /// Default is <c>100</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.MaxTracesSubmittedPerSecond"/>
+        /// <seealso cref="ConfigurationKeys.TraceRateLimit"/>
         public int MaxTracesSubmittedPerSecond { get; set; }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -86,7 +86,9 @@ namespace Datadog.Trace.Configuration
                                    false;
 
             MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.TraceRateLimit) ??
+#pragma warning disable 618 // this parameter has been replaced but may still be used
                                           source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
+#pragma warning restore 618
                                           // default value
                                           100;
 

--- a/tracer/test/test-applications/integrations/Samples.Console/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.Console/Properties/launchSettings.json
@@ -14,7 +14,7 @@
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
         "DD_VERSION": "1.0.0",
 
-        "DD_MAX_TRACES_PER_SECOND": "50"
+        "DD_TRACE_RATE_LIMIT": "50"
       },
       "nativeDebugging": true
     }

--- a/tracer/test/test-applications/integrations/Samples.RateLimiter/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RateLimiter/Program.cs
@@ -20,7 +20,7 @@ namespace Samples.RateLimiter
         {
             var numberOfSeconds = 5;
             var maxMilliseconds = numberOfSeconds * 1000;
-            var configuredLimitPerSecond = int.Parse(Environment.GetEnvironmentVariables()["DD_MAX_TRACES_PER_SECOND"].ToString());
+            var configuredLimitPerSecond = int.Parse(Environment.GetEnvironmentVariables()["DD_TRACE_RATE_LIMIT"].ToString());
 
             Console.WriteLine($"Ready to run for {numberOfSeconds} seconds.");
             Console.WriteLine($"Configured rate limit of {configuredLimitPerSecond}");

--- a/tracer/test/test-applications/integrations/Samples.RateLimiter/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.RateLimiter/Properties/launchSettings.json
@@ -14,7 +14,7 @@
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
         "DD_VERSION": "1.0.0",
 
-        "DD_MAX_TRACES_PER_SECOND": "50"
+        "DD_TRACE_RATE_LIMIT": "50"
       },
       "nativeDebugging": true
     }


### PR DESCRIPTION
It is the parameter used by other tracers

## Summary of changes
Adding `DD_TRACE_RATE_LIMIT` to ultimately replace the `DD_MAX_TRACES_PER_SECOND` parameter. Indeed, even if they work the same, only the .NET tracer uses the later one.

## Reason for change
For consistency with other tracers.

## Implementation details
For now, I've just added `DD_TRACE_RATE_LIMIT` parameter. It has precedence over `DD_MAX_TRACES_PER_SECOND`. But it is still there for retro compatibility.

## Test coverage
None

## Other details
Documentation change: https://github.com/DataDog/documentation/pull/13351
