### PR TITLE
Refactor Logging API

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Log.h
@@ -7,8 +7,12 @@
 
 #include <string>
 
+#include "shared/src/native-src/logger.h"
 #include "shared/src/native-src/logger_impl.h"
+#include "shared/src/native-src/logmanager.h"
 #include "shared/src/native-src/string.h"
+
+namespace ds = datadog::shared;
 
 class Log final
 {
@@ -27,38 +31,40 @@ private:
         };
     };
 
+    inline static ds::Logger* const Instance = ds::LogManager::Get<Log::ProfilerLoggerPolicy>();
+
 public:
     static bool IsDebugEnabled()
     {
-        return shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->IsDebugEnabled();
+        return Instance->IsDebugEnabled();
     }
 
     static void EnableDebug()
     {
-        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->EnableDebug();
+        Instance->EnableDebug();
     }
 
     template <typename... Args>
     static inline void Debug(const Args&... args)
     {
-        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Debug<Args...>(args...);
+        Instance->Debug<Args...>(args...);
     }
 
     template <typename... Args>
     static void Info(const Args&... args)
     {
-        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Info<Args...>(args...);
+        Instance->Info<Args...>(args...);
     }
 
     template <typename... Args>
     static void Warn(const Args&... args)
     {
-        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Warn<Args...>(args...);
+        Instance->Warn<Args...>(args...);
     }
 
     template <typename... Args>
     static void Error(const Args&... args)
     {
-        shared::LoggerImpl<ProfilerLoggerPolicy>::Instance()->Error<Args...>(args...);
+        Instance->Error<Args...>(args...);
     }
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1,10 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 #include "Configuration.h"
+#include "EnvironmentHelper.h"
 #include "EnvironmentVariables.h"
 #include "OpSysTools.h"
 
@@ -12,26 +13,7 @@
 
 using namespace std::literals::chrono_literals;
 
-extern void setenv(const shared::WSTRING& name, const shared::WSTRING& value);
-
 extern void unsetenv(const shared::WSTRING& name);
-
-class EnvironmentVariableAutoReset
-{
-public:
-    EnvironmentVariableAutoReset(shared::WSTRING const& env, shared::WSTRING value) :
-        _env{env}
-    {
-        setenv(_env, value);
-    }
-    ~EnvironmentVariableAutoReset()
-    {
-        unsetenv(_env);
-    }
-
-private:
-    shared::WSTRING const& _env;
-};
 
 TEST(ConfigurationTest, CheckIfDebugLogIsNotEnabledWhenVariableIsNotSet)
 {
@@ -42,21 +24,21 @@ TEST(ConfigurationTest, CheckIfDebugLogIsNotEnabledWhenVariableIsNotSet)
 
 TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenEnvVariableIsSetToTrue)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DebugLogEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DebugLogEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsDebugLogEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenEnvVariableIsSetToFalse)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DebugLogEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DebugLogEnabled, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsDebugLogEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenEnvVariableIsSetEmptyString)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DebugLogEnabled, WStr(""));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DebugLogEnabled, WStr(""));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsDebugLogEnabled());
 }
@@ -64,7 +46,7 @@ TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenEnvVariableIsSetEmptyString)
 TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenInDev)
 {
     unsetenv(EnvironmentVariables::DebugLogEnabled);
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
 
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsDebugLogEnabled());
@@ -72,21 +54,21 @@ TEST(ConfigurationTest, CheckIfDebugLogIsEnabledWhenInDev)
 
 TEST(ConfigurationTest, CheckIfNativeFramesIsEnabledWhenEnvVariableIsSetToTrue)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::NativeFramesEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::NativeFramesEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsNativeFramesEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfNativeFramesIsEnabledWhenEnvVariableIsSetToFalse)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::NativeFramesEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::NativeFramesEnabled, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsNativeFramesEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfNativeFramesIsEnabledWhenEnvVariableIsSetEmptyString)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::NativeFramesEnabled, WStr(""));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::NativeFramesEnabled, WStr(""));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsNativeFramesEnabled());
 }
