### PR TITLE
[Tracer] Implement Code Hotspot feature

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ConfigurationKeys.cs
@@ -1,13 +1,13 @@
-// <copyright file="EnvironmentVariables.cs" company="Datadog">
+// <copyright file="ConfigurationKeys.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 namespace Datadog.Trace.ContinuousProfiler
 {
-    internal static class EnvironmentVariables
+    internal static class ConfigurationKeys
     {
         public const string ProfilingEnabled = "DD_PROFILING_ENABLED";
-        public const string CodeHotspotEnabled = "DD_PROFILING_CODEHOTSPOT_ENABLED";
+        public const string CodeHotspotsEnabled = "DD_PROFILING_CODEHOTSPOTS_ENABLED";
     }
 }

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/Constants.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/Constants.cs
@@ -1,0 +1,18 @@
+// <copyright file="Constants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal class Constants
+    {
+#if NETFRAMEWORK
+        internal const string NativeProfilerLibNameX86 = "Datadog.AutoInstrumentation.Profiler.Native.x86.dll";
+        internal const string NativeProfilerLibNameX64 = "Datadog.AutoInstrumentation.Profiler.Native.x64.dll";
+#else
+        internal const string NativeProfilerLibNameX86 = "Datadog.AutoInstrumentation.Profiler.Native.x86";
+        internal const string NativeProfilerLibNameX64 = "Datadog.AutoInstrumentation.Profiler.Native.x64";
+#endif
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -1,0 +1,120 @@
+// <copyright file="ContextTracker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal class ContextTracker
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContextTracker));
+
+        private readonly ProfilerStatus _status;
+        private readonly bool _isFlagSet;
+        private readonly ThreadLocal<IntPtr> _traceContextPtr;
+
+        public ContextTracker(ProfilerStatus status)
+        {
+            _status = status;
+            _isFlagSet = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariables.CodeHotspotEnabled)?.ToBoolean() ?? false;
+            _traceContextPtr = new ThreadLocal<IntPtr>();
+            Log.Information("CodeHotspots feature is {IsEnabled}.", _isFlagSet ? "enabled" : "disabled");
+        }
+
+        public bool IsEnabled
+        {
+            get
+            {
+                return _status.IsProfilerReady && _isFlagSet;
+            }
+        }
+
+        public void Set(ulong localRootSpanId, ulong spanId)
+        {
+            WriteToNative(new SpanContext(localRootSpanId, spanId));
+        }
+
+        public void Reset()
+        {
+            WriteToNative(SpanContext.Zero);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void WriteContext(IntPtr ptr, in SpanContext ctx)
+        {
+            Marshal.StructureToPtr(ctx, ptr, false);
+        }
+
+        private void EnsureIsInitialized()
+        {
+            if (_traceContextPtr.IsValueCreated)
+            {
+                return;
+            }
+
+            try
+            {
+                _traceContextPtr.Value = NativeInterop.GetTraceContextNativePointer();
+            }
+            catch (Exception e)
+            {
+                Log.Debug("Unable to get the tracing context pointer for the thread {ThreadID}: {Reason}", Environment.CurrentManagedThreadId.ToString(), e.Message);
+                _traceContextPtr.Value = IntPtr.Zero;
+            }
+        }
+
+        private void WriteToNative(in SpanContext ctx)
+        {
+            if (!IsEnabled)
+            {
+                return;
+            }
+
+            EnsureIsInitialized();
+
+            var ctxPtr = _traceContextPtr.Value;
+
+            if (ctxPtr == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                WriteContext(ctxPtr, ctx);
+            }
+            catch (Exception e)
+            {
+                Log.Debug("Failed to write tracing context at {CtxPtr} for {ThreadID}: {Reason}", ctxPtr, Environment.CurrentManagedThreadId.ToString(), e.Message);
+            }
+        }
+
+        // This stuct in defined in <repos>/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+        // /!\ We must keep both layout in sync.
+        [StructLayout(LayoutKind.Explicit)]
+        private readonly struct SpanContext
+        {
+            public static readonly SpanContext Zero = new(0, 0);
+
+            [FieldOffset(0)]
+            public readonly ulong LocalRootSpanId;
+
+            [FieldOffset(8)]
+            public readonly ulong SpanId;
+
+            public SpanContext(ulong localRootSpanId, ulong spanId)
+            {
+                LocalRootSpanId = localRootSpanId;
+                SpanId = spanId;
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ContinuousProfiler
             }
             catch (Exception e)
             {
-                Log.Debug(e, "Unable to get the tracing context pointer for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
+                Log.Warning(e, "Unable to get the tracing context pointer for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
                 _traceContextPtr.Value = IntPtr.Zero;
             }
         }
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ContinuousProfiler
             }
             catch (Exception e)
             {
-                Log.Debug(e, "Failed to write tracing context at {CtxPtr} for {ThreadID}", ctxPtr, Environment.CurrentManagedThreadId.ToString());
+                Log.Warning(e, "Failed to write tracing context at {CtxPtr} for {ThreadID}", ctxPtr, Environment.CurrentManagedThreadId.ToString());
             }
         }
 

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ContinuousProfiler
         public ContextTracker(ProfilerStatus status)
         {
             _status = status;
-            _isFlagSet = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariables.CodeHotspotEnabled)?.ToBoolean() ?? false;
+            _isFlagSet = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.CodeHotspotsEnabled)?.ToBoolean() ?? false;
             _traceContextPtr = new ThreadLocal<IntPtr>();
             Log.Information("CodeHotspots feature is {IsEnabled}.", _isFlagSet ? "enabled" : "disabled");
         }
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ContinuousProfiler
             }
             catch (Exception e)
             {
-                Log.Debug("Unable to get the tracing context pointer for the thread {ThreadID}: {Reason}", Environment.CurrentManagedThreadId.ToString(), e.Message);
+                Log.Debug(e, "Unable to get the tracing context pointer for the thread {ThreadID}", Environment.CurrentManagedThreadId.ToString());
                 _traceContextPtr.Value = IntPtr.Zero;
             }
         }
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ContinuousProfiler
             }
             catch (Exception e)
             {
-                Log.Debug("Failed to write tracing context at {CtxPtr} for {ThreadID}: {Reason}", ctxPtr, Environment.CurrentManagedThreadId.ToString(), e.Message);
+                Log.Debug(e, "Failed to write tracing context at {CtxPtr} for {ThreadID}", ctxPtr, Environment.CurrentManagedThreadId.ToString());
             }
         }
 

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/EnvironmentVariables.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/EnvironmentVariables.cs
@@ -1,0 +1,13 @@
+// <copyright file="EnvironmentVariables.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal static class EnvironmentVariables
+    {
+        public const string ProfilingEnabled = "DD_PROFILING_ENABLED";
+        public const string CodeHotspotEnabled = "DD_PROFILING_CODEHOTSPOT_ENABLED";
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/NativeInterop.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/NativeInterop.cs
@@ -1,0 +1,48 @@
+// <copyright file="NativeInterop.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal class NativeInterop
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static IntPtr GetProfilerStatusPointer()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return GetProfilerStatusPointer_x64();
+            }
+
+            return GetProfilerStatusPointer_x86();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static IntPtr GetTraceContextNativePointer()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return GetTraceContextNativePointer_x64();
+            }
+
+            return GetTraceContextNativePointer_x86();
+        }
+
+        [DllImport(Constants.NativeProfilerLibNameX64, EntryPoint = "GetNativeProfilerIsReadyPtr")]
+        private static extern IntPtr GetProfilerStatusPointer_x64();
+
+        [DllImport(Constants.NativeProfilerLibNameX86, EntryPoint = "GetNativeProfilerIsReadyPtr")]
+        private static extern IntPtr GetProfilerStatusPointer_x86();
+
+        [DllImport(dllName: Constants.NativeProfilerLibNameX64, EntryPoint = "GetPointerToNativeTraceContext")]
+        private static extern IntPtr GetTraceContextNativePointer_x64();
+
+        [DllImport(dllName: Constants.NativeProfilerLibNameX86, EntryPoint = "GetPointerToNativeTraceContext")]
+        private static extern IntPtr GetTraceContextNativePointer_x86();
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
@@ -1,0 +1,38 @@
+// <copyright file="Profiler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading;
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal class Profiler
+    {
+        private static Profiler _instance;
+
+        private readonly ContextTracker _contextTracker;
+
+        private Profiler(ContextTracker contextTracker)
+        {
+            _contextTracker = contextTracker;
+        }
+
+        public static Profiler Instance
+        {
+            get { return LazyInitializer.EnsureInitialized(ref _instance, () => Create()); }
+        }
+
+        public ContextTracker ContextTracker
+        {
+            get { return _contextTracker; }
+        }
+
+        private static Profiler Create()
+        {
+            var status = new ProfilerStatus();
+            var contextTracker = new ContextTracker(status);
+            return new Profiler(contextTracker);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -1,0 +1,73 @@
+// <copyright file="ProfilerStatus.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal class ProfilerStatus
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProfilerStatus));
+
+        private readonly bool _isProfilingEnabled;
+        private readonly object _lockObj;
+        private bool _isInitiliazed;
+        private IntPtr _engineStatusPtr;
+
+        public ProfilerStatus()
+        {
+            _isProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariables.ProfilingEnabled)?.ToBoolean() ?? false;
+            Log.Information("Continuous Profiler is {IsEnabled}.", _isProfilingEnabled ? "enabled" : "disabled");
+            _lockObj = new();
+            _isInitiliazed = false;
+        }
+
+        public bool IsProfilerReady
+        {
+            get
+            {
+                if (!_isProfilingEnabled)
+                {
+                    return false;
+                }
+
+                EnsureNativeIsIntialized();
+                return _engineStatusPtr != IntPtr.Zero && Marshal.ReadByte(_engineStatusPtr) != 0;
+            }
+        }
+
+        private void EnsureNativeIsIntialized()
+        {
+            if (_isInitiliazed)
+            {
+                return;
+            }
+
+            lock (_lockObj)
+            {
+                if (_isInitiliazed)
+                {
+                    return;
+                }
+
+                _isInitiliazed = true;
+
+                try
+                {
+                    _engineStatusPtr = NativeInterop.GetProfilerStatusPointer();
+                }
+                catch (Exception e)
+                {
+                    Log.Warning("No profiler related feature(s) will be enabled. Failed to retrieve profiler status native pointer: {Reason}", e.Message);
+                    _engineStatusPtr = IntPtr.Zero;
+                }
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ContinuousProfiler
 
         public ProfilerStatus()
         {
-            _isProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariables.ProfilingEnabled)?.ToBoolean() ?? false;
+            _isProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false;
             Log.Information("Continuous Profiler is {IsEnabled}.", _isProfilingEnabled ? "enabled" : "disabled");
             _lockObj = new();
             _isInitiliazed = false;
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ContinuousProfiler
                 }
                 catch (Exception e)
                 {
-                    Log.Warning("No profiler related feature(s) will be enabled. Failed to retrieve profiler status native pointer: {Reason}", e.Message);
+                    Log.Warning(e, "No profiler related feature(s) will be enabled. Failed to retrieve profiler status native pointer.");
                     _engineStatusPtr = IntPtr.Zero;
                 }
             }

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ContinuousProfiler
 
         private readonly bool _isProfilingEnabled;
         private readonly object _lockObj;
