### PR TITLE
[Tracer] Rework exporter settings

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
@@ -30,13 +30,6 @@ namespace Datadog.Trace.Tools.Runner
             else
             {
                 configuration = new ExporterSettings { AgentUri = new Uri(settings.Url) };
-
-                // TODO: Remove when the logic has been moved to the ImmutableExporterSettings constructor
-                if (settings.Url.StartsWith("unix://"))
-                {
-                    configuration.TracesTransport = TracesTransportType.UnixDomainSocket;
-                    configuration.TracesUnixDomainSocketPath = configuration.AgentUri.PathAndQuery;
-                }
             }
 
             var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(configuration)).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -82,13 +82,6 @@ namespace Datadog.Trace.Configuration
         public const string PartialFlushMinSpans = "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS";
 
         /// <summary>
-        /// Configuration key for the unix domain socket where the Tracer can send traces.
-        /// Default value is <c>null</c>.
-        /// </summary>
-        /// <seealso cref="ExporterSettings.TracesUnixDomainSocketPath"/>
-        public const string TracesUnixDomainSocketPath = "DD_APM_RECEIVER_SOCKET";
-
-        /// <summary>
         /// Configuration key for the unix domain socket that DogStatsD binds to.
         /// Default value is <c>null</c>.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Agent;
 
 namespace Datadog.Trace.Configuration
@@ -45,6 +46,7 @@ namespace Datadog.Trace.Configuration
 
             PartialFlushEnabled = settings.PartialFlushEnabled;
             PartialFlushMinSpans = settings.PartialFlushMinSpans;
+            ValidationWarnings = settings.ValidationWarnings;
         }
 
         /// <summary>
@@ -97,7 +99,6 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets the unix domain socket path where the Tracer can connect to the Agent.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.TracesUnixDomainSocketPath"/>
         public string TracesUnixDomainSocketPath { get; }
 
         /// <summary>
@@ -115,5 +116,7 @@ namespace Datadog.Trace.Configuration
         /// Gets the transport used to connect to the DogStatsD.
         /// </summary>
         internal Vendors.StatsdClient.Transport.TransportType MetricsTransport { get; }
+
+        internal List<string> ValidationWarnings { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -392,6 +392,16 @@ namespace Datadog.Trace
                     writer.WritePropertyName("direct_logs_submission_error");
                     writer.WriteValue(string.Join(", ", instanceSettings.LogSubmissionSettings.ValidationErrors));
 
+                    writer.WritePropertyName("exporter_settings_warning");
+                    writer.WriteStartArray();
+
+                    foreach (var warning in instanceSettings.Exporter.ValidationWarnings)
+                    {
+                        writer.WriteValue(warning);
+                    }
+
+                    writer.WriteEndArray();
+
                     writer.WritePropertyName("dd_trace_methods");
                     writer.WriteValue(instanceSettings.TraceMethods);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -520,7 +520,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 var metricsUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, metricsUdsPath) { UseDogstatsD = useStatsD });
+                agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, metricsUdsPath, useStatsD));
             }
             else if (TransportType == TestTransports.WindowsNamedPipe)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -292,10 +292,10 @@ namespace Datadog.Trace.TestHelpers
         {
             if (TransportType == TestTransports.Uds)
             {
-                string apmKey = "DD_APM_RECEIVER_SOCKET";
+                string agentUrlKey = "DD_TRACE_AGENT_URL";
                 string dsdKey = "DD_DOGSTATSD_SOCKET";
 
-                environmentVariables.Add(apmKey, agent.TracesUdsPath);
+                environmentVariables.Add(agentUrlKey, "unix://" + agent.TracesUdsPath);
                 environmentVariables.Add(dsdKey, agent.StatsUdsPath);
             }
             else if (TransportType == TestTransports.WindowsNamedPipe)

--- a/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
@@ -7,16 +7,22 @@ namespace Datadog.Trace.TestHelpers
 {
     public class UnixDomainSocketConfig
     {
-        public UnixDomainSocketConfig(string traces, string metrics)
+        public UnixDomainSocketConfig(string traces)
+        {
+            Traces = traces;
+        }
+
+        public UnixDomainSocketConfig(string traces, string metrics, bool useDogstatsD = false)
         {
             Traces = traces;
             Metrics = metrics;
+            UseDogstatsD = useDogstatsD;
         }
 
         public string Traces { get; }
 
         public string Metrics { get; }
 
-        public bool UseDogstatsD { get; set; } = false;
+        public bool UseDogstatsD { get; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -192,16 +192,16 @@ namespace Datadog.Trace.Tests.Configuration
         /// If for some reason the priority needs to change in the future, there is no compelling reason why this test can't change.
         /// </summary>
         [Fact]
-        public void Traces_SocketFilesExist_ExplicitConfigForWindowsPipeAndUdp_PrioritizesWindowsPipe()
+        public void Traces_SocketFilesExist_ExplicitConfigForWindowsPipeAndAgent_PrioritizesWindowsPipe()
         {
-            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe", "DD_APM_RECEIVER_SOCKET:somesocket");
+            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe", "DD_TRACE_AGENT_PORT:8111");
             AssertPipeIsConfigured(settings, "somepipe");
         }
 
         [Fact] // fails for now, because Url has no precedence
         public void Traces_SocketFilesExist_ExplicitConfigForAll_UsesDefaultTcp()
         {
-            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_AGENT_URL:http://toto:1234", "DD_TRACE_PIPE_NAME:somepipe", "DD_APM_RECEIVER_SOCKET:somesocket");
+            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_AGENT_URL:http://toto:1234", "DD_TRACE_PIPE_NAME:somepipe");
             AssertHttpIsConfigured(settings, new Uri("http://toto:1234"));
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -76,6 +76,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.PartialFlushMinSpans == i.PartialFlushMinSpans,
                 (e, i) => e.MetricsUnixDomainSocketPath == i.MetricsUnixDomainSocketPath,
                 (e, i) => e.TracesUnixDomainSocketPath == i.TracesUnixDomainSocketPath,
+                (e, i) => e.ValidationWarnings == i.ValidationWarnings,
             };
 
             var mutableProperties = typeof(ExporterSettings)

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var url = $"unix://{tracesUdsPath}";
 
-            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, null));
+            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath));
 
             using var helper = await StartConsole(enableProfiler: false, ("DD_TRACE_AGENT_URL", url));
 
