### PR TITLE
Do not load the tracer when loading NInject temporary appdomain

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -843,7 +843,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     // As there are no use case where we would like to load the tracer in that appdomain, just don't
     if (module_info.assembly.app_domain_name == WStr("NinjectModuleLoader") && !runtime_information_.is_core())
     {
-        Logger::Warn("JITCompilationStarted: NInjectModuleLoader appdomain deteceted. Not registering startup hook.");
+        Logger::Info("JITCompilationStarted: NInjectModuleLoader appdomain deteceted. Not registering startup hook.");
         return S_OK;
     }
 


### PR DESCRIPTION
## Summary of changes

Do not inject our startup hook when running insided the `NinjectModuleLoader` Appdomain on .NET Framework.

## Reason for change

In .NET Framework, NInject creates a [temporary Appdomain that they unload quickly](https://github.com/ninject/Ninject/blob/3ff6bdaad8cde418724b8b18edb3a457b9785f8e/src/Ninject/Modules/AssemblyNameRetriever.cs#L49) to load modules.  
When Ninject tries to unload the Appdomain, a customer gets a `CannotUnloadAppDomainException`. We suspect that we may timeout while initializing of the performance counters used for runtime metrics even though I haven’t been able to reproduce.

## Implementation details
Just added an early break inside `JITCompilationStarted` to handle that use case and added this warning log:
`[warning] JITCompilationStarted: NInjectModuleLoader appdomain deteceted. Not registering startup hook.`

## Test coverage
None

## Other details
Fixes APMS-6835