### PR TITLE
[Log Submission] Fallback to using GlobalTags for direct log submission

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
@@ -37,7 +37,8 @@ namespace Datadog.Trace.Configuration
             /// <summary>
             /// Configuration key for a list of tags to be applied globally to all logs directly submitted.
             /// Supports multiple key key-value pairs which are comma-separated, and for which the key and
-            /// value are colon-separated. For example Key1:Value1, Key2:Value2
+            /// value are colon-separated. For example Key1:Value1, Key2:Value2. If not provided,
+            /// <see cref="ConfigurationKeys.GlobalTags"/> are used instead
             /// </summary>
             /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionGlobalTags"/>
             public const string GlobalTags = "DD_LOGS_DIRECT_SUBMISSION_TAGS";

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -30,7 +32,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
         {
         }
 
-        public DirectLogSubmissionSettings(IConfigurationSource source)
+        public DirectLogSubmissionSettings(IConfigurationSource? source)
         {
             DirectLogSubmissionHost = source?.GetString(ConfigurationKeys.DirectLogSubmission.Host)
                                    ?? HostMetadata.Instance.Hostname;
@@ -56,9 +58,13 @@ namespace Datadog.Trace.Logging.DirectSubmission
             DirectLogSubmissionMinimumLevel = DirectSubmissionLogLevelExtensions.Parse(
                 source?.GetString(ConfigurationKeys.DirectLogSubmission.MinimumLevel), DefaultMinimumLevel);
 
-            DirectLogSubmissionGlobalTags = source?.GetDictionary(ConfigurationKeys.DirectLogSubmission.GlobalTags)
-                                                   ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
-                                                   .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
+            var globalTags = source?.GetDictionary(ConfigurationKeys.DirectLogSubmission.GlobalTags)
+                          ?? source?.GetDictionary(ConfigurationKeys.GlobalTags)
+                             // backwards compatibility for names used in the past
+                          ?? source?.GetDictionary("DD_TRACE_GLOBAL_TAGS");
+
+            DirectLogSubmissionGlobalTags = globalTags?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                                                       .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
                                          ?? new Dictionary<string, string>();
 
             var logSubmissionIntegrations = source?.GetString(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations)
@@ -104,7 +110,8 @@ namespace Datadog.Trace.Logging.DirectSubmission
         internal string DirectLogSubmissionSource { get; set; }
 
         /// <summary>
-        /// Gets or sets the global tags, which are applied to all directly submitted logs
+        /// Gets or sets the global tags, which are applied to all directly submitted logs. If not provided,
+        /// <see cref="TracerSettings.GlobalTags"/> are used instead
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DirectLogSubmission.GlobalTags" />
         internal IDictionary<string, string> DirectLogSubmissionGlobalTags { get; set; }
@@ -113,7 +120,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
         /// Gets or sets the url to send logs to
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DirectLogSubmission.Url" />
-        internal string DirectLogSubmissionUrl { get; set; }
+        internal string? DirectLogSubmissionUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the minimum level logs should have to be sent to the intake.
@@ -142,6 +149,6 @@ namespace Datadog.Trace.Logging.DirectSubmission
         /// <summary>
         /// Gets or sets the Datadog API key
         /// </summary>
-        internal string ApiKey { get; set; }
+        internal string? ApiKey { get; set; }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Use `DD_TAGS` for tag direct log submission tags when `DD_LOGS_DIRECT_SUBMISSION_TAGS` is not provided

## Reason for change

You can currently set the global tags for any logs sent through DirectLogSubmission by setting `DD_LOGS_DIRECT_SUBMISSION_TAGS`. However, in many cases, this will be needless duplication of the existing `DD_TAGS` variable.

To make the direct log submission feature easier for customers to configure (while maintaining backwards compatibility) we will fall back to using `DD_TAGS` when `DD_LOGS_DIRECT_SUBMISSION_TAGS` is not provided. When `DD_LOGS_DIRECT_SUBMISSION_TAGS` is provided, we will use that only, which allows setting different tags for the logs than the traces if desired.

## Test coverage

Unit tests

## Other details
Thanks @OmerRaviv for flagging!
