### PR TITLE
Allows our pipeline to be monitored

### DIFF
--- a/.azure-pipelines/monitoring.yml
+++ b/.azure-pipelines/monitoring.yml
@@ -1,0 +1,24 @@
+# app-ci YAML pipeline
+# We are setting up a pipeline resource that references the security-lib-ci
+# pipeline and setting up a pipeline completion trigger so that our app-ci
+# pipeline runs when a run of the security-lib-ci pipeline completes
+resources:
+  pipelines:
+  - pipeline: consolidated-pipeline # Name of the pipeline resource.
+    source: consolidated-pipeline # The name of the pipeline referenced by this pipeline resource.
+    trigger: true # Run when any run of consolidated-pipeline completes
+
+steps:
+- bash: echo $(resources.pipeline.consolidated-pipeline.runID)
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    command: build
+    workingDirectory: 'tracer/tools/PipelineMonitor'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run monitoring'
+  inputs:
+    command: run
+    workingDirectory: 'tracer/tools/PipelineMonitor'
+    arguments: '$(resources.pipeline.consolidated-pipeline.runID)'

--- a/.azure-pipelines/monitoring.yml
+++ b/.azure-pipelines/monitoring.yml
@@ -1,7 +1,4 @@
-# app-ci YAML pipeline
-# We are setting up a pipeline resource that references the security-lib-ci
-# pipeline and setting up a pipeline completion trigger so that our app-ci
-# pipeline runs when a run of the security-lib-ci pipeline completes
+
 resources:
   pipelines:
   - pipeline: consolidated-pipeline # Name of the pipeline resource.

--- a/.azure-pipelines/monitoring.yml
+++ b/.azure-pipelines/monitoring.yml
@@ -1,21 +1,19 @@
+trigger: none
+pr: none
 
 resources:
   pipelines:
-  - pipeline: consolidated-pipeline # Name of the pipeline resource.
-    source: consolidated-pipeline # The name of the pipeline referenced by this pipeline resource.
+  - pipeline: consolidated-pipeline
+    source: consolidated-pipeline
     trigger: true # Run when any run of consolidated-pipeline completes
 
 steps:
-- bash: echo $(resources.pipeline.consolidated-pipeline.runID)
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    command: build
-    workingDirectory: 'tracer/tools/PipelineMonitor'
 
-- task: DotNetCoreCLI@2
-  displayName: 'Run monitoring'
-  inputs:
-    command: run
-    workingDirectory: 'tracer/tools/PipelineMonitor'
-    arguments: '$(resources.pipeline.consolidated-pipeline.runID)'
+- bash: dotnet build
+  displayName: "Build"
+  workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
+    
+
+- bash: dotnet run $(resources.pipeline.consolidated-pipeline.runID)
+  displayName: "Run"
+  workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -131,7 +131,7 @@ partial class Build
 
                 foreach(var label in config.Labels)
                 {
-                    try 
+                    try
                     {
                         if (!string.IsNullOrEmpty(label.Title))
                         {
@@ -326,6 +326,7 @@ partial class Build
                 "tracer/src/Datadog.Trace/Datadog.Trace.csproj",
                 "tracer/src/Datadog.Trace/TracerConstants.cs",
                 "tracer/test/test-applications/regression/AutomapperTest/Dockerfile",
+                "tracer/tools/PipelineMonitor/PipelineMonitor.csproj",
             };
 
             if (ExpectChangelogUpdate)
@@ -743,7 +744,7 @@ partial class Build
 
             Console.WriteLine("::set-output name=artifacts_link::" + resourceDownloadUrl);
             Console.WriteLine("::set-output name=artifacts_path::" + OutputDirectory / artifact.Name);
-            
+
             await DownloadGitlabArtifacts(OutputDirectory, commitSha, FullVersion);
             Console.WriteLine("::set-output name=gitlab_artifacts_path::" + OutputDirectory / commitSha);
         });
