### PR TITLE
[Profiler] Use Monitoring-home package in Profiler Rel.Env.

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -411,7 +411,7 @@ jobs:
       - name: Download profiler artifact
         uses: actions/download-artifact@v2
         with:
-          name: profiler-home.Windows.Release
+          name: monitoring-home.Windows.Release
           path: DDProf-Deploy
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
## Summary of changes

## Reason for change

The profiler reliability environment uses the profiler-only package to run the tests. We would like the reliability environment to run the profiler as the customers run it: using the native dispatcher/loader as CLR profiler.

## Implementation details

Change the file to be deployed to AWS S3

## Test coverage

## Other details
<!-- Fixes #{issue} -->
