### PR TITLE
Add wildcard support to DD_TRACE_METHODS

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -75,47 +75,30 @@ std::vector<IntegrationDefinition> GetIntegrationsFromTraceMethodsConfiguration(
             continue;
         }
 
-        std::vector<IntegrationDefinition> typeIntegrationDefinitions;
         type_name = trace_method_type.substr(0, firstOpenBracket);
         auto method_definitions_array = shared::Split(method_definitions, ',');
         for (const shared::WSTRING& method_definition : method_definitions_array)
         {
             std::vector<shared::WSTRING> signatureTypes;
-            if (method_definition == WStr("*"))
-            {
-                typeIntegrationDefinitions.clear();
-                typeIntegrationDefinitions.push_back(IntegrationDefinition(
-                    MethodReference(tracemethodintegration_assemblyname, type_name, method_definition,
-                                    Version(0, 0, 0, 0), Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX),
-                                    signatureTypes),
-                    integration_type, false, false));
+            integrationDefinitions.push_back(IntegrationDefinition(
+                MethodReference(tracemethodintegration_assemblyname, type_name, method_definition,
+                                Version(0, 0, 0, 0), Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX),
+                                signatureTypes),
+                integration_type, false, false));
 
-                if (Logger::IsDebugEnabled())
+            if (Logger::IsDebugEnabled())
+            {
+                if (method_definition == WStr("*"))
                 {
-                    Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name, ".* -- Preserving only the '*' wildcard method definition.");
+                    Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name,
+                                    ".* -- Preserving only the '*' wildcard method definition.");
                 }
-
-                break;
-            }
-            else
-            {
-                typeIntegrationDefinitions.push_back(IntegrationDefinition(
-                    MethodReference(tracemethodintegration_assemblyname, type_name, method_definition, Version(0, 0, 0, 0),
-                                    Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX), signatureTypes),
-                    integration_type, false, false));
-
-                if (Logger::IsDebugEnabled())
+                else
                 {
-                    Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name, ".", method_definition, "(",
-                                  signatureTypes.size(), ")");
+                    Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name, ".",
+                                    method_definition, "(", signatureTypes.size(), ")");
                 }
             }
-        }
-
-        integrationDefinitions.reserve(integrationDefinitions.size() + typeIntegrationDefinitions.size());
-        for (const auto& integration : typeIntegrationDefinitions)
-        {
-            integrationDefinitions.push_back(integration);
         }
     }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -81,17 +81,17 @@ std::vector<IntegrationDefinition> GetIntegrationsFromTraceMethodsConfiguration(
         {
             std::vector<shared::WSTRING> signatureTypes;
             integrationDefinitions.push_back(IntegrationDefinition(
-                MethodReference(tracemethodintegration_assemblyname, type_name, method_definition,
-                                Version(0, 0, 0, 0), Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX),
-                                signatureTypes),
+                MethodReference(tracemethodintegration_assemblyname, type_name, method_definition, Version(0, 0, 0, 0),
+                                Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX), signatureTypes),
                 integration_type, false, false));
 
             if (Logger::IsDebugEnabled())
             {
-                if (method_definition == WStr("*"))
+                if (method_definition == tracemethodintegration_wildcardmethodname)
                 {
                     Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name,
-                                    ".* -- Preserving only the '*' wildcard method definition.");
+                                    ".* -- All methods except .ctor, .cctor, Equals, GetHashCode, ToString,"
+                                    " and property getters/setters will automatically be instrumented.");
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -90,7 +90,7 @@ std::vector<IntegrationDefinition> GetIntegrationsFromTraceMethodsConfiguration(
                 if (method_definition == tracemethodintegration_wildcardmethodname)
                 {
                     Logger::Debug("GetIntegrationsFromTraceMethodsConfiguration:  * Target: ", type_name,
-                                    ".* -- All methods except .ctor, .cctor, Equals, GetHashCode, ToString,"
+                                    ".* -- All methods except .ctor, .cctor, Equals, Finalize, GetHashCode, ToString,"
                                     " and property getters/setters will automatically be instrumented.");
                 }
                 else

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -18,7 +18,7 @@ namespace trace
 const size_t kPublicKeySize = 8;
 const shared::WSTRING tracemethodintegration_assemblyname = WStr("#TraceMethodFeature");
 const std::unordered_set<shared::WSTRING> tracemethodintegration_wildcard_ignored_methods(
-    {WStr(".ctor"), WStr(".cctor"), WStr("Equals"), WStr("GetHashCode"), WStr("ToString")});
+    {WStr(".ctor"), WStr(".cctor"), WStr("Equals"), WStr("Finalize"), WStr("GetHashCode"), WStr("ToString")});
 const shared::WSTRING tracemethodintegration_wildcardmethodname = WStr("*");
 const shared::WSTRING tracemethodintegration_setterprefix = WStr("set_");
 const shared::WSTRING tracemethodintegration_getterprefix = WStr("get_");

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -5,6 +5,7 @@
 #include <iomanip>
 #include <sstream>
 #include <vector>
