### PR TITLE
Add timeouts to remote requests

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #nullable enable
 
+using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
@@ -16,12 +17,15 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public static IApiRequestFactory Get(ImmutableDirectLogSubmissionSettings settings)
         {
+            // Still quite a long time, but we could be sending a lot of data
+            var timeout = TimeSpan.FromSeconds(15);
+
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
-            return new HttpClientRequestFactory(LogsApiHeaderNames.DefaultHeaders);
+            return new HttpClientRequestFactory(LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
-            return new ApiWebRequestFactory(LogsApiHeaderNames.DefaultHeaders);
+            return new ApiWebRequestFactory(LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryTransportFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryTransportFactory.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Telemetry
 
         public ITelemetryTransport Create()
         {
-            var timeout = TimeSpan.FromSeconds(10);
+            var timeout = TimeSpan.FromSeconds(15);
 #if NETCOREAPP
             Log.Debug("Using {FactoryType} for telemetry transport.", nameof(JsonHttpClientTelemetryTransport));
             var httpClient = new System.Net.Http.HttpClient { BaseAddress = _baseEndpoint, Timeout = timeout };

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryTransportFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryTransportFactory.cs
@@ -22,13 +22,14 @@ namespace Datadog.Trace.Telemetry
 
         public ITelemetryTransport Create()
         {
+            var timeout = TimeSpan.FromSeconds(10);
 #if NETCOREAPP
             Log.Debug("Using {FactoryType} for telemetry transport.", nameof(JsonHttpClientTelemetryTransport));
-            var httpClient = new System.Net.Http.HttpClient { BaseAddress = _baseEndpoint };
+            var httpClient = new System.Net.Http.HttpClient { BaseAddress = _baseEndpoint, Timeout = timeout };
             return new JsonHttpClientTelemetryTransport(httpClient, _apiKey);
 #else
             Log.Debug("Using {FactoryType} for telemetry transport.", nameof(JsonWebRequestTelemetryTransport));
-            return new JsonWebRequestTelemetryTransport(_baseEndpoint, _apiKey);
+            return new JsonWebRequestTelemetryTransport(_baseEndpoint, _apiKey, timeout);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/JsonWebRequestTelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/JsonWebRequestTelemetryTransport.cs
@@ -16,11 +16,13 @@ namespace Datadog.Trace.Telemetry
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<JsonWebRequestTelemetryTransport>();
         private readonly string _apiKey;
+        private readonly int _timeoutMilliseconds;
         private readonly Uri _endpoint;
 
-        public JsonWebRequestTelemetryTransport(Uri baseEndpoint, string apiKey)
+        public JsonWebRequestTelemetryTransport(Uri baseEndpoint, string apiKey, TimeSpan timeout)
         {
             _apiKey = apiKey;
+            _timeoutMilliseconds = (int)timeout.TotalMilliseconds;
             _endpoint = new Uri(baseEndpoint, TelemetryConstants.TelemetryPath);
         }
 
@@ -36,6 +38,7 @@ namespace Datadog.Trace.Telemetry
                 request.Method = "POST";
                 request.ContentType = "application/json";
                 request.ContentLength = bytes.Length;
+                request.Timeout = _timeoutMilliseconds;
 
                 foreach (var defaultHeader in TelemetryHttpHeaderNames.DefaultHeaders)
                 {


### PR DESCRIPTION
## Summary of changes
- Add timeout to log submission HttpClient
- Add timeout to Telemetry clients

## Reason for change

The default timeouts are 100s which is a _looong_ time.

## Implementation details

Used 15s for the log submission timeout, and 10s for telemetry. These both feel a bit long to me still, but CI app is using 15s, so it seems an ok-ish bet, and we don't have any telemetry about better values to use yet.

