### PR TITLE
[Profiler] Do not export empty profiles

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -74,7 +74,7 @@ private:
 
     ddprof_ffi_Request* CreateRequest(SerializedProfile const& encodedProfile, ddprof_ffi_ProfileExporterV3* exporter) const;
     ddprof_ffi_EndpointV3 CreateEndpoint(IConfiguration* configuration);
-    ddprof_ffi_Profile* GetProfile(std::string_view runtimeId);
+    std::pair<ddprof_ffi_Profile*, std::int32_t>& GetProfileAndSamplesCount(std::string_view runtimeId);
 
 
     void ExportToDisk(const std::string& applicationName, SerializedProfile const& encodedProfile, int idx);
@@ -100,7 +100,7 @@ private:
     std::vector<ddprof_ffi_Line> _lines;
     std::string _agentUrl;
     std::size_t _locationsAndLinesSize;
-    std::unordered_map<std::string_view, ddprof_ffi_Profile*> _profilePerApplication;
+    std::unordered_map<std::string_view, std::pair<ddprof_ffi_Profile*, std::int32_t>> _profilePerApplication;
     ddprof_ffi_EndpointV3 _endpoint;
     Tags _exporterBaseTags;
     IApplicationStore* const _applicationStore;


### PR DESCRIPTION
## Summary of changes

## Reason for change

When running on IIS, we can end up in a situation where no thread is running in an AppDomain, so no callstack will be collected for this AppDomain/Application.
But still, every minute we send one profile per application to the back-end and we have empty profiles in the dashboard.

## Implementation details

Keep the count of samples added to each profile. Check that count to decide if the profile has to be sent or not.

## Test coverage

Adding unit test.

## Other details
This is a simple implementation. A refactoring is needed and will be done after the 2nd beta release.

<!-- Fixes #{issue} -->
