### PR TITLE
Add null checks and remove the possibility to do wrong type casting

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -163,6 +163,11 @@ namespace Datadog.Trace.Ci
                 return absolutePath;
             }
 
+            if (string.IsNullOrEmpty(absolutePath))
+            {
+                return pivotFolder;
+            }
+
             char folderSeparator = Path.DirectorySeparatorChar;
             if (pivotFolder[pivotFolder.Length - 1] != folderSeparator)
             {


### PR DESCRIPTION
Fix MethodSymbolResolver by adding null checks and remove the possibility to do wrong type casting.