### PR TITLE
Add simplistic labeller

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -1,0 +1,21 @@
+labels:
+  - name: "area-ciapp"
+    title: "^\\[?(?i)ciapp"
+
+  - name: "area-serverless"
+    title: "^\\[?(?i)serverless"
+
+  - name: "area-appsec"
+    title: "^\\[?(?i)appsec"
+
+  - name: "area-profiler"
+    title: "^\\[?(?i)profiler"
+
+  - name: "area-debugger"
+    title: "^\\[?(?i)debugger"
+
+  - name: "area-profiler"
+    allFilesIn: "profiler\/.*"
+
+  - name: "area-debugger"
+    allFilesIn: "debugger\/.*" 

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -39,7 +39,7 @@ labels:
     allFilesIn: ".*OpenTracing.*"
 
   - name: "area:shared-components"
-    allFilesIn: "shared\/.*"
+    allFilesIn: "(?!.*msi-installer.*)(shared\/.*)"
 
   - name: "area:tests"
     allFilesIn: "tracer/test/.*"

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -33,7 +33,7 @@ labels:
     allFilesIn: "shared\/src\/msi-installer\/.*"
 
   - name: "area:integrations"
-    allFilesIn: "tracer\/src\/Datadog.Trace\/ClrProfiler\/.*|tracer\/src\/Datadog\\.Trace\\.AspNet\/.*|tracer\/test\/Datadog\\.Trace\\.ClrProfiler\\.IntegrationTests\/.*|tracer\/test\/Datadog\\.Trace\\.ClrProfiler\\.Managed\\.Tests\/.*"
+    allFilesIn: "tracer\/src\/Datadog\\.Trace\/ClrProfiler\/AutoInstrumentation\/.*|tracer\/src\/Datadog\\.Trace\\.AspNet\/.*|tracer\/test\/.*"
 
   - name: "area:opentracing"
     allFilesIn: ".*OpenTracing.*"
@@ -43,9 +43,6 @@ labels:
 
   - name: "area:tests"
     allFilesIn: "tracer/test/.*"
-
-  - name: "area:test-apps"
-    allFilesIn: ".*\/test-applications\/.*"
 
   # if any modified file is in tracer/src/Datadog.Trace, excluding files in ClrProfiler, AppSec or Ci
   - name: "area:tracer"

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -18,4 +18,35 @@ labels:
     allFilesIn: "profiler\/.*"
 
   - name: "area-debugger"
-    allFilesIn: "debugger\/.*" 
+    allFilesIn: "debugger\/.*"
+
+  - name: "area:builds"
+    allFilesIn: "\\.github\/.*|tracer\/build\/.*|\\.azure-pipelines\/.*|gitlab-ci\\.yml"
+
+  - name: "area:vendors"
+    allFilesIn: "tracer\/src\/Datadog\\.Trace\/vendors\/.*"
+
+  - name: "area:docs"
+    allFilesIn: "docs\/.*|.*README.*|.*\\.md"
+
+  - name: "area:installers"
+    allFilesIn: "shared\/src\/msi-installer\/.*"
+
+  - name: "area:integrations"
+    allFilesIn: "tracer\/src\/Datadog.Trace\/ClrProfiler\/.*|tracer\/src\/Datadog\\.Trace\\.AspNet\/.*|tracer\/test\/Datadog\\.Trace\\.ClrProfiler\\.IntegrationTests\/.*|tracer\/test\/Datadog\\.Trace\\.ClrProfiler\\.Managed\\.Tests\/.*"
+
+  - name: "area:opentracing"
+    allFilesIn: ".*OpenTracing.*"
+
+  - name: "area:shared-components"
+    allFilesIn: "shared\/.*"
+
+  - name: "area:tests"
+    allFilesIn: "tracer/test/.*"
+
+  - name: "area:test-apps"
+    allFilesIn: ".*\/test-applications\/.*"
+
+  # if any modified file is in tracer/src/Datadog.Trace, excluding files in ClrProfiler, AppSec or Ci
+  - name: "area:tracer"
+    allFilesIn: "(?!.*ClrProfiler.*|.*\/Ci\/.*|.*\/AppSec\/.*)(src\/Datadog\\.Trace\/.*)|tracer\/test\/.*"

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -1,0 +1,23 @@
+name: Label PRs
+
+on:
+- pull_request
+
+jobs:
+  add-labels:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: "Add labels"
+        run: ./tracer/build.sh AssignLabelsToPullRequest
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PullRequestNumber: "${{ github.event.pull_request.number }}" 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BenchmarkComparison;
 using Microsoft.TeamFoundation.Build.WebApi;
