### PR TITLE
Add scope property to UserDetails

### DIFF
--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -56,6 +56,11 @@ namespace Datadog.Trace
             {
                 localRootSpan.SetTag(Tags.User.Role, userDetails.Role);
             }
+
+            if (userDetails.Scope is not null)
+            {
+                localRootSpan.SetTag(Tags.User.Scope, userDetails.Scope);
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -486,6 +486,7 @@ namespace Datadog.Trace
             internal const string Id = "usr.id";
             internal const string SessionId = "usr.session_id";
             internal const string Role = "usr.role";
+            internal const string Scope = "usr.scope";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/UserDetails.cs
+++ b/tracer/src/Datadog.Trace/UserDetails.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace
             Name = null;
             SessionId = null;
             Role = null;
+            Scope = null;
         }
 
         /// <summary>
@@ -55,5 +56,10 @@ namespace Datadog.Trace
         /// Gets or sets the role associated with the user
         /// </summary>
         public string? Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scopes or granted authorities the client currently possesses extracted from token or application security context
+        /// </summary>
+        public string? Scope { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
@@ -326,6 +326,7 @@ namespace Datadog.Trace
         public string Id { get; set; }
         public string? Name { get; set; }
         public string? Role { get; set; }
+        public string? Scope { get; set; }
         public string? SessionId { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -546,6 +546,7 @@ namespace Datadog.Trace.Tests
             var id = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var role = "admin";
+            var scope = "read:message, write:files";
 
             var userDetails = new UserDetails()
             {
@@ -554,6 +555,7 @@ namespace Datadog.Trace.Tests
                 Id = id,
                 SessionId = sessionId,
                 Role = role,
+                Scope = scope,
             };
             tracer.ActiveScope?.Span.SetUser(userDetails);
 
@@ -562,6 +564,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(id, rootTestScope.Span.GetTag(Tags.User.Id));
             Assert.Equal(sessionId, rootTestScope.Span.GetTag(Tags.User.SessionId));
             Assert.Equal(role, rootTestScope.Span.GetTag(Tags.User.Role));
+            Assert.Equal(scope, rootTestScope.Span.GetTag(Tags.User.Scope));
         }
 
         [Fact]
@@ -583,6 +586,7 @@ namespace Datadog.Trace.Tests
             var id = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var role = "admin";
+            var scope = "read:message, write:files";
 
             var userDetails = new UserDetails()
             {
@@ -591,6 +595,7 @@ namespace Datadog.Trace.Tests
                 Id = id,
                 SessionId = sessionId,
                 Role = role,
+                Scope = scope,
             };
             tracer.ActiveScope?.Span.SetUser(userDetails);
 
@@ -601,6 +606,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(id, rootTestScope.Span.GetTag(Tags.User.Id));
             Assert.Equal(sessionId, rootTestScope.Span.GetTag(Tags.User.SessionId));
             Assert.Equal(role, rootTestScope.Span.GetTag(Tags.User.Role));
+            Assert.Equal(scope, rootTestScope.Span.GetTag(Tags.User.Scope));
         }
 
         [Fact]
@@ -613,6 +619,7 @@ namespace Datadog.Trace.Tests
             var id = Guid.NewGuid().ToString();
             var sessionId = Guid.NewGuid().ToString();
             var role = "admin";
+            var scope = "read:message, write:files";
 
             var userDetails = new UserDetails()
             {
@@ -621,6 +628,7 @@ namespace Datadog.Trace.Tests
                 Id = id,
                 SessionId = sessionId,
                 Role = role,
+                Scope = scope,
             };
             testSpan.SetUser(userDetails);
 
@@ -629,6 +637,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(id, testSpan.GetTag(Tags.User.Id));
             Assert.Equal(sessionId, testSpan.GetTag(Tags.User.SessionId));
             Assert.Equal(role, testSpan.GetTag(Tags.User.Role));
+            Assert.Equal(scope, testSpan.GetTag(Tags.User.Scope));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Add `scope` tag to `UserDetails` object.

## Reason for change

Overlooked this property in #2546.