### PR TITLE
[Profiler] Prevent additional/useless copies in logging wrappers

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -39,19 +39,19 @@ public:
     }
 
     template <typename... Args>
-    static inline void Debug(const Args... args)
+    static inline void Debug(const Args&... args)
     {
         shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Debug<Args...>(args...);
     }
 
     template <typename... Args>
-    static void Info(const Args... args)
+    static void Info(const Args&... args)
     {
         shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Info<Args...>(args...);
     }
 
     template <typename... Args>
-    static void Error(const Args... args)
+    static void Error(const Args&... args)
     {
         shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Error<Args...>(args...);
     }

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/log.h
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/log.h
@@ -39,25 +39,25 @@ public:
     }
 
     template <typename... Args>
-    static inline void Debug(const Args... args)
+    static inline void Debug(const Args&... args)
     {
         shared::LoggerImpl<NativeLoaderLoggerPolicy>::Instance()->Debug<Args...>(args...);
     }
 
     template <typename... Args>
-    static void Info(const Args... args)
+    static void Info(const Args&... args)
     {
         shared::LoggerImpl<NativeLoaderLoggerPolicy>::Instance()->Info<Args...>(args...);
     }
 
     template <typename... Args>
-    static void Warn(const Args... args)
+    static void Warn(const Args&... args)
     {
         shared::LoggerImpl<NativeLoaderLoggerPolicy>::Instance()->Warn<Args...>(args...);
     }
 
     template <typename... Args>
-    static void Error(const Args... args)
+    static void Error(const Args&... args)
     {
         shared::LoggerImpl<NativeLoaderLoggerPolicy>::Instance()->Error<Args...>(args...);
     }


### PR DESCRIPTION
## Summary of changes

When using the logging wrappers (profiler and native proxy), useless copies were made. Just pass them `byref` avoid them.

## Reason for change

Additional copies incur useless CPU and Memory overhead.

## Implementation details

pass the argument by reference instead.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
