### PR TITLE
Add additional diagnostic for Tags source generator

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Diagnostics/InvalidUseOfLanguageDiagnostic.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Diagnostics/InvalidUseOfLanguageDiagnostic.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="InvalidUseOfLanguageDiagnostic.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Microsoft.CodeAnalysis;
+
+namespace Datadog.Trace.SourceGenerators.TagsListGenerator.Diagnostics;
+
+internal static class InvalidUseOfLanguageDiagnostic
+{
+    internal const string Id = "TL6";
+    private const string Message = "You must not use 'language' as a key value";
+    private const string Title = "Invalid use of language";
+
+    public static Diagnostic Create(SyntaxNode? currentNode) =>
+        Diagnostic.Create(
+            new DiagnosticDescriptor(
+                Id, Title, Message, category: SourceGenerators.Constants.Usage, defaultSeverity: DiagnosticSeverity.Warning, isEnabledByDefault: true),
+            currentNode?.GetLocation());
+}

--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
@@ -232,6 +232,13 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
                                 hasMisconfiguredInput = true;
                                 break;
                             }
+
+                            if (key == "language")
+                            {
+                                reportDiagnostic(InvalidUseOfLanguageDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                hasMisconfiguredInput = true;
+                                break;
+                            }
                         }
 
                         if (hasMisconfiguredInput)

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
@@ -560,6 +560,25 @@ namespace MyTests.TestListNameSpace
             Assert.Contains(diagnostics, diag => diag.Id == InvalidUseOfOriginDiagnostic.Id);
         }
 
+        [Fact]
+        public void CanNotGenerateTagsListWithTagThatContainsLanguage()
+        {
+            const string input = @"using Datadog.Trace.SourceGenerators;
+namespace MyTests.TestListNameSpace
+{
+    public class TestList 
+    { 
+        [Tag(""TestId"")]
+    	public string Id { get; set; }
+
+        [Tag(""language"")]
+    	public string Language { get; set; }
+    }
+}";
+            var (diagnostics, output) = TestHelpers.GetGeneratedOutput<TagListGenerator>(input);
+            Assert.Contains(diagnostics, diag => diag.Id == InvalidUseOfLanguageDiagnostic.Id);
+        }
+
         [Theory]
         [InlineData(@"null")]
         [InlineData("\"\"")]


### PR DESCRIPTION
## Summary of changes

- Add a check that we're not manually using "language" tag in our `Tags` implementations

## Reason for change

When I rebased https://github.com/DataDog/dd-trace-dotnet/pull/2535 and https://github.com/DataDog/dd-trace-dotnet/pull/2545 on top of master, all the integration tests failed. I eventually traced this to https://github.com/DataDog/dd-trace-dotnet/pull/2542, in which we automatically add the `language` tag. As we weren't previously doing that, and I was adding it _manually_, the message pack serialization was broken which was causing the agentwriter to hang. 

> I haven't checked yet whether the issue was with the agent writer or with the mock agent deserialization - if the former, then we may need to dig into more.

## Implementation details

Same as for the `_dd.origin` tag, make sure we don't use it in the source generator

## Test coverage

Unit test!