@@ -1033,10 +1034,10 @@ partial class Build
     static async Task DownloadGitlabArtifacts(AbsolutePath outputDirectory, string commitSha, string version)
     {
         var awsUri = $"https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/{commitSha}/";
-        var artifactsFiles= new [] 
+        var artifactsFiles= new []
         {
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi",
-            $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi", 
+            $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi",
             $"{awsUri}windows-native-symbols.zip",
             $"{awsUri}windows-tracer-home.zip",
         };

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -189,6 +189,10 @@ namespace PrepareRelease
                 "../shared/src/msi-installer/WindowsInstaller.wixproj",
                 WixProjReplace);
 
+            SynchronizeVersion(
+                "tools/PipelineMonitor/PipelineMonitor.csproj",
+                DatadogTraceNugetDependencyVersionReplace);
+
             Console.WriteLine($"Completed synchronizing versions to {VersionString()}");
         }
 

--- a/tracer/tools/PipelineMonitor/Build.cs
+++ b/tracer/tools/PipelineMonitor/Build.cs
@@ -1,0 +1,52 @@
+namespace PipelineMonitor
+{
+    public class Build
+    {
+        public int Id;
+        public string BuildNumber { get; set; }
+        public string Status { get; set; }
+        public string Result { get; set; }
+        public DateTime? QueueTime { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? FinishTime { get; set; }
+        public string Url { get; set; }
+        public Definition Definition { get; set; }
+        public string SourceBranch { get; set; }
+        public string SourceVersion { get; set; }
+        public string Priority { get; set; }
+        public string Reason { get; set; }
+        public Links _Links { get; set; }
+
+        public TriggerInfo TriggerInfo { get; set; }
+    }
+
+    public class TriggerInfo
+    {
+        public string PrSourceBranch { get; set; }
+        public string PrSourceSha { get; set; }
+        public string PrId { get; set; }
+        public string PrTitle { get; set; }
+        public string PrNumber { get; set; }
+        public string PrIsFork { get; set; }
+        public string PrDraft { get; set; }
+        public string PrSenderName { get; set; }
+        public string PrSenderAvatarUrl { get; set; }
+        public string PrSenderIsExternal { get; set; }
+        public string PrAutoCancel { get; set; }
+    }
+
+    public class Links
+    {
+        public Link Timeline { get; set; }
+        public Link Web { get; set; }
+    }
+
+    public class Link
+    {
+        public string Href { get; set; }
+    }
+    public class Definition
+    {
+        public string Name { get; set; }
+    }
+}

--- a/tracer/tools/PipelineMonitor/BuildProcessor.cs
+++ b/tracer/tools/PipelineMonitor/BuildProcessor.cs
@@ -1,0 +1,165 @@
+﻿using Datadog.Trace;
+using Datadog.Trace.ExtensionMethods;
+
+namespace PipelineMonitor;
+
+public class BuildProcessor
+{
+    private Build _build;
+    private TimelineData _timeline;
+    private TimeSpan _offset;
+    private List<Record> _rootStages = new();
+    private Dictionary<Guid, List<Record>> _recordsPerParentId = new();
+
+    public BuildProcessor(Build build, TimelineData timeline)
+    {
+        _build = build;
+        _timeline = timeline;
+    }
+
+    public void Process()
+    {
+        if (_build.Status != "completed")
+            return;
+
+        if (!_build.StartTime.HasValue || !_build.FinishTime.HasValue)
+            return;
+
+        var startTime = _build.StartTime;
+        var endTime = _build.FinishTime;
+
+        if (!startTime.HasValue || !endTime.HasValue)
+        {
+            Console.WriteLine("only finished spans will be taken into account");
+            return;
+        }
+
+        CalculateOffset(endTime.Value);
+
+        var settings = new SpanCreationSettings() { StartTime = startTime + _offset};
+
+        using var scope = Tracer.Instance.StartActive("ci-run", settings);
+        DecorateRootSpan(scope);
+
+        GetRootStages(_timeline);
+        foreach (var stage in _rootStages)
+        {
+            if (stage.Result != "skipped")
+                SendTraces(scope, stage);
+        }
+
+        scope.Span.Finish(endTime.Value + _offset);
+    }
+
+    // avoid any issue at intake level, so move all the times to a more recent one
+    void CalculateOffset(DateTime endTime)
+    {
+        _offset = DateTime.UtcNow - endTime - TimeSpan.FromSeconds(30);
+    }
+
+    void DecorateRootSpan(IScope scope)
+    {
+        scope.Span.ServiceName = _build.Definition.Name;
+        scope.Span.ResourceName = GetResourceName();
+        if (_build.Result != "succeeded")
+            scope.Span.Error = true;
+
+        scope.Span.SetTag("azdo.Id", _build.Id.ToString());
+        scope.Span.SetTag("azdo.BuildNumber", _build.BuildNumber);
+        scope.Span.SetTag("azdo.Status", _build.Status);
+        scope.Span.SetTag("azdo.Result", _build.Result);
+        scope.Span.SetTag("azdo.QueueTime", _build.QueueTime.ToString());
+        scope.Span.SetTag("azdo.StartTime", _build.StartTime.ToString());
+        scope.Span.SetTag("azdo.FinishTime", _build.FinishTime.ToString());
+        scope.Span.SetTag("azdo.url.api", _build.Url);
+        scope.Span.SetTag("azdo.url.web", _build._Links.Web.Href);
+        scope.Span.SetTag("azdo.Pipeline", _build.Definition.Name);
+        scope.Span.SetTag("azdo.SourceBranch", _build.SourceBranch);
+        scope.Span.SetTag("azdo.SourceVersion", _build.SourceVersion);
+        scope.Span.SetTag("azdo.Priority", _build.Priority);
+        scope.Span.SetTag("azdo.Reason", _build.Reason);
+
+        scope.Span.SetTag("pr.title", _build.TriggerInfo.PrTitle);
+        scope.Span.SetTag("pr.number", _build.TriggerInfo.PrNumber);
+        scope.Span.SetTag("pr.isfork", _build.TriggerInfo.PrIsFork);
+        scope.Span.SetTag("pr.draft", _build.TriggerInfo.PrDraft);
+        scope.Span.SetTag("pr.sender.name", _build.TriggerInfo.PrSenderName);
+        scope.Span.SetTag("pr.sender.AvatarUrl", _build.TriggerInfo.PrSenderAvatarUrl);
+        scope.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+    }
+
+    void GetRootStages(TimelineData buildData)
+    {
+        foreach (var record in buildData.Records)
+        {
+            if (record.ParentId is null)
+            {
+                _rootStages.Add(record);
+            }
+            else
+            {
+                if (!_recordsPerParentId.ContainsKey(record.ParentId.Value))
+                    _recordsPerParentId.Add(record.ParentId.Value, new List<Record>());
+
+                _recordsPerParentId[record.ParentId.Value].Add(record);
+            }
+        }
+
+        _rootStages.Sort((@r1, @r2) => r1.StartTime < r2.StartTime ? -1 : 1);
+    }
+
+    void SendTraces(IScope parent, Record node, string serviceName = "")
+    {
+        var startTime = node.StartTime + _offset;
+        var endTime = node.FinishTime + _offset;
+
+        if (!startTime.HasValue || !endTime.HasValue)
+        {
+            Console.WriteLine("only finished spans will be taken into account");
+            return;
+        }
+
+        var settings = new SpanCreationSettings() { Parent = parent.Span.Context, StartTime = startTime };
+
+        using var scope = Tracer.Instance.StartActive(node.Name, settings);
+        if (node.IsStage)
+            serviceName = node.Name;
+
+        if (!string.IsNullOrEmpty(serviceName))
+            scope.Span.ServiceName = serviceName;
+
+        scope.Span.ResourceName = GetResourceName();
+
+        scope.Span.SetTag("azdo.type", node.Type);
+        scope.Span.SetTag("azdo.name", node.Name);
+        scope.Span.SetTag("azdo.state", node.State);
+        scope.Span.SetTag("azdo.percentcomplete", node.PercentComplete.ToString());
+        scope.Span.SetTag("azdo.workername", node.WorkerName);
+        scope.Span.SetTag("azdo.errorcount", node.ErrorCount.ToString());
+        scope.Span.SetTag("azdo.logurl", node.Log?.Url?.ToString());
+        scope.Span.SetTag("azdo.atempt", node.Attempt.ToString());
+
+        if (node.Result == "failed")
+            scope.Span.Error = true;
+
+        if (_recordsPerParentId.ContainsKey(node.Id))
+        {
+            var children = _recordsPerParentId[node.Id];
+            children.Sort((@r1, @r2) => r1.StartTime < r2.StartTime ? -1 : 1);
+
+            foreach (var childRecord in children)
+            {
+                if (childRecord.ShouldBeTraced)
+                    SendTraces(scope, childRecord, serviceName);
+            }
+        }
+
+        scope.Span.Finish(endTime.Value);
+    }
+
+    private string GetResourceName()
+    {   
+        return _build.SourceBranch;
+    }
+
+}

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Datadog.Trace" Version="2.6.0" />
+    </ItemGroup>
+
+</Project>

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.sln
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineMonitor", "PipelineMonitor.csproj", "{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\..\..\build\_build.csproj", "{D477398F-D4A3-4142-BE68-C6EE2C039D22}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D477398F-D4A3-4142-BE68-C6EE2C039D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D477398F-D4A3-4142-BE68-C6EE2C039D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.sln
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.sln
@@ -2,16 +2,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PipelineMonitor", "PipelineMonitor.csproj", "{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\..\..\build\_build.csproj", "{D477398F-D4A3-4142-BE68-C6EE2C039D22}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D477398F-D4A3-4142-BE68-C6EE2C039D22}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D477398F-D4A3-4142-BE68-C6EE2C039D22}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EA9CCCA0-063B-4DD0-B4F6-3F589B44CB05}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/tracer/tools/PipelineMonitor/Program.cs
+++ b/tracer/tools/PipelineMonitor/Program.cs
@@ -1,0 +1,71 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using System.Diagnostics;
+using System.Text.Json;
+using Datadog.Trace;
+using Datadog.Trace.Configuration;
+using PipelineMonitor;
+
+const string azDoApi = "https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/";
+var _cli = new HttpClient();
+
+var tracerSettings = new TracerSettings {Environment = "apm-dotnet-pipeline-monitoring", GlobalSamplingRate = 100};
+Tracer.Configure(tracerSettings);
+
+if (args?.Length == 0)
+{
+    Console.WriteLine("please provide a buildid");
+    return;
+}
+
+var buildId = args[0];
+Console.WriteLine("Processing pipeline: " + buildId);
+Build? buildData;
+TimelineData? timeline;
+
+try
+{
+    var json = await _cli.GetStringAsync(azDoApi + buildId);
+    buildData = JsonSerializer.Deserialize<Build>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+    if (buildData is null || string.IsNullOrEmpty(buildData._Links.Timeline.Href))
+    {
+        Console.WriteLine("Timeline url not found");
+        return;
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine("An error occured getting build data. Build Url: {0}", azDoApi + buildId);
+    Console.WriteLine("Exception: {0}", ex);
+    return;
+}
+
+try
+{
+    var jsonTimeline = await _cli.GetStringAsync(buildData._Links.Timeline.Href);
+    timeline = JsonSerializer.Deserialize<TimelineData>(jsonTimeline, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+    if (timeline is null)
+    {
+        Console.WriteLine("Timeline data hasn't been deserialized");
+        return;
+    }
+}
+catch (Exception ex)
+{
+    Console.WriteLine("An error occured getting timeline data. Timeline Url: {0}", buildData._Links.Timeline.Href);
+    Console.WriteLine("Exception: {0}", ex);
+    return;
+}
+
+try
+{
+    var processor = new BuildProcessor(buildData, timeline);
+    processor.Process();
+    Console.WriteLine("Build " + buildId + " has been processed successfully. It should be visible at: https://ddstaging.datadoghq.com/apm/services/consolidated-pipeline/operations/ci_run/resources");
+}
+catch (Exception ex)
+{
+    Console.WriteLine("an error occured while processing the pipeline. Ex: {0}", ex);
+}

--- a/tracer/tools/PipelineMonitor/Properties/launchSettings.json
+++ b/tracer/tools/PipelineMonitor/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "PipelineMonitor": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "DD_TRACE_DEBUG": "true"
+      },
+      "commandLineArgs": "97098B"
+    }
+  }
+} 