@@ -154,7 +154,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, null))
+            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath))
             {
                 Version = expectedVersion
             };

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -91,7 +92,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             _ = await AgentConnectivityCheck.RunAsync(processInfo!);
 
-            console.Output.Should().Contain(ConnectToEndpointFormat(url, "domain sockets"));
+            console.Output.Should().Contain(ConnectToEndpointFormat(tracesUdsPath.Replace("\\", "/"), "domain sockets"));
         }
 #endif
 

--- a/tracer/test/test-applications/integrations/Samples.LargePayload/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.LargePayload/Properties/launchSettings.json
@@ -16,7 +16,7 @@
     "UnixDomainSocket": {
       "commandName": "Project",
       "environmentVariables": {
-        "DD_APM_RECEIVER_SOCKET": "%TEMP%\\apm.socket",
+        "DD_TRACE_AGENT_URL": "unix://%TEMP%/apm.socket",
         "DD_DOGSTATSD_SOCKET": "%TEMP%\\dsd.socket",
         // These variables are to override environmental settings to be sure that the payload is always approximately the same size
         "DD_ENV": "payload-test",


### PR DESCRIPTION
## Summary of changes
First, this is a subset of https://github.com/DataDog/dd-trace-dotnet/pull/2455. I did another one as I thought it would be easier to follow up the changes. Also note that I'm trying to make the review easier if you do it commit by commit. 
Then, here are the changes so far:
- Add more tests
- Change the order of precedence of the settings to put the URL back on top
- Added a few validation checks (eg the URI is well formed), allowed fallbacking and added validation warnings
- Changing a property recomputes the strategy. This one is a bit tricky as we keep the precedence. So if a URL had been set by config, and the user changes the socket path, then it won't change anything.

## Reason for change
The main reason is that we introduced a bug by breaking the order of precedence of the parameters. BTW, this order is now documented [here](https://github.com/DataDog/architecture/pull/1000). But this implementation has many flaws:
- Setting a unix:// URI after a http uri would just break as we're not changing the transport strategy
- Setting `TracesUnixDomainSocketPath`, `MetricsUnixDomainSocketPath`, `MetricsPipeName`, `TracesPipeName` properties is useless if you hadn't given an equivalent configuration through environment. Indeed, we don't recompute the strategy when we set those.

## Implementation details
In this PR, I'm not changing the way it works. Thus, all the computation stilll happen in `ExporterSettings`.  Doing so to avoid breaking changes in behavior.

Minor detail, I've pushed commit 5332cf03e3f99f2bcd21136b7f2ca4a0e6b82a95 in order to prevent an issue in partial trust environment. As we don't support it, I think I can revert it, but we'd need to drop the Sandbox tests in that case. FYI, here the issue was `Cannot change initonly field outside its .ctor`. I've verified with PEVerify that the issue has been solved (though the code is even uglier, so I'd be happy to revert)

## Test coverage
I've done TDD. So I've added tests that match the target behavior. Added them in the first commit marking the ones that fail. And commit by commit I remove the comments.

## Other details
Fixes https://github.com/DataDog/dd-trace-dotnet/issues/2426

## Next steps
- [ ] Shall we set `TracesUnixDomainSocketPath` if a path has been provided by URL?
- [ ] Switch to a builder template in 3.0
