### PR TITLE
Return `CORPROF_E_PROFILER_CANCEL_ACTIVATION` if Tracing is Disabled

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -76,7 +76,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     {
         Logger::Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET 5.0 runtime or greater is required on this "
                      "architecture.");
-        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+        return E_FAIL;
     }
 #endif
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -58,7 +58,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         else
         {
             Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled in ", environment::tracing_enabled);
-            return E_FAIL;
+            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
     }
 
@@ -76,7 +76,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     {
         Logger::Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET 5.0 runtime or greater is required on this "
                      "architecture.");
-        return E_FAIL;
+        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
 #endif
 
@@ -99,7 +99,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     {
         Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " not found in ",
                      environment::include_process_names, ".");
-        return E_FAIL;
+        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
 
     const auto& exclude_process_names = shared::GetEnvironmentValues(environment::exclude_process_names);
@@ -109,7 +109,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     {
         Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " found in ",
                      environment::exclude_process_names, ".");
-        return E_FAIL;
+        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
 
     Logger::Info("Environment variables:");
@@ -133,7 +133,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
             Logger::Info(
                 "DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", environment::azure_app_services_app_pool_id, " ",
                 app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
-            return E_FAIL;
+            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
 
         const auto& cli_telemetry_profile_value =
@@ -143,7 +143,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         {
             Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", app_pool_id_value,
                          " is recognized as Kudu, an Azure App Services reserved process.");
-            return E_FAIL;
+            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
 
         const auto& functions_worker_runtime_value =
@@ -152,7 +152,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         if (!functions_worker_runtime_value.empty() && !IsAzureFunctionsEnabled())
         {
             Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler explicitly disabled for Azure Functions.");
-            return E_FAIL;
+            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
     }
 


### PR DESCRIPTION
## Summary of changes

Changed return from `E_FAIL` to `CORPROF_E_PROFILER_CANCEL_ACTIVATION` for scenarios where the tracer is intentionally disabled by either the code or the user setting `DD_TRACE_ENABLED` set to `false`.

## Reason for change

To avoid printing misleading error event logs when there is not actual error.

## Test coverage

Tested locally using the command below to build the tracer locally:
`.\tracer\build.ps1 BuildTracerHome BuildNativeLoader PackageTracerHome`

After doing so I simply compared the outcome of disabling the tracer setting `DD_TRACE_ENABLED=false` in the tracer with the changes vs the one without them:

- Returning `E_FAIL`:
![Image 2022-04-21 at 2 28 58 PM](https://user-images.githubusercontent.com/28125428/164529998-755a5575-3adf-4744-b957-d1bffd16133e.jpg)

- Returning `CORPROF_E_PROFILER_CANCEL_ACTIVATION`:
![Image 2022-04-21 at 2 29 05 PM](https://user-images.githubusercontent.com/28125428/164529571-6f48326a-3d0e-430f-941d-f71c37029db9.jpg)

NOTE: Also uninstalled & reinstalled the tracer and so no issues in the Event Logs or the in test service.