### PR TITLE
[Profiler] Add beta revision in the profiler version

### DIFF
--- a/.github/scripts/package_and_deploy.sh
+++ b/.github/scripts/package_and_deploy.sh
@@ -6,8 +6,9 @@ ddprof_deploy_folder=$1
 commit_sha=$2
 commit_author=$3
 
-
-profiler_version=v2.5.0.0_$(date -u +%G%m%d%H%M%S)
+current_profiler_version=$(sed -rn 's/constexpr auto PROFILER_VERSION = "([^"]+)";/\1/p' ../profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h)
+current_profiler_beta_version=$(sed -rn 's/constexpr auto PROFILER_BETA_REVISION = "([^"]+)";/\1/p' ../profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h)
+profiler_version=v${current_profiler_version}.${current_profiler_beta_version}_$(date -u +%G%m%d%H%M%S)
 
 ## Create master.index.txt file
 cat <<- EOF > master.index.txt

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -25,7 +25,7 @@
 
 tags LibddprofExporter::CommonTags = {
     {"language", "dotnet"},
-    {"profiler_version", PROFILER_VERSION},
+    {"profiler_version", PROFILER_VERSION + std::string(".") + PROFILER_BETA_REVISION},
 #ifdef BIT64
     {"process_architecture", "x64"},
 #else

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
@@ -4,3 +4,5 @@
 #pragma once
 
 constexpr auto PROFILER_VERSION = "2.7.0";
+// The beta revision is temporary
+constexpr auto PROFILER_BETA_REVISION = "1";


### PR DESCRIPTION
## Summary of changes

## Reason for change

Today, the beta revision is not part of the version of the profiler (when sending the pprof). We would like it to be part of the version so we can track issues/features.

## Implementation details

Add a `PROFILER_BETA_REVISION` variable in `dd_profiler_version.h`

## Test coverage

## Other details
<!-- Fixes #{issue} -->
