### PR TITLE
Explicit that we usually don't expect patches on master

### DIFF
--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Next Version Number (x.x.x)'
+        description: 'Next Version Number (x.y.z). On master, the automatic version bump will work only if the version is x.y.0.'
         required: true
       is_prerelease:
         description: 'Is Prerelease version? (true/false)'


### PR DESCRIPTION
## Summary of changes
Explicit in the `Manual Version Bump` workflow that we usually don't expect a patch on master.

## Reason for change
This is what the automatic version bump expects. So if we do one x.y.!0 release, the automatic version bump won't trigger.

