### PR TITLE
Strengthen GraphQL span expectation to address test flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -28,6 +28,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public bool IsGraphQLError { get; set; }
 
+        public override bool Matches(MockSpan span)
+        {
+            // Add ResourceName check to avoid test flakiness due to span ordering
+            return span.Service == ServiceName
+                && span.Name == OperationName
+                && span.Type == Type
+                && span.Resource == ResourceName;
+        }
+
         private IEnumerable<string> ExpectErrorMatch(MockSpan span)
         {
             var error = GetTag(span, Tags.ErrorMsg);


### PR DESCRIPTION
To make sure the expectations for the GraphQL spans are applied to the correct spans, enforce that the resource name of the span matches when retrieving the span to assert against. This should resolve the current issue where an assertion is running against a span with the same servcie/name/type but clearly different resource name.