### PR TITLE
Refactor base endpoint calculations

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
@@ -38,7 +38,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             DisplayInfoMessage(settings);
 
-            var request = requestFactory.Create(new Uri(settings.AgentUri, "/v0.4/traces"));
+            var endpoint = requestFactory.GetEndpoint("/v0.4/traces");
+            var request = requestFactory.Create(endpoint);
 
             var content = new ByteArrayContent(payload);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/msgpack");

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -33,7 +33,6 @@ namespace Datadog.Trace.Agent
         private string _agentVersion;
 
         public Api(
-            Uri baseEndpoint,
             IApiRequestFactory apiRequestFactory,
             IDogStatsd statsd,
             Action<Dictionary<string, float>> updateSampleRates,
@@ -44,11 +43,12 @@ namespace Datadog.Trace.Agent
             _log = log ?? StaticLog;
             _log.Debug("Creating new Api");
             _updateSampleRates = updateSampleRates;
-            _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
             _statsd = statsd;
             _containerId = ContainerMetadata.GetContainerId();
             _apiRequestFactory = apiRequestFactory;
             _isPartialFlushEnabled = isPartialFlushEnabled;
+            _tracesEndpoint = _apiRequestFactory.GetEndpoint(TracesPath);
+            _log.Debug("Using traces endpoint {TracesEndpoint}", _tracesEndpoint.ToString());
         }
 
         public async Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces)

--- a/tracer/src/Datadog.Trace/Agent/IApiRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequestFactory.cs
@@ -12,6 +12,8 @@ namespace Datadog.Trace.Agent
     {
         string Info(Uri endpoint);
 
+        Uri GetEndpoint(string relativePath);
+
         IApiRequest Create(Uri endpoint);
 
         void SetProxy(WebProxy proxy, NetworkCredential credential);

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -36,10 +36,10 @@ namespace Datadog.Trace.Agent
                 default:
 #if NETCOREAPP
                     Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
-                    return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
+                    return new HttpClientRequestFactory(settings.AgentUri, AgentHttpHeaderNames.DefaultHeaders);
 #else
                     Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
-                    return new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
+                    return new ApiWebRequestFactory(settings.AgentUri, AgentHttpHeaderNames.DefaultHeaders);
 #endif
             }
         }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
+using Datadog.Trace.Util;
+
 #pragma warning disable CS0618 // WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.
 
 namespace Datadog.Trace.Agent.Transports
@@ -13,12 +15,14 @@ namespace Datadog.Trace.Agent.Transports
     internal class ApiWebRequestFactory : IApiRequestFactory
     {
         private readonly KeyValuePair<string, string>[] _defaultHeaders;
+        private readonly Uri _baseEndpoint;
         private WebProxy _proxy;
         private NetworkCredential _credential;
         private TimeSpan? _timeout;
 
-        public ApiWebRequestFactory(KeyValuePair<string, string>[] defaultHeaders, TimeSpan? timeout = null)
+        public ApiWebRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, TimeSpan? timeout = null)
         {
+            _baseEndpoint = baseEndpoint;
             _defaultHeaders = defaultHeaders;
             _timeout = timeout;
         }
@@ -27,6 +31,8 @@ namespace Datadog.Trace.Agent.Transports
         {
             return endpoint.ToString();
         }
