### PR TITLE
Fix issue where PdbReaderTests fail when running locally but pass in CI

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -40,4 +40,9 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
 </Project>

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/xunit.runner.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "shadowCopy": false
+}


### PR DESCRIPTION
This PR fixes an issue where `PDBReaderTests.ReadPDB` fails when run locally on `net461` with the following error:

```
[xUnit.net 00:00:01.93]     Datadog.Trace.ClrProfiler.Managed.Tests.PdbReaderTests.ReadPDBs [FAIL]
  Failed Datadog.Trace.ClrProfiler.Managed.Tests.PdbReaderTests.ReadPDBs [446 ms]
  Error Message:
   System.IO.IOException : Could not open file C:\Users\Robert\AppData\Local\Temp\44b2e520-e28b-48ec-9a94-df0fdb4421a4\44b2e520-e28b-48ec-9a94-df0fdb4421a4\assembly\dl3\3383b17c\c9aefbf8_0b49d801\Datadog.Trace.ClrProfiler.Managed.Tests.pdb for reading. Error: 00000002
```

The underlying issue is that the test relies on `Assembly.Current.Location` to locate an assembly's associated PDB file. This fails due to the .NET Framework "[shadow-copy assemblies](https://docs.microsoft.com/en-us/dotnet/framework/app-domains/shadow-copy-assemblies)" feature which copies the assembly (but not the PDB) to a separate temporary folder. 

This PR fixes the issue by explicitly turning "shadow-copy" off. Note that the test passed just fine in CI (perhaps shadow-copying is disabled there by default). 