@@ -100,21 +82,21 @@ TEST(ConfigurationTest, CheckIfNativeFramesIsEnabledWhenVariableIsNotSet)
 
 TEST(ConfigurationTest, CheckIfOperationalMetricsIsEnabledWhenEnvVariableIsSetToTrue)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::OperationalMetricsEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::OperationalMetricsEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsOperationalMetricsEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfOperationalMetricsIsEnabledWhenEnvVariableIsSetToFalse)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::OperationalMetricsEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::OperationalMetricsEnabled, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsOperationalMetricsEnabled());
 }
 
 TEST(ConfigurationTest, CheckIfOperationalMetricsIsEnabledWhenEnvVariableIsSetEmptyString)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::OperationalMetricsEnabled, WStr(""));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::OperationalMetricsEnabled, WStr(""));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsOperationalMetricsEnabled());
 }
@@ -142,7 +124,7 @@ TEST(ConfigurationTest, CheckDefaultLogDirectoryWhenVariableIsNotSet)
 TEST(ConfigurationTest, CheckLogDirectoryWhenVariableIsSet)
 {
     auto expectedValue = fs::path(WStr("MyFolder/WhereIWantIt/ToBe"));
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::LogDirectory, shared::ToWSTRING(expectedValue.string()));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LogDirectory, shared::ToWSTRING(expectedValue.string()));
     auto configuration = Configuration{};
     ASSERT_EQ(expectedValue, configuration.GetLogDirectory());
 }
@@ -163,7 +145,7 @@ TEST(ConfigurationTest, CheckDefaultPprofDirectoryWhenVariableIsNotSet)
 TEST(ConfigurationTest, CheckProfileDirectoryWhenVariableIsSet)
 {
     auto expectedValue = fs::path(WStr("MyFolder/WhereIWantIt/ToBe"));
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::ProfilesOutputDir, shared::ToWSTRING(expectedValue.string()));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ProfilesOutputDir, shared::ToWSTRING(expectedValue.string()));
     auto configuration = Configuration{};
     ASSERT_EQ(expectedValue, configuration.GetProfilesOutputDirectory());
 }
@@ -171,7 +153,7 @@ TEST(ConfigurationTest, CheckProfileDirectoryWhenVariableIsSet)
 TEST(ConfigurationTest, CheckDefaultUploadIntervalInDevMode)
 {
     unsetenv(EnvironmentVariables::UploadInterval);
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_EQ(20s, configuration.GetUploadInterval());
 }
@@ -179,14 +161,14 @@ TEST(ConfigurationTest, CheckDefaultUploadIntervalInDevMode)
 TEST(ConfigurationTest, CheckDefaultUploadIntervalInNonDevMode)
 {
     unsetenv(EnvironmentVariables::UploadInterval);
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DevelopmentConfiguration, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DevelopmentConfiguration, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_EQ(60s, configuration.GetUploadInterval());
 }
 
 TEST(ConfigurationTest, CheckUploadIntervalWhenVariableIsSet)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::UploadInterval, WStr("200"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::UploadInterval, WStr("200"));
     auto configuration = Configuration{};
     ASSERT_EQ(200s, configuration.GetUploadInterval());
 }
@@ -194,7 +176,7 @@ TEST(ConfigurationTest, CheckUploadIntervalWhenVariableIsSet)
 TEST(ConfigurationTest, CheckDefaultSiteInDevMode)
 {
     unsetenv(EnvironmentVariables::Site);
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DevelopmentConfiguration, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_EQ("datad0g.com", configuration.GetSite());
 }
@@ -202,7 +184,7 @@ TEST(ConfigurationTest, CheckDefaultSiteInDevMode)
 TEST(ConfigurationTest, CheckDefaultSiteInNonDevMode)
 {
     unsetenv(EnvironmentVariables::Site);
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::DevelopmentConfiguration, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DevelopmentConfiguration, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_EQ("datadoghq.com", configuration.GetSite());
 }
@@ -210,7 +192,7 @@ TEST(ConfigurationTest, CheckDefaultSiteInNonDevMode)
 TEST(ConfigurationTest, CheckSiteWhenVariableIsSet)
 {
     auto expectedValue = WStr("MySite");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Site, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Site, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetSite());
 }
@@ -225,7 +207,7 @@ TEST(ConfigurationTest, CheckVersionIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckVersionWhenVariableIsSet)
 {
     auto expectedValue = WStr("MyVersion");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Version, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Version, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetVersion());
 }
@@ -240,7 +222,7 @@ TEST(ConfigurationTest, CheckEnvironmentIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckEnvrionmentWhenVariableIsSet)
 {
     auto expectedValue = WStr("MyEnv");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Environment, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Environment, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetEnvironment());
 }
@@ -255,7 +237,7 @@ TEST(ConfigurationTest, CheckHostnameIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckHostnameWhenVariableIsSet)
 {
     auto expectedValue = WStr("Myhost");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Environment, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Environment, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetEnvironment());
 }
@@ -270,7 +252,7 @@ TEST(ConfigurationTest, CheckAgentUrlIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckAgentUrlWhenVariableIsSet)
 {
     auto expectedValue = WStr("MyAgentUrl");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::AgentUrl, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::AgentUrl, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetAgentUrl());
 }
@@ -285,7 +267,7 @@ TEST(ConfigurationTest, CheckAgentHostIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckAgentHostWhenVariableIsSet)
 {
     auto expectedValue = WStr("MyAgenthost");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::AgentHost, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::AgentHost, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetAgentHost());
 }
@@ -300,7 +282,7 @@ TEST(ConfigurationTest, CheckAgentPortIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckAgentPortWhenVariableIsSet)
 {
     auto expectedValue = WStr("4242");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::AgentPort, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::AgentPort, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(4242, configuration.GetAgentPort());
 }
@@ -315,7 +297,7 @@ TEST(ConfigurationTest, CheckApiKeyIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckApiKeyWhenVariableIsSet)
 {
     auto expectedValue = WStr("4242XXX");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::ApiKey, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ApiKey, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetApiKey());
 }
@@ -330,7 +312,7 @@ TEST(ConfigurationTest, CheckApplicationNameIfVariableIsNotSet)
 TEST(ConfigurationTest, CheckApplicationNameWhenVariableIsSet)
 {
     auto expectedValue = WStr("MyApplication");
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::ServiceName, expectedValue);
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ServiceName, expectedValue);
     auto configuration = Configuration{};
     ASSERT_EQ(shared::ToString(expectedValue), configuration.GetServiceName());
 }
@@ -344,50 +326,49 @@ TEST(ConfigurationTest, CheckUserTagsWhenVariableIsNotSet)
 
 TEST(ConfigurationTest, CheckUserTagsWhenVariableIsSet)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Tags, WStr("foo:bar,lab1:val1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Tags, WStr("foo:bar,lab1:val1"));
     auto configuration = Configuration{};
     EXPECT_THAT(configuration.GetUserTags(), ::testing::ContainerEq(tags{{"foo", "bar"}, {"lab1", "val1"}}));
 }
 
 TEST(ConfigurationTest, CheckUserTagsWhenVariableIsSetWithIncompleteTag)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::Tags, WStr("foo:bar,foobar:barbar,lab1:"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::Tags, WStr("foo:bar,foobar:barbar,lab1:"));
     auto configuration = Configuration{};
     EXPECT_THAT(configuration.GetUserTags(), ::testing::ContainerEq(tags{{"foo", "bar"}, {"foobar", "barbar"}, {"lab1", ""}}));
 }
 