+
+        public Uri GetEndpoint(string relativePath) => UriHelpers.Combine(_baseEndpoint, relativePath);
 
         public IApiRequest Create(Uri endpoint)
         {

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -8,7 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using Datadog.Trace.Ci;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Agent.Transports
 {
@@ -16,11 +16,13 @@ namespace Datadog.Trace.Agent.Transports
     {
         private readonly HttpClient _client;
         private readonly HttpClientHandler _handler;
+        private readonly Uri _baseEndpoint;
 
-        public HttpClientRequestFactory(KeyValuePair<string, string>[] defaultHeaders, HttpClientHandler handler = null, TimeSpan? timeout = null)
+        public HttpClientRequestFactory(Uri baseEndpoint, KeyValuePair<string, string>[] defaultHeaders, HttpClientHandler handler = null, TimeSpan? timeout = null)
         {
             _handler = handler ?? new HttpClientHandler();
             _client = new HttpClient(_handler);
+            _baseEndpoint = baseEndpoint;
             if (timeout.HasValue)
             {
                 _client.Timeout = timeout.Value;
@@ -31,6 +33,8 @@ namespace Datadog.Trace.Agent.Transports
                 _client.DefaultRequestHeaders.Add(pair.Key, pair.Value);
             }
         }
+
+        public Uri GetEndpoint(string relativePath) => UriHelpers.Combine(_baseEndpoint, relativePath);
 
         public string Info(Uri endpoint)
         {

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Ci.Agent
         {
             var isPartialFlushEnabled = settings.Exporter.PartialFlushEnabled;
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
-            var api = new Api(settings.Exporter.AgentUri, apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), isPartialFlushEnabled);
+            var api = new Api(apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), isPartialFlushEnabled);
             _agentWriter = new AgentWriter(api, null, maxBufferSize: maxBufferSize);
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Ci.Agent
 
         private readonly ICIAgentlessWriterSender _sender;
 
-        public CIAgentlessWriter(ImmutableTracerSettings settings, ISampler sampler, ICIAgentlessWriterSender sender)
+        public CIAgentlessWriter(ICIAgentlessWriterSender sender)
         {
             _eventQueue = new BlockingCollection<IEvent>(MaxItemsInQueue);
             _flushTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Ci
             {
                 if (!string.IsNullOrEmpty(_settings.ApiKey))
                 {
-                    return new CIAgentlessWriter(settings, sampler, new CIWriterHttpSender(GetRequestFactory(settings)));
+                    return new CIAgentlessWriter(new CIWriterHttpSender(GetRequestFactory(settings)));
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Ci
             {
                 if (!string.IsNullOrEmpty(_settings.ApiKey))
                 {
-                    return new CIAgentlessWriter(settings, sampler, new CIWriterHttpSender(GetRequestFactory()));
+                    return new CIAgentlessWriter(settings, sampler, new CIWriterHttpSender(GetRequestFactory(settings)));
                 }
                 else
                 {
@@ -74,17 +74,17 @@ namespace Datadog.Trace.Ci
             }
         }
 
-        private IApiRequestFactory GetRequestFactory()
+        private IApiRequestFactory GetRequestFactory(ImmutableTracerSettings settings)
         {
             IApiRequestFactory factory = null;
             TimeSpan agentlessTimeout = TimeSpan.FromSeconds(15);
 
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
-            factory = new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders, timeout: agentlessTimeout);
+            factory = new HttpClientRequestFactory(settings.Exporter.AgentUri, AgentHttpHeaderNames.DefaultHeaders, timeout: agentlessTimeout);
 #else
             Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
-            factory = new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders, timeout: agentlessTimeout);
+            factory = new ApiWebRequestFactory(settings.Exporter.AgentUri, AgentHttpHeaderNames.DefaultHeaders, timeout: agentlessTimeout);
 #endif
 
             if (!string.IsNullOrWhiteSpace(_settings.ProxyHttps))

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             }
 
             var apiFactory = LogsTransportStrategy.Get(settings);
-            var logsApi = new LogsApi(settings.IntakeUrl, settings.ApiKey, apiFactory);
+            var logsApi = new LogsApi(settings.ApiKey, apiFactory);
 
             return new DirectLogSubmissionManager(settings, new DatadogSink(logsApi, formatter, settings.BatchingOptions), formatter);
         }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -22,10 +22,10 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
-            return new HttpClientRequestFactory(LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
+            return new HttpClientRequestFactory(settings.IntakeUrl, LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
-            return new ApiWebRequestFactory(LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
+            return new ApiWebRequestFactory(settings.IntakeUrl, LogsApiHeaderNames.DefaultHeaders, timeout: timeout);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
     internal class LogsApi : ILogsApi
     {
-        internal const string LogIntakePath = "api/v2/logs";
+        internal const string LogIntakePath = "/api/v2/logs";
         internal const string IntakeHeaderNameApiKey = "DD-API-KEY";
 
         private const string MimeType = "application/json";
@@ -27,16 +27,12 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly Uri _logsIntakeEndpoint;
 
-        public LogsApi(Uri baseEndpoint, string apiKey, IApiRequestFactory apiRequestFactory)
+        public LogsApi(string apiKey, IApiRequestFactory apiRequestFactory)
         {
-            var builder = new UriBuilder(baseEndpoint);
-            builder.Path = builder.Path.EndsWith("/")
-                               ? builder.Path + LogIntakePath
-                               : builder.Path + "/" + LogIntakePath;
-
-            _logsIntakeEndpoint = builder.Uri;
             _apiKey = apiKey;
             _apiRequestFactory = apiRequestFactory;
+            _logsIntakeEndpoint = _apiRequestFactory.GetEndpoint(LogIntakePath);
+            Log.Debug("Using logs intake endpoint {LogsIntakeEndpoint}", _logsIntakeEndpoint.ToString());
         }
 
         public void Dispose()

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -113,6 +113,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.Platform, value: FrameworkDescription.Instance.ProcessArchitecture),
                 new(ConfigTelemetryData.Enabled, value: settings.TraceEnabled),
                 new(ConfigTelemetryData.AgentUrl, value: settings.Exporter.AgentUri.ToString()),
+                new(ConfigTelemetryData.AgentTraceTransport, value: settings.Exporter.TracesTransport.ToString()),
                 new(ConfigTelemetryData.Debug, value: GlobalSettings.Source.DebugEnabled),
 #pragma warning disable CS0618
                 new(ConfigTelemetryData.AnalyticsEnabled, value: settings.AnalyticsEnabled),

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.Telemetry
         public const string Platform = "platform";
         public const string Enabled = "enabled";
         public const string AgentUrl = "agent_url";
+        public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -292,6 +292,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("agent_url");
                     writer.WriteValue(instanceSettings.Exporter.AgentUri);
 
+                    writer.WritePropertyName("agent_transport");
+                    writer.WriteValue(instanceSettings.Exporter.TracesTransport.ToString());
+
                     writer.WritePropertyName("debug");
                     writer.WriteValue(GlobalSettings.Source.DebugEnabled);
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace
         protected virtual IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ISampler sampler)
         {
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
-            var api = new Api(settings.Exporter.AgentUri, apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled);
+            var api = new Api(apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled);
             return new AgentWriter(api, statsd, maxBufferSize: settings.TraceBufferSize);
         }
 

--- a/tracer/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/UriHelpers.cs
@@ -146,6 +146,19 @@ namespace Datadog.Trace.Util
             return containsNumber;
         }
 
+        /// <summary>
+        /// Combines an absolute base <see cref="Uri"/> <paramref name="baseUri"/> with a path <paramref name="relativePath"/>.
+        /// If <paramref name="baseUri"/> includes a path component, this will be included in the final <see cref="Uri"/>.
+        /// The final <see cref="Uri"/> will always contain all path segments from both parameters.
+        /// </summary>
+        /// <example>The following calls all return the <see cref="Uri"/> <c>http://host/a/b/c</c>.
+        /// <code>Combine(new Uri("http://host/a/b"), "c");
+        /// Combine(new Uri("http://host/a/b"), "/c");
+        /// Combine(new Uri("http://host/a/b/"), "c");
+        /// Combine(new Uri("http://host/a/b/"), "/c");</code></example>
+        /// <param name="baseUri">The base <see cref="Uri"/>, which may or may not end with a <c>/</c>. </param>
+        /// <param name="relativePath">The relative path, which may or may not start with a <c>/</c>.</param>
+        /// <returns>The combined <see cref="Uri"/></returns>
         public static Uri Combine(Uri baseUri, string relativePath)
         {
             var builder = new UriBuilder(baseUri);

--- a/tracer/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/UriHelpers.cs
@@ -145,5 +145,20 @@ namespace Datadog.Trace.Util
 
             return containsNumber;
         }
+
+        public static Uri Combine(Uri baseUri, string relativePath)
+        {
+            var builder = new UriBuilder(baseUri);
+            builder.Path =
+                builder.Path.EndsWith("/")
+                    ? (relativePath.StartsWith("/")
+                           ? $"{builder.Path.Substring(0, builder.Path.Length - 1)}{relativePath}"
+                           : $"{builder.Path}{relativePath}")
+                    : (relativePath.StartsWith("/")
+                           ? $"{builder.Path}{relativePath}"
+                           : $"{builder.Path}/{relativePath}");
+
+            return builder.Uri;
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
@@ -18,18 +18,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
 {
     public class CIAgentlessWriterTests
     {
-        private readonly Configuration.ImmutableTracerSettings _settings;
-
-        public CIAgentlessWriterTests()
-        {
-            _settings = new Configuration.ImmutableTracerSettings(Ci.Configuration.CIVisibilitySettings.FromDefaultSources().TracerSettings);
-        }
-
         [Fact]
         public async Task AgentlessTestEventTest()
         {
             var sender = new Mock<ICIAgentlessWriterSender>();
-            var agentlessWriter = new CIAgentlessWriter(_settings, null, sender.Object);
+            var agentlessWriter = new CIAgentlessWriter(sender.Object);
 
             var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
             span.Type = SpanTypes.Test;
@@ -60,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             var flushTcs = new TaskCompletionSource<bool>();
 
             var sender = new Mock<ICIAgentlessWriterSender>();
-            var agentlessWriter = new CIAgentlessWriter(_settings, null, sender.Object);
+            var agentlessWriter = new CIAgentlessWriter(sender.Object);
             var lstPayloads = new List<byte[]>();
 
             sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.EventsPayload>()))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -80,6 +80,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key)
         {
+            var (latestConfigurationData, configurationPayload) = telemetry.AssertConfiguration();
+            configurationPayload.Should().ContainSingle(telemetryValue => telemetryValue.Name == key);
+            return latestConfigurationData;
+        }
+
+        public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key, string value)
+        {
+            var (latestConfigurationData, configurationPayload) = telemetry.AssertConfiguration();
+            configurationPayload.Should()
+                                .ContainSingle(telemetryValue => telemetryValue.Name == key && telemetryValue.Value.ToString() == value);
+
+            return latestConfigurationData;
+        }
+
+        private static (TelemetryData LatestConfigurationData, ICollection<TelemetryValue> ConfigurationPayload) AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry)
+        {
+            telemetry.WaitForLatestTelemetry(x => x.RequestType == TelemetryRequestTypes.AppStarted);
             var allData = telemetry.Telemetry.ToArray();
             var (latestConfigurationData, configurationPayload) =
                 allData
@@ -96,9 +113,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             latestConfigurationData.Should().NotBeNull();
             configurationPayload.Should().NotBeNull();
 
-            configurationPayload.Single(telemetryValue => telemetryValue.Name == key).Should().NotBeNull();
-
-            return latestConfigurationData;
+            return (latestConfigurationData, configurationPayload);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -106,8 +106,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int telemetryPort = TcpPortProvider.GetOpenPort();
             using var telemetry = new MockTelemetryAgent<TelemetryData>(telemetryPort);
 
-            SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "false");
-
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="TransportTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Datadog.Trace.Agent;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class TransportTests : TestHelper
+    {
+        // Using Telemetry sample as it's simple
+        public TransportTests(ITestOutputHelper output)
+            : base("Telemetry", output)
+        {
+        }
+
+        public static IEnumerable<object[]> Data =>
+            Enum.GetValues(typeof(TracesTransportType))
+                .Cast<TracesTransportType>()
+                .Where(x => x != TracesTransportType.WindowsNamedPipe)
+#if !NETCOREAPP3_1_OR_GREATER
+                .Where(x => x != TracesTransportType.UnixDomainSocket)
+#endif
+                .Select(x => new object[] { x });
+
+        [SkippableTheory]
+        [MemberData(nameof(Data))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void TransportsWorkCorrectly(Enum transport)
+        {
+            const int expectedSpanCount = 2;
+            EnvironmentHelper.TransportType = GetTransport((TracesTransportType)transport);
+
+            using var agent = GetAgent((TracesTransportType)transport);
+
+            int httpPort = TcpPortProvider.GetOpenPort();
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            {
+                processResult.ExitCode.Should().Be(0);
+                var spans = agent.WaitForSpans(expectedSpanCount);
+
+                spans.Count.Should().Be(expectedSpanCount);
+            }
+
+            MockTracerAgent GetAgent(TracesTransportType transportType)
+                => transportType switch
+                {
+                    TracesTransportType.Default => new MockTracerAgent(),
+#if NETCOREAPP3_1_OR_GREATER
+                    TracesTransportType.UnixDomainSocket
+                        => new MockTracerAgent(new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), null)),
+#endif
+                    _ => throw new InvalidOperationException("Unsupported transport type " + transportType),
+                };
+
+            TestTransports GetTransport(TracesTransportType transportType)
+                => transportType switch
+                {
+                    TracesTransportType.Default => TestTransports.Tcp,
+                    TracesTransportType.UnixDomainSocket => TestTransports.Uds,
+                    TracesTransportType.WindowsNamedPipe => TestTransports.WindowsNamedPipe,
+                    _ => throw new InvalidOperationException("Unsupported transport type " + transportType),
+                };
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -402,7 +402,7 @@ namespace Datadog.Trace.TestHelpers
 
             var response = $"HTTP/1.1 200 OK";
             response += DatadogHttpValues.CrLf;
-            response += $" Date: {DateTime.UtcNow.ToString("ddd, dd MMM yyyy H:mm::ss K")}";
+            response += $"Date: {DateTime.UtcNow.ToString("ddd, dd MMM yyyy H:mm::ss K")}";
             response += DatadogHttpValues.CrLf;
             response += $"Connection: Keep-Alive";
             response += DatadogHttpValues.CrLf;
@@ -526,17 +526,7 @@ namespace Datadog.Trace.TestHelpers
                     HandlePotentialTraces(request);
                     await stream.WriteAsync(GetResponseBytes());
 
-                    // Wait for client to close the connection
-                    // If you're reading this and you know about sockets:
-                    // I have NO IDEA if that's the right way to wait until the response was properly sent
-                    // If you know a better way, by all means, please replace this code.
-                    var buffer = new byte[256];
-                    var status = handler.Receive(buffer);
-
-                    if (status > 0)
-                    {
-                        throw new InvalidOperationException($"Read an extra {status} bytes past the expected end of the stream. It might indicate a protocol error on the client side.");
-                    }
+                    handler.Shutdown(SocketShutdown.Both);
                 }
                 catch (SocketException ex)
                 {

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Moq;
@@ -30,8 +32,9 @@ namespace Datadog.Trace.Tests
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            factoryMock.Setup(x => x.GetEndpoint(It.IsAny<string>())).Returns(new Uri("http://localhost/traces"));
 
-            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
@@ -49,8 +52,9 @@ namespace Datadog.Trace.Tests
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            factoryMock.Setup(x => x.GetEndpoint(It.IsAny<string>())).Returns(new Uri("http://localhost/traces"));
 
-            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
@@ -71,10 +75,11 @@ namespace Datadog.Trace.Tests
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            factoryMock.Setup(x => x.GetEndpoint(It.IsAny<string>())).Returns(new Uri("http://localhost/traces"));
 
             var logMock = new Mock<IDatadogLogger>();
 
-            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: true, log: logMock.Object);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: true, log: logMock.Object);
 
             // First time should write the warning
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
@@ -109,10 +114,11 @@ namespace Datadog.Trace.Tests
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            factoryMock.Setup(x => x.GetEndpoint(It.IsAny<string>())).Returns(new Uri("http://localhost/traces"));
 
             var ratesWereSet = false;
             Action<Dictionary<string, float>> updateSampleRates = _ => ratesWereSet = true;
-            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, isPartialFlushEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, isPartialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
             ratesWereSet.Should().BeTrue();
@@ -128,7 +134,17 @@ namespace Datadog.Trace.Tests
         [InlineData("", false, false)] // Version check fail, partial flush disabled
         public void LogPartialFlushWarning(string agentVersion, bool partialFlushEnabled, bool expectedResult)
         {
-            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: null, statsd: null, updateSampleRates: null, isPartialFlushEnabled: partialFlushEnabled);
+            var responseMock = new Mock<IApiResponse>();
+            responseMock.Setup(x => x.StatusCode).Returns(200);
+
+            var requestMock = new Mock<IApiRequest>();
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>())).ReturnsAsync(responseMock.Object);
+
+            var factoryMock = new Mock<IApiRequestFactory>();
+            factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
+            factoryMock.Setup(x => x.GetEndpoint(It.IsAny<string>())).Returns(new Uri("http://localhost/traces"));
+
+            var api = new Api(factoryMock.Object, statsd: null, updateSampleRates: null, isPartialFlushEnabled: partialFlushEnabled);
 
             // First call depends on the parameters of the test
             api.LogPartialFlushWarningIfRequired(agentVersion).Should().Be(expectedResult);

