### PR TITLE
Remove remaining references to nlohmann.json NuGet package

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,7 +6,6 @@ Datadog.Trace,https://github.com/JamesNK/Newtonsoft.Json,MIT,Copyright (c) 2007 
 Datadog.Trace.ClrProfiler.Native,https://github.com/dotnet/runtime,MIT,Copyright (c) .NET Foundation and contributors. All rights reserved.
 Datadog.Trace.ClrProfiler.Native,https://github.com/Microsoft/clr-samples,MIT,Copyright (c) .NET Foundation and contributors. All rights reserved.
 Datadog.Trace.ClrProfiler.Native,https://github.com/MicrosoftArchive/clrprofiler,MIT,Copyright (c) Microsoft Corporation.  All rights reserved.
-Datadog.Trace.ClrProfiler.Native,https://github.com/nlohmann/json,MIT,Copyright (c) 2013-2018 Niels Lohmann
 Datadog.Trace.ClrProfiler.Native,https://github.com/dropbox/miniutf,MIT,"Copyright (c) 2013 Dropbox, Inc."
 Datadog.Trace.ClrProfiler.Native,https://github.com/gabime/spdlog,MIT,Copyright (c) 2016 Gabi Melman.
 Datadog.Trace.ClrProfiler.Native,https://github.com/fmtlib/fmt,MIT,"Copyright (c) 2012 - present, Victor Zverovich"

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -102,14 +102,6 @@ SET(DOTNET_TRACER_REPO_ROOT_PATH ${CMAKE_SOURCE_DIR}/../../../)
 # ******************************************************
 
 # Prepare dependencies
-if (NOT EXISTS ${OUTPUT_DEPS_DIR}/json)
-    add_custom_command(
-        OUTPUT ${OUTPUT_DEPS_DIR}/json
-        COMMAND git clone --quiet --depth 1 --branch v3.3.0 https://github.com/nlohmann/json.git
-        WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
-    )
-endif()
-
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/re2)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/re2

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj
@@ -99,7 +99,6 @@
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\..\packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets" Condition="Exists('..\..\..\packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets')" />
     <Import Project="..\..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets" Condition="Exists('..\..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -197,7 +196,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\nlohmann.json.3.5.0\build\native\nlohmann.json.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets'))" />
   </Target>
 </Project>

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1" targetFramework="native" />
-  <package id="nlohmann.json" version="3.5.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary of changes
Removes remaining references to nlohmann.json NuGet package. Thanks @Kielek for spotting this!

## Reason for change
This is no longer needed since we no longer use integrations.json to read integrations.

## Implementation details
N/A

## Test coverage
N/A

## Other details
N/A
