### PR TITLE
Run system tests over UDS

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1698,6 +1698,17 @@ stages:
         condition: always()
         displayName: System tests logs
         artifact: system-tests_$(System.JobAttempt)
+        
+      - script: ./run.sh UDS
+        workingDirectory: system-tests
+        displayName: Run tests over UDS
+        env:
+          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
+
+      - publish: system-tests/logs_uds
+        condition: always()
+        displayName: System tests UDS logs
+        artifact: system-tests-uds_$(System.JobAttempt)
 
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))


### PR DESCRIPTION
Runs system-tests suite with UDS as the transport.
https://github.com/DataDog/system-tests/blob/main/run.sh#L39

https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=93484&view=logs&j=f9b5f215-18f7-5982-482b-42aaa98babdc&t=9bf544a1-4734-5bba-2149-54200227990d
![image](https://user-images.githubusercontent.com/1801443/158251652-fe49326a-d896-4481-bd0c-d7033f01e1d4.png)
![image](https://user-images.githubusercontent.com/1801443/158252042-343cb32f-58f3-43d4-8aa7-ad05d4937c24.png)
![image](https://user-images.githubusercontent.com/1801443/158252315-b018ebbd-a182-484f-bc44-b2df3fa1b3c2.png)
