### PR TITLE
[Profiler] Add Undefined-Behavior sanitizer on the profiler

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -311,15 +311,6 @@ jobs:
           echo "DD_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
           echo "DD_TRACE_DEBUG=1" >> $GITHUB_ENV
 
-      - name: Run Computer01 for 2min
-        timeout-minutes: 4
-        run: |
-          source profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh `pwd`/profiler/_build/DDProf-Deploy &&
-          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Computer01/net5.0 &&
-          UBSAN_OPTIONS=print_stacktrace=1 LD_PRELOAD="libubsan.so.1:$LD_PRELOAD" dotnet Datadog.Demos.Computer01.dll --scenario 1 --timeout 120
-        env:
-          DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED: "0"
-
       - name: Run Computer01 for 2min with the new pipeline
         timeout-minutes: 4
         if: '${{ always() }}'

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -272,6 +272,74 @@ jobs:
             ${{ env.DD_TESTING_OUPUT_DIR }}
           retention-days: 1
 
+  build_linux_ubsan:
+    name: Build Linux Profiler UBSAN
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Install libubsan
+        run: sudo apt-get install -y libubsan1
+
+      - name: Clone dd-trace-dotnet repository
+        uses: actions/checkout@v2
+
+      - name: Build Managed Loader
+        run: dotnet build -c Release shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
+
+      - name: Build Managed Profiler Engine
+        run: dotnet build -c Release profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+
+      - name: Build Native Profiler Engine
+        run: |
+          CXX=clang++ CC=clang cmake -S profiler -B __build -DRUN_UBSAN=ON
+          cd __build
+          make
+
+      - name: Build sample applications
+        run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
+
+      - name: Prepare environment to run the application
+        run: |
+          #
+          # set profiler deployment and test output dir folder path for the test
+          #
+          tests_output_dir="$(realpath .)/test_output"
+          echo "DD_TESTING_OUPUT_DIR=$tests_output_dir" >> $GITHUB_ENV
+          echo "DD_PROFILING_LOG_DIR=$tests_output_dir/logs" >> $GITHUB_ENV
+          echo "DD_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
+          echo "DD_TRACE_DEBUG=1" >> $GITHUB_ENV
+
+      - name: Run Computer01 for 2min
+        timeout-minutes: 4
+        run: |
+          source profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh `pwd`/profiler/_build/DDProf-Deploy &&
+          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Computer01/net5.0 &&
+          UBSAN_OPTIONS=print_stacktrace=1 LD_PRELOAD="libubsan.so.1:$LD_PRELOAD" dotnet Datadog.Demos.Computer01.dll --scenario 1 --timeout 120
+        env:
+          DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED: "0"
+
+      - name: Run Computer01 for 2min with the new pipeline
+        timeout-minutes: 4
+        if: '${{ always() }}'
+        run: |
+          source profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh `pwd`/profiler/_build/DDProf-Deploy &&
+          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Computer01/net5.0 &&
+          UBSAN_OPTIONS=print_stacktrace=1 LD_PRELOAD="libubsan.so.1:$LD_PRELOAD" dotnet Datadog.Demos.Computer01.dll --scenario 1 --timeout 120
+        env:
+          DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED: "1"
+
+      - name: 'Publish Test results, Logs and PProf files'
+        uses: actions/upload-artifact@v2
+        if: '${{ always() }}'
+        with:
+          if-no-files-found: error
+          name: Ubsan_Tests_result_logs_and_pprofs_files.Linux.Release.x64
+          path: |
+            ${{ env.DD_TESTING_OUPUT_DIR }}
+          retention-days: 1
+
   build_windows:
     name: Build Windows Profiler and Tracer
     runs-on: windows-2019

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -5,6 +5,10 @@
 project("Datadog.AutoInstrumentation.Profiler.Native.Linux" VERSION 2.7.0)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
+option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
+
+message(STATUS "Run Clang Address Sanitizer: " ${RUN_ASAN})
+message(STATUS "Run Clang Undefined-Behavior Sanitizer: " ${RUN_UBSAN})
 
 # ******************************************************
 # Compiler options
@@ -20,6 +24,10 @@ if (RUN_ASAN)
     add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
 endif()
 
+if (RUN_UBSAN)
+    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
+endif()
+
 if (BIT64)
     add_compile_options(-DBIT64)
     add_compile_options(-DHOST_64BIT)
@@ -33,6 +41,7 @@ elseif (ISARM64)
 elseif (ISARM)
     add_compile_options(-DARM)
 endif()
+
 
 # ******************************************************
 # Environment detection
@@ -135,6 +144,19 @@ target_include_directories(${PROFILER_STATIC_LIB_NAME}
 )
 
 # Define linker libraries
+
+if (RUN_UBSAN)
+    target_link_libraries(${PROFILER_STATIC_LIB_NAME} -fsanitize=undefined)
+endif()
+
+if (RUN_ASAN)
+    target_link_libraries(${PROFILER_STATIC_LIB_NAME} -fsanitize=address)
+endif()
+
+if (NOT RUN_ASAN AND NOT RUN_UBSAN)
+    target_link_libraries(${PROFILER_STATIC_LIB_NAME} -Wl,--no-undefined)
+endif()
+
 target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     fmt-lib
     libunwind-x86_64-lib
@@ -148,12 +170,6 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -ldl
     -luuid
 )
-
-if (RUN_ASAN)
-    target_link_libraries(${PROFILER_STATIC_LIB_NAME} -fsanitize=address)
-else()
-    target_link_libraries(${PROFILER_STATIC_LIB_NAME} -Wl,--no-undefined)
-endif()
 
 add_dependencies(${PROFILER_STATIC_LIB_NAME} fmt-lib libunwind-x86_64-lib libunwind-lib libddprof-lib)
 


### PR DESCRIPTION
## Summary of changes

Add a new job to build the profiler with Clang Undefined-Behavior sanitizer.

## Reason for change

This will help us in finding various issue:
*  Array subscript out of bounds
* Misalignment

More [here](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)

## Implementation details

Add new job:
- Ensure libubsan is installed
- Run the application with and without the new pipeline
/!\ for now we do not fail the job if with the old pipeline there is an issue. This pipeline is deprecated and will be soon removed

## Test coverage

## Other details
<!-- Fixes #{issue} -->
