### PR TITLE
CLI - Display the version of the profiler and tracer

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using Spectre.Console;
 
@@ -49,8 +50,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
             }
             else
             {
-                var version = FileVersionInfo.GetVersionInfo(profilerModule);
-                AnsiConsole.WriteLine(ProfilerVersion(version.FileVersion ?? "{empty}"));
+                // Only check the version of the native binary on Windows
+                // .so modules don't have version metadata
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var version = FileVersionInfo.GetVersionInfo(profilerModule);
+                    AnsiConsole.WriteLine(ProfilerVersion(version.FileVersion ?? "{empty}"));
+                }
             }
 
             var tracerModules = FindTracerModules(process).ToArray();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -40,10 +40,17 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 runtime = ProcessInfo.Runtime.NetFx;
             }
 
-            if (FindProfilerModule(process) == null)
+            var profilerModule = FindProfilerModule(process);
+
+            if (profilerModule == null)
             {
                 Utils.WriteWarning(ProfilerNotLoaded);
                 ok = false;
+            }
+            else
+            {
+                var version = FileVersionInfo.GetVersionInfo(profilerModule);
+                AnsiConsole.WriteLine(ProfilerVersion(version.FileVersion ?? "{empty}"));
             }
 
             var tracerModules = FindTracerModules(process).ToArray();
@@ -52,6 +59,11 @@ namespace Datadog.Trace.Tools.Runner.Checks
             {
                 Utils.WriteWarning(TracerNotLoaded);
                 ok = false;
+            }
+            else if (tracerModules.Length == 1)
+            {
+                var version = FileVersionInfo.GetVersionInfo(tracerModules[0]);
+                AnsiConsole.WriteLine(TracerVersion(version.FileVersion ?? "{empty}"));
             }
             else if (tracerModules.Length > 1)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string NetCoreRuntime = "Target process is running with .NET Core";
         public const string RuntimeDetectionFailed = "Failed to detect target process runtime, assuming .NET Framework";
         public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
-        public const string ProfilerNotLoaded = "Profiler is not loaded into the process";
+        public const string ProfilerNotLoaded = "The native library is not loaded into the process";
         public const string TracerNotLoaded = "Tracer is not loaded into the process";
         public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
         public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
@@ -31,6 +31,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+
+        public static string ProfilerVersion(string version) => $"The native library version {version} is loaded into the process.";
+
+        public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";
 
         public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set";
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -170,6 +170,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().BeTrue();
 
+            console.Output.Should().Contain(TracerVersion(TracerConstants.AssemblyVersion));
+            console.Output.Should().Contain(ProfilerVersion(TracerConstants.AssemblyVersion));
+
             console.Output.Should().NotContainAny(
                 ProfilerNotLoaded,
                 TracerNotLoaded,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -171,7 +171,11 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             result.Should().BeTrue();
 
             console.Output.Should().Contain(TracerVersion(TracerConstants.AssemblyVersion));
-            console.Output.Should().Contain(ProfilerVersion(TracerConstants.AssemblyVersion));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                console.Output.Should().Contain(ProfilerVersion(TracerConstants.AssemblyVersion));
+            }
 
             console.Output.Should().NotContainAny(
                 ProfilerNotLoaded,


### PR DESCRIPTION
When the tracer and/or the profiler are detected in the target process, display the version number even if there is no conflict. This could be useful if the output is copy/pasted to support.

Also, change "profiler" to "native library" in messages.