-        private bool _isInitiliazed;
+        private bool _isInitialized;
         private IntPtr _engineStatusPtr;
 
         public ProfilerStatus()
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ContinuousProfiler
             _isProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false;
             Log.Information("Continuous Profiler is {IsEnabled}.", _isProfilingEnabled ? "enabled" : "disabled");
             _lockObj = new();
-            _isInitiliazed = false;
+            _isInitialized = false;
         }
 
         public bool IsProfilerReady
@@ -44,19 +44,19 @@ namespace Datadog.Trace.ContinuousProfiler
 
         private void EnsureNativeIsIntialized()
         {
-            if (_isInitiliazed)
+            if (_isInitialized)
             {
                 return;
             }
 
             lock (_lockObj)
             {
-                if (_isInitiliazed)
+                if (_isInitialized)
                 {
                     return;
                 }
 
-                _isInitiliazed = true;
+                _isInitialized = true;
 
                 try
                 {


### PR DESCRIPTION
## Summary of changes

This is a first step in implementing the CodeHotspots feature: The tracer sends the Local root span id and the span id to the profiler for each thread.

## Reason for change

CodeHotspots is feature that allows to link traces to profiles. Customers are asking for it since the first line of profiler was written.

## Implementation details

Check that the profiler is up and ready and the feature is activated (Currently, we leave it as disabled by default until the feature is fully implemented and properly tested).

Each time a scope is created, we check if the profiler is ready and the feature is enabled: 
- If the profiler is not ready or the feature is deactivated, we create an `AsyncLocal` object as before (no callback)
- If the profiler is ready and the feature is enabled:
We create an `AsyncLocal` with a callback. This callback will be responsible of sending the span context (local root span id and span id) to the profiler each time a thread execution context changes. 
The first time a thread "sends" its `local root span id` and `span id` to the profiler, we first ask the profiler for a pointer to a memory where the span context will be written. This memory area is dedicated to the current thread and has the same layout as `SpanContext` struct (struct with 2 int64 fields). 
If that memory is ok (not equal to `IntPtr.Zero`), then we write data in that memory area.

## Test coverage

- Manual testing has been done: enabled (ensuring the profile file contains `local root span id` and `span id` and we have the same produced by the tracer) and disable (both profiler and tracer work as expected)
- Current tests will validate that if the feature is not activated and/or the profiler not present, the tracer still works as expected

Specific tests will be added in another PR:
- We need to build a monitoring artifact with the profiler and the tracer
- Add tests in  the profiler test suites

## Other details
<!-- Fixes #{issue} -->