@@ -18,6 +19,7 @@ using Nuke.Common.Tools.Git;
 using Octokit;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
+using YamlDotNet.Serialization.NamingConventions;
 using static Nuke.Common.IO.CompressionTasks;
 using static Nuke.Common.IO.FileSystemTasks;
 using Issue = Octokit.Issue;
@@ -82,6 +84,89 @@ partial class Build
                 new IssueUpdate { Milestone = milestone.Number });
 
             Console.WriteLine($"PR assigned");
+        });
+
+    Target AssignLabelsToPullRequest => _ => _
+       .Unlisted()
+       .Requires(() => GitHubRepositoryName)
+       .Requires(() => GitHubToken)
+       .Requires(() => PullRequestNumber)
+       .Executes(async() =>
+        {
+            var client = GetGitHubClient();
+
+            // var milestone = await GetOrCreateVNextMilestone(client);
+            var pr = await client.PullRequest.Get(
+                owner: GitHubRepositoryOwner,
+                name: GitHubRepositoryName,
+                number: PullRequestNumber.Value);
+
+            GitTasks.Git("fetch origin master:master", logOutput: false);
+            var changedFiles = GitTasks.Git("diff --name-only master").Select(f => f.Text);
+            var config = GetLabellerConfiguration();
+            Console.WriteLine($"Checking labels for PR {PullRequestNumber}");
+
+            var updatedLabels = ComputeLabels(config, pr.Title, pr.Labels.Select(l => l.Name), changedFiles);
+            var issueUpdate = new IssueUpdate();
+            updatedLabels.ForEach(l => issueUpdate.AddLabel(l));
+
+            await client.Issue.Update(
+                owner: GitHubRepositoryOwner,
+                name: GitHubRepositoryName,
+                number: PullRequestNumber.Value,
+                issueUpdate);
+
+            Console.WriteLine($"PR labels updated");
+
+            HashSet<String> ComputeLabels(LabbelerConfiguration config, string prTitle, IEnumerable<string> labels, IEnumerable<string> changedFiles)
+            {
+                var updatedLabels = new HashSet<string>(labels);
+
+                foreach(var label in config.Labels)
+                {
+                    try 
+                    {
+                        if (!string.IsNullOrEmpty(label.Title))
+                        {
+                            Console.WriteLine("Checking if pr title matches: " + label.Title);
+                            var regex = new Regex(label.Title, RegexOptions.Compiled);
+                            if (regex.IsMatch(prTitle))
+                            {
+                                Console.WriteLine("Yes it does. Adding label " + label.Name);
+                                updatedLabels.Add(label.Name);
+                            }
+                        }
+                        else if (!string.IsNullOrEmpty(label.AllFilesIn))
+                        {
+                            Console.WriteLine("Checking if changed files are all located in:" + label.AllFilesIn);
+                            var regex = new Regex(label.AllFilesIn, RegexOptions.Compiled);
+                            if(!changedFiles.Any(x => !regex.IsMatch(x)))
+                            {
+                                Console.WriteLine("Yes they do. Adding label " + label.Name);
+                                updatedLabels.Add(label.Name);
+                            }
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        Logger.Warn($"There was an error trying to check labels: {ex}");
+                    }
+                }
+                return updatedLabels;
+            }
+
+           LabbelerConfiguration GetLabellerConfiguration()
+           {
+               var labellerConfigYaml = RootDirectory / ".github" / "labeller.yml";
+               Logger.Info($"Reading {labellerConfigYaml} YAML file");
+               var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+                                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                                 .IgnoreUnmatchedProperties()
+                                 .Build();
+
+               using var sr = new StreamReader(labellerConfigYaml);
+               return deserializer.Deserialize<LabbelerConfiguration>(sr);
+           }
         });
 
     Target CloseMilestone => _ => _
@@ -1006,4 +1091,15 @@ partial class Build
         return allOpenMilestones.FirstOrDefault(x => x.Title == milestoneName);
     }
 
