### PR TITLE
Use Azure VMSS hosted runners

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -153,9 +153,6 @@ stages:
     pool:
       vmImage: windows-2019
     steps:
-    - checkout: self
-      path: s
-
     - template: steps/install-latest-dotnet-sdk.yml
     - script: tracer\build.cmd BuildTracerHome
       displayName: Build tracer home
@@ -182,9 +179,6 @@ stages:
     pool:
       vmImage: windows-2019
     steps:
-    - checkout: self
-      path: s
-
     - template: steps/install-latest-dotnet-sdk.yml
 
     - script: tracer\build.cmd BuildProfilerHome
@@ -210,7 +204,7 @@ stages:
         alpine:
           baseImage: alpine
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-scale-set
 
     steps:
 
@@ -431,7 +425,7 @@ stages:
         alpine:
           baseImage: alpine
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-scale-set
 
     steps:
     - template: steps/restore-working-directory.yml
@@ -503,7 +497,7 @@ stages:
 
   - job: Win
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     timeoutInMinutes: 100
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -565,7 +559,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -635,7 +629,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-scale-set
 
     steps:
     # Doing a clean of obj files _before_ restore to remove build output from previous runs


### PR DESCRIPTION
## Summary of changes

Converts the following stages to use self-hosted VMSS runner agent pool
- build_linux
- unit_tests_linux
- integration_tests_linux
- integration_tests_windows
- integration_tests_windows_iis

## Reason for change

We are running out of drive space in the MS hosted runners, which is making it impossible to build some branches. This PR should resolve the most pressing issue, but it also opens the way for more optimisations.

## Implementation details

For details of the setup process and installed software, see [this doc](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2390917483/Azure+VM+Scale+sets+for+Azure+Devops#Creating-a-VMSS). The basics are described below.

Only using for the above stages at the moment, as these spawn a _lot_ of jobs. I also didn't notice a significant speed up for the build stage under Windows. Linux saw more speedup thanks to docker caching, hence its use here.

> The images and build are only a first pass, we have lots of room to improve the agents, cache nuget packages, optimise the build, use beefier agents etc. This is about unblocking existing problems.

### Linux

- Installs docker + docker-compose
- pre-pulls all the images in ./docker-compose.yml
- pre-builds the debian and alpine "runner" images
- ~60GB of available drive space
- Currently using D2ads_v5 runners (2 CPU, 8GB memory)

### Windows

- Re-uses [the scripts MS use to build their hosted images](https://github.com/actions/virtual-environments/), but cherry-picks what we need
- Pre-pulls some default Windows docker images, but room for improvement here
- Configures VSTS to use the D Drive to avoid compatibility issues with hosted runners
- 75GB of available drive space
- Currently using D2ads_v5 runners (2 CPU, 8GB memory)

## Test coverage

Initial tests show some moderate improvements in build times already (ignoring provisioning times, which we can play with by increasing max vm counts):

- Linux
  - build_linux take ~7 mins vs 10mins
  - integration_tests_linux tests take ~22mins vs 40mins
  - unit_tests_linux take ~15mins vs 20mins
- Windows 
  - build tracer takes ~10mins, same as with MS hosted runner (hence not included for now)
  - integration tests take ~20 mins, vs 25/30 min average
  - iis integration tests take ~15 mins (netcore) and ~35 mins (net461) vs 25mins and 45mins
