### PR TITLE
Explicit public changes in PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,8 @@
 ## Summary of changes
 
+## Public changes
+<!-- Public API changes, new configuration keys... -->
+
 ## Reason for change
 
 ## Implementation details


### PR DESCRIPTION
## Summary of changes
Change the PR Template to add a section for public changes (eg Configuration keys, API changes)

## Reason for change
The aim is to make more visible public changes. Indeed, we may not want to review all PRs but seeing in our notifications the public changes could help for visibility.

## Implementation details
Just added a section here, in 2nd place, for better visibility