+    class LabbelerConfiguration
+    {
+        public Label[] Labels { get; set; }
+
+        public class Label
+        {
+            public string Name { get; set; }
+            public string Title { get; set; }
+            public string AllFilesIn { get; set; }
+        }
+    }
 }

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -95,7 +95,6 @@ partial class Build
         {
             var client = GetGitHubClient();
 
-            // var milestone = await GetOrCreateVNextMilestone(client);
             var pr = await client.PullRequest.Get(
                 owner: GitHubRepositoryOwner,
                 name: GitHubRepositoryName,

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -440,6 +440,7 @@ partial class Build
             const string appSec = "AppSec";
             const string profiler = "Continuous Profiler";
             const string debugger = "Debugger";
+            const string appSec = "Serverless";
 
             var artifactsLink = Environment.GetEnvironmentVariable("PIPELINE_ARTIFACTS_LINK");
             var nextVersion = FullVersion;
@@ -481,12 +482,14 @@ partial class Build
             sb.AppendLine("## Summary").AppendLine();
             sb.AppendLine("Write here any high level summary you may find relevant or delete the section.").AppendLine();
 
+            sb.AppendLine("## Changes").AppendLine();
+
             var issueGroups = issues
                              .Select(CategorizeIssue)
                              .GroupBy(x => x.category)
                              .Select(issues =>
                               {
-                                  var sb = new StringBuilder($"## {issues.Key}");
+                                  var sb = new StringBuilder($"### {issues.Key}");
                                   sb.AppendLine();
                                   foreach (var issue in issues)
                                   {
@@ -527,7 +530,8 @@ partial class Build
                     { "area:ci-app", ciApp },
                     { "area:app-sec", appSec },
                     { "area:profiler", profiler },
-                    { "area:debugger", debugger }
+                    { "area:debugger", debugger },
+                    { "area:serverless", serverless }
                 };
 
                 var buildAndTestIssues = new []
@@ -572,8 +576,9 @@ partial class Build
                 appSec => 2,
                 profiler => 3,
                 debugger => 4,
-                fixes => 5,
-                _ => 6
+                serverless => 5,
+                fixes => 6,
+                _ => 7
             };
         });
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -100,8 +100,7 @@ partial class Build
                 name: GitHubRepositoryName,
                 number: PullRequestNumber.Value);
 
-            GitTasks.Git("fetch origin master:master", logOutput: false);
-            var changedFiles = GitTasks.Git("diff --name-only master").Select(f => f.Text);
+            var changedFiles = GitTasks.Git("diff --name-only origin/master").Select(f => f.Text);
             var config = GetLabellerConfiguration();
             Console.WriteLine($"Checking labels for PR {PullRequestNumber}");
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -440,7 +440,7 @@ partial class Build
             const string appSec = "AppSec";
             const string profiler = "Continuous Profiler";
             const string debugger = "Debugger";
-            const string appSec = "Serverless";
+            const string serverless = "Serverless";
 
             var artifactsLink = Environment.GetEnvironmentVariable("PIPELINE_ARTIFACTS_LINK");
             var nextVersion = FullVersion;

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -100,7 +100,9 @@ partial class Build
                 name: GitHubRepositoryName,
                 number: PullRequestNumber.Value);
 
-            var changedFiles = GitTasks.Git("diff --name-only origin/master").Select(f => f.Text);
+            // Fixes an issue (ambiguous argument) when we do git diff in the Action.
+            GitTasks.Git("fetch origin master:master", logOutput: false);
+            var changedFiles = GitTasks.Git("diff --name-only master").Select(f => f.Text);
             var config = GetLabellerConfiguration();
             Console.WriteLine($"Checking labels for PR {PullRequestNumber}");
 


### PR DESCRIPTION
## Summary of changes
Adding a simplistic labeler that allows adding label when
- PR title matches a string (eg `[CIApp]` or `CIApp`)
- All modified files path matches a string (eg `profiler/*`)

Currently, this allows to add `CIApp`, `Serverless`, `AppSec`, `Profiler` and `Debugger` labels easily.
In a second commit, I've also added more labels taken from Lucas' PR (https://github.com/DataDog/dd-trace-dotnet/pull/2212) and in a third, modified the release notes to contain Serverless as well

## Reason for change
Following https://github.com/DataDog/dd-trace-dotnet/pull/2607, we now categorize release notes based on labels, using the `area-{component}` label. So we thought we could revisit having a labeler. I spent a bit of time trying to find one already available but they do not match our needs (matching PR description, matching all files, not removing labels). So I decided to implement a simplistic one as we already have all the tools to do so.

## Implementation details
Added an action, its configuration and a Nuke target.

## Test coverage
Tested on my fork (mainly the first commit)

## Next steps
We could imagine also:
- Adding the `type:bug` when the PR summary `Fixes` section is filled
- Split regexp on multiple lines for readability
- Discuss with other tracer team to see if this target could interest them and make it a real action? 
