### PR TITLE
[Trace Annotation Tests] Rely on snapshots 

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
-                spans.Count.Should().Be(expectedSpanCount);
+                // let's not assert the span count right away and rely on verify to tell us what would be missing
 
                 var orderedSpans = spans.OrderBy(s => s.Start);
                 var rootSpan = orderedSpans.First();


### PR DESCRIPTION
## Summary of changes
Removed an assertion to better understand what span is missing

## Reason for change
Flaky tests. I think 40 or 41 spans is ok, as it validates the tracer work. But I'd rather see if there's a good reason for the missing span before working around the issue.

## Implementation details
Removed an assertion

