### PR TITLE
Ensure we test a consistent commit for PRs

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -1,0 +1,37 @@
+parameters:
+  - name: masterCommitId
+    type: string
+
+steps:
+- ${{ if endsWith(variables['build.sourceBranch'], '/merge') }}:
+  - checkout: none
+  - bash: |
+      # As this is a pull request, we need to do a fake merge
+      # uses similar process to existing checkout task
+      set +x
+      prBranch=$SYSTEM_PULLREQUEST_SOURCEBRANCH
+      echo "Checking out merge commit for ${{ parameters.masterCommitId }} and $prBranch"
+      git version
+      git lfs version
+      echo "Updating git config"
+      git config --global init.defaultBranch master
+      git init "$BUILD_REPOSITORY_LOCALPATH"
+      git remote add origin "$BUILD_REPOSITORY_URI"
+      git config gc.auto 0
+      git config --get-all http.$BUILD_REPOSITORY_URI.extraheader
+      git config --get-all http.extraheader
+      git config --get-regexp .*extraheader
+      git config --get-all http.proxy
+      git config http.version HTTP/1.1
+      git fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules origin +refs/heads/master:refs/remotes/origin/master +refs/heads/$prBranch:refs/remotes/origin/$prBranch
+      git checkout --force $prBranch
+    displayName: checkout
+  - bash: |
+      git config --global user.email "gitfun@example.com"
+      git config --global user.name "Automatic Merge"
+      git merge ${{ parameters.masterCommitId }}
+      git status
+    displayName: merge
+    failOnStderr: true
+- ${{ else }}:
+  - checkout: self

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -122,8 +122,35 @@ resources:
 
 # Stages
 stages:
-- stage: generate_variables
+# This step grabs the current commit of master, and records it for subsequent stages
+# We use it to ensure that we are always running PRs against the same commit, even
+# if master is updated while the build is in progress. This guards against CI flakiness
+# where the first stages of the build execute against one merge commit, and later stages
+# run against another
+
+- stage: master_commit_id
   dependsOn: []
+  jobs:
+  - job: fetch
+    pool:
+      vmImage: ubuntu-18.04
+
+    steps:
+    - checkout: none
+    - bash: |
+        git clone --quiet --no-checkout --depth 1 --branch master $BUILD_REPOSITORY_URI ./s
+        cd s
+        MASTER_SHA=$(git rev-parse origin/master)
+        echo "Using master commit ID $MASTER_SHA"
+        echo "##vso[task.setvariable variable=master;isOutput=true]$MASTER_SHA"
+      failOnStderr: true
+      displayName: Fetch master id
+      name: set_sha
+
+- stage: generate_variables
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -135,6 +162,9 @@ stages:
       vmImage: windows-2019
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
 
     - powershell: |
@@ -143,7 +173,9 @@ stages:
       name: generate_variables_step
 
 - stage: build_windows_tracer
-  dependsOn: []
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -153,6 +185,9 @@ stages:
     pool:
       vmImage: windows-2019
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
     - script: tracer\build.cmd BuildTracerHome
       displayName: Build tracer home
@@ -169,7 +204,9 @@ stages:
       artifact: build-windows-working-directory
 
 - stage: build_windows_profiler
-  dependsOn: []
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -179,6 +216,9 @@ stages:
     pool:
       vmImage: windows-2019
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
 
     - script: tracer\build.cmd BuildProfilerHome
@@ -189,7 +229,9 @@ stages:
       artifact: windows-profiler-home
 
 - stage: build_linux
-  dependsOn: []
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -207,7 +249,9 @@ stages:
       name: azure-linux-scale-set
 
     steps:
-
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/run-in-docker.yml
       parameters:
         build: true
@@ -228,7 +272,9 @@ stages:
       artifact: build-linux-$(baseImage)-working-directory
 
 - stage: build_arm64
-  dependsOn: []
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -241,6 +287,9 @@ stages:
     workspace:
       clean: all
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/run-in-docker.yml
       parameters:
         build: true
@@ -262,7 +311,9 @@ stages:
 
 - stage: build_macos
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: []
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -273,6 +324,9 @@ stages:
     pool:
       vmImage: macOS-10.15
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
 
     - script: ./tracer/build.sh BuildTracerHome
@@ -288,7 +342,9 @@ stages:
 
 - stage: package_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [ build_windows_tracer, build_windows_profiler]
