### PR TITLE
Add small amount of Debug logs for runtime metrics submission

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 
 using System;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -16,6 +17,7 @@ namespace Datadog.Trace.RuntimeMetrics
     {
         internal const string EnvironmentVariableName = "WEBSITE_COUNTERS_CLR";
 
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AzureAppServicePerformanceCounters>();
         private readonly IDogStatsd _statsd;
 
         private int? _previousGen0Count;
@@ -63,6 +65,8 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen0Count = gen0;
             _previousGen1Count = gen1;
             _previousGen2Count = gen2;
+
+            Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}]");
         }
 
         private class PerformanceCountersValue

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -107,6 +107,8 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen0Count = gen0;
             _previousGen1Count = gen1;
             _previousGen2Count = gen2;
+
+            Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.ContentionCount}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}]");
         }
 
         protected virtual void InitializePerformanceCounters()

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -74,6 +74,8 @@ namespace Datadog.Trace.RuntimeMetrics
             _statsd.Counter(MetricsNames.ContentionCount, Interlocked.Exchange(ref _contentionCount, 0));
 
             _statsd.Gauge(MetricsNames.ThreadPoolWorkersCount, ThreadPool.ThreadCount);
+
+            Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.ContentionTime}, {MetricsNames.ContentionCount}, {MetricsNames.ThreadPoolWorkersCount}]");
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
@@ -104,6 +106,7 @@ namespace Datadog.Trace.RuntimeMetrics
                     if (start != null)
                     {
                         _statsd.Timer(MetricsNames.GcPauseTime, (eventData.TimeStamp - start.Value).TotalMilliseconds);
+                        Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.GcPauseTime}]");
                     }
                 }
                 else
@@ -116,6 +119,8 @@ namespace Datadog.Trace.RuntimeMetrics
                         _statsd.Gauge(MetricsNames.Gen1HeapSize, stats.Gen1Size);
                         _statsd.Gauge(MetricsNames.Gen2HeapSize, stats.Gen2Size);
                         _statsd.Gauge(MetricsNames.LohSize, stats.LohSize);
+
+                        Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}]");
                     }
                     else if (eventData.EventId == EventContentionStop)
                     {
@@ -134,6 +139,7 @@ namespace Datadog.Trace.RuntimeMetrics
                         }
 
                         _statsd.Increment(GcCountMetricNames[heapHistory.Generation], 1, tags: heapHistory.Compacting ? CompactingGcTags : NotCompactingGcTags);
+                        Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.GcMemoryLoad}, runtime.dotnet.gc.count.gen#]");
                     }
                 }
             }
@@ -183,6 +189,7 @@ namespace Datadog.Trace.RuntimeMetrics
                     var value = (double)rawValue;
 
                     _statsd.Gauge(statName, value);
+                    Log.Debug("Sent the following metrics to the DD agent: [{CounterName}]", statName);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -121,6 +121,8 @@ namespace Datadog.Trace.RuntimeMetrics
                     _statsd.Gauge(MetricsNames.CpuSystemTime, systemCpu.TotalMilliseconds / _delay.TotalSeconds);
 
                     _statsd.Gauge(MetricsNames.CpuPercentage, Math.Round(totalCpu.TotalMilliseconds * 100 / maximumCpu, 1, MidpointRounding.AwayFromZero));
+
+                    Log.Debug($"Sent the following metrics to the DD agent: [{MetricsNames.ThreadsCount}, {MetricsNames.CommittedMemory}, {MetricsNames.CpuUserTime}, {MetricsNames.CpuSystemTime}, {MetricsNames.CpuPercentage}]");
                 }
 
                 if (!_exceptionCounts.IsEmpty)
@@ -133,6 +135,12 @@ namespace Datadog.Trace.RuntimeMetrics
                     // There's a race condition where we could clear items that haven't been pushed
                     // Having an exact exception count is probably not worth the overhead required to fix it
                     _exceptionCounts.Clear();
+
+                    Log.Debug($"Sent {MetricsNames.ExceptionsCount} metrics to the DD agent");
+                }
+                else
+                {
+                    Log.Debug($"No {MetricsNames.ExceptionsCount} metrics sent to the DD agent");
                 }
             }
             catch (Exception ex)

--- a/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Properties/launchSettings.json
@@ -12,6 +12,7 @@
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "DD_RUNTIME_METRICS_ENABLED": "1",
         "DD_VERSION": "1.0.0"
       },
       "nativeDebugging": true


### PR DESCRIPTION
## Summary of changes
Adds several Debug log lines when sending runtime metrics to the agent.

## Reason for change
When we send traces to the agent, we write a Debug log to indicate that this occurred. Before this change, we do no such thing for runtime metrics so the only logs we would get were failure logs.

## Implementation details
Calls `Log.Debug` in the update code path. Since the default update delay is 10 seconds, this means we emit several log lines every 10 seconds when debug mode is activated. I don't think this is too overwhelming, but we can certainly modify this if needed.

## Test coverage
N/A

## Other details
N/A
