### PR TITLE
[AppSec] Move AppSec config keys to their own file

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -18,17 +18,17 @@ namespace Datadog.Trace.AppSec
         public SecuritySettings(IConfigurationSource source)
         {
             // both should default to false
-            Enabled = source?.GetBool(ConfigurationKeys.AppSecEnabled) ?? false;
-            Rules = source?.GetString(ConfigurationKeys.AppSecRules);
-            CustomIpHeader = source?.GetString(ConfigurationKeys.AppSecCustomIpHeader);
-            var extraHeaders = source?.GetString(ConfigurationKeys.AppSecExtraHeaders);
+            Enabled = source?.GetBool(ConfigurationKeys.AppSec.Enabled) ?? false;
+            Rules = source?.GetString(ConfigurationKeys.AppSec.Rules);
+            CustomIpHeader = source?.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
+            var extraHeaders = source?.GetString(ConfigurationKeys.AppSec.ExtraHeaders);
             ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders.Split(',') : Array.Empty<string>();
-            KeepTraces = source?.GetBool(ConfigurationKeys.AppSecKeepTraces) ?? true;
+            KeepTraces = source?.GetBool(ConfigurationKeys.AppSec.KeepTraces) ?? true;
 
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
-            TraceRateLimit = source?.GetInt32(ConfigurationKeys.AppSecTraceRateLimit) ?? 100;
+            TraceRateLimit = source?.GetInt32(ConfigurationKeys.AppSec.TraceRateLimit) ?? 100;
 
-            var wafTimeoutString = source?.GetString(ConfigurationKeys.AppSecWafTimeout);
+            var wafTimeoutString = source?.GetString(ConfigurationKeys.AppSec.WafTimeout);
             const int defaultWafTimeout = 100_000;
             if (string.IsNullOrWhiteSpace(wafTimeoutString))
             {
@@ -40,7 +40,7 @@ namespace Datadog.Trace.AppSec
                 var wafTimeout = ParseWafTimeout(wafTimeoutString);
                 if (wafTimeout <= 0)
                 {
-                    Log.Warning<string, string>("Ignoring '{WafTimeoutKey}' of '{wafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSecWafTimeout, wafTimeoutString);
+                    Log.Warning<string, string>("Ignoring '{WafTimeoutKey}' of '{wafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
                     wafTimeout = defaultWafTimeout;
                 }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -1,0 +1,60 @@
+// <copyright file="ConfigurationKeys.AppSec.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Configuration
+{
+    internal partial class ConfigurationKeys
+    {
+        internal class AppSec
+        {
+            /// <summary>
+            /// Configuration key for enabling or disabling the AppSec.
+            /// Default is value is false (disabled).
+            /// </summary>
+            public const string Enabled = "DD_APPSEC_ENABLED";
+
+            /// <summary>
+            /// Override the default rules file provided. Must be a path to a valid JSON rules file.
+            /// Default is value is null (do not override).
+            /// </summary>
+            public const string Rules = "DD_APPSEC_RULES";
+
+            /// <summary>
+            /// Configuration key indicating the optional name of the custom header to take into account for the ip address.
+            /// Default is value is null (do not override).
+            /// </summary>
+            public const string CustomIpHeader = "DD_APPSEC_IPHEADER";
+
+            /// <summary>
+            /// Comma separated keys indicating the optional custom headers the user wants to send.
+            /// Default is value is null.
+            /// </summary>
+            public const string ExtraHeaders = "DD_APPSEC_EXTRA_HEADERS";
+
+            /// <summary>
+            /// Specifies if the AppSec traces should be explicitly kept or dropped.
+            /// Default is true, to keep all traces, false means drop all traces (by setting AutoReject as sampling priority).
+            /// For internal testing only.
+            /// </summary>
+            internal const string KeepTraces = "DD_APPSEC_KEEP_TRACES";
+
+            /// <summary>
+            /// Limits the amount of AppSec traces sent per second with an integer value, strictly positive.
+            /// </summary>
+            internal const string TraceRateLimit = "DD_APPSEC_TRACE_RATE_LIMIT";
+
+            /// <summary>
+            /// WAF timeout in microseconds of each WAF execution (the timeout value passed to ddwaf_run).
+            /// </summary>
+            internal const string WafTimeout = "DD_APPSEC_WAF_TIMEOUT";
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -47,47 +47,6 @@ namespace Datadog.Trace.Configuration
         public const string TraceEnabled = "DD_TRACE_ENABLED";
 
         /// <summary>
-        /// Configuration key for enabling or disabling the AppSec.
-        /// Default is value is false (disabled).
-        /// </summary>
-        public const string AppSecEnabled = "DD_APPSEC_ENABLED";
-
-        /// <summary>
-        /// Override the default rules file provided. Must be a path to a valid JSON rules file.
-        /// Default is value is null (do not override).
-        /// </summary>
-        public const string AppSecRules = "DD_APPSEC_RULES";
-
-        /// <summary>
-        /// Configuration key indicating the optional name of the custom header to take into account for the ip address.
-        /// Default is value is null (do not override).
-        /// </summary>
-        public const string AppSecCustomIpHeader = "DD_APPSEC_IPHEADER";
-
-        /// <summary>
-        /// Comma separated keys indicating the optional custom headers the user wants to send.
-        /// Default is value is null.
-        /// </summary>
-        public const string AppSecExtraHeaders = "DD_APPSEC_EXTRA_HEADERS";
-
-        /// <summary>
-        /// Specifies if the AppSec traces should be explicitly kept or dropped.
-        /// Default is true, to keep all traces, false means drop all traces (by setting AutoReject as sampling priority).
-        /// For internal testing only.
-        /// </summary>
-        internal const string AppSecKeepTraces = "DD_APPSEC_KEEP_TRACES";
-
-        /// <summary>
-        /// Limits the amount of AppSec traces sent per second with an integer value, strictly positive.
-        /// </summary>
-        internal const string AppSecTraceRateLimit = "DD_APPSEC_TRACE_RATE_LIMIT";
-
-        /// <summary>
-        /// WAF timeout in microseconds of each WAF execution (the timeout value passed to ddwaf_run).
-        /// </summary>
-        internal const string AppSecWafTimeout = "DD_APPSEC_WAF_TIMEOUT";
-
-        /// <summary>
         /// Configuration key for enabling or disabling the Tracer's debug mode.
         /// Default is value is false (disabled).
         /// </summary>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecRules, DefaultRuleFile);
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -101,12 +101,12 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecRules, DefaultRuleFile);
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             if (traceRateLimit.HasValue)
             {
-                SetEnvironmentVariable(ConfigurationKeys.AppSecTraceRateLimit, _traceRateLimit.ToString());
+                SetEnvironmentVariable(ConfigurationKeys.AppSec.TraceRateLimit, _traceRateLimit.ToString());
             }
 
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base("WebApi", output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecRules, DefaultRuleFile);
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base("WebForms", output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecRules, DefaultRuleFile);
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         private static SecuritySettings CreateTestTarget(string stringToBeParsed)
         {
-            var config = new NameValueCollection() { { ConfigurationKeys.AppSecWafTimeout, stringToBeParsed } };
+            var config = new NameValueCollection() { { ConfigurationKeys.AppSec.WafTimeout, stringToBeParsed } };
 
             var target = new SecuritySettings(new NameValueConfigurationSource(config));
             return target;

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -252,12 +252,12 @@ namespace Datadog.Trace.TestHelpers
 
             if (enableSecurity)
             {
-                environmentVariables[ConfigurationKeys.AppSecEnabled] = enableSecurity.ToString();
+                environmentVariables[ConfigurationKeys.AppSec.Enabled] = enableSecurity.ToString();
             }
 
             if (!string.IsNullOrEmpty(externalRulesFile))
             {
-                environmentVariables[ConfigurationKeys.AppSecRules] = externalRulesFile;
+                environmentVariables[ConfigurationKeys.AppSec.Rules] = externalRulesFile;
             }
 
             foreach (var name in new[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -424,7 +424,7 @@ namespace Datadog.Trace.TestHelpers
 
         protected void SetSecurity(bool security)
         {
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecEnabled, security ? "true" : "false");
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Enabled, security ? "true" : "false");
         }
 
         protected void EnableDirectLogSubmission(int intakePort, string integrationName, string host = "integration_tests")

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), ServiceName, EmptyAasSettings);
             var source = new NameValueConfigurationSource(new NameValueCollection
             {
-                { ConfigurationKeys.AppSecEnabled, enabled.ToString() },
+                { ConfigurationKeys.AppSec.Enabled, enabled.ToString() },
             });
             collector.RecordSecuritySettings(new SecuritySettings(source));
 


### PR DESCRIPTION
## Summary of changes

Regroups app sec config keys in their own file, for improved readability.

## Reason for change

Request from @andrewlock 

