### PR TITLE
Normalize DogStatsD client service name with Trace Agent logic

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Processors;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
@@ -159,7 +160,7 @@ namespace Datadog.Trace
                                        $"lang_interpreter:{FrameworkDescription.Instance.Name}",
                                        $"lang_version:{FrameworkDescription.Instance.ProductVersion}",
                                        $"tracer_version:{TracerConstants.AssemblyVersion}",
-                                       $"service:{serviceName}",
+                                       $"service:{NormalizerTraceProcessor.NormalizeService(serviceName)}",
                                        $"{Tags.RuntimeId}:{Tracer.RuntimeId}"
                                    };
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private void RunTest()
         {
-            var inputServiceName = "123_$#Samples.$RuntimeMetrics";
+            var inputServiceName = "12_$#Samples.$RuntimeMetrics";
             var normalizedServiceName = "samples._runtimemetrics";
             SetEnvironmentVariable("DD_SERVICE", inputServiceName);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "1");
@@ -74,12 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Assert.True(exceptionRequestsCount > 0, "No exception metrics received. Metrics received: " + string.Join("\n", requests));
 
             // Assert service, env, and version
-            foreach (var request in requests)
-            {
-                requests.Should().OnlyContain(s => s.Contains($"service:{normalizedServiceName}"));
-                requests.Should().OnlyContain(s => s.Contains("env:integration_tests"));
-                requests.Should().OnlyContain(s => s.Contains("version:1.0.0"));
-            }
+            requests.Should().OnlyContain(s => s.Contains($"service:{normalizedServiceName}"));
+            requests.Should().OnlyContain(s => s.Contains("env:integration_tests"));
+            requests.Should().OnlyContain(s => s.Contains("version:1.0.0"));
 
             // Check if .NET Framework or .NET Core 3.1+
             if (!EnvironmentHelper.IsCoreClr()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public RuntimeMetricsTests(ITestOutputHelper output)
             : base("RuntimeMetrics", output)
         {
+            SetServiceVersion("1.0.0");
         }
 
         [SkippableFact]
@@ -55,6 +57,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private void RunTest()
         {
+            var inputServiceName = "123_$#Samples.$RuntimeMetrics";
+            var normalizedServiceName = "samples._runtimemetrics";
+            SetEnvironmentVariable("DD_SERVICE", inputServiceName);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "1");
             using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
             using var processResult = RunSampleAndWaitForExit(agent);
@@ -67,6 +72,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var exceptionRequestsCount = requests.Count(r => r.Contains("runtime.dotnet.exceptions.count"));
 
             Assert.True(exceptionRequestsCount > 0, "No exception metrics received. Metrics received: " + string.Join("\n", requests));
+
+            // Assert service, env, and version
+            foreach (var request in requests)
+            {
+                requests.Should().OnlyContain(s => s.Contains($"service:{normalizedServiceName}"));
+                requests.Should().OnlyContain(s => s.Contains("env:integration_tests"));
+                requests.Should().OnlyContain(s => s.Contains("version:1.0.0"));
+            }
 
             // Check if .NET Framework or .NET Core 3.1+
             if (!EnvironmentHelper.IsCoreClr()


### PR DESCRIPTION
## Summary of changes
Adds service name normalization when creating the DogStatsD client for runtime metrics and tracer health metrics

## Reason for change
The Trace Agent normalizes the service name but DogStatsD does not. This results in uncorrelated services in the UI when the service name had "invalid" characters that required replacement.

## Implementation details

## Test coverage
Updates the RuntimeMetricsTests E2E test to set the service name to one that requires modification during the normalization process and asserts that the new service name appears in the metrics. Also asserts the env, and version tags

Note: I couldn't find a simple way to unit test this without doing reflection and forcing the test to know a lot of internal behaviors. This integration test tests the real-world scenario by testing the final metrics that left the process, so I think this is sufficient.

## Other details
AIT-391 
