### PR TITLE
Make running integration tests on OSx great again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,6 +333,15 @@ tracer/src/Datadog.Trace.ClrProfiler.Native/Makefile
 tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeCache.txt
 tracer/src/Datadog.Trace.ClrProfiler.Native/cmake_install.cmake
 !tracer/src/Datadog.Trace.ClrProfiler.Native/lib/**
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/build/
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/deps/
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeFiles/
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/tmp.*
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/Makefile
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeCache.txt
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/cmake_install.cmake
+tracer/src/Datadog.AutoInstrumentation.NativeLoader/cmake-build-debug/
+!tracer/src/Datadog.AutoInstrumentation.NativeLoader/lib/**
 profiler/_build/
 
 .ionide/

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -102,7 +102,10 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 .\build.sh PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-.\build.sh BuildAndRunIntegrationTests
+.\build.sh BuildAndRunLinuxIntegrationTests
+
+# Build and run integration tests filtering on one framework, one set of tests and a sample app.
+.\build.sh BuildAndRunLinuxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
 ```
 
 ## Additional Technical Documentation

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeLists.txt
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeLists.txt
@@ -167,6 +167,7 @@ add_library("Datadog.AutoInstrumentation.NativeLoader" SHARED
         dllmain.cpp
         dynamic_dispatcher.cpp
         dynamic_instance.cpp
+        runtimeid_store.cpp
         ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-src/miniutf.cpp
         ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/pal/prebuilt/idl/corprof_i.cpp
         ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-src/string.cpp

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
@@ -643,14 +643,14 @@ namespace datadog::shared::nativeloader
         RunInAllProfilers(ExceptionSearchCatcherFound(functionId));
     }
 
-    HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerEnter(UINT_PTR __unused)
+    HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerEnter(UINT_PTR unused_variable)
     {
-        RunInAllProfilers(ExceptionOSHandlerEnter(__unused));
+        RunInAllProfilers(ExceptionOSHandlerEnter(unused_variable));
     }
 
-    HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerLeave(UINT_PTR __unused)
+    HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionOSHandlerLeave(UINT_PTR unused_variable)
     {
-        RunInAllProfilers(ExceptionOSHandlerLeave(__unused));
+        RunInAllProfilers(ExceptionOSHandlerLeave(unused_variable));
     }
 
     HRESULT STDMETHODCALLTYPE CorProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace.TestHelpers
                 ("win", "X86")     => "Datadog.AutoInstrumentation.NativeLoader.x86.dll",
                 ("linux", "X64")   => "Datadog.AutoInstrumentation.NativeLoader.so",
                 ("linux", "Arm64") => "Datadog.AutoInstrumentation.NativeLoader.so",
-                ("osx", _)         => throw new PlatformNotSupportedException("The Native Loader is not yet supported on osx"),
+                ("osx", _)         => "Datadog.AutoInstrumentation.NativeLoader.dylib",
                 _ => throw new PlatformNotSupportedException()
             };
 


### PR DESCRIPTION
## Summary of changes
Allow running linux ITests locally on Mac, ie build nativeloader on this OS.

## Reason for change
I have a Mac

## Implementation details
Made a few changes for the native loader to build in MacOs (some variables renaming and declaring runtimeid_store definition). Thank you @gleocadie for the help ;) 
Made a few modifications in the build process and EnvironmentHelper.

## Test coverage
Tested locally 