-
 TEST(ConfigurationTest, CheckThatFFIsLibddprofIsEnabledWhenEnvVariableIsSetToTrue)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("true"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("true"));
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsFFLibddprofEnabled());
 }
 
 TEST(ConfigurationTest, CheckThatFFIsLibddprofIsEnabledWhenEnvVariableIsSetToOne)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_TRUE(configuration.IsFFLibddprofEnabled());
 }
 
 TEST(ConfigurationTest, CheckThatFFIsLibddprofIsDisabledWhenEnvVariableIsSetToFalse)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("false"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("false"));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsFFLibddprofEnabled());
 }
 
 TEST(ConfigurationTest, CheckThatFFIsLibddprofIsDisabledWhenEnvVariableIsSetToZero)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::FF_LibddprofEnabled, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsFFLibddprofEnabled());
 }
 
 TEST(ConfigurationTest, CheckThatFFIsLibddprofIsDisabledWhenEnvVariableIsSetEmptyString)
 {
-    EnvironmentVariableAutoReset ar(EnvironmentVariables::FF_LibddprofEnabled, WStr(""));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::FF_LibddprofEnabled, WStr(""));
     auto configuration = Configuration{};
     ASSERT_FALSE(configuration.IsFFLibddprofEnabled());
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -43,9 +43,11 @@
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\DogstatsdService.cpp" />
     <ClCompile Include="AppDomainStoreHelper.cpp" />
     <ClCompile Include="ConfigurationTest.cpp" />
+    <ClCompile Include="EnvironmentHelper.cpp" />
     <ClCompile Include="FrameStoreHelper.cpp" />
     <ClCompile Include="IMetricsSenderFactoryTest.cpp" />
     <ClCompile Include="LibddprofExporterTest.cpp" />
+    <ClCompile Include="LogTest.cpp" />
     <ClCompile Include="ProfilerMockedInterface.cpp" />
     <ClCompile Include="SamplesProviderTest.cpp" />
     <ClCompile Include="SamplesAggregatorTest.cpp" />
@@ -55,6 +57,7 @@
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.cpp" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\IMetricsSenderFactory.cpp" />
     <ClInclude Include="AppDomainStoreHelper.h" />
+    <ClInclude Include="EnvironmentHelper.h" />
     <ClInclude Include="FrameStoreHelper.h" />
     <ClInclude Include="ProfilerMockedInterface.h" />
   </ItemGroup>

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -24,12 +24,6 @@
     <ClCompile Include="IMetricsSenderFactoryTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\..\dd-trace-dotnet\shared\src\native-src\util.cpp">
-      <Filter>Referenced from: Datadog.Profiler.Native\Util</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\dd-trace-dotnet\shared\src\native-src\string.cpp">
-      <Filter>Referenced from: Datadog.Profiler.Native\Util</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\DogstatsdService.cpp">
       <Filter>Referenced from: Datadog.Profiler.Native</Filter>
     </ClCompile>
@@ -68,6 +62,18 @@
     <ClCompile Include="SamplesProviderTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="LogTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="EnvironmentHelper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\shared\src\native-src\string.cpp">
+      <Filter>Referenced from: Datadog.Profiler.Native\Util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\shared\src\native-src\util.cpp">
+      <Filter>Referenced from: Datadog.Profiler.Native\Util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">
@@ -80,6 +86,9 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="AppDomainStoreHelper.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="EnvironmentHelper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>

--- a/profiler/test/Datadog.Profiler.Native.Tests/IMetricsSenderFactoryTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/IMetricsSenderFactoryTest.cpp
@@ -3,43 +3,14 @@
 
 #include "gtest/gtest.h"
 
+#include "EnvironmentHelper.h"
 #include "EnvironmentVariables.h"
 #include "IMetricsSender.h"
 #include "IMetricsSenderFactory.h"
 
 #include "string.h"
 
