### PR TITLE
Update joint MSI with original .NET Tracer configuration

### DIFF
--- a/shared/src/msi-installer/Config.wxi
+++ b/shared/src/msi-installer/Config.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Include>
-  <?define BaseProductName = ".NET Monitoring" ?>
+  <?define BaseProductName = ".NET Tracer" ?>
   <?define ArpManufacturer = "Datadog, Inc." ?>
   <?define Company = "Datadog" ?>
   <?define ProductNamePlatformAgnostic = "Datadog $(var.BaseProductName)" ?>

--- a/shared/src/msi-installer/Product.wxs
+++ b/shared/src/msi-installer/Product.wxs
@@ -76,7 +76,7 @@
         <Directory Id="ProgramFilesFolder.Datadog" Name="$(var.Company)">
           <!-- ".\Datadog" -->
           <Directory Id="INSTALLFOLDER" Name="$(var.BaseProductName)">
-            <!-- ".\.NET Monitoring" -->
+            <!-- ".\.NET Tracer" -->
             <Directory Id="Tracer" Name="Tracer">
               <!-- Tracer -->
               <Directory Id="Tracer.net461" Name="net461">
@@ -130,7 +130,7 @@
         <Directory Id="ProgramFilesFolder.Datadog.32" Name="$(var.Company)">
           <!-- ".\Datadog" -->
           <Directory Id="INSTALLFOLDER.32" Name="$(var.BaseProductName)">
-            <!-- ".\.NET Monitoring" -->
+            <!-- ".\.NET Tracer" -->
             <Directory Id="Tracer.32" Name="Tracer">
             <!-- Tracer -->
             </Directory>

--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -8,8 +8,6 @@
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
         <Environment Id="DD_NATIVELOADER_CONFIGFILE" Name="DD_NATIVELOADER_CONFIGFILE" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]loader.conf" Part="all" />
-        <!-- For now, turn on Continuous Profiling automatically and watch it work its magic -->
-        <Environment Id="DD_PROFILING_ENABLED" Name="DD_PROFILING_ENABLED" Action="set" Permanent="no" System="yes" Value="1" Part="all" />
       </Component>
     </ComponentGroup>
   


### PR DESCRIPTION
## Summary of changes
Makes the following changes to the joint MSI
- Rename the ProductName from ".NET Monitoring" to ".NET Tracer" 
- Rename install folder from `C:\Program Files\Datadog\.NET Monitoring` to `C:\Program Files\Datadog\.NET Tracer`
- Remove `DD_PROFILING_ENABLED=1` from being set machine-wide. This means customers using the beta Profiler will need to set this themselves
