### PR TITLE
[dnlib] Enable THREAD_SAFE preprocessor constant

### DIFF
--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -113,4 +113,10 @@
     <DefineConstants>$(DefineConstants);NAMED_PIPE_AVAILABLE</DefineConstants>
   </PropertyGroup>
 
+  <!--dnlib-->
+  <!--Enable thread safe support for vendored dnlib library -->
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);THREAD_SAFE</DefineConstants>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
## Summary of changes
Modification of the `Datadog.Trace` project to add the `THREAD_SAFE` constant.

## Reason for change
We are getting errors in a class using `dnlib` related to multithreading issue: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=97033&view=logs&j=6db5a8ca-3dd0-58a1-e82d-eea5a6ffe077&t=c968783e-a99c-5f66-c39d-422239603e51

![image](https://user-images.githubusercontent.com/69803/164754322-633bf9c0-f901-4b3d-bd67-53d914d72163.png)

## Implementation details
`dnlib` enables thread safety by project configuration, this PR adds the `THREAD_SAFE`  constant to the Datadog.Trace project.