-void setenv(const shared::WSTRING& name, const shared::WSTRING& value)
-{
-#ifdef _WINDOWS
-    SetEnvironmentVariable(name.c_str(), value.c_str());
-#else
-    setenv(shared::ToString(name).c_str(), shared::ToString(value).c_str(), 1);
-#endif
-}
-
-void unsetenv(const shared::WSTRING& name)
-{
-#ifdef _WINDOWS
-    SetEnvironmentVariable(name.c_str(), nullptr);
-#else
-    unsetenv(shared::ToString(name).c_str());
-#endif
-}
-
-class IMetricsSenderFactoryTestFixture : public ::testing::Test
-{
-public:
-    IMetricsSenderFactoryTestFixture() = default;
-
-protected:
-    void SetUp() override
-    {
-        unsetenv(EnvironmentVariables::OperationalMetricsEnabled);
-    }
-};
-
-TEST_F(IMetricsSenderFactoryTestFixture, MustReturnNullIfEnvVarNotSet)
+TEST(IMetricsSenderFactoryTest, MustReturnNullIfEnvVarNotSet)
 {
     auto envVarValue = std::getenv(shared::ToString(EnvironmentVariables::OperationalMetricsEnabled).c_str());
     EXPECT_TRUE(envVarValue == nullptr);
@@ -48,23 +19,23 @@ TEST_F(IMetricsSenderFactoryTestFixture, MustReturnNullIfEnvVarNotSet)
     EXPECT_TRUE(metricsSender == nullptr);
 }
 
-TEST_F(IMetricsSenderFactoryTestFixture, MustReturnNullIfEnvVarSetToZero)
+TEST(IMetricsSenderFactoryTest, MustReturnNullIfEnvVarSetToZero)
 {
-    setenv(EnvironmentVariables::OperationalMetricsEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable er(EnvironmentVariables::OperationalMetricsEnabled, WStr("0"));
     auto metricsSender = IMetricsSenderFactory::Create();
     EXPECT_TRUE(metricsSender == nullptr);
 }
 
-TEST_F(IMetricsSenderFactoryTestFixture, MustReturnNullIfEnvVarValueIsNotValid)
+TEST(IMetricsSenderFactoryTest, MustReturnNullIfEnvVarValueIsNotValid)
 {
-    setenv(EnvironmentVariables::OperationalMetricsEnabled, WStr("NotValidValue"));
+    EnvironmentHelper::EnvironmentVariable er(EnvironmentVariables::OperationalMetricsEnabled, WStr("NotValidValue"));
     auto metricsSender = IMetricsSenderFactory::Create();
     EXPECT_TRUE(metricsSender == nullptr);
 }
 
-TEST_F(IMetricsSenderFactoryTestFixture, MustReturnValidPointerIfSetToOne)
+TEST(IMetricsSenderFactoryTest, MustReturnValidPointerIfSetToOne)
 {
-    setenv(EnvironmentVariables::OperationalMetricsEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable er(EnvironmentVariables::OperationalMetricsEnabled, WStr("1"));
     auto metricsSender = IMetricsSenderFactory::Create();
     EXPECT_TRUE(metricsSender != nullptr);
 }

--- a/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems
+++ b/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems
@@ -22,7 +22,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)il_rewriter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)il_rewriter_wrapper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)loader.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)logger.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)logger_impl.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)logmanager.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)miniutf.hpp" />
     <ClInclude Include="$(MSBuildThisFileDirectory)miniutfdata.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)pal.h" />

--- a/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems.filters
+++ b/shared/src/native-src/Shared.ManagedLibraryLoader.vcxitems.filters
@@ -65,5 +65,11 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)logger_impl.h">
       <Filter>Logging</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)logmanager.h">