+#include <unordered_set>
 
 #include "../../../shared/src/native-src/string.h"
 
@@ -16,6 +17,11 @@ namespace trace
 
 const size_t kPublicKeySize = 8;
 const shared::WSTRING tracemethodintegration_assemblyname = WStr("#TraceMethodFeature");
+const std::unordered_set<shared::WSTRING> tracemethodintegration_wildcard_ignored_methods(
+    {WStr(".ctor"), WStr(".cctor"), WStr("Equals"), WStr("GetHashCode"), WStr("ToString")});
+const shared::WSTRING tracemethodintegration_wildcardmethodname = WStr("*");
+const shared::WSTRING tracemethodintegration_setterprefix = WStr("set_");
+const shared::WSTRING tracemethodintegration_getterprefix = WStr("get_");
 
 // PublicKey represents an Assembly Public Key token, which is an 8 byte binary
 // RSA key.

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_preprocessor.cpp
@@ -73,21 +73,20 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             continue;
         }
 
+        const auto numOfArgs = functionInfo.method_signature.NumberOfArguments();
         if (wildcard_enabled)
         {
-            if (tracemethodintegration_wildcard_ignored_methods.find(caller.name) !=
-                tracemethodintegration_wildcard_ignored_methods.end())
+            if (tracemethodintegration_wildcard_ignored_methods.find(caller.name) != tracemethodintegration_wildcard_ignored_methods.end() ||
+                caller.name.find(tracemethodintegration_setterprefix) == 0 ||
+                caller.name.find(tracemethodintegration_getterprefix) == 0)
             {
-                continue;
-            }
-            else if (caller.name.find(tracemethodintegration_setterprefix) == 0 ||
-                     caller.name.find(tracemethodintegration_getterprefix) == 0)
-            {
+                Logger::Warn(
+                    "    * Skipping enqueue for ReJIT, special method detected during '*' wildcard search [ModuleId=", moduleInfo.id, ", MethodDef=", shared::TokenStr(&methodDef),
+                    ", Type=", caller.type.name, ", Method=", caller.name, "(", numOfArgs, " params), Signature=", caller.signature.str(), "]");
                 continue;
             }
         }
 
-        const auto numOfArgs = functionInfo.method_signature.NumberOfArguments();
         auto is_exact_signature_match = GetIsExactSignatureMatch(definition);
         if (is_exact_signature_match)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var ddTraceMethodsString = "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync]";
             foreach (var type in TestTypes)
             {
-                ddTraceMethodsString += $";{type}[VoidMethod,ReturnValueMethod,ReturnReferenceMethod,ReturnNullMethod,ReturnGenericMethod,ReturnTaskMethod,ReturnValueTaskMethod,ReturnTaskTMethod,ReturnValueTaskTMethod];System.Net.Http.HttpRequestMessage[set_Method]";
+                ddTraceMethodsString += $";{type}[*];System.Net.Http.HttpRequestMessage[set_Method]";
             }
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var ddTraceMethodsString = "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync]";
             foreach (var type in TestTypes)
             {
-                ddTraceMethodsString += $";{type}[*];System.Net.Http.HttpRequestMessage[set_Method]";
+                ddTraceMethodsString += $";{type}[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]";
             }
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);
@@ -83,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         public async Task SubmitTraces()
         {
-            var expectedSpanCount = 41;
+            var expectedSpanCount = 45;
 
             const string expectedOperationName = "trace.annotation";
 

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -568,6 +568,62 @@
   {
     TraceId: Id_1,
     SpanId: Id_42,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
     Name: trace.annotation,
     Resource: set_Method,
     Service: Samples.TraceAnnotations,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -568,6 +568,62 @@
   {
     TraceId: Id_1,
     SpanId: Id_42,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
     Name: trace.annotation,
     Resource: set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -568,6 +568,62 @@
   {
     TraceId: Id_1,
     SpanId: Id_42,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
     Name: trace.annotation,
     Resource: set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: VoidMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -568,6 +568,62 @@
   {
     TraceId: Id_1,
     SpanId: Id_42,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
     Name: trace.annotation,
     Resource: set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[VoidMethod,ReturnValueMethod,ReturnReferenceMethod,ReturnNullMethod,ReturnGenericMethod,ReturnTaskMethod,ReturnValueTaskMethod,ReturnTaskTMethod,ReturnValueTaskTMethod];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[VoidMethod,ReturnValueMethod,ReturnReferenceMethod,ReturnNullMethod,ReturnGenericMethod,ReturnTaskMethod,ReturnValueTaskMethod,ReturnTaskTMethod,ReturnValueTaskTMethod];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
         "DD_VERSION": "1.0.0",
-        "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[VoidMethod,ReturnValueMethod,ReturnReferenceMethod,ReturnNullMethod,ReturnGenericMethod,ReturnTaskMethod,ReturnValueTaskMethod,ReturnTaskTMethod,ReturnValueTaskTMethod];System.Net.Http.HttpRequestMessage[set_Method]"
+        "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
       },
       "nativeDebugging": true
     }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -9,6 +9,8 @@ namespace Samples.TraceAnnotations
         public static async Task RunTestsAsync()
         {
             var testType = new TestType();
+            testType.Name = testType.Name is null ? "append" : testType.Name += "append";
+
             testType.VoidMethod("Hello world", 42, Tuple.Create(1, 2));
             testType.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2));
             testType.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2));
@@ -23,6 +25,8 @@ namespace Samples.TraceAnnotations
             await Task.Delay(500);
 
             var testTypeGenericString = new TestTypeGeneric<string>();
+            testTypeGenericString.Name = testTypeGenericString.Name is null ? "append" : testTypeGenericString.Name += "append";
+
             testTypeGenericString.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeGenericString.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeGenericString.ReturnReferenceMethod("Hello World", 42, Tuple.Create(1, 2));
@@ -37,6 +41,8 @@ namespace Samples.TraceAnnotations
             await Task.Delay(500);
 
             var testTypeStruct = new TestTypeStruct();
+            testTypeStruct.Name = testTypeStruct.Name is null ? "append" : testTypeStruct.Name += "append";
+
             testTypeStruct.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeStruct.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeStruct.ReturnReferenceMethod("Hello World", 42, Tuple.Create(1, 2));
@@ -50,6 +56,7 @@ namespace Samples.TraceAnnotations
 
             await Task.Delay(500);
 
+            TestTypeStatic.Name = TestTypeStatic.Name is null ? "append" : TestTypeStatic.Name += "append";
             TestTypeStatic.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             TestTypeStatic.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
             TestTypeStatic.ReturnReferenceMethod("Hello World", 42, Tuple.Create(1, 2));

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -21,7 +21,15 @@ namespace Samples.TraceAnnotations
             await testType.ReturnTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             await testType.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testType.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
+            testType.Finalize(0);
 
