### PR TITLE
[Profiler] Enable CodeHotspot feature by default when the profiler is enabled

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ContinuousProfiler
         public ContextTracker(ProfilerStatus status)
         {
             _status = status;
-            _isCodeHotspotsEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.CodeHotspotsEnabled)?.ToBoolean() ?? false;
+            _isCodeHotspotsEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.CodeHotspotsEnabled)?.ToBoolean() ?? true;
             _traceContextPtr = new ThreadLocal<IntPtr>();
             Log.Information("CodeHotspots feature is {IsEnabled}.", _isCodeHotspotsEnabled ? "enabled" : "disabled");
         }


### PR DESCRIPTION
## Summary of changes

## Reason for change

Code Hotspot feature is activated by default in the other profilers.

## Implementation details

Just change the default value.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
