### PR TITLE
[CIApp] - Add agentless url configuration key

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CITestCyclePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CITestCyclePayload.cs
@@ -12,9 +12,18 @@ namespace Datadog.Trace.Ci.Agent.Payloads
     {
         public CITestCyclePayload()
         {
-            var builder = new UriBuilder("https://datadog.host.com/api/v2/citestcycle");
-            builder.Host = "citestcycle-intake." + CIVisibility.Settings.Site;
-            Url = builder.Uri;
+            if (!string.IsNullOrWhiteSpace(CIVisibility.Settings.AgentlessUrl))
+            {
+                var builder = new UriBuilder(CIVisibility.Settings.AgentlessUrl);
+                builder.Path = "api/v2/citestcycle";
+                Url = builder.Uri;
+            }
+            else
+            {
+                var builder = new UriBuilder("https://datadog.host.com/api/v2/citestcycle");
+                builder.Host = "citestcycle-intake." + CIVisibility.Settings.Site;
+                Url = builder.Uri;
+            }
         }
 
         public override Uri Url { get; }

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.Ci.Configuration
             Logs = source?.GetBool(ConfigurationKeys.CIVisibility.Logs) ?? false;
             ApiKey = source?.GetString(ConfigurationKeys.ApiKey);
             Site = source?.GetString(ConfigurationKeys.Site) ?? "datadoghq.com";
+            AgentlessUrl = source?.GetString(ConfigurationKeys.CIVisibility.AgentlessUrl);
 
             // By default intake payloads has a 5MB limit
             MaximumAgentlessPayloadSize = 5 * 1024 * 1024;
@@ -44,6 +45,11 @@ namespace Datadog.Trace.Ci.Configuration
         /// Gets a value indicating whether the Agentless writer is going to be used.
         /// </summary>
         public bool Agentless { get; }
+
+        /// <summary>
+        /// Gets the Agentless url.
+        /// </summary>
+        public string AgentlessUrl { get; }
 
         /// <summary>
         /// Gets the Api Key to use in Agentless mode

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -343,6 +343,11 @@ namespace Datadog.Trace.Configuration
             public const string AgentlessEnabled = "DD_CIVISIBILITY_AGENTLESS_ENABLED";
 
             /// <summary>
+            /// Configuration key for setting the agentless url endpoint
+            /// </summary>
+            public const string AgentlessUrl = "DD_CIVISIBILITY_AGENTLESS_URL";
+
+            /// <summary>
             /// Configuration key for enabling or disabling Logs direct submission.
             /// Default is value is false (disabled).
             /// </summary>


### PR DESCRIPTION
Add support to use a custom agentless url, this is required for the `test-environment` repo.