### PR TITLE
If DirectLogSubmission is enabled, enable Logs Injection by default

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -43,7 +43,6 @@ namespace Datadog.Trace.Configuration
 #pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabled = settings.AnalyticsEnabled;
 #pragma warning restore 618
-            LogsInjectionEnabled = settings.LogsInjectionEnabled;
             MaxTracesSubmittedPerSecond = settings.MaxTracesSubmittedPerSecond;
             CustomSamplingRules = settings.CustomSamplingRules;
             GlobalSamplingRate = settings.GlobalSamplingRate;
@@ -68,6 +67,8 @@ namespace Datadog.Trace.Configuration
             TraceMethods = settings.TraceMethods;
 
             LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
+            // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
+            LogsInjectionEnabled = settings.LogSubmissionSettings.LogsInjectionEnabled ?? LogSubmissionSettings.IsEnabled;
 
             // we cached the static instance here, because is being used in the hotpath
             // by IsIntegrationEnabled method (called from all integrations)

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -81,10 +81,6 @@ namespace Datadog.Trace.Configuration
                                false;
 #pragma warning restore 618
 
-            LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
-                                   // default value
-                                   false;
-
             MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.TraceRateLimit) ??
 #pragma warning disable 618 // this parameter has been replaced but may still be used
                                           source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
@@ -237,10 +233,15 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets a value indicating whether correlation identifiers are
         /// automatically injected into the logging context.
-        /// Default is <c>false</c>.
+        /// Default is <c>false</c>, unless <see cref="ConfigurationKeys.DirectLogSubmission.EnabledIntegrations"/>
+        /// enables Direct Log Submission.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
-        public bool LogsInjectionEnabled { get; set; }
+        public bool LogsInjectionEnabled
+        {
+            get => LogSubmissionSettings?.LogsInjectionEnabled ?? false;
+            set => LogSubmissionSettings.LogsInjectionEnabled = value;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating the maximum number of traces set to AutoKeep (p1) per second.

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -89,6 +89,8 @@ namespace Datadog.Trace.Logging.DirectSubmission
                     : seconds.Value);
 
             ApiKey = source?.GetString(ConfigurationKeys.ApiKey);
+
+            LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled);
         }
 
         /// <summary>
@@ -150,5 +152,10 @@ namespace Datadog.Trace.Logging.DirectSubmission
         /// Gets or sets the Datadog API key
         /// </summary>
         internal string? ApiKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether logs injection has been explicitly enabled or disabled
+        /// </summary>
+        internal bool? LogsInjectionEnabled { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -173,5 +173,71 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             var expected = new List<string> { nameof(IntegrationId.NLog) };
             logSettings.EnabledIntegrationNames.Should().BeEquivalentTo(expected);
         }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void WhenLogsInjectionIsExplicitlySetViaEnvironmentThenValueIsUsed(bool logsInjectionEnabled, bool directLogSubmissionEnabled)
+        {
+            var config = new NameValueCollection(Defaults);
+            config[ConfigurationKeys.LogsInjectionEnabled] = logsInjectionEnabled.ToString();
+
+            if (!directLogSubmissionEnabled)
+            {
+                config.Remove(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations);
+            }
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(config));
+            var immutableSettings = new ImmutableTracerSettings(tracerSettings);
+
+            immutableSettings.LogSubmissionSettings.IsEnabled.Should().Be(directLogSubmissionEnabled);
+            immutableSettings.LogsInjectionEnabled.Should().Be(logsInjectionEnabled);
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void WhenLogsInjectionIsExplicitlySetViaCodeThenValueIsUsed(bool logsInjectionEnabled, bool directLogSubmissionEnabled)
+        {
+            var config = new NameValueCollection(Defaults);
+            config.Remove(ConfigurationKeys.LogsInjectionEnabled);
+
+            if (!directLogSubmissionEnabled)
+            {
+                config.Remove(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations);
+            }
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(config));
+            tracerSettings.LogsInjectionEnabled = logsInjectionEnabled;
+
+            var immutableSettings = new ImmutableTracerSettings(tracerSettings);
+
+            immutableSettings.LogSubmissionSettings.IsEnabled.Should().Be(directLogSubmissionEnabled);
+            immutableSettings.LogsInjectionEnabled.Should().Be(logsInjectionEnabled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WhenLogsInjectionIsNotSetThenValueIsSameAsLogSubmissionEnabled(bool directLogSubmissionEnabled)
+        {
+            var config = new NameValueCollection(Defaults);
+            config.Remove(ConfigurationKeys.LogsInjectionEnabled);
+
+            if (!directLogSubmissionEnabled)
+            {
+                config.Remove(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations);
+            }
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(config));
+            var immutableSettings = new ImmutableTracerSettings(tracerSettings);
+
+            immutableSettings.LogSubmissionSettings.IsEnabled.Should().Be(directLogSubmissionEnabled);
+            immutableSettings.LogsInjectionEnabled.Should().Be(directLogSubmissionEnabled);
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Enables logs injection by default when direct log submission is enabled

## Reason for change

Improve onboarding for direct log submission

## Implementation details

Previously, users had to remember to set `DD_LOGS_INJECTION` as well as `DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS` to have their traces correlated. There are vanishingly few cases where you would want to enable `DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS` but _not_ enable `DD_LOGS_INJECTION`.

> The only scenario I could think of is where a user is _not_ using tracing, but they want to use direct log submission to send logs and _also_ output to a different sink, where enabling logs injection would break their output. This seems an incredibly niche scenario, and one that can be solved by explicitly setting `DD_LOGS_INJECTION=0` if required. 

Unfortunately, `LogsInjectionEnabled` is one of the properties we allow to be set in code, so it makes implementing this slightly trickier, but I think the work around in this PR is sufficient.

## Test coverage

Unit tests for the setting value

