### PR TITLE
Fix framework version regex

### DIFF
--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace
 #endif
                     Match match = Regex.Match(
                         location,
-                        @"/[^/]*microsoft\.netcore\.app/(\d+\.\d+\.\d+[^/]*)/",
+                        @"[\\/][^\\/]*microsoft\.netcore\.app[\\/](\d+\.\d+\.\d+[^/]*)[\\/]",
                         RegexOptions.IgnoreCase);
 
                     if (match.Success && match.Groups.Count > 0 && match.Groups[1].Success)


### PR DESCRIPTION
## Summary of changes

- Fixes the Regex used to extract framework version from Location/CodeBase

## Reason for change

I was a little hasty merging #2405 

## Implementation details

As described [in this comment](https://github.com/DataDog/dd-trace-dotnet/pull/2405#discussion_r804201294)

`Assembly.CodeBase` returns something like

```
file:///C:/Program Files/dotnet/shared/Microsoft.NETCore.App/6.0.2/System.Private.CoreLib.dll
```

`Assembly.Location` returns

```
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\6.0.2\System.Private.CoreLib.dll
```

The Regex only worked with the former. Updated it to also work with the latter.

## Test coverage

We don't have any coverage for this, but as it worked before and won't _actually_ be hit in net5+, I'm not too worried
