### PR TITLE
Labeler shouldn't check test folders for tracer and integrations areas

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -32,8 +32,9 @@ labels:
   - name: "area:installers"
     allFilesIn: "shared\/src\/msi-installer\/.*"
 
+  # Will work only if tests aren't modified. Needs to be revisited
   - name: "area:integrations"
-    allFilesIn: "tracer\/src\/Datadog\\.Trace\/ClrProfiler\/AutoInstrumentation\/.*|tracer\/src\/Datadog\\.Trace\\.AspNet\/.*|tracer\/test\/.*"
+    allFilesIn: "tracer\/src\/Datadog\\.Trace\/ClrProfiler\/AutoInstrumentation\/.*|tracer\/src\/Datadog\\.Trace\\.AspNet\/.*"
 
   - name: "area:opentracing"
     allFilesIn: ".*OpenTracing.*"
@@ -45,5 +46,6 @@ labels:
     allFilesIn: "tracer/test/.*"
 
   # if any modified file is in tracer/src/Datadog.Trace, excluding files in ClrProfiler, AppSec or Ci
+  # Will work only if tests aren't modified. Needs to be revisited
   - name: "area:tracer"
-    allFilesIn: "(?!.*ClrProfiler.*|.*\/Ci\/.*|.*\/AppSec\/.*)(src\/Datadog\\.Trace\/.*)|tracer\/test\/.*"
+    allFilesIn: "(?!.*ClrProfiler.*|.*\/Ci\/.*|.*\/AppSec\/.*)(src\/Datadog\\.Trace\/.*)"

--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -1,11 +1,11 @@
 labels:
-  - name: "area:ciapp"
+  - name: "area:ci-app"
     title: "^\\[?(?i)ciapp"
 
   - name: "area:serverless"
     title: "^\\[?(?i)serverless"
 
-  - name: "area:appsec"
+  - name: "area:app-sec"
     title: "^\\[?(?i)appsec"
 
   - name: "area:profiler"


### PR DESCRIPTION
## Summary of changes
Not checking if all files are within test folders when checking tracer and integrations areas. 

## Reason for change
It was over labelling obviously. The labeler should actually handle tests differently, but this can be improved later as those areas were already best effort. 
