### PR TITLE
[CI-App] Adds test.bundle tag

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/TestTags.cs
@@ -11,6 +11,11 @@ namespace Datadog.Trace.Ci.Tags
     internal static class TestTags
     {
         /// <summary>
+        /// Test bundle name
+        /// </summary>
+        public const string Bundle = "test.bundle";
+
+        /// <summary>
         /// Test suite name
         /// </summary>
         public const string Suite = "test.suite";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             object[] testMethodArguments = testMethodInfo.Arguments;
 
             string testFramework = "MSTestV2";
+            string testBundle = testMethodInfo.MethodInfo?.DeclaringType?.Assembly?.GetName().Name;
             string testSuite = testMethodInfo.TestClassName;
             string testName = testMethodInfo.TestMethodName;
 
@@ -44,6 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(Tags.Language, TracerConstants.Language);
+            span.SetTag(TestTags.Bundle, testBundle);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -40,6 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
             string testName = testMethod.Name;
             string testSuite = testMethod.DeclaringType?.FullName;
+            string testBundle = testMethod.DeclaringType?.Assembly?.GetName().Name;
 
             // Extract the test suite from the full name to support custom fixture parameters and test declared in base classes.
             if (fullName.EndsWith("." + composedTestName))
@@ -57,6 +58,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(Tags.Language, TracerConstants.Language);
+            span.SetTag(TestTags.Bundle, testBundle);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 
         internal static Scope CreateScope(ref TestRunnerStruct runnerInstance, Type targetType)
         {
+            string testBundle = runnerInstance.TestClass.Assembly?.GetName().Name;
             string testSuite = runnerInstance.TestClass.ToString();
             string testName = runnerInstance.TestMethod.Name;
 
@@ -35,6 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(Tags.Language, TracerConstants.Language);
+            span.SetTag(TestTags.Bundle, testBundle);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     public class MsTestV2Tests : TestHelper
     {
         private const string TestSuiteName = "Samples.MSTestTests.TestSuite";
+        private const string TestBundleName = "Samples.MSTestTests";
 
         public MsTestV2Tests(ITestOutputHelper output)
             : base("MSTestTests", output)
@@ -61,6 +62,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the runtime values
                         CheckRuntimeValues(targetSpan);
+
+                        // check the bundle name
+                        AssertTargetSpanEqual(targetSpan, TestTags.Bundle, TestBundleName);
 
                         // check the suite name
                         AssertTargetSpanEqual(targetSpan, TestTags.Suite, TestSuiteName);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     {
         private const int ExpectedSpanCount = 20;
 
+        private const string TestBundleName = "Samples.NUnitTests";
         private static string[] _testSuiteNames = new string[]
         {
             "Samples.NUnitTests.TestSuite",
@@ -76,6 +77,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the runtime values
                         CheckRuntimeValues(targetSpan);
+
+                        // check the bundle name
+                        AssertTargetSpanAnyOf(targetSpan, TestTags.Bundle, TestBundleName);
 
                         // check the suite name
                         AssertTargetSpanAnyOf(targetSpan, TestTags.Suite, _testSuiteNames);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class XUnitTests : TestHelper
     {
+        private const string TestBundleName = "Samples.XUnitTests";
         private const string TestSuiteName = "Samples.XUnitTests.TestSuite";
         private const int ExpectedSpanCount = 13;
 
@@ -69,6 +70,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the runtime values
                         CheckRuntimeValues(targetSpan);
+
+                        // check the bundle name
+                        AssertTargetSpanEqual(targetSpan, TestTags.Bundle, TestBundleName);
 
                         // check the suite name
                         AssertTargetSpanEqual(targetSpan, TestTags.Suite, TestSuiteName);


### PR DESCRIPTION
This PR adds the `test.bundle` tag to testing framework integrations.