--- a/tracer/tools/PipelineMonitor/Properties/launchSettings.json
+++ b/tracer/tools/PipelineMonitor/Properties/launchSettings.json
@@ -4,13 +4,7 @@
     "PipelineMonitor": {
       "commandName": "Project",
       "environmentVariables": {
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
-        "CORECLR_ENABLE_PROFILING": "1",
-        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "DD_TRACE_DEBUG": "true"
-      },
-      "commandLineArgs": "97098B"
+      }
     }
   }
-} 
+}

--- a/tracer/tools/PipelineMonitor/Timeline.cs
+++ b/tracer/tools/PipelineMonitor/Timeline.cs
@@ -1,0 +1,64 @@
+namespace PipelineMonitor
+{
+    public class TimelineData
+    {
+        public string LastChangedBy { get; set; }
+        public DateTime LastChangedOn { get; set; }
+        public Guid Id { get; set; }
+        public int ChangeId { get; set; }
+        public Uri Url { get; set; }
+        public List<Record> Records { get; set; }
+    }
+
+    public class Record
+    {
+        private object PreviousAttempts { get; set; }
+        public Guid Id { get; set; }
+        public Guid? ParentId { get; set; }
+        public string Type { get; set; }
+        public string Name { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? FinishTime { get; set; }
+        public string CurrentOperation { get; set; }
+        public int? PercentComplete { get; set; }
+        public string State { get; set; }
+        public string Result { get; set; }
+        public string ResultCode { get; set; }
+        public int ChangeId { get; set; }
+        public DateTime? LastModified { get; set; }
+        public string WorkerName { get; set; }
+        public string Details { get; set; }
+        public int ErrorCount { get; set; }
+        public int WarningCount { get; set; }
+        public string Url { get; set; }
+        public Log Log { get; set; }
+        public Task Task { get; set; }
+        public int Attempt { get; set; }
+        public string Identifier { get; set; }
+
+        public bool IsStage
+        {
+            get => Type == "Stage";
+        }
+
+        public bool ShouldBeTraced
+        {
+            get => Result != "skipped" && Type != "Checkpoint";
+        }
+    }
+
+    public class Log
+    {
+        public int Id { get; set; }
+        public string Type { get; set; }
+        public Uri Url { get; set; }
+    }
+
+    public class Task
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Version { get; set; }
+    }
+
+}


### PR DESCRIPTION
## Summary of changes
Added a CLI tool that call AzDo api to get the timeline of a build and then creates a flamegraph in DD here: https://ddstaging.datadoghq.com/apm/services/consolidated-pipeline/operations/ci_run/resources

This tool is ran in a dedicated pipeline that is triggered on consolidated-pipeline completion

## Reason for change
To be able to better monitor our builds

## Test coverage
Tested locally and the pipeline has been tested on a fork.

## Other details
Jira AIT-379
 