### PR TITLE
[AppSec] small fix: don't log a warning if no waf timeout has been specified

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Configuration
         internal const string AppSecTraceRateLimit = "DD_APPSEC_TRACE_RATE_LIMIT";
 
         /// <summary>
-        /// Limits the amount of AppSec traces sent per second with an integer value, strictly positive.
+        /// WAF timeout in microseconds of each WAF execution (the timeout value passed to ddwaf_run).
         /// </summary>
         internal const string AppSecWafTimeout = "DD_APPSEC_WAF_TIMEOUT";
 


### PR DESCRIPTION
## Summary of changes
Dont log a warning always even if no DD_APPSEC_WAF_TIMEOUT has been set
## Reason for change
Logs a warning the waf timeout is wrong even if no appsec waf timeout was specified
## Implementation details
If no value, dont log a warning and set default
## Test coverage

## Other details
<!-- Fixes #{issue} -->