+      <Filter>Logging</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)logger.h">
+      <Filter>Logging</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -1,0 +1,226 @@
+#pragma once
+
+#include <memory>
+#include <regex>
+#include <sstream>
+
+#include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/spdlog.h>
+
+#include "dd_filesystem.hpp"
+#include "pal.h"
+#include "string.h"
+
+namespace datadog::shared
+{
+
+/// <summary>
+/// Logger class is created only by LogManager class.
+/// </summary>
+class Logger
+{
+public:
+
+    template <typename... Args>
+    void Debug(const Args&... args);
+
+    template <typename... Args>
+    void Info(const Args&... args);
+
+    template <typename... Args>
+    void Warn(const Args&... args);
+
+    template <typename... Args>
+    void Error(const Args&... args);
+
+    template <typename... Args>
+    void Critical(const Args&... args);
+
+    inline void Flush();
+
+    inline void EnableDebug();
+    inline bool IsDebugEnabled() const;
+
+
+private:
+
+    friend class LogManager;
+
+    Logger(std::shared_ptr<spdlog::logger> const& logger) : _internalLogger{logger}, m_debug_logging_enabled{false}
+    {
+    }
+
+    ~Logger()
+    {
+        _internalLogger->flush();
+        spdlog::shutdown(); // <--- Not sure we still should do that since in the same process we could have Tracer Logger
+    }
+
+    template <class LoggerPolicy>
+    static Logger Create();
+
+    static inline std::string SanitizeProcessName(std::string const& processName);
+    static inline std::string BuildLogFileSuffix();
+
+    template <class LoggerPolicy>
+    static std::string GetLogPath(const std::string& file_name_suffix);
+
+    template <class LoggerPolicy>
+    static std::shared_ptr<spdlog::logger> CreateInternalLogger();
+
+    std::shared_ptr<spdlog::logger> _internalLogger;
+    bool m_debug_logging_enabled;
+};
+
+template <class LoggerPolicy>
+inline Logger Logger::Create()
+{
+    return {Logger::CreateInternalLogger<LoggerPolicy>()};
+}
+
+inline std::string Logger::SanitizeProcessName(std::string const& processName)
+{
+    const auto process_name_without_extension = processName.substr(0, processName.find_last_of("."));
+    const std::regex dash_or_space_or_tab("-|\\s|\\t");
+    return std::regex_replace(process_name_without_extension, dash_or_space_or_tab, "_");
+}
+
+inline std::string Logger::BuildLogFileSuffix()
+{
+    std::ostringstream oss;
+
+    auto processName = Logger::SanitizeProcessName(::shared::ToString(::shared::GetCurrentProcessName()));
+    oss << "-" << processName << "-" << ::shared::GetPID();
+    return oss.str();
+}
+
+template <class LoggerPolicy>
+std::shared_ptr<spdlog::logger> Logger::CreateInternalLogger()
+{
+    spdlog::set_error_handler([](const std::string& msg) {
+        // By writing into the stderr was changing the behavior in a CI scenario.
+        // There's not a good way to report errors when trying to create the log file.
+        // But we never should be changing the normal behavior of an app.
+        // std::cerr << "LoggerImpl Handler: " << msg << std::endl;
+    });
+
+    spdlog::flush_every(std::chrono::seconds(3));
+
+    static auto file_name_suffix = Logger::BuildLogFileSuffix();
+
+    std::shared_ptr<spdlog::logger> logger;
+
+    try
+    {
+        logger =
+            spdlog::rotating_logger_mt("Logger", Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10);
+    }
+    catch (...)
+    {
+        // By writing into the stderr was changing the behavior in a CI scenario.
+        // There's not a good way to report errors when trying to create the log file.
+        // But we never should be changing the normal behavior of an app.
+        // std::cerr << "LoggerImpl Handler: Error creating native log file." << std::endl;
+        logger = spdlog::null_logger_mt("LoggerImpl");
+    }
+
+    logger->set_level(spdlog::level::debug);
+
+    logger->set_pattern(LoggerPolicy::pattern);
+
+    logger->flush_on(spdlog::level::info);
+
+    return logger;
+}
+
+template <class TLoggerPolicy>
+std::string Logger::GetLogPath(const std::string& file_name_suffix)
+{
+    auto path = ::shared::ToString(::shared::GetDatadogLogFilePath<TLoggerPolicy>(file_name_suffix));
+
+    const auto log_path = fs::path(path);
+
+    if (log_path.has_parent_path())
+    {
+        const auto parent_path = log_path.parent_path();
+
+        if (!fs::exists(parent_path))
+        {
+            fs::create_directories(parent_path);
+        }
+    }
+
+    return path;
+}
+
+template <class T>
+void WriteToStream(std::ostringstream& oss, T const& x)
+{
+    if constexpr (std::is_same<T, ::shared::WSTRING>::value)
+    {
+        oss << ::shared::ToString(x);
+    }
+    else
+    {
+        oss << x;
+    }
+}
+
+template <typename... Args>
+static std::string LogToString(Args const&... args)
+{
+    std::ostringstream oss;
+    (WriteToStream(oss, args), ...);
+
+    return oss.str();
+}
+
+template <typename... Args>
+void Logger::Debug(const Args&... args)
+{
+    if (IsDebugEnabled())
+    {
+        _internalLogger->debug(LogToString(args...));
+    }
+}
+
+template <typename... Args>
+void Logger::Info(const Args&... args)
+{
+    _internalLogger->info(LogToString(args...));
+}
+
+template <typename... Args>
+void Logger::Warn(const Args&... args)
+{
+    _internalLogger->warn(LogToString(args...));
+}
+
+template <typename... Args>
+void Logger::Error(const Args&... args)
+{
+    _internalLogger->error(LogToString(args...));
+}
+
+template <typename... Args>
+void Logger::Critical(const Args&... args)
+{
+    _internalLogger->critical(LogToString(args...));
+}
+
+inline void Logger::Flush()
+{
+    _internalLogger->flush();
+}
+
+inline void Logger::EnableDebug()
+{
+    m_debug_logging_enabled = true;
+}
+
+inline bool Logger::IsDebugEnabled() const
+{
+    return m_debug_logging_enabled;
+}
+} // namespace datadog::shared

