### PR TITLE
[Profiler] Do not compute a default output path for pprof files

### DIFF
--- a/profiler/src/Demos/BuggyBits/Properties/launchSettings.json
+++ b/profiler/src/Demos/BuggyBits/Properties/launchSettings.json
@@ -19,6 +19,7 @@
 
         "DD_PROFILING_ENABLED": "1",
         "DD_DOTNET_PROFILER_HOME": "$(BuildOutputRoot)\\bin\\$(Configuration)-AnyCPU\\profiler\\src\\ProfilerEngine\\Datadog.Profiler.Managed\\",
+        "DD_INTERNAL_PROFILING_OUTPUT_DIR": "$(PROGRAMDATA)\\Datadog-APM\\Pprof-files\\DotNet",
 
         "DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION": "true",
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -41,6 +42,7 @@
 
         "DD_PROFILING_ENABLED": "1",
         "DD_DOTNET_PROFILER_HOME": "$(BuildOutputRoot)\\bin\\$(Configuration)-AnyCPU\\profiler\\src\\ProfilerEngine\\Datadog.Profiler.Managed\\",
+        "DD_INTERNAL_PROFILING_OUTPUT_DIR": "$(PROGRAMDATA)\\Datadog-APM\\Pprof-files\\DotNet",
 
         "DD_TRACE_DEBUG": "1",
         "DD_RUNTIME_METRICS_ENABLED": "1",

--- a/profiler/src/Demos/Computer01/Properties/launchSettings.json
+++ b/profiler/src/Demos/Computer01/Properties/launchSettings.json
@@ -18,6 +18,7 @@
 
         "DD_PROFILING_ENABLED": "1",
         "DD_DOTNET_PROFILER_HOME": "$(BuildOutputRoot)\\bin\\$(Configuration)-AnyCPU\\profiler\\src\\ProfilerEngine\\Datadog.Profiler.Managed\\",
+        "DD_INTERNAL_PROFILING_OUTPUT_DIR": "$(PROGRAMDATA)\\Datadog-APM\\Pprof-files\\DotNet",
 
         "DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION": "true"
       },

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Configuration/EnvironmentVariablesConfigurationProvider.cs
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Configuration/EnvironmentVariablesConfigurationProvider.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="EnvironmentVariablesConfigurationProvider.cs" company="Datadog">
+// <copyright file="EnvironmentVariablesConfigurationProvider.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
@@ -49,7 +49,7 @@ namespace Datadog.Configuration
                 }
             }
 
-            if (TryGetEnvironmentVariable("DD_PROFILING_OUTPUT_DIR", out string directory))
+            if (TryGetEnvironmentVariable("DD_INTERNAL_PROFILING_OUTPUT_DIR", out string directory))
             {
                 mutableConfig.ProfilesExport_LocalFiles_Directory = directory;
             }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -67,7 +67,7 @@ fs::path Configuration::ExtractPprofDirectory()
 {
     auto value = shared::GetEnvironmentValue(EnvironmentVariables::ProfilesOutputDir);
     if (value.empty())
-        return GetDefaultPprofDirectoryPath();
+        return fs::path();
 
     return fs::path(value);
 }
@@ -170,16 +170,6 @@ fs::path Configuration::GetDefaultLogDirectoryPath()
     return baseDirectory / WStr(R"(Datadog-APM\logs\DotNet)");
 #else
     return baseDirectory / WStr("dotnet");
-#endif
-}
-
-fs::path Configuration::GetDefaultPprofDirectoryPath()
-{
-    auto baseDirectory = fs::path(GetApmBaseDirectory());
-#ifdef _WINDOWS
-    return baseDirectory / WStr(R"(Datadog-APM\Pprof-files\DotNet)");
-#else
-    return baseDirectory / WStr("pprof-files");
 #endif
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -46,7 +46,6 @@ private:
     static std::string GetDefaultSite();
     static std::string ExtractSite();
     static std::chrono::seconds ExtractUploadInterval();
-    static fs::path GetDefaultPprofDirectoryPath();
     static fs::path GetDefaultLogDirectoryPath();
     static fs::path GetApmBaseDirectory();
     static fs::path ExtractLogDirectory();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -25,7 +25,7 @@ public:
     inline static const shared::WSTRING Hostname                    = WStr("DD_HOSTNAME");
     inline static const shared::WSTRING Tags                        = WStr("DD_TAGS");
     inline static const shared::WSTRING NativeFramesEnabled         = WStr("DD_PROFILING_FRAMES_NATIVE_ENABLED");
-    inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_PROFILING_OUTPUT_DIR");
+    inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_INTERNAL_PROFILING_OUTPUT_DIR");
     inline static const shared::WSTRING DevelopmentConfiguration    = WStr("DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION");
     inline static const shared::WSTRING Agentless                   = WStr("DD_PROFILING_AGENTLESS");
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -9,7 +9,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
     {
         public const string LibDdPprofPipepline = "DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED";
         public const string ProfilingLogDir = "DD_PROFILING_LOG_DIR";
-        public const string ProfilingPprofDir = "DD_PROFILING_OUTPUT_DIR";
+        public const string ProfilingPprofDir = "DD_INTERNAL_PROFILING_OUTPUT_DIR";
         public const string ProfilerInstallationFolder = "DD_TESTING_PROFILER_FOLDER";
         public const string CodeHotSpotsEnable = "DD_PROFILING_CODEHOTSPOTS_ENABLED";
         public const string UseNativeLoader = "USE_NATIVE_LOADER";

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -133,12 +133,7 @@ TEST(ConfigurationTest, CheckDefaultPprofDirectoryWhenVariableIsNotSet)
 {
     unsetenv(EnvironmentVariables::ProfilesOutputDir);
     auto configuration = Configuration{};
-    auto expectedValue =
-#ifdef _WINDOWS
-        WStr("C:\\ProgramData\\Datadog-APM\\Pprof-files\\DotNet");
-#else
-        WStr("/var/log/datadog/pprof-files");
-#endif
+    auto expectedValue = shared::WSTRING();
     ASSERT_EQ(expectedValue, configuration.GetProfilesOutputDirectory());
 }
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -129,7 +129,7 @@ TEST(ConfigurationTest, CheckLogDirectoryWhenVariableIsSet)
     ASSERT_EQ(expectedValue, configuration.GetLogDirectory());
 }
 
-TEST(ConfigurationTest, CheckDefaultPprofDirectoryWhenVariableIsNotSet)
+TEST(ConfigurationTest, CheckNoDefaultPprofDirectoryWhenVariableIsNotSet)
 {
     unsetenv(EnvironmentVariables::ProfilesOutputDir);
     auto configuration = Configuration{};


### PR DESCRIPTION
## Summary of changes

If the environment variable is not set, do not create a default output path for pprof files.

## Reason for change

Writting pprof files on disk is only for debugging/development purpose. So by default, there is no need to write them on disk (so no need to compute a default output path).

## Implementation details

Remove the computation of the default output path if the env var is not set.
+ rename the env var into `DD_INTERNAL_PROFILING_OUTPUT_DIR` since it's an internal flag.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