+            // Release the reference to testType
+            testType = null;
+
+            // Force a garbage collection, try to invoke finalizer on previous testType object
+            GC.Collect();
+
+            // Delay
             await Task.Delay(500);
 
             var testTypeGenericString = new TestTypeGeneric<string>();
@@ -37,7 +45,15 @@ namespace Samples.TraceAnnotations
             await testTypeGenericString.ReturnTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             await testTypeGenericString.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testTypeGenericString.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
+            testTypeGenericString.Finalize(0);
 
+            // Release the reference to testTypeGenericString
+            testTypeGenericString = null;
+
+            // Force a garbage collection, try to invoke finalizer on previous testTypeGenericString object
+            GC.Collect();
+
+            // Delay
             await Task.Delay(500);
 
             var testTypeStruct = new TestTypeStruct();
@@ -54,6 +70,7 @@ namespace Samples.TraceAnnotations
             await testTypeStruct.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testTypeStruct.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
 
+            // Do not try to invoke finalizer for struct as it does not have a finalizer
             await Task.Delay(500);
 
             var testTypeStaticName = TestTypeStatic.Name;

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -9,7 +9,7 @@ namespace Samples.TraceAnnotations
         public static async Task RunTestsAsync()
         {
             var testType = new TestType();
-            testType.Name = testType.Name is null ? "append" : testType.Name += "append";
+            var testTypeName = testType.Name;
 
             testType.VoidMethod("Hello world", 42, Tuple.Create(1, 2));
             testType.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2));
@@ -25,7 +25,7 @@ namespace Samples.TraceAnnotations
             await Task.Delay(500);
 
             var testTypeGenericString = new TestTypeGeneric<string>();
-            testTypeGenericString.Name = testTypeGenericString.Name is null ? "append" : testTypeGenericString.Name += "append";
+            var testTypeGenericStringName = testTypeGenericString.Name;
 
             testTypeGenericString.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeGenericString.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
@@ -41,7 +41,7 @@ namespace Samples.TraceAnnotations
             await Task.Delay(500);
 
             var testTypeStruct = new TestTypeStruct();
-            testTypeStruct.Name = testTypeStruct.Name is null ? "append" : testTypeStruct.Name += "append";
+            var testTypeStructName = testTypeStruct.Name;
 
             testTypeStruct.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             testTypeStruct.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
@@ -56,7 +56,7 @@ namespace Samples.TraceAnnotations
 
             await Task.Delay(500);
 
-            TestTypeStatic.Name = TestTypeStatic.Name is null ? "append" : TestTypeStatic.Name += "append";
+            var testTypeStaticName = TestTypeStatic.Name;
             TestTypeStatic.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
             TestTypeStatic.ReturnValueMethod("Hello World", 42, Tuple.Create(1, 2));
             TestTypeStatic.ReturnReferenceMethod("Hello World", 42, Tuple.Create(1, 2));

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[VoidMethod,ReturnValueMethod,ReturnReferenceMethod,ReturnNullMethod,ReturnGenericMethod,ReturnTaskMethod,ReturnValueTaskMethod,ReturnTaskTMethod,ReturnValueTaskTMethod];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
@@ -21,6 +21,14 @@ namespace Samples.TraceAnnotations
             var other = (TestType)obj;
             return this.Name == other.Name;
         }
+        ~TestType()
+        {
+            // Finalizer code
+        }
+        public void Finalize(int someInt)
+        {
+            // Non-finalizer code
+        }
 
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
@@ -50,6 +58,14 @@ namespace Samples.TraceAnnotations
             // Return true if  x and y fields match.
             var other = (TestTypeGeneric<T>)obj;
             return this.Name == other.Name;
+        }
+        ~TestTypeGeneric()
+        {
+            // Finalizer code
+        }
+        public void Finalize(int someInt)
+        {
+            // Non-finalizer code
         }
 
         public void VoidMethod(string arg1, int arg2, object arg3) { }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
