### PR TITLE
Convert AWS lambda tests to using snapshots

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -80,7 +80,14 @@ namespace Datadog.Trace.TestHelpers
             {
                 while (span.ParentId is not null)
                 {
-                    span = allSpans.First(x => x.SpanId == span.ParentId.Value);
+                    var parent = allSpans.FirstOrDefault(x => x.SpanId == span.ParentId.Value);
+                    if (parent is null)
+                    {
+                        // no span with the given Parent Id, so treat this one as the root instead
+                        break;
+                    }
+
+                    span = parent;
                 }
 
                 return span.Resource;
@@ -91,7 +98,14 @@ namespace Datadog.Trace.TestHelpers
                 var depth = 0;
                 while (span.ParentId is not null)
                 {
-                    span = allSpans.First(x => x.SpanId == span.ParentId.Value);
+                    var parent = allSpans.FirstOrDefault(x => x.SpanId == span.ParentId.Value);
+                    if (parent is null)
+                    {
+                        // no span with the given Parent Id, so treat this one as the root instead
+                        break;
+                    }
+
+                    span = parent;
                     depth++;
                 }
 

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -1,0 +1,272 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerNoParamAsync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerNoParamAsync,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerNoParamSync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerNoParamSync,
+      runtime-id: Guid_2,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerNoParamVoid,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerNoParamVoid,
+      runtime-id: Guid_3,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerOneParamAsync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerOneParamAsync,
+      runtime-id: Guid_4,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerOneParamSync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerOneParamSync,
+      runtime-id: Guid_5,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerOneParamVoid,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerOneParamVoid,
+      runtime-id: Guid_6,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsAsync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsAsync,
+      runtime-id: Guid_7,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsSync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsSync,
+      runtime-id: Guid_8,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsVoid,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsVoid,
+      runtime-id: Guid_9,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

- Converts AWS Lambda tests to using snapshots

## Reason for change

Noticed some flakiness, and thought it would be a good idea to convert to snapshots. This appears to reveal that the tests aren't actually working, but need to confirm. 

## Implementation details

Switched to use Verify. Needed to update the helper, as the spans all refer to a parent span that doesn't exist. May need to do additional / alternative sorting to ensure consistency (can potentially get rid of the thread sleeps then)
