### PR TITLE
[Release] Upload the windows-tracer-home file from GitLab

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1395,12 +1395,6 @@ stages:
             path: $(Build.ArtifactStagingDirectory)
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download Windows tracer home
-          inputs:
-            artifact: windows-tracer-home.zip
-            path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
           displayName: Download distribution nuget package
           inputs:
             artifact: distribution-nuget-package
@@ -1439,7 +1433,15 @@ stages:
           artifact: $(tracer_version)-release-artifacts
 
         # We don't include the MSIs in the artifact upload as they're
-        # not signed, but we do include them in the push to Azure
+        # not signed, and we use the windows-tracer-home.zip file from
+        # GitLab so that it matches the native symbols file,
+        # but we include them all in the push to Azure
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Windows tracer home
+          inputs:
+            artifact: windows-tracer-home.zip
+            path: $(Build.ArtifactStagingDirectory)
+
         - task: DownloadPipelineArtifact@2
           displayName: Download x64 MSI
           inputs:

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -911,6 +911,7 @@ partial class Build
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi",
             $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi", 
             $"{awsUri}windows-native-symbols.zip",
+            $"{awsUri}windows-tracer-home.zip",
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64-profiler-beta.msi",
         };
 


### PR DESCRIPTION
## Summary of changes

Upload the windows-tracer-home file from GitLab instead of AzureDevops

## Reason for change

We need the `windows-native-symbols.zip` to be generated at the same time as the `windows-tracer-home.zip`, otherwise we have mismatches between the dlls and pdbs.

## Implementation details

Download the `windows-tracer-home.zip` file from GitLab when doing a release. Exclude the `windows-tracer-home.zip` file from the release artifiacts upload in AzDo