--- a/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -31,9 +31,9 @@ namespace Datadog.Trace.Tests
 
             try
             {
-                var factory = new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
+                var factory = new ApiWebRequestFactory(new Uri("http://localhost"), AgentHttpHeaderNames.DefaultHeaders);
 
-                var request = factory.Create(new Uri("http://localhost"));
+                var request = factory.Create(factory.GetEndpoint(string.Empty));
 
                 Assert.NotNull(request);
             }

--- a/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Linq;
 using System.Net.Http;
@@ -21,8 +21,8 @@ namespace Datadog.Trace.Tests
         {
             var handler = new CustomHandler();
 
-            var factory = new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders, handler);
-            var request = factory.Create(new Uri("http://localhost/"));
+            var factory = new HttpClientRequestFactory(new Uri("http://localhost/"), AgentHttpHeaderNames.DefaultHeaders, handler);
+            var request = factory.Create(factory.GetEndpoint(string.Empty));
 
             request.AddHeader("Hello", "World");
 
@@ -42,8 +42,8 @@ namespace Datadog.Trace.Tests
         {
             var handler = new CustomHandler();
 
-            var factory = new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders, handler);
-            var request = factory.Create(new Uri("http://localhost/"));
+            var factory = new HttpClientRequestFactory(new Uri("http://localhost/"), AgentHttpHeaderNames.DefaultHeaders, handler);
+            var request = factory.Create(factory.GetEndpoint(string.Empty));
 
             await request.PostAsync(ArraySegment<byte>.Empty, MimeTypes.MsgPack);
 

