### PR TITLE
[CLI] Correctly handle end of stream in ProcessMemoryStream 

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/ProcessMemoryStream.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Windows/ProcessMemoryStream.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Tools.Runner.Checks.Windows
                 if (currentCount == 0)
                 {
                     // EOF
-                    return 0;
+                    return totalCount;
                 }
 
                 bool throwOnError = pageStart == _firstPageAddress;


### PR DESCRIPTION
## Summary of changes

`ProcessMemoryStream` wasn't properly handling requests for reading more data than available. It was returning `0` instead of the number of bytes read until that point.

## Reason for change

For the greater good. (And it was probably responsible for the flaky process check tests in CI on the VMSS runners)