+  dependsOn: [ build_windows_tracer, build_windows_profiler, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
     vmImage: windows-2019
   jobs:
@@ -301,6 +357,9 @@ stages:
       # Temporarily use the profiling repo's commit hash for the beta MSI's filename
       BetaMsiSuffix: $[ stageDependencies.build_windows_profiler.build.outputs['SetMsiSuffix.BetaMsiSuffix']]
     steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          masterCommitId: $(masterCommitId)
       - template: steps/install-latest-dotnet-sdk.yml
       - template: steps/restore-working-directory.yml
       - script: echo $(BetaMsiSuffix) # TODO Remove
@@ -335,7 +394,9 @@ stages:
 
 - stage: unit_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: build_windows_tracer
+  dependsOn: [build_windows_tracer, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
     vmImage: windows-2019
   jobs:
@@ -345,6 +406,9 @@ stages:
 
     - job: managed
       steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          masterCommitId: $(masterCommitId)
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml
 
@@ -365,6 +429,9 @@ stages:
 
     - job: native
       steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          masterCommitId: $(masterCommitId)
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml
 
@@ -379,7 +446,9 @@ stages:
 
 - stage: unit_tests_macos
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: build_macos
+  dependsOn: [build_macos, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -411,7 +480,9 @@ stages:
 
 - stage: unit_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_linux]
+  dependsOn: [build_linux, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -428,6 +499,9 @@ stages:
       name: azure-linux-scale-set
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-linux-$(baseImage)-working-directory
@@ -452,7 +526,9 @@ stages:
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_arm64]
+  dependsOn: [build_arm64, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -464,6 +540,9 @@ stages:
       workspace:
         clean: all
       steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            masterCommitId: $(masterCommitId)
         - template: steps/restore-working-directory.yml
           parameters:
             artifact: build-linux-arm64-working-directory
@@ -488,8 +567,9 @@ stages:
 
 - stage: integration_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows_tracer, generate_variables]
-
+  dependsOn: [build_windows_tracer, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -505,6 +585,9 @@ stages:
       USE_NATIVE_LOADER: true
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-dotnet-sdks.yml
       parameters:
         includeX86: true
@@ -553,7 +636,9 @@ stages:
 
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows_tracer, package_windows, generate_variables]
+  dependsOn: [build_windows_tracer, package_windows, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
 
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -571,7 +656,9 @@ stages:
       USE_NATIVE_LOADER: true
 
     steps:
-
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-dotnet-sdks.yml
       parameters:
         includeX86: true
@@ -627,7 +714,9 @@ stages:
 
 - stage: integration_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_linux, generate_variables]
+  dependsOn: [build_linux, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -645,6 +734,9 @@ stages:
       name: azure-linux-scale-set
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     # Doing a clean of obj files _before_ restore to remove build output from previous runs
     # Can't do a full clean, as otherwise restore-working-directory fails
     # Only necessary for ARM64, but shouldn't cause any harm on others
@@ -721,7 +813,9 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_arm64]
+  dependsOn: [build_arm64, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -744,6 +838,9 @@ stages:
         name: Arm64
 
       steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            masterCommitId: $(masterCommitId)
         # Doing a clean of obj files _before_ restore to remove build output from previous runs
         # Can't do a full clean, as otherwise restore-working-directory fails
         # Only necessary for ARM64, but shouldn't cause any harm on others
@@ -824,7 +921,9 @@ stages:
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )
-  dependsOn: [build_windows_tracer, generate_variables]
+  dependsOn: [build_windows_tracer, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
 
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -843,6 +942,9 @@ stages:
       dd_agent: dd_agent
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-dotnet-sdks.yml
       parameters:
         includeX86: true
@@ -874,7 +976,9 @@ stages:
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )
-  dependsOn: [build_linux, generate_variables]
+  dependsOn: [build_linux, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -892,6 +996,9 @@ stages:
       dd_agent: dd_agent
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     # Doing a clean of obj files _before_ restore to remove build output from previous runs
     # Can't do a full clean, as otherwise restore-working-directory fails
     # Only necessary for ARM64, but shouldn't cause any harm on others
@@ -955,7 +1062,9 @@ stages:
 
 - stage: benchmarks
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: build_windows_tracer
+  dependsOn: [build_windows_tracer, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -972,6 +1081,13 @@ stages:
       dd_agent: dd_agent
 
     steps:
+#    NOTE: doing a "normal" clone instead of using the template.
+#    For pull requests this MAY mean we're testing a different
+#    merge commit here, but it's a small risk, and the benchmark server
+#    doesn't have bash installed, so suck it up
+#    - template: steps/clone-repo.yml
+#      parameters:
+#        masterCommitId: $(masterCommitId)
 
     - template: steps/install-latest-dotnet-sdk.yml
     - template: steps/restore-working-directory.yml
@@ -999,7 +1115,9 @@ stages:
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
-  dependsOn: [build_windows_tracer, build_linux, build_arm64, build_macos]
+  dependsOn: [build_windows_tracer, build_linux, build_arm64, build_macos, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1011,6 +1129,9 @@ stages:
       vmImage: windows-2019
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
     - template: steps/restore-working-directory.yml
 
@@ -1136,8 +1257,9 @@ stages:
       displayName: Add $(dotnetToolTag) build tag
 
 - stage: tool_artifacts_tests_windows
-  dependsOn: [dotnet_tool]
+  dependsOn: [dotnet_tool, master_commit_id]
   variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     runnerTool: $(System.DefaultWorkingDirectory)/$(relativeRunnerTool)
     runnerStandalone: $(System.DefaultWorkingDirectory)/$(relativeRunnerStandalone)
   jobs:
@@ -1157,6 +1279,9 @@ stages:
       vmImage: windows-2019
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
       parameters:
         includeX86: true
@@ -1188,8 +1313,9 @@ stages:
       condition: succeededOrFailed()
 
 - stage: tool_artifacts_tests_linux
-  dependsOn: [dotnet_tool]
+  dependsOn: [dotnet_tool, master_commit_id]
   variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     runnerTool: $(System.DefaultWorkingDirectory)/$(relativeRunnerTool)
     runnerStandalone: $(System.DefaultWorkingDirectory)/$(relativeRunnerStandalone)
   jobs:
@@ -1221,6 +1347,9 @@ stages:
       name: $(poolName)
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-linux-$(baseImage)-working-directory
@@ -1261,7 +1390,9 @@ stages:
 
 - stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, build_linux, build_arm64]
+  dependsOn: [package_windows, build_linux, build_arm64, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - job: s3_upload
 
@@ -1269,6 +1400,9 @@ stages:
       vmImage: ubuntu-18.04
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
 
     - script: |
         mkdir s3_upload
@@ -1355,12 +1489,17 @@ stages:
 
 - stage: upload_to_azure
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool]
+  dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
     - job: upload
       pool:
         vmImage: ubuntu-18.04
       steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            masterCommitId: $(masterCommitId)
 
         - task: DownloadPipelineArtifact@2
           displayName: Download NuGet packages
@@ -1486,7 +1625,9 @@ stages:
 
 - stage: throughput
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_linux, build_arm64, build_windows_tracer]
+  dependsOn: [build_linux, build_arm64, build_windows_tracer, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool: Throughput
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -1498,6 +1639,9 @@ stages:
     timeoutInMinutes: 60
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
@@ -1518,6 +1662,9 @@ stages:
     timeoutInMinutes: 60
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - task: DownloadPipelineArtifact@2
       displayName: Download windows native binary
       inputs:
@@ -1538,6 +1685,9 @@ stages:
     timeoutInMinutes: 60
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 native binary
       inputs:
@@ -1556,7 +1706,9 @@ stages:
 
 - stage: throughput_appsec
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_linux]
+  dependsOn: [build_linux, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool: Throughput-AppSec
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -1568,6 +1720,9 @@ stages:
     timeoutInMinutes: 60
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
@@ -1586,7 +1741,9 @@ stages:
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
-  dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]
+  dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
     - job: Windows
       timeoutInMinutes: 30
@@ -1595,6 +1752,9 @@ stages:
         vmImage: windows-2019
 
       steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          masterCommitId: $(masterCommitId)
       - template: steps/install-latest-dotnet-sdk.yml
       - template: steps/restore-working-directory.yml
 
@@ -1626,7 +1786,9 @@ stages:
 
 - stage: execution_benchmarks
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_windows_tracer]
+  dependsOn: [build_windows_tracer, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1639,6 +1801,9 @@ stages:
     services:
       dd_agent: dd_agent
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
 
@@ -1696,7 +1861,9 @@ stages:
 
 - stage: system_tests
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_linux]
+  dependsOn: [build_linux, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1707,6 +1874,7 @@ stages:
       vmImage: ubuntu-18.04
 
     steps:
+      - checkout: none
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 
@@ -1750,7 +1918,9 @@ stages:
 
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_linux, generate_variables]
+  dependsOn: [build_linux, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -1765,6 +1935,9 @@ stages:
       vmImage: ubuntu-18.04
 
     steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
     - task: DownloadPipelineArtifact@2
       displayName: Download artifacts to smoke test directory
       inputs:
@@ -1788,7 +1961,9 @@ stages:
 
 - stage: installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_arm64, generate_variables]
+  dependsOn: [build_arm64, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

For pull requests, don't use the built-in clone command in Azure Devops, as it uses the variable "merge" commit. Instead, clone the branch, and do the merge manually. 

## Reason for change

Merging PRs to master can currently cause unrelated PR builds to fail, because the commit being built changes for later stages.

## Implementation details

By default, Azure Devops clones the special "merge" commit the GitHub creates for PRs. As we clone the repo multiple times (generally, once for each stage), that means later stages can end up cloning a different commit, if there have been commits to master since the first stages run. This often causes failures if those new commits introduce additional tests, or generally change anything.

To ensure we test all stages against the same commit, we make a note of the current commit ID of master before starting the pipeline. If we're running a branch directly, then we use the built-in clone command, so this change is a noop. If we're running a PR however, we clone the PR branch and then merge with the original commit ID _manually_. This ensures we are always testing the same effective merge commit.

> The main downside is the additional complexity required in the pipeline, but what's a 100 extra lines in a 2000 line yaml file between friends 😬

## Test coverage

Ran test branches to confirm it does the merge correctly + it doesn't merge when not doing a PR

## Other details

Alternative approaches considered: 

- Only doing the checkout once, and using `tar` to pass around artifacts. A very good alternative. I thought this approach was going to be easier, but we run into drive space issues from "duplicating" everything on disk.
- Moving all build stages to a single stage. Currently hard to do without a big impact on ci throughput, but would be ideal.