--- a/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Util
@@ -53,6 +54,20 @@ namespace Datadog.Trace.Tests.Util
         public void GetCleanUriPath_ByUri_ShouldExtractThePathAndRemoveIds(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(new Uri(url)));
+        }
+
+        [Theory]
+        [InlineData("http://localhost", "some/path")]
+        [InlineData("http://localhost/", "some/path")]
+        [InlineData("http://localhost", "/some/path")]
+        [InlineData("http://localhost/", "/some/path")]
+        [InlineData("http://localhost/some", "path")]
+        [InlineData("http://localhost/some/", "path")]
+        [InlineData("http://localhost/some", "/path")]
+        [InlineData("http://localhost/some/", "/path")]
+        public void Combine_ShouldMergeCorrectly(string baseUri, string relativePath)
+        {
+            Trace.Util.UriHelpers.Combine(new Uri(baseUri), relativePath).Should().Be("http://localhost/some/path");
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.Telemetry/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Telemetry/Program.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace;
 
 namespace Samples.Telemetry
 {
@@ -32,7 +31,7 @@ namespace Samples.Telemetry
                 Console.WriteLine("Sending async request with default HttpClient.");
                 using (var client = new HttpClient())
                 {
-                    using (Tracer.Instance.StartActive("GetAsync"))
+                    using (SampleHelpers.CreateScope("GetAsync"))
                     {
                         await client.GetAsync(url);
                         Console.WriteLine("Received response for client.GetAsync(String)");

--- a/tracer/test/test-applications/integrations/Samples.Telemetry/Samples.Telemetry.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Telemetry/Samples.Telemetry.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
## Summary of changes

- Refactors how we interact with `IApiRequestFactory` so the factory is responsible for creating the `Uri` endpoint.

## Reason for change

Currently, with UDS, we are creating malformed HTTP requests. These appear to still be working with the agent (but I and Kevin have no idea why😅). For example, the start of a request over UDS on Windows looks like this:

```http
POST C:/v0.4/traces HTTP/1.1
Host:
...
```

Note the `C:` prefix on the path, and the empty `Host` header. This PR fixes this, so we send  valid http headers for UDS requests:

```http
POST /v0.4/traces HTTP/1.1
Host: localhost
...
```

## Implementation details

The crux of the problem is code that does something like:

```csharp
_tracesEndpoint = new Uri(exporterSettings.AgentUri, "/v0.4/traces");
```

For UDS, `AgentUri` is a file path, so the endpoint URI becomes a franken-URI. Remarkably, this isn't a problem with our existing implementations, but when I tried to use the .NET 6 `HttpClient` implementation in #2665 everything fell apart 😅 

The solution I settled on was adding the following API to `IApiRequestFactory`:

```diff
internal interface IApiRequestFactory
{
        string Info(Uri endpoint);
        IApiRequest Create(Uri endpoint);
        void SetProxy(WebProxy proxy, NetworkCredential credential);
+       Uri GetEndpoint(string relativePath);
}
```

This allows the different factories to create the appropriate `Uri` format. It also means that direct consumers of `IApiRequestFactory` shouldn't supply the "base" URI (`AgentUri` etc). Instead, this should be supplied in the `IApiRequestFactory` _implementation's_ constructor.

In addition:
- Fixed some bugs in the `MockTracerAgent` implementation
- Add the selected trace transport (UDS/default) etc to logs and telemetry
- Additional tests

## Test coverage

Added explicit "transport" tests, to test full end-to-end UDS trace can be sent and received.

## Other details
Blocker for #2665 and #2617
