### PR TITLE
Fix tag concatenation for direct log submission

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 sb.Append(tagPair.Key)
                   .Append(':')
                   .Append(tagPair.Value)
-                  .Append(';');
+                  .Append(',');
             }
 
             // remove final joiner

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
             HasExpectedValue(log, !hasRenderedSource, $"\"ddsource\":\"{Source}\"");
             HasExpectedValue(log, !hasRenderedService, $"\"service\":\"{Service}\"");
             HasExpectedValue(log, !hasRenderedHost, $"\"host\":\"{Host}\"");
-            HasExpectedValue(log, !hasRenderedTags, $"\"ddtags\":\"Key1:Value1;Key2:Value2\"");
+            HasExpectedValue(log, !hasRenderedTags, $"\"ddtags\":\"Key1:Value1,Key2:Value2\"");
             HasExpectedValue(log, !hasRenderedEnv, $"\"dd_env\":\"{Env}\"");
             HasExpectedValue(log, !hasRenderedVersion, $"\"dd_version\":\"{Version}\"");
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             logSettings.ApiKey.Should().Be(apiKey);
             logSettings.Host.Should().Be(hostName);
             logSettings.IntakeUrl?.ToString().Should().Be("http://localhost:1234/");
-            logSettings.GlobalTags.Should().Be("sometag:value,someothertag:someothervalue");
+            logSettings.GlobalTags.Should().Be("someothertag:someothervalue,sometag:value");
             logSettings.IsEnabled.Should().BeTrue();
             logSettings.MinimumLevel.Should().Be(DirectSubmissionLogLevel.Information);
             logSettings.Source.Should().Be("csharp");

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             logSettings.ApiKey.Should().Be(apiKey);
             logSettings.Host.Should().Be(hostName);
             logSettings.IntakeUrl?.ToString().Should().Be("http://localhost:1234/");
-            logSettings.GlobalTags.Should().Be("someothertag:someothervalue,sometag:value");
+            logSettings.GlobalTags.Should().BeOneOf("someothertag:someothervalue,sometag:value", "sometag:value,someothertag:someothervalue");
             logSettings.IsEnabled.Should().BeTrue();
             logSettings.MinimumLevel.Should().Be(DirectSubmissionLogLevel.Information);
             logSettings.Source.Should().Be("csharp");

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
                 { ConfigurationKeys.DirectLogSubmission.Host, hostName },
                 { ConfigurationKeys.DirectLogSubmission.Url, intake },
                 { ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, string.Join(";", enabledIntegrations) },
-                { ConfigurationKeys.DirectLogSubmission.GlobalTags, "sometag:value" },
+                { ConfigurationKeys.DirectLogSubmission.GlobalTags, "sometag:value, someothertag:someothervalue" },
             };
 
             IConfigurationSource source = new NameValueConfigurationSource(collection);
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             logSettings.ApiKey.Should().Be(apiKey);
             logSettings.Host.Should().Be(hostName);
             logSettings.IntakeUrl?.ToString().Should().Be("http://localhost:1234/");
-            logSettings.GlobalTags.Should().Be("sometag:value");
+            logSettings.GlobalTags.Should().Be("sometag:value,someothertag:someothervalue");
             logSettings.IsEnabled.Should().BeTrue();
             logSettings.MinimumLevel.Should().Be(DirectSubmissionLogLevel.Information);
             logSettings.Source.Should().Be("csharp");


### PR DESCRIPTION
## Summary of changes

Fix bug in direct log submission tagging

## Reason for change

We were using the wrong symbol (should be `,` not `;`), so multiple tags would be concatenated in the back end.

## Test coverage

Extra unit test for format + manually checked against the backend(thanks again @OmerRaviv), 