--- a/shared/src/native-src/logmanager.h
+++ b/shared/src/native-src/logmanager.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "logger.h"
+
+#include <memory>
+
+namespace datadog::shared
+{
+class LogManager
+{
+public:
+    LogManager() = delete;
+
+    /// <summary>
+    /// This templated method returns a pointer to a logger in respect to the TLoggerPolicy trait.
+    /// Callers of this method borrow the pointer, this means that they do not have/must not call delete,
+    /// nor free on it.
+    /// </summary>
+    /// <typeparam name="TLoggerPolicy">Policy used to configure the Logger</typeparam>
+    /// <returns>A pointer to a Logger instance</returns>
+    template <class TLoggerPolicy>
+    static Logger* Get()
+    {
+        static Logger instance = Logger::Create<TLoggerPolicy>();
+        return &instance;
+    }
+};
+}


### PR DESCRIPTION
## Summary of changes


## Reason for change

Today, Loggers (tracer, profiler & native loader) are static. When writing native shared code, it's impossible to inject a logger (depending on which component uses it) without complex boiler plate templated code.

## Implementation details

Create `Logger` and `LogManager` classes:
- `LogManager` is a static class responsible for creating and caching `Logger` instance for a specific `policy/trait`. This trait is used to configure the internal logger.
- `Logger` class embeds an internal logger (`spdlog`) and just forward calls to it (templated methods `Info`, `Debug`...). `Logger` instance can only be created by `LogManager` class. Most of the configuration is copy/pasted from `logger_impl.h` file.

For now, we still keep a pointer to the `Logger` instance for each component.

## Test coverage

Added a test in the profiler suite test to check that it's still working.
## Other details
<!-- Fixes #{issue} -->
