### PR TITLE
Add tests for extension methods with DD_TRACE_METHODS

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -80,8 +80,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var ddTraceMethodsString = string.Empty;
             foreach (var type in TestTypes)
             {
-                ddTraceMethodsString += $";{type}[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]";
+                ddTraceMethodsString += $";{type}[*,get_Name]";
             }
+
+            ddTraceMethodsString += ";Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]";
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);
 

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -218,8 +218,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_17,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -232,8 +232,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Name: overridden.attribute,
+    Resource: set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -358,6 +358,20 @@
   {
     TraceId: Id_1,
     SpanId: Id_27,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
     Name: overridden.attribute,
     Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations,
@@ -371,23 +385,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_28,
-    Name: trace.annotation,
-    Resource: get_Name,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_29,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -401,160 +401,6 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_31,
-    Name: trace.annotation,
-    Resource: ReturnValueMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_32,
-    Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_33,
-    Name: trace.annotation,
-    Resource: ReturnNullMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_34,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_35,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_36,
-    Name: trace.annotation,
-    Resource: ReturnTaskMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_37,
-    Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_38,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_39,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_40,
-    Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
-    Service: Samples.TraceAnnotations,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_41,
-    Name: trace.annotation,
     Resource: get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
@@ -567,7 +413,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_42,
+    SpanId: Id_31,
     Name: overridden.attribute,
     Resource: set_Name,
     Service: Samples.TraceAnnotations,
@@ -581,9 +427,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_43,
+    SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStruct_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -595,7 +441,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_44,
+    SpanId: Id_33,
     Name: trace.annotation,
     Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations,
@@ -609,7 +455,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_45,
+    SpanId: Id_34,
     Name: trace.annotation,
     Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
@@ -623,7 +469,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_46,
+    SpanId: Id_35,
     Name: trace.annotation,
     Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations,
@@ -637,7 +483,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_47,
+    SpanId: Id_36,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
@@ -651,7 +497,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_48,
+    SpanId: Id_37,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
@@ -665,7 +511,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_49,
+    SpanId: Id_38,
     Name: trace.annotation,
     Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
@@ -679,7 +525,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_50,
+    SpanId: Id_39,
     Name: trace.annotation,
     Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
@@ -693,7 +539,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_51,
+    SpanId: Id_40,
     Name: trace.annotation,
     Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
@@ -707,7 +553,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_52,
+    SpanId: Id_41,
     Name: trace.annotation,
     Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
@@ -721,9 +567,163 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_53,
+    SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: get_Name,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: overridden.attribute,
+    Resource: set_Name,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: trace.annotation,
+    Resource: TestTypeStatic_VoidMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: trace.annotation,
+    Resource: ReturnValueMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: trace.annotation,
+    Resource: ReturnReferenceMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: trace.annotation,
+    Resource: ReturnNullMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -764,6 +764,48 @@
   {
     TraceId: Id_1,
     SpanId: Id_56,
+    Name: overridden.attribute,
+    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: trace.annotation,
+    Resource: set_Method,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: trace.annotation,
+    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
     Name: overridden.attribute,
     Resource: Program_WaitUsingOfficialAttribute,
     Service: Samples.TraceAnnotations,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -218,8 +218,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_17,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -232,8 +232,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Name: overridden.attribute,
+    Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -358,6 +358,20 @@
   {
     TraceId: Id_1,
     SpanId: Id_27,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
     Name: overridden.attribute,
     Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -371,23 +385,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_28,
-    Name: trace.annotation,
-    Resource: get_Name,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_29,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,160 +401,6 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_31,
-    Name: trace.annotation,
-    Resource: ReturnValueMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_32,
-    Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_33,
-    Name: trace.annotation,
-    Resource: ReturnNullMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_34,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_35,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_36,
-    Name: trace.annotation,
-    Resource: ReturnTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_37,
-    Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_38,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_39,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_40,
-    Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
-    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_41,
-    Name: trace.annotation,
     Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
@@ -567,7 +413,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_42,
+    SpanId: Id_31,
     Name: overridden.attribute,
     Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -581,9 +427,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_43,
+    SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStruct_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -595,7 +441,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_44,
+    SpanId: Id_33,
     Name: trace.annotation,
     Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -609,7 +455,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_45,
+    SpanId: Id_34,
     Name: trace.annotation,
     Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -623,7 +469,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_46,
+    SpanId: Id_35,
     Name: trace.annotation,
     Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -637,7 +483,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_47,
+    SpanId: Id_36,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -651,7 +497,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_48,
+    SpanId: Id_37,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -665,7 +511,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_49,
+    SpanId: Id_38,
     Name: trace.annotation,
     Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -679,7 +525,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_50,
+    SpanId: Id_39,
     Name: trace.annotation,
     Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -693,7 +539,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_51,
+    SpanId: Id_40,
     Name: trace.annotation,
     Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -707,7 +553,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_52,
+    SpanId: Id_41,
     Name: trace.annotation,
     Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
@@ -721,9 +567,163 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_53,
+    SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: get_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: overridden.attribute,
+    Resource: set_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: trace.annotation,
+    Resource: TestTypeStatic_VoidMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: trace.annotation,
+    Resource: ReturnValueMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: trace.annotation,
+    Resource: ReturnReferenceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: trace.annotation,
+    Resource: ReturnNullMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -764,6 +764,48 @@
   {
     TraceId: Id_1,
     SpanId: Id_56,
+    Name: overridden.attribute,
+    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: trace.annotation,
+    Resource: set_Method,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: trace.annotation,
+    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
     Name: overridden.attribute,
     Resource: Program_WaitUsingOfficialAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -218,8 +218,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_17,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -232,8 +232,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Name: overridden.attribute,
+    Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -358,6 +358,20 @@
   {
     TraceId: Id_1,
     SpanId: Id_27,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
     Name: overridden.attribute,
     Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -371,23 +385,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_28,
-    Name: trace.annotation,
-    Resource: get_Name,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_29,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,160 +401,6 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_31,
-    Name: trace.annotation,
-    Resource: ReturnValueMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_32,
-    Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_33,
-    Name: trace.annotation,
-    Resource: ReturnNullMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_34,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_35,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_36,
-    Name: trace.annotation,
-    Resource: ReturnTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_37,
-    Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_38,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_39,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_40,
-    Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
-    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_41,
-    Name: trace.annotation,
     Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
@@ -567,7 +413,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_42,
+    SpanId: Id_31,
     Name: overridden.attribute,
     Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -581,9 +427,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_43,
+    SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStruct_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -595,7 +441,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_44,
+    SpanId: Id_33,
     Name: trace.annotation,
     Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -609,7 +455,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_45,
+    SpanId: Id_34,
     Name: trace.annotation,
     Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -623,7 +469,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_46,
+    SpanId: Id_35,
     Name: trace.annotation,
     Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -637,7 +483,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_47,
+    SpanId: Id_36,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -651,7 +497,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_48,
+    SpanId: Id_37,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -665,7 +511,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_49,
+    SpanId: Id_38,
     Name: trace.annotation,
     Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -679,7 +525,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_50,
+    SpanId: Id_39,
     Name: trace.annotation,
     Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -693,7 +539,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_51,
+    SpanId: Id_40,
     Name: trace.annotation,
     Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -707,7 +553,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_52,
+    SpanId: Id_41,
     Name: trace.annotation,
     Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
@@ -721,9 +567,163 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_53,
+    SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: get_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: overridden.attribute,
+    Resource: set_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: trace.annotation,
+    Resource: TestTypeStatic_VoidMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: trace.annotation,
+    Resource: ReturnValueMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: trace.annotation,
+    Resource: ReturnReferenceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: trace.annotation,
+    Resource: ReturnNullMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -764,6 +764,48 @@
   {
     TraceId: Id_1,
     SpanId: Id_56,
+    Name: overridden.attribute,
+    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: trace.annotation,
+    Resource: set_Method,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: trace.annotation,
+    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
     Name: overridden.attribute,
     Resource: Program_WaitUsingOfficialAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -218,8 +218,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_17,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -232,8 +232,8 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Name: overridden.attribute,
+    Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -358,6 +358,20 @@
   {
     TraceId: Id_1,
     SpanId: Id_27,
+    Name: trace.annotation,
+    Resource: ReturnValueTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
     Name: overridden.attribute,
     Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -371,23 +385,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_28,
-    Name: trace.annotation,
-    Resource: get_Name,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
     SpanId: Id_29,
-    Name: overridden.attribute,
-    Resource: set_Name,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -401,160 +401,6 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_31,
-    Name: trace.annotation,
-    Resource: ReturnValueMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_32,
-    Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_33,
-    Name: trace.annotation,
-    Resource: ReturnNullMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_34,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_35,
-    Name: trace.annotation,
-    Resource: ReturnGenericMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_36,
-    Name: trace.annotation,
-    Resource: ReturnTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_37,
-    Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_38,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_39,
-    Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_40,
-    Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
-    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
-    ParentId: Id_2,
-    Tags: {
-      component: trace,
-      env: integration_tests,
-      language: dotnet,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_41,
-    Name: trace.annotation,
     Resource: get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
@@ -567,7 +413,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_42,
+    SpanId: Id_31,
     Name: overridden.attribute,
     Resource: set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -581,9 +427,9 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_43,
+    SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStruct_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -595,7 +441,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_44,
+    SpanId: Id_33,
     Name: trace.annotation,
     Resource: ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -609,7 +455,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_45,
+    SpanId: Id_34,
     Name: trace.annotation,
     Resource: ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -623,7 +469,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_46,
+    SpanId: Id_35,
     Name: trace.annotation,
     Resource: ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -637,7 +483,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_47,
+    SpanId: Id_36,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -651,7 +497,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_48,
+    SpanId: Id_37,
     Name: trace.annotation,
     Resource: ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -665,7 +511,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_49,
+    SpanId: Id_38,
     Name: trace.annotation,
     Resource: ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -679,7 +525,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_50,
+    SpanId: Id_39,
     Name: trace.annotation,
     Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -693,7 +539,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_51,
+    SpanId: Id_40,
     Name: trace.annotation,
     Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -707,7 +553,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_52,
+    SpanId: Id_41,
     Name: trace.annotation,
     Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
@@ -721,9 +567,163 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_53,
+    SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: trace.annotation,
+    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: trace.annotation,
+    Resource: get_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: overridden.attribute,
+    Resource: set_Name,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: trace.annotation,
+    Resource: TestTypeStatic_VoidMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: trace.annotation,
+    Resource: ReturnValueMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: trace.annotation,
+    Resource: ReturnReferenceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: trace.annotation,
+    Resource: ReturnNullMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: trace.annotation,
+    Resource: ReturnGenericMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: trace.annotation,
+    Resource: ReturnTaskMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: trace.annotation,
+    Resource: ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Resource: ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -764,6 +764,48 @@
   {
     TraceId: Id_1,
     SpanId: Id_56,
+    Name: overridden.attribute,
+    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: trace.annotation,
+    Resource: set_Method,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: trace.annotation,
+    Resource: UninstrumentedType_ReturnTaskTMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
     Name: overridden.attribute,
     Resource: Program_WaitUsingOfficialAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
         "DD_VERSION": "1.0.0",
-        "DD_TRACE_METHODS": "Samples.TraceAnnotations.ProgramHelpers[RunTestsAsync];Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
+        "DD_TRACE_METHODS": "Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]"
       },
       "nativeDebugging": true
     }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -28,6 +28,7 @@ namespace Samples.TraceAnnotations
             await testType.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testType.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             testType.ReturnGenericMethodAttribute<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2));
+            testType.ExtensionMethodForTestType();
             testType.Finalize(0);
 
             // Release the reference to testType
@@ -54,6 +55,7 @@ namespace Samples.TraceAnnotations
             await testTypeGenericString.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testTypeGenericString.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             testTypeGenericString.ReturnGenericMethodAttribute<string, Tuple<int, int>>("Hello World", 42, Tuple.Create(1, 2));
+            testTypeGenericString.ExtensionMethodForTestTypeGeneric();
             testTypeGenericString.Finalize(0);
 
             // Release the reference to testTypeGenericString
@@ -80,6 +82,7 @@ namespace Samples.TraceAnnotations
             await testTypeStruct.ReturnValueTaskMethod("Hello world", 42, Tuple.Create(1, 2));
             await testTypeStruct.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             testTypeStruct.ReturnGenericMethodAttribute<string, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2));
+            testTypeStruct.ExtensionMethodForTestTypeTypeStruct();
 
             // Do not try to invoke finalizer for struct as it does not have a finalizer
             await Task.Delay(500);

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
           "DD_VERSION": "1.0.0",
-          "DD_TRACE_METHODS": "Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];System.Net.Http.HttpRequestMessage[set_Method]"
+          "DD_TRACE_METHODS": "Samples.TraceAnnotations.TestTypeGeneric`1[*,get_Name];Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
@@ -142,6 +142,13 @@ namespace Samples.TraceAnnotations
         public static T ReturnGenericMethodAttribute<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
 
+    static class ExtensionMethods
+    {
+        public static void ExtensionMethodForTestType(this TestType testType) { }
+        public static void ExtensionMethodForTestTypeGeneric<T>(this TestTypeGeneric<T> testTypeGeneric) { }
+        public static void ExtensionMethodForTestTypeTypeStruct(this TestTypeStruct testTypeStruct) { }
+    }
+
     static class AttributeOnlyStatic
     {
         [Trace(ResourceName = "UninstrumentedType_ReturnTaskTMethod")]


### PR DESCRIPTION
## Summary of changes
Adds extension methods to the `Samples.TraceAnnotations` to ensure compatibility with extension methods

## Reason for change

## Implementation details

## Test coverage
Adds new extension methods to the `Samples.TraceAnnotations` application, adds the methods to the DD_TRACE_METHODS configuration, and invokes them.

## Other details
<!-- Fixes #{issue} -->
