### PR TITLE
Update GraphQL tests to take a memory dump when not shutting down

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -38,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [MemberData(nameof(TestData))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces(string packageVersion)
+        public Task SubmitsTraces(string packageVersion)
             => RunSubmitsTraces(packageVersion);
     }
 #endif
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces()
+        public Task SubmitsTraces()
             => RunSubmitsTraces();
     }
 
@@ -67,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces()
+        public Task SubmitsTraces()
             => RunSubmitsTraces();
     }
 
@@ -90,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion(ServiceVersion);
         }
 
-        protected void RunSubmitsTraces(string packageVersion = "")
+        protected async Task RunSubmitsTraces(string packageVersion = "")
         {
             using var telemetry = this.ConfigureTelemetry();
             int? aspNetCorePort = null;
@@ -156,7 +157,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     if (!process.WaitForExit(5000))
                     {
-                        Output.WriteLine("The process didn't exit in time. Killing it.");
+                        Output.WriteLine("The process didn't exit in time. Taking proc dump and killing it.");
+                        await TakeMemoryDump(process);
+
                         process.Kill();
                     }
                 }


### PR DESCRIPTION
## Summary of changes

- If GraphQL process fails to exit, take a memory dump

## Reason for change

We occasionally see the GraphQL process fail to exit correctly. This causes flaky test behaviour, because in that case we often don't receive the telemetry. Taking a memory dump will help us to diagnose the problem.

## Implementation details

Downloads procdump and runs against the process. Crude, but it works, assuming the process isn't just a bit slow in shutting down. Now we play the waiting game.

## Test coverage

Did a test in which I remove the shutdown endpoint in graphql, so it never shuts down. This generates the memory dump as expected, and uploads it inside the `logs` artifact for the job.

