### PR TITLE
Simplify native loader p/invoke

### DIFF
--- a/tracer/src/Datadog.Trace/Util/NativeLoaderInterop.cs
+++ b/tracer/src/Datadog.Trace/Util/NativeLoaderInterop.cs
@@ -1,0 +1,41 @@
+// <copyright file="NativeLoaderInterop.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Datadog.Trace.Util
+{
+    internal class NativeLoaderInterop
+    {
+#if NETFRAMEWORK
+        private const string NativeLoaderLibNameX86 = "Datadog.AutoInstrumentation.NativeLoader.x86.dll";
+        private const string NativeLoaderLibNameX64 = "Datadog.AutoInstrumentation.NativeLoader.x64.dll";
+#else
+        private const string NativeLoaderLibNameX86 = "Datadog.AutoInstrumentation.NativeLoader.x86";
+        private const string NativeLoaderLibNameX64 = "Datadog.AutoInstrumentation.NativeLoader.x64";
+#endif
+
+        // Adding the attribute MethodImpl(MethodImplOptions.NoInlining) allows the caller to
+        // catch the SecurityException in case of we are running in a partial trust environment.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal static string GetRuntimeIdFromNative()
+        {
+            if (Environment.Is64BitProcess)
+            {
+                return GetRuntimeIdFromNativeX64();
+            }
+
+            return GetRuntimeIdFromNativeX86();
+        }
+
+        [DllImport(NativeLoaderLibNameX86, CallingConvention = CallingConvention.StdCall, EntryPoint = "GetCurrentAppDomainRuntimeId")]
+        private static extern string GetRuntimeIdFromNativeX86();
+
+        [DllImport(NativeLoaderLibNameX64, CallingConvention = CallingConvention.StdCall, EntryPoint = "GetCurrentAppDomainRuntimeId")]
+        private static extern string GetRuntimeIdFromNativeX64();
+    }
+}

--- a/tracer/src/Datadog.Trace/Util/RuntimeId.cs
+++ b/tracer/src/Datadog.Trace/Util/RuntimeId.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Datadog.Trace.Logging;
@@ -13,14 +12,6 @@ namespace Datadog.Trace.Util
 {
     internal static class RuntimeId
     {
-#if NETFRAMEWORK
-        private const string NativeLoaderLibNameX86 = "Datadog.AutoInstrumentation.NativeLoader.x86.dll";
-        private const string NativeLoaderLibNameX64 = "Datadog.AutoInstrumentation.NativeLoader.x64.dll";
-#else
-        private const string NativeLoaderLibNameX86 = "Datadog.AutoInstrumentation.NativeLoader.x86";
-        private const string NativeLoaderLibNameX64 = "Datadog.AutoInstrumentation.NativeLoader.x64";
-#endif
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RuntimeId));
         private static string _runtimeId;
 
@@ -40,31 +31,11 @@ namespace Datadog.Trace.Util
             return guid;
         }
 
-        [DllImport(NativeLoaderLibNameX86, CallingConvention = CallingConvention.StdCall, EntryPoint = "GetCurrentAppDomainRuntimeId")]
-        private static extern IntPtr GetRuntimeIdFromNativeX86();
-
-        [DllImport(NativeLoaderLibNameX64, CallingConvention = CallingConvention.StdCall, EntryPoint = "GetCurrentAppDomainRuntimeId")]
-        private static extern IntPtr GetRuntimeIdFromNativeX64();
-
-        // Adding the attribute MethodImpl(MethodImplOptions.NoInlining) allows the caller to
-        // catch the SecurityException in case of we are running in a partial trust environment.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static IntPtr GetRuntimeIdFromNative()
-        {
-            if (Environment.Is64BitProcess)
-            {
-                return GetRuntimeIdFromNativeX64();
-            }
-
-            return GetRuntimeIdFromNativeX86();
-        }
-
         private static bool TryGetRuntimeIdFromNative(out string runtimeId)
         {
             try
             {
-                var runtimeIdPtr = GetRuntimeIdFromNative();
-                runtimeId = Marshal.PtrToStringAnsi(runtimeIdPtr);
+                runtimeId = NativeLoaderInterop.GetRuntimeIdFromNative();
                 return !string.IsNullOrWhiteSpace(runtimeId);
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Util/RuntimeId.cs
+++ b/tracer/src/Datadog.Trace/Util/RuntimeId.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Datadog.Trace.Logging;
 


### PR DESCRIPTION
## Summary of changes

- Change the signature of the runtime id p/invoke to directly return a string
- Move the native loader p/invokes to a dedicated class

## Reason for change

The previous code returned a pointer to the string then marshalled it. While it's technically correct, there is no point in doing that since the framework can emit this boilerplate code for us.

Moving the p/invoke to a dedicated class will make the code easier to maintain as more p/invokes are added (soon).
