### PR TITLE
Use CustomTestFramework in runner integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -17,8 +17,13 @@ namespace Datadog.Trace.TestHelpers
 {
     public class CustomTestFramework : XunitTestFramework
     {
-        public CustomTestFramework(IMessageSink messageSink, Type typeTestedAssembly)
+        public CustomTestFramework(IMessageSink messageSink)
             : base(messageSink)
+        {
+        }
+
+        public CustomTestFramework(IMessageSink messageSink, Type typeTestedAssembly)
+            : this(messageSink)
         {
             var targetPath = GetProfilerTargetFolder();
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CustomTestFramework.cs
@@ -1,0 +1,20 @@
+// <copyright file="CustomTestFramework.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+using Xunit.Abstractions;
+
+[assembly: TestFramework("Datadog.Trace.Tools.Runner.IntegrationTests.CustomTestFramework", "Datadog.Trace.Tools.Runner.IntegrationTests")]
+
+namespace Datadog.Trace.Tools.Runner.IntegrationTests
+{
+    public class CustomTestFramework : TestHelpers.CustomTestFramework
+    {
+        public CustomTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+    }
+}


### PR DESCRIPTION
There has been at least one case of the runner integration tests getting stuck in the CI. Adding the CustomTestFramework to find out what test in particular needs to be fixed.