### PR TITLE
Allow setting `force_run_exploration_tests_isTracerChanged` variables

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -37,11 +37,20 @@ partial class Build : NukeBuild
 
                 void GenerateConditionVariableBasedOnGitChange(string variableName, string[] filters, string[] exclusionFilters)
                 {
-                    var changedFiles = GetGitChangedFiles("origin/master");
+                    bool isChanged;
+                    var forceExplorationTestsWithVariableName = $"force_exploration_tests_with_{variableName}";
+                    if (bool.Parse(Environment.GetEnvironmentVariable(forceExplorationTestsWithVariableName) ?? "false"))
+                    {
+                        Logger.Info($"{forceExplorationTestsWithVariableName} was set - forcing exploration tests");
+                        isChanged = true;
+                    }
+                    else
+                    {
+                        var changedFiles = GetGitChangedFiles("origin/master");
 
-                    var isChanged = changedFiles.Any(s => filters.Any(filter => s.Contains(filter)) && !exclusionFilters.Any(filter => s.Contains(filter)));
-
-                    // Choose changedFiles that meet any of the filters => Choose changedFiles that DON'T meet any of the exclusion filters
+                        // Choose changedFiles that meet any of the filters => Choose changedFiles that DON'T meet any of the exclusion filters
+                        isChanged = changedFiles.Any(s => filters.Any(filter => s.Contains(filter)) && !exclusionFilters.Any(filter => s.Contains(filter)));
+                    }
 
                     Logger.Info($"{variableName} - {isChanged}");
 


### PR DESCRIPTION
## Summary of changes

Allows forcing the exploration tests to run when they otherwise would not have

## Reason for change

#2609 added a fix to the PDB reader which was causing failures in the exploration tests. We want to run the exploration tests with this fix, but as the fix is not in Tracer files, they will not currently run. This allows us to force them to run, similar to how we can force it for benchmark runs etc

## Implementation details

Added 3 new variables to azure devops:

- `force_exploration_tests_with_isDebuggerChanged`
- `force_exploration_tests_with_isProfilerChanged`
- `force_exploration_tests_with_isTracerChanged`

These can be overridden at build time: 

![image](https://user-images.githubusercontent.com/18755388/160807698-61b8de7f-1f0d-472e-b12d-40c041bd520f.png)

If set, these take precedence over the "calculated" values of `isTracerChanged` etc.