### PR TITLE
Remove direct Datadog.Trace assembly references in integration tests

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
 using System.Reflection;
 
 namespace Samples
@@ -16,6 +13,8 @@ namespace Samples
         private static readonly MethodInfo StartActiveMethod = TracerType.GetMethod("StartActive", types: new[] { typeof(string) });
         private static readonly MethodInfo ActiveScopeProperty = TracerType.GetProperty("ActiveScope").GetMethod;
         private static readonly MethodInfo SpanProperty = ScopeType.GetProperty("Span", BindingFlags.NonPublic | BindingFlags.Instance).GetMethod;
+        private static readonly MethodInfo SetResourceNameProperty = SpanType.GetProperty("ResourceName", BindingFlags.NonPublic | BindingFlags.Instance).SetMethod;
+        private static readonly MethodInfo SetTagMethod = SpanType.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
 
         public static bool IsProfilerAttached()
@@ -64,6 +63,29 @@ namespace Samples
         {
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
             return (IDisposable) StartActiveMethod.Invoke(tracer, new object[] { operationName });
+        }
+
+        public static IDisposable GetActiveScope()
+        {
+            var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
+            return (IDisposable) ActiveScopeProperty.Invoke(tracer, Array.Empty<object>());
+        }
+
+        public static ulong GetCorrelationIdentifierTraceId()
+        {
+            return (ulong)CorrelationIdentifierTraceIdProperty.Invoke(null, Array.Empty<object>());
+        }
+
+        public static void TrySetResourceName(object scope, string resourceName)
+        {
+            var span = SpanProperty.Invoke(scope, Array.Empty<object>());
+            SetResourceNameProperty.Invoke(span, new object[] { resourceName });
+        }
+
+        public static void TrySetTag(object scope, string key, string value)
+        {
+            var span = SpanProperty.Invoke(scope, Array.Empty<object>());
+            SetTagMethod.Invoke(span, new object[] { key, value });
         }
 
         public static void TrySetExceptionOnActiveScope(Exception exception)

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Samples
@@ -9,10 +12,12 @@ namespace Samples
         private static readonly Type TracerType = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace");
         private static readonly Type ScopeType = Type.GetType("Datadog.Trace.Scope, Datadog.Trace");
         private static readonly Type SpanType = Type.GetType("Datadog.Trace.Span, Datadog.Trace");
+        private static readonly Type CorrelationIdentifierType = Type.GetType("Datadog.Trace.CorrelationIdentifier, Datadog.Trace");
         private static readonly MethodInfo GetTracerInstance = TracerType.GetProperty("Instance").GetMethod;
         private static readonly MethodInfo StartActiveMethod = TracerType.GetMethod("StartActive", types: new[] { typeof(string) });
         private static readonly MethodInfo ActiveScopeProperty = TracerType.GetProperty("ActiveScope").GetMethod;
         private static readonly MethodInfo SpanProperty = ScopeType.GetProperty("Span", BindingFlags.NonPublic | BindingFlags.Instance).GetMethod;
+        private static readonly MethodInfo CorrelationIdentifierTraceIdProperty = CorrelationIdentifierType.GetProperty("TraceId", BindingFlags.NonPublic | BindingFlags.Instance).GetMethod;
         private static readonly MethodInfo SetResourceNameProperty = SpanType.GetProperty("ResourceName", BindingFlags.NonPublic | BindingFlags.Instance).SetMethod;
         private static readonly MethodInfo SetTagMethod = SpanType.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/tracer/test/test-applications/aspnet/Samples.AspNetAsyncHandler/HttpHandler.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetAsyncHandler/HttpHandler.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Web;
-using Datadog.Trace;
 
 namespace Samples.AspNetAsyncHandler
 {
@@ -16,7 +14,7 @@ namespace Samples.AspNetAsyncHandler
                 return;
             }
 
-            Tracer.Instance.StartActive("HttpHandler").Dispose();
+            SampleHelpers.CreateScope("HttpHandler").Dispose();
 
             context.Response.StatusCode = 200;
             context.Response.Write("Success");

--- a/tracer/test/test-applications/aspnet/Samples.AspNetAsyncHandler/Samples.AspNetAsyncHandler.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetAsyncHandler/Samples.AspNetAsyncHandler.csproj
@@ -107,12 +107,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{8e1baa6a-47cc-47f0-a7d6-74741118eb7c}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Global.asax" />
     <Content Include="Web.config" />
   </ItemGroup>

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Handlers/CustomTracingExceptionHandler.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Handlers/CustomTracingExceptionHandler.cs
@@ -28,10 +28,10 @@ namespace Samples.AspNetMvc5.Handlers
             }
 #endif
 
