### PR TITLE
Remove manual call to logger shutdown

### DIFF
--- a/shared/src/native-src/logger_impl.h
+++ b/shared/src/native-src/logger_impl.h
@@ -63,11 +63,6 @@ public:
     void EnableDebug();
     bool IsDebugEnabled() const;
 
-    static void Shutdown()
-    {
-        spdlog::shutdown();
-    }
-
 private:
     bool m_debug_logging_enabled;
 };

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -734,7 +734,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
     Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.size());
     Logger::Debug("   FirstJitCompilationAppDomains: ", first_jit_compilation_app_domains.size());
     Logger::Info("Stats: ", Stats::Instance()->ToString());
-    Logger::Shutdown();
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/logger.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/logger.h
@@ -73,11 +73,6 @@ public:
         return shared::LoggerImpl<TracerLoggerPolicy>::Instance()->IsDebugEnabled();
     }
 
-    static void Shutdown()
-    {
-        shared::LoggerImpl<TracerLoggerPolicy>::Shutdown();
-    }
-
     static void Flush()
     {
         shared::LoggerImpl<TracerLoggerPolicy>::Instance()->Flush();


### PR DESCRIPTION
This PR removes the manual call to the logger shutdown method. 
Final flush and shutdown will be handled by the destructor.