### PR TITLE
[CiApp] Fix null environment variable in payload

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -30,16 +30,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
         public CIEventMessagePackFormatter(TracerSettings tracerSettings)
         {
-            var environment = tracerSettings.Environment;
-            if (environment is not null)
-            {
-                _environmentValueBytes = StringEncoding.UTF8.GetBytes(environment);
-            }
-            else
-            {
-                _environmentValueBytes = null;
-            }
-
+            _environmentValueBytes = StringEncoding.UTF8.GetBytes(tracerSettings.Environment ?? "none");
             _envelopBytes = GetEnvelopeArraySegment();
         }
 


### PR DESCRIPTION
This PR avoids null values in `env` variable (not allowed in the backend)