-            using (var scope = Tracer.Instance.StartActive("CustomTracingExceptionHandler.handle-async"))
+            using (var scope = SampleHelpers.CreateScope("CustomTracingExceptionHandler.handle-async"))
             {
                 // Set span kind of span to server to pass through server span filtering
-                scope.Span.SetTag(Tags.SpanKind, SpanKinds.Server);
+                SampleHelpers.TrySetTag(scope, Tags.SpanKind, SpanKinds.Server);
             }
         }
     }

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Handlers/CustomTracingExceptionHandler.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Handlers/CustomTracingExceptionHandler.cs
@@ -1,6 +1,3 @@
-using Datadog.Trace;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
 using System.Web.Http.ExceptionHandling;
 
@@ -31,7 +28,7 @@ namespace Samples.AspNetMvc5.Handlers
             using (var scope = SampleHelpers.CreateScope("CustomTracingExceptionHandler.handle-async"))
             {
                 // Set span kind of span to server to pass through server span filtering
-                SampleHelpers.TrySetTag(scope, Tags.SpanKind, SpanKinds.Server);
+                SampleHelpers.TrySetTag(scope, "span.kind", "server");
             }
         }
     }

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -144,12 +144,6 @@
   <ItemGroup>
     <Folder Include="Areas\Datadog\Models\" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{8e1baa6a-47cc-47f0-a7d6-74741118eb7c}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/DDCustomLoggingModule.cs
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/DDCustomLoggingModule.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Web;
-using Datadog.Trace;
 
 namespace Samples.WebForms
 {
@@ -23,12 +19,12 @@ namespace Samples.WebForms
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nDDCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + CorrelationIdentifier.TraceId + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + SampleHelpers.GetCorrelationIdentifierTraceId() + "\n");
         }
 
         private void OnEndRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nDDCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + CorrelationIdentifier.TraceId + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + SampleHelpers.GetCorrelationIdentifierTraceId() + "\n");
         }
     }
 }

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -232,12 +232,6 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{8e1baa6a-47cc-47f0-a7d6-74741118eb7c}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -6,10 +6,6 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/Startup.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/Startup.cs
@@ -1,11 +1,11 @@
-﻿using System.Linq;
-using Datadog.Trace;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Samples;
 
 namespace LogsInjection.ILogger
 {
@@ -25,7 +25,7 @@ namespace LogsInjection.ILogger
         {
             // Not injected as we won't have a traceId
             logger.UninjectedLog("Building pipeline");
-            using (var scope = Tracer.Instance.StartActive("pipeline build"))
+            using (var scope = SampleHelpers.CreateScope("pipeline build"))
             {
                 logger.LogInformation("Still building pipeline...");
             }
@@ -47,7 +47,7 @@ namespace LogsInjection.ILogger
             {
                 logger.ConditionalLog("Received request, echoing");
 
-                using var scope = Tracer.Instance.StartActive("middleware execution");
+                using var scope = SampleHelpers.CreateScope("middleware execution");
                 logger.LogInformation("Sending response");
                 return context.Response.WriteAsync("PONG");
             });

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/Worker.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/Worker.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Samples;
 
 namespace LogsInjection.ILogger
 {
@@ -39,7 +40,7 @@ namespace LogsInjection.ILogger
                 return;
             }
 
-            using (var scope = Datadog.Trace.Tracer.Instance.StartActive("worker request"))
+            using (var scope = SampleHelpers.CreateScope("worker request"))
             {
                 try
                 {

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS;
 using Amazon.SQS.Model;
-using Datadog.Trace;
 using Newtonsoft.Json;
 
 namespace Samples.AWS.SQS
@@ -25,7 +24,7 @@ namespace Samples.AWS.SQS
         {
             Console.WriteLine("Beginning Async methods");
 
-            using (var scope = Tracer.Instance.StartActive("async-methods"))
+            using (var scope = SampleHelpers.CreateScope("async-methods"))
             {
                 await CreateSqsQueueAsync(sqsClient);
                 await ListQueuesAsync(sqsClient);

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="$(ApiVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/SyncHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/SyncHelpers.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amazon.SQS;
 using Amazon.SQS.Model;
-using Datadog.Trace;
 
 namespace Samples.AWS.SQS
 {
@@ -26,7 +25,7 @@ namespace Samples.AWS.SQS
         {
             Console.WriteLine("Beginning Synchronous methods");
 
-            using (var scope = Tracer.Instance.StartActive("sync-methods"))
+            using (var scope = SampleHelpers.CreateScope("sync-methods"))
             {
                 CreateSqsQueue(sqsClient);
                 ListQueues(sqsClient);

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -5,13 +5,13 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace;
 
 namespace Samples.HttpMessageHandler
 {
     public static class RequestHelpers
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
+        private const string TracingEnabled = "x-datadog-tracing-enabled";
 
         public static void SendAsyncHttpClientRequests(HttpClient client, bool tracingDisabled, string url, string requestContent)
         {
@@ -22,12 +22,12 @@ namespace Samples.HttpMessageHandler
 
                 if (tracingDisabled)
                 {
-                    client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                    client.DefaultRequestHeaders.Add(TracingEnabled, "false");
                 }
 
-                using (Tracer.Instance.StartActive("HttpClientRequestAsync"))
+                using (SampleHelpers.CreateScope("HttpClientRequestAsync"))
                 {
-                    using (Tracer.Instance.StartActive("DeleteAsync"))
+                    using (SampleHelpers.CreateScope("DeleteAsync"))
                     {
                         client.DeleteAsync(url).Wait();
                         Console.WriteLine("Received response for client.DeleteAsync(String)");
@@ -42,7 +42,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.DeleteAsync(Uri, CancellationToken)");
                     }
 
-                    using (Tracer.Instance.StartActive("GetAsync"))
+                    using (SampleHelpers.CreateScope("GetAsync"))
                     {
                         client.GetAsync(url).Wait();
                         Console.WriteLine("Received response for client.GetAsync(String)");
@@ -69,7 +69,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption, CancellationToken)");
                     }
 
-                    using (Tracer.Instance.StartActive("GetByteArrayAsync"))
+                    using (SampleHelpers.CreateScope("GetByteArrayAsync"))
                     {
                         client.GetByteArrayAsync(url).Wait();
                         Console.WriteLine("Received response for client.GetByteArrayAsync(String)");
@@ -78,7 +78,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.GetByteArrayAsync(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("GetStreamAsync"))
+                    using (SampleHelpers.CreateScope("GetStreamAsync"))
                     {
                         using Stream stream1 = client.GetStreamAsync(url).Result;
                         Console.WriteLine("Received response for client.GetStreamAsync(String)");
@@ -87,7 +87,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.GetStreamAsync(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("GetStringAsync"))
+                    using (SampleHelpers.CreateScope("GetStringAsync"))
                     {
                         client.GetStringAsync(url).Wait();
                         Console.WriteLine("Received response for client.GetStringAsync(String)");
@@ -97,7 +97,7 @@ namespace Samples.HttpMessageHandler
                     }
 
 #if NETCOREAPP
-                    using (Tracer.Instance.StartActive("PatchAsync"))
+                    using (SampleHelpers.CreateScope("PatchAsync"))
                     {
                         client.PatchAsync(url, new StringContent(requestContent, Utf8)).Wait();
                         Console.WriteLine("Received response for client.PatchAsync(String, HttpContent)");
@@ -113,7 +113,7 @@ namespace Samples.HttpMessageHandler
                     }
 
 #endif
-                    using (Tracer.Instance.StartActive("PostAsync"))
+                    using (SampleHelpers.CreateScope("PostAsync"))
                     {
                         client.PostAsync(url, new StringContent(requestContent, Utf8)).Wait();
                         Console.WriteLine("Received response for client.PostAsync(String, HttpContent)");
@@ -128,7 +128,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent, CancellationToken)");
                     }
 
-                    using (Tracer.Instance.StartActive("PutAsync"))
+                    using (SampleHelpers.CreateScope("PutAsync"))
                     {
                         client.PutAsync(url, new StringContent(requestContent, Utf8)).Wait();
                         Console.WriteLine("Received response for client.PutAsync(String, HttpContent)");
@@ -143,7 +143,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent, CancellationToken)");
                     }
 
-                    using (Tracer.Instance.StartActive("SendAsync"))
+                    using (SampleHelpers.CreateScope("SendAsync"))
                     {
                         client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url)).Wait();
                         Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
@@ -158,7 +158,7 @@ namespace Samples.HttpMessageHandler
                         Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                     }
 
-                    using (Tracer.Instance.StartActive("ErrorSpanBelow"))
+                    using (SampleHelpers.CreateScope("ErrorSpanBelow"))
                     {
                         client.GetAsync($"{url}HttpErrorCode").Wait();
                         Console.WriteLine("Received response for client.GetAsync Error Span");
@@ -181,12 +181,12 @@ namespace Samples.HttpMessageHandler
 
             if (tracingDisabled)
             {
-                client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                client.DefaultRequestHeaders.Add(TracingEnabled, "false");
             }
 
-            using (Tracer.Instance.StartActive("HttpClientRequest"))
+            using (SampleHelpers.CreateScope("HttpClientRequest"))
             {
-                using (Tracer.Instance.StartActive("Send.Delete"))
+                using (SampleHelpers.CreateScope("Send.Delete"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Delete, url));
                     Console.WriteLine("Received response for DELETE client.Send(HttpRequestMessage)");
@@ -201,7 +201,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Received response for DELETE client.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("Send.Get"))
+                using (SampleHelpers.CreateScope("Send.Get"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Get, url));
                     Console.WriteLine("Received response for GET client.Send(HttpRequestMessage)");
@@ -216,7 +216,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Received response for GET client.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("Send.Patch"))
+                using (SampleHelpers.CreateScope("Send.Patch"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Patch, url) { Content = new StringContent(requestContent, Utf8) });
                     Console.WriteLine("Received response for PATCH client.Send(HttpRequestMessage)");
@@ -231,7 +231,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Received response for PATCH client.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("Send.Post"))
+                using (SampleHelpers.CreateScope("Send.Post"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Post, url) { Content = new StringContent(requestContent, Utf8) });
                     Console.WriteLine("Received response for POST client.Send(HttpRequestMessage)");
@@ -246,7 +246,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Received response for POST client.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("Send.Put"))
+                using (SampleHelpers.CreateScope("Send.Put"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Put, url) { Content = new StringContent(requestContent, Utf8) });
                     Console.WriteLine("Received response for PUT client.Send(HttpRequestMessage)");
@@ -261,7 +261,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Received response for PUT client.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("ErrorSpanBelow"))
+                using (SampleHelpers.CreateScope("ErrorSpanBelow"))
                 {
                     client.Send(new HttpRequestMessage(HttpMethod.Get, $"{url}HttpErrorCode"));
                     Console.WriteLine("Received response for client.Get Error Span");
@@ -278,7 +278,7 @@ namespace Samples.HttpMessageHandler
 
             if (tracingDisabled)
             {
-                httpRequest.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                httpRequest.Headers.Add(TracingEnabled, "false");
             }
 
             httpRequest.Method = HttpMethod.Get;

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Handlers/CustomTracingExceptionHandler.cs
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Handlers/CustomTracingExceptionHandler.cs
@@ -1,4 +1,3 @@
-using Datadog.Trace;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http.ExceptionHandling;
@@ -9,10 +8,10 @@ namespace Samples.Owin.WebApi2.Handlers
     {
         public override async Task HandleAsync(ExceptionHandlerContext context, CancellationToken cancellationToken)
         {
-            using (var scope = Tracer.Instance.StartActive("CustomTracingExceptionHandler.handle-async"))
+            using (var scope = SampleHelpers.CreateScope("CustomTracingExceptionHandler.handle-async"))
             {
                 // Set span kind of span to server to pass through server span filtering
-                scope.Span.SetTag(Tags.SpanKind, SpanKinds.Server);
+                SampleHelpers.TrySetTag(scope, "span.kind", "server");
 
                 await base.HandleAsync(context, cancellationToken);
             }

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
@@ -14,7 +14,5 @@
     <Compile Include="..\..\aspnet\Samples.AspNetMvc5\Controllers\ApiController.cs" Link="Controllers\ApiController.cs" />
     <Compile Include="..\..\aspnet\Samples.AspNetMvc5\Controllers\ConventionsController.cs" Link="Controllers\ConventionsController.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
+
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text;
 using System.Threading;
-using Datadog.Trace;
 using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 
@@ -55,7 +54,7 @@ namespace Samples.RabbitMQ
             using (var connection = factory.CreateConnection())
             using (var channel = connection.CreateModel())
             {
-                using (Tracer.Instance.StartActive("PublishAndGet()"))
+                using (SampleHelpers.CreateScope("PublishAndGet()"))
                 {
                     channel.ExchangeDeclare(exchangeName, "direct");
                     channel.QueueDeclare(queue: queueName,
@@ -103,7 +102,7 @@ namespace Samples.RabbitMQ
             {
                 string defaultQueueName;
 
-                using (Tracer.Instance.StartActive("PublishAndGetDefault()"))
+                using (SampleHelpers.CreateScope("PublishAndGetDefault()"))
                 {
                     defaultQueueName = channel.QueueDeclare().QueueName;
                     channel.QueuePurge(queueName); // Ensure there are no more messages in this queue
@@ -151,7 +150,7 @@ namespace Samples.RabbitMQ
 
                 for (int i = 0; i < 3; i++)
                 {
-                    using (Tracer.Instance.StartActive("PublishToConsumer()"))
+                    using (SampleHelpers.CreateScope("PublishToConsumer()"))
                     {
                         string message = $"Send - Message #{i}";
                         var body = Encoding.UTF8.GetBytes(message);
@@ -191,7 +190,7 @@ namespace Samples.RabbitMQ
                 var consumer = new EventingBasicConsumer(channel);
                 consumer.Received += (model, ea) =>
                 {
-                    using (Tracer.Instance.StartActive("consumer.Received event"))
+                    using (SampleHelpers.CreateScope("consumer.Received event"))
                     {
 #if RABBITMQ_6_0
                         var body = ea.Body.ToArray();

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="$(ApiVersion)" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Program.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
-using Datadog.Trace;
 
 namespace Samples.WebRequest.NetFramework20
 {
@@ -32,14 +31,14 @@ namespace Samples.WebRequest.NetFramework20
                 Console.WriteLine();
                 Console.WriteLine("Sending request with WebClient.");
 
-                using (Tracer.Instance.StartActive("RequestHelpers.SendWebClientRequests"))
+                using (SampleHelpers.CreateScope("RequestHelpers.SendWebClientRequests"))
                 {
                     RequestHelpers.SendWebClientRequests(tracingDisabled, url, RequestContent);
                 }
 
                 Console.WriteLine("Sending request with WebRequest.");
 
-                using (Tracer.Instance.StartActive("RequestHelpers.SendWebRequestRequests"))
+                using (SampleHelpers.CreateScope("RequestHelpers.SendWebRequestRequests"))
                 {
                     RequestHelpers.SendWebRequestRequests(tracingDisabled, url, RequestContent);
                 }

--- a/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\dependency-libs\Samples.WebRequestHelper.NetFramework20\Samples.WebRequestHelper.NetFramework20.csproj" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -4,17 +4,20 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace;
 
 namespace Samples.WebRequest
 {
     public static class Program
     {
+        private const string TraceId = "x-datadog-trace-id";
+        private const string ParentId = "x-datadog-parent-id";
+        private const string SamplingPriority = "x-datadog-sampling-priority";
+
         private const string RequestContent = "PING";
         private const string ResponseContent = "PONG";
         private static readonly Encoding Utf8 = Encoding.UTF8;
 
-        private static readonly string[] ExpectedHeaders = { HttpHeaderNames.TraceId, HttpHeaderNames.ParentId, HttpHeaderNames.SamplingPriority };
+        private static readonly string[] ExpectedHeaders = { TraceId, ParentId, SamplingPriority };
 
         private static bool _tracingDisabled;
         private static bool _ignoreAsync;
@@ -44,8 +47,6 @@ namespace Samples.WebRequest
                 Console.WriteLine();
                 Console.WriteLine("Stopping HTTP listener.");
             }
-
-            await Tracer.Instance.ForceFlushAsync();
         }
 
         private static void HandleHttpRequests(HttpListenerContext context)

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace;
 
 namespace Samples.WebRequest
 {
@@ -13,6 +12,7 @@ namespace Samples.WebRequest
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
         private static readonly AutoResetEvent _allDone = new(false);
+        private const string TracingEnabled = "x-datadog-tracing-enabled";
 
         public static async Task SendWebClientRequests(bool tracingDisabled, string url, string requestContent)
         {
@@ -24,12 +24,12 @@ namespace Samples.WebRequest
 
                 if (tracingDisabled)
                 {
-                    webClient.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                    webClient.Headers.Add(TracingEnabled, "false");
                 }
 
-                using (Tracer.Instance.StartActive("WebClient"))
+                using (SampleHelpers.CreateScope("WebClient"))
                 {
-                    using (Tracer.Instance.StartActive("DownloadData"))
+                    using (SampleHelpers.CreateScope("DownloadData"))
                     {
                         webClient.DownloadData(GetUrlForTest("DownloadData", url));
                         Console.WriteLine("Received response for client.DownloadData(String)");
@@ -38,7 +38,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadData(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadDataAsync"))
+                    using (SampleHelpers.CreateScope("DownloadDataAsync"))
                     {
                         webClient.DownloadDataAsyncAndWait(new Uri(GetUrlForTest("DownloadDataAsync", url)));
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri)");
@@ -47,7 +47,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadDataTaskAsync"))
+                    using (SampleHelpers.CreateScope("DownloadDataTaskAsync"))
                     {
                         await webClient.DownloadDataTaskAsync(GetUrlForTest("DownloadDataTaskAsync", url));
                         Console.WriteLine("Received response for client.DownloadDataTaskAsync(String)");
@@ -56,7 +56,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadDataTaskAsync(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadFile"))
+                    using (SampleHelpers.CreateScope("DownloadFile"))
                     {
                         webClient.DownloadFile(GetUrlForTest("DownloadFile", url), "DownloadFile.string.txt");
                         Console.WriteLine("Received response for client.DownloadFile(String, String)");
@@ -65,7 +65,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFile(Uri, String)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadFileAsync"))
+                    using (SampleHelpers.CreateScope("DownloadFileAsync"))
                     {
                         webClient.DownloadFileAsyncAndWait(new Uri(GetUrlForTest("DownloadFileAsync", url)), "DownloadFileAsync.uri.txt");
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String)");
@@ -74,7 +74,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadFileTaskAsync"))
+                    using (SampleHelpers.CreateScope("DownloadFileTaskAsync"))
                     {
                         await webClient.DownloadFileTaskAsync(GetUrlForTest("DownloadFileTaskAsync", url), "DownloadFileTaskAsync.string.txt");
                         Console.WriteLine("Received response for client.DownloadFileTaskAsync(String, String)");
@@ -83,7 +83,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFileTaskAsync(Uri, String)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadString"))
+                    using (SampleHelpers.CreateScope("DownloadString"))
                     {
                         webClient.DownloadString(GetUrlForTest("DownloadString", url));
                         Console.WriteLine("Received response for client.DownloadString(String)");
@@ -92,7 +92,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadString(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadStringAsync"))
+                    using (SampleHelpers.CreateScope("DownloadStringAsync"))
                     {
                         webClient.DownloadStringAsyncAndWait(new Uri(GetUrlForTest("DownloadStringAsync", url)));
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri)");
@@ -101,7 +101,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("DownloadStringTaskAsync"))
+                    using (SampleHelpers.CreateScope("DownloadStringTaskAsync"))
                     {
                         await webClient.DownloadStringTaskAsync(GetUrlForTest("DownloadStringTaskAsync", url));
                         Console.WriteLine("Received response for client.DownloadStringTaskAsync(String)");
@@ -110,7 +110,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadStringTaskAsync(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("OpenRead"))
+                    using (SampleHelpers.CreateScope("OpenRead"))
                     {
                         webClient.OpenRead(GetUrlForTest("OpenRead", url)).Close();
                         Console.WriteLine("Received response for client.OpenRead(String)");
@@ -119,7 +119,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenRead(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("OpenReadAsync"))
+                    using (SampleHelpers.CreateScope("OpenReadAsync"))
                     {
                         webClient.OpenReadAsyncAndWait(new Uri(GetUrlForTest("OpenReadAsync", url)));
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri)");
@@ -128,7 +128,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("OpenReadTaskAsync"))
+                    using (SampleHelpers.CreateScope("OpenReadTaskAsync"))
                     {
                         using Stream readStream1 = await webClient.OpenReadTaskAsync(GetUrlForTest("OpenReadTaskAsync", url));
                         Console.WriteLine("Received response for client.OpenReadTaskAsync(String)");
@@ -137,7 +137,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenReadTaskAsync(Uri)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadData"))
+                    using (SampleHelpers.CreateScope("UploadData"))
                     {
                         webClient.UploadData(GetUrlForTest("UploadData", url), new byte[0]);
                         Console.WriteLine("Received response for client.UploadData(String, Byte[])");
@@ -152,7 +152,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadData(Uri, String, Byte[])");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadDataAsync"))
+                    using (SampleHelpers.CreateScope("UploadDataAsync"))
                     {
                         webClient.UploadDataAsyncAndWait(new Uri(GetUrlForTest("UploadDataAsync", url)), new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, Byte[])");
@@ -164,7 +164,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, String, Byte[], Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadDataTaskAsync"))
+                    using (SampleHelpers.CreateScope("UploadDataTaskAsync"))
                     {
                         await webClient.UploadDataTaskAsync(GetUrlForTest("UploadDataTaskAsync", url), new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataTaskAsync(String, Byte[])");
@@ -181,7 +181,7 @@ namespace Samples.WebRequest
 
                     File.WriteAllText("UploadFile.txt", requestContent);
 
-                    using (Tracer.Instance.StartActive("UploadFile"))
+                    using (SampleHelpers.CreateScope("UploadFile"))
                     {
                         webClient.UploadFile(GetUrlForTest("UploadFile", url), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFile(String, String)");
@@ -196,7 +196,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFile(Uri, String, String)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadFileAsync"))
+                    using (SampleHelpers.CreateScope("UploadFileAsync"))
                     {
                         webClient.UploadFileAsyncAndWait(new Uri(GetUrlForTest("UploadFileAsync", url)), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String)");
@@ -208,7 +208,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String, String, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadFileTaskAsync"))
+                    using (SampleHelpers.CreateScope("UploadFileTaskAsync"))
                     {
                         await webClient.UploadFileTaskAsync(GetUrlForTest("UploadFileTaskAsync", url), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileTaskAsync(String, String)");
@@ -223,7 +223,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFileTaskAsync(Uri, String, String)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadString"))
+                    using (SampleHelpers.CreateScope("UploadString"))
                     {
                         webClient.UploadString(GetUrlForTest("UploadString", url), requestContent);
                         Console.WriteLine("Received response for client.UploadString(String, String)");
@@ -238,7 +238,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadString(Uri, String, String)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadStringAsync"))
+                    using (SampleHelpers.CreateScope("UploadStringAsync"))
                     {
                         webClient.UploadStringAsyncAndWait(new Uri(GetUrlForTest("UploadStringAsync", url)), requestContent);
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String)");
@@ -250,7 +250,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String, String, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadStringTaskAsync"))
+                    using (SampleHelpers.CreateScope("UploadStringTaskAsync"))
                     {
                         await webClient.UploadStringTaskAsync(GetUrlForTest("UploadStringTaskAsync", url), requestContent);
                         Console.WriteLine("Received response for client.UploadStringTaskAsync(String, String)");
@@ -266,7 +266,7 @@ namespace Samples.WebRequest
                     }
 
                     var values = new NameValueCollection();
-                    using (Tracer.Instance.StartActive("UploadValues"))
+                    using (SampleHelpers.CreateScope("UploadValues"))
                     {
                         webClient.UploadValues(GetUrlForTest("UploadValues", url), values);
                         Console.WriteLine("Received response for client.UploadValues(String, NameValueCollection)");
@@ -281,7 +281,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadValues(Uri, String, NameValueCollection)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadValuesAsync"))
+                    using (SampleHelpers.CreateScope("UploadValuesAsync"))
                     {
                         webClient.UploadValuesAsyncAndWait(new Uri(GetUrlForTest("UploadValuesAsync", url)), values);
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, NameValueCollection)");
@@ -293,7 +293,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, String, NameValueCollection, Object)");
                     }
 
-                    using (Tracer.Instance.StartActive("UploadValuesTaskAsync"))
+                    using (SampleHelpers.CreateScope("UploadValuesTaskAsync"))
                     {
                         await webClient.UploadValuesTaskAsync(GetUrlForTest("UploadValuesTaskAsync", url), values);
                         Console.WriteLine("Received response for client.UploadValuesTaskAsync(String, NameValueCollection)");
@@ -315,56 +315,56 @@ namespace Samples.WebRequest
         {
             Console.WriteLine($"[WebRequest] sending requests to {url}");
 
-            using (Tracer.Instance.StartActive("WebRequest"))
+            using (SampleHelpers.CreateScope("WebRequest"))
             {
-                using (Tracer.Instance.StartActive("GetResponse"))
+                using (SampleHelpers.CreateScope("GetResponse"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponse", url));
                     if (tracingDisabled)
                     {
-                        request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                        request.Headers.Add(TracingEnabled, "false");
                     }
 
                     request.GetResponse().Close();
                     Console.WriteLine("Received response for request.GetResponse()");
                 }
 
-                using (Tracer.Instance.StartActive("GetResponseAsync"))
+                using (SampleHelpers.CreateScope("GetResponseAsync"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsync", url));
                     if (tracingDisabled)
                     {
-                        request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                        request.Headers.Add(TracingEnabled, "false");
                     }
 
                     (await request.GetResponseAsync()).Close();
                     Console.WriteLine("Received response for request.GetResponseAsync()");
                 }
 
-                using (Tracer.Instance.StartActive("GetRequestStream"))
+                using (SampleHelpers.CreateScope("GetRequestStream"))
                 {
                     GetRequestStream(tracingDisabled, url);
                 }
 
-                using (Tracer.Instance.StartActive("BeginGetRequestStream"))
+                using (SampleHelpers.CreateScope("BeginGetRequestStream"))
                 {
                     BeginGetRequestStream(tracingDisabled, url);
                 }
 
-                using (Tracer.Instance.StartActive("BeginGetResponse"))
+                using (SampleHelpers.CreateScope("BeginGetResponse"))
                 {
                     BeginGetResponse(tracingDisabled, url);
                 }
 
-                using (Tracer.Instance.StartActive("BeginGetResponse TaskFactoryFromAsync"))
+                using (SampleHelpers.CreateScope("BeginGetResponse TaskFactoryFromAsync"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("TaskFactoryFromAsync", url));
                     if (tracingDisabled)
                     {
-                        request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                        request.Headers.Add(TracingEnabled, "false");
                     }
 
                     await Task.Factory.FromAsync(
@@ -390,7 +390,7 @@ namespace Samples.WebRequest
 
             if (tracingDisabled)
             {
-                request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                request.Headers.Add(TracingEnabled, "false");
             }
 
             var stream = request.GetRequestStream();
@@ -422,7 +422,7 @@ namespace Samples.WebRequest
 
             if (tracingDisabled)
             {
-                request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                request.Headers.Add(TracingEnabled, "false");
             }
 
             request.BeginGetRequestStream(
@@ -453,7 +453,7 @@ namespace Samples.WebRequest
 
             if (tracingDisabled)
             {
-                request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                request.Headers.Add(TracingEnabled, "false");
             }
 
             var stream = request.GetRequestStream();

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
@@ -1,5 +1,3 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
+
 </Project>

--- a/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Program.cs
+++ b/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace;
 using Samples;
 
 namespace HttpMessageHandler.StackOverflowException
@@ -21,7 +20,7 @@ namespace HttpMessageHandler.StackOverflowException
                 var regularHttpClient = new HttpClient { BaseAddress = baseAddress };
                 var customHandlerHttpClient = new HttpClient(new DerivedHandler()) { BaseAddress = baseAddress };
 
-                using (var scope = Tracer.Instance.StartActive("main"))
+                using (var scope = SampleHelpers.CreateScope("main"))
                 {
                     Console.WriteLine("Calling regularHttpClient.GetAsync");
                     await regularHttpClient.GetAsync("default-handler");
@@ -55,7 +54,7 @@ namespace HttpMessageHandler.StackOverflowException
     {
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            Tracer.Instance.ActiveScope?.Span.SetTag("class", nameof(DerivedHandler));
+            SampleHelpers.TrySetTag(SampleHelpers.GetActiveScope(), "class", nameof(DerivedHandler));
 
             Console.WriteLine("Calling base.SendAsync()");
             var result = await base.SendAsync(request, cancellationToken);

--- a/tracer/test/test-applications/security/Samples.AspNetCore5/Samples.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.AspNetCore5/Samples.AspNetCore5.csproj
@@ -14,8 +14,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## Summary of changes
Replaces direct usages of `Datadog.Trace.Tracer` with methods from the `SampleHelpers` class so the applications do not have an assembly reference to `Datadog.Trace`. This achieves the same result as #1726 where `Datadog.Trace.dll` will no longer exist in the application bin directory, with the one downside that if a sample is run locally without automatic instrumentation attached properly, the reflection operations will fail.

## Reason for change
The main motivation is to remove `Datadog.Trace.dll` from the application bin to aid with code coverage. A secondary motivation is to make the applications more similar to real applications that don't reference the `Datadog.Trace.dll` assembly.

## Implementation details
Replaces usages with calls to the `SampleHelpers` class and adds several more helper methods to set resource names and tags on custom spans.

## Test coverage
Runs the same integration tests as before.

## Other details
N/A