@@ -4,6 +4,24 @@ namespace Samples.TraceAnnotations
 {
     internal class TestType
     {
+        static TestType() { }
+        public TestType() { }
+        public string Name { get; set; }
+        public override string ToString() => Name;
+        public override int GetHashCode()
+        {
+            return (Name ?? "").GetHashCode();
+        }
+        public override bool Equals(object obj)
+        {
+            // If this and obj do not refer to the same type, then they are not equal.
+            if (obj.GetType() != this.GetType()) return false;
+
+            // Return true if  x and y fields match.
+            var other = (TestType)obj;
+            return this.Name == other.Name;
+        }
+
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg, int arg21, object arg3) => "Hello World";
@@ -16,6 +34,24 @@ namespace Samples.TraceAnnotations
     }
     class TestTypeGeneric<T>
     {
+        static TestTypeGeneric() { }
+        public TestTypeGeneric() { }
+        public string Name { get; set; }
+        public override string ToString() => Name;
+        public override int GetHashCode()
+        {
+            return (Name ?? "").GetHashCode();
+        }
+        public override bool Equals(object obj)
+        {
+            // If this and obj do not refer to the same type, then they are not equal.
+            if (obj.GetType() != this.GetType()) return false;
+
+            // Return true if  x and y fields match.
+            var other = (TestTypeGeneric<T>)obj;
+            return this.Name == other.Name;
+        }
+
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
@@ -28,6 +64,24 @@ namespace Samples.TraceAnnotations
     }
     struct TestTypeStruct
     {
+        static TestTypeStruct() { }
+        public TestTypeStruct() { Name = null; }
+        public string Name { get; set; }
+        public override string ToString() => Name;
+        public override int GetHashCode()
+        {
+            return (Name ?? "").GetHashCode();
+        }
+        public override bool Equals(object obj)
+        {
+            // If this and obj do not refer to the same type, then they are not equal.
+            if (obj.GetType() != this.GetType()) return false;
+
+            // Return true if  x and y fields match.
+            var other = (TestTypeStruct)obj;
+            return this.Name == other.Name;
+        }
+
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
@@ -40,6 +94,9 @@ namespace Samples.TraceAnnotations
     }
     static class TestTypeStatic
     {
+        static TestTypeStatic() { }
+        public static string Name { get; set; }
+
         public static void VoidMethod(string arg1, int arg2, object arg3) { }
         public static int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";


### PR DESCRIPTION
## Summary of changes
In the first implementation of `DD_TRACE_METHODS` for the .NET Tracer, the developer needed to specify each method in a type to be instrumented. This feature adds the ability to set `DD_TRACE_METHODS=TypeName[*]` to instrument all methods within a specified type, except the following special methods:
- Constructors (`.ctor`)
- Static constructor (`.cctor`)
- `Equals`
- `GetHashCode`
- `ToString`
- Property getters/setters (`get_XXX`/`set_XXX`)

If you want to instrument a special method via `DD_TRACE_METHODS` you must explicitly include it in the configuration. For example, to instrument all methods within a type named `Type1`, all of the special methods listed above, and the getter/setter for a property named `Name`, the configuration would be `DD_TRACE_METHODS=Type1[*,.ctor,.cctor,Equals,GetHashCode,ToString,get_Name,set_Name]`

## Reason for change
It can be error-prone to configure a large number of methods within one type, so a wildcard character `*` lowers the burden for configuration.

## Implementation details
The implementation has two steps:
- Parsing the `DD_TRACE_METHODS` configuration: There is no special parsing to handle the `*` method specifier, it just generates an `IntegrationDefinition` object like all other strings.
- In the cross-product `RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit`, allow the method name `*` to enumerate all methods for a typeDef (`metadataImport->EnumMethods`) instead of enumerating the methods with a specific method (`metadataImport->EnumMethodsWithName`). When processing the methods from the `*` method search, do string comparisons and string finds to exclude the special methods above.

## Test coverage
- Unit tests: Added another test case for the DD_TRACE_METHODS parsing logic to ensure that the wildcard modifier generates an `IntegrationDefinition`.
- Integration tests: Existing tests have been modified to use the new `*` wildcard and a special method (property getter) is added and tested for span-ification.

## Other details
N/A
