### PR TITLE
CLI - Check for suspicious registry keys in WOW6432Node

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -156,12 +156,17 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
                 bool foundKey = false;
 
-                foreach (var name in registry.GetLocalMachineValueNames(@"SOFTWARE\Microsoft\.NETFramework"))
+                var parentKeys = new[] { @"SOFTWARE\Microsoft\.NETFramework", @"SOFTWARE\WOW6432Node\Microsoft\.NETFramework" };
+
+                foreach (var parentKey in parentKeys)
                 {
-                    if (suspiciousNames.Contains(name))
+                    foreach (var name in registry.GetLocalMachineValueNames(parentKey))
                     {
-                        Utils.WriteWarning(SuspiciousRegistryKey(name));
-                        foundKey = true;
+                        if (suspiciousNames.Contains(name))
+                        {
+                            Utils.WriteWarning(SuspiciousRegistryKey(parentKey, name));
+                            foundKey = true;
+                        }
                     }
                 }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string ErrorCheckingRegistry(string error) => $"Error trying to read the registry: {error}";
 
-        public static string SuspiciousRegistryKey(string key) => $@"The registry key HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
+        public static string SuspiciousRegistryKey(string parentKey, string key) => $@"The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
 
         public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. Make sure the tracer has been properly installed with the MSI.";
 


### PR DESCRIPTION
If the target process is 32 bits, the .NET Framework will look into `SOFTWARE\WOW6432Node\Microsoft\.NETFramework` instead of `SOFTWARE\Microsoft\.NETFramework`. With this change, the tool will check both locations.