### PR TITLE
Update default resource name for TraceAnnotationsIntegration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationInfoFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationInfoFactory.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations
             }
             else
             {
+                string defaultResourceName = method.DeclaringType is null ? method.Name : method.DeclaringType!.Name + "." + method.Name;
                 var attributes = method.GetCustomAttributes(true);
                 foreach (var attr in attributes)
                 {
@@ -31,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations
                     {
                         try
                         {
-                            string resourceName = attrType.GetProperty("ResourceName")?.GetValue(attr) as string ?? method.Name;
+                            string resourceName = attrType.GetProperty("ResourceName")?.GetValue(attr) as string ?? defaultResourceName;
                             string operationName = attrType.GetProperty("OperationName")?.GetValue(attr) as string ?? TraceAnnotationInfo.DefaultOperationName;
                             return new TraceAnnotationInfo(resourceName, operationName);
                         }
@@ -42,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations
                     }
                 }
 
-                return new TraceAnnotationInfo(resourceName: method.Name, operationName: TraceAnnotationInfo.DefaultOperationName);
+                return new TraceAnnotationInfo(resourceName: defaultResourceName, operationName: TraceAnnotationInfo.DefaultOperationName);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationInfoFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationInfoFactory.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations
             }
             else
             {
-                string defaultResourceName = method.DeclaringType is null ? method.Name : method.DeclaringType!.Name + "." + method.Name;
+                string defaultResourceName = method.DeclaringType is null ? method.Name : method.DeclaringType.Name + "." + method.Name;
                 var attributes = method.GetCustomAttributes(true);
                 foreach (var attr in attributes)
                 {

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
@@ -3,7 +3,7 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: trace.annotation,
-    Resource: RunTestsAsync,
+    Resource: ProgramHelpers.RunTestsAsync,
     Service: Samples.TraceAnnotations,
     Tags: {
       component: trace,
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestType.get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: TestType_VoidMethod,
+    Resource: TestType_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestType.ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestType.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -93,7 +93,7 @@
     TraceId: Id_1,
     SpanId: Id_8,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestType.ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestType.ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestType.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestType.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestType.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: overridden.attribute,
-    Resource: TestType_ReturnGenericMethodAttribute,
+    Resource: TestType_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestType,
+    Resource: ExtensionMethods.ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeGeneric`1.get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Resource: TestTypeGeneric_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric`1.ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeGeneric`1.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeGeneric`1.ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeGeneric`1.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: overridden.attribute,
-    Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
+    Resource: TestTypeGeneric_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeGeneric,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStruct.get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
+    Resource: TestTypeStruct_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStruct.ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStruct.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStruct.ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStruct.ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStruct.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStruct.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStruct.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -569,7 +569,7 @@
     TraceId: Id_1,
     SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -583,7 +583,7 @@
     TraceId: Id_1,
     SpanId: Id_43,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeTypeStruct,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -597,7 +597,7 @@
     TraceId: Id_1,
     SpanId: Id_44,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStatic.get_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -611,7 +611,7 @@
     TraceId: Id_1,
     SpanId: Id_45,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -625,7 +625,7 @@
     TraceId: Id_1,
     SpanId: Id_46,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStatic_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -639,7 +639,7 @@
     TraceId: Id_1,
     SpanId: Id_47,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStatic.ReturnValueMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -653,7 +653,7 @@
     TraceId: Id_1,
     SpanId: Id_48,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStatic.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -667,7 +667,7 @@
     TraceId: Id_1,
     SpanId: Id_49,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStatic.ReturnNullMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -681,7 +681,7 @@
     TraceId: Id_1,
     SpanId: Id_50,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -695,7 +695,7 @@
     TraceId: Id_1,
     SpanId: Id_51,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -709,7 +709,7 @@
     TraceId: Id_1,
     SpanId: Id_52,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStatic.ReturnTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -723,7 +723,7 @@
     TraceId: Id_1,
     SpanId: Id_53,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStatic.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStatic.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStatic.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -765,7 +765,7 @@
     TraceId: Id_1,
     SpanId: Id_56,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStatic_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {
@@ -779,7 +779,7 @@
     TraceId: Id_1,
     SpanId: Id_57,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: HttpRequestMessage.set_Method,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
@@ -36,7 +36,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
@@ -232,7 +232,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
@@ -414,7 +414,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_31,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,
@@ -610,7 +610,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_45,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations,
     ParentId: Id_2,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
@@ -3,7 +3,7 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: trace.annotation,
-    Resource: RunTestsAsync,
+    Resource: ProgramHelpers.RunTestsAsync,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     Tags: {
       component: trace,
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestType.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: TestType_VoidMethod,
+    Resource: TestType_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestType.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestType.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -93,7 +93,7 @@
     TraceId: Id_1,
     SpanId: Id_8,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestType.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestType.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestType.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestType.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestType.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: overridden.attribute,
-    Resource: TestType_ReturnGenericMethodAttribute,
+    Resource: TestType_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestType,
+    Resource: ExtensionMethods.ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeGeneric`1.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Resource: TestTypeGeneric_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric`1.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeGeneric`1.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeGeneric`1.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeGeneric`1.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: overridden.attribute,
-    Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
+    Resource: TestTypeGeneric_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeGeneric,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStruct.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
+    Resource: TestTypeStruct_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStruct.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStruct.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStruct.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStruct.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStruct.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStruct.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStruct.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -569,7 +569,7 @@
     TraceId: Id_1,
     SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -583,7 +583,7 @@
     TraceId: Id_1,
     SpanId: Id_43,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeTypeStruct,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -597,7 +597,7 @@
     TraceId: Id_1,
     SpanId: Id_44,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStatic.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -611,7 +611,7 @@
     TraceId: Id_1,
     SpanId: Id_45,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -625,7 +625,7 @@
     TraceId: Id_1,
     SpanId: Id_46,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStatic_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -639,7 +639,7 @@
     TraceId: Id_1,
     SpanId: Id_47,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStatic.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -653,7 +653,7 @@
     TraceId: Id_1,
     SpanId: Id_48,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStatic.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -667,7 +667,7 @@
     TraceId: Id_1,
     SpanId: Id_49,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStatic.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -681,7 +681,7 @@
     TraceId: Id_1,
     SpanId: Id_50,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -695,7 +695,7 @@
     TraceId: Id_1,
     SpanId: Id_51,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -709,7 +709,7 @@
     TraceId: Id_1,
     SpanId: Id_52,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStatic.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -723,7 +723,7 @@
     TraceId: Id_1,
     SpanId: Id_53,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStatic.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStatic.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStatic.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -765,7 +765,7 @@
     TraceId: Id_1,
     SpanId: Id_56,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStatic_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {
@@ -779,7 +779,7 @@
     TraceId: Id_1,
     SpanId: Id_57,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: HttpRequestMessage.set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
@@ -36,7 +36,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
@@ -232,7 +232,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
@@ -414,7 +414,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_31,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,
@@ -610,7 +610,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_45,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
     ParentId: Id_2,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
@@ -36,7 +36,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
@@ -232,7 +232,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
@@ -414,7 +414,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_31,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
@@ -610,7 +610,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_45,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
@@ -3,7 +3,7 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: trace.annotation,
-    Resource: RunTestsAsync,
+    Resource: ProgramHelpers.RunTestsAsync,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     Tags: {
       component: trace,
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestType.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: TestType_VoidMethod,
+    Resource: TestType_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestType.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestType.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -93,7 +93,7 @@
     TraceId: Id_1,
     SpanId: Id_8,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestType.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestType.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestType.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestType.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestType.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: overridden.attribute,
-    Resource: TestType_ReturnGenericMethodAttribute,
+    Resource: TestType_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestType,
+    Resource: ExtensionMethods.ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeGeneric`1.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Resource: TestTypeGeneric_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric`1.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeGeneric`1.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeGeneric`1.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeGeneric`1.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: overridden.attribute,
-    Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
+    Resource: TestTypeGeneric_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeGeneric,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStruct.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
+    Resource: TestTypeStruct_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStruct.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStruct.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStruct.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStruct.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStruct.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStruct.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStruct.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -569,7 +569,7 @@
     TraceId: Id_1,
     SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -583,7 +583,7 @@
     TraceId: Id_1,
     SpanId: Id_43,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeTypeStruct,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -597,7 +597,7 @@
     TraceId: Id_1,
     SpanId: Id_44,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStatic.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -611,7 +611,7 @@
     TraceId: Id_1,
     SpanId: Id_45,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -625,7 +625,7 @@
     TraceId: Id_1,
     SpanId: Id_46,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStatic_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -639,7 +639,7 @@
     TraceId: Id_1,
     SpanId: Id_47,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStatic.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -653,7 +653,7 @@
     TraceId: Id_1,
     SpanId: Id_48,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStatic.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -667,7 +667,7 @@
     TraceId: Id_1,
     SpanId: Id_49,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStatic.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -681,7 +681,7 @@
     TraceId: Id_1,
     SpanId: Id_50,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -695,7 +695,7 @@
     TraceId: Id_1,
     SpanId: Id_51,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -709,7 +709,7 @@
     TraceId: Id_1,
     SpanId: Id_52,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStatic.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -723,7 +723,7 @@
     TraceId: Id_1,
     SpanId: Id_53,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStatic.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStatic.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStatic.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -765,7 +765,7 @@
     TraceId: Id_1,
     SpanId: Id_56,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStatic_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {
@@ -779,7 +779,7 @@
     TraceId: Id_1,
     SpanId: Id_57,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: HttpRequestMessage.set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
@@ -3,7 +3,7 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: trace.annotation,
-    Resource: RunTestsAsync,
+    Resource: ProgramHelpers.RunTestsAsync,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     Tags: {
       component: trace,
@@ -23,7 +23,7 @@
     TraceId: Id_1,
     SpanId: Id_3,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestType.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -37,7 +37,7 @@
     TraceId: Id_1,
     SpanId: Id_4,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -51,7 +51,7 @@
     TraceId: Id_1,
     SpanId: Id_5,
     Name: trace.annotation,
-    Resource: TestType_VoidMethod,
+    Resource: TestType_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -65,7 +65,7 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestType.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -79,7 +79,7 @@
     TraceId: Id_1,
     SpanId: Id_7,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestType.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -93,7 +93,7 @@
     TraceId: Id_1,
     SpanId: Id_8,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestType.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -107,7 +107,7 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -121,7 +121,7 @@
     TraceId: Id_1,
     SpanId: Id_10,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestType.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -135,7 +135,7 @@
     TraceId: Id_1,
     SpanId: Id_11,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestType.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -149,7 +149,7 @@
     TraceId: Id_1,
     SpanId: Id_12,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestType.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -163,7 +163,7 @@
     TraceId: Id_1,
     SpanId: Id_13,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestType.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -177,7 +177,7 @@
     TraceId: Id_1,
     SpanId: Id_14,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestType.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -191,7 +191,7 @@
     TraceId: Id_1,
     SpanId: Id_15,
     Name: overridden.attribute,
-    Resource: TestType_ReturnGenericMethodAttribute,
+    Resource: TestType_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -205,7 +205,7 @@
     TraceId: Id_1,
     SpanId: Id_16,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestType,
+    Resource: ExtensionMethods.ExtensionMethodForTestType,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -219,7 +219,7 @@
     TraceId: Id_1,
     SpanId: Id_17,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeGeneric`1.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -233,7 +233,7 @@
     TraceId: Id_1,
     SpanId: Id_18,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -247,7 +247,7 @@
     TraceId: Id_1,
     SpanId: Id_19,
     Name: trace.annotation,
-    Resource: TestTypeGeneric_VoidMethod,
+    Resource: TestTypeGeneric_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -261,7 +261,7 @@
     TraceId: Id_1,
     SpanId: Id_20,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeGeneric`1.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -275,7 +275,7 @@
     TraceId: Id_1,
     SpanId: Id_21,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeGeneric`1.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -289,7 +289,7 @@
     TraceId: Id_1,
     SpanId: Id_22,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeGeneric`1.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -303,7 +303,7 @@
     TraceId: Id_1,
     SpanId: Id_23,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeGeneric`1.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -317,7 +317,7 @@
     TraceId: Id_1,
     SpanId: Id_24,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -331,7 +331,7 @@
     TraceId: Id_1,
     SpanId: Id_25,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -345,7 +345,7 @@
     TraceId: Id_1,
     SpanId: Id_26,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -359,7 +359,7 @@
     TraceId: Id_1,
     SpanId: Id_27,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeGeneric`1.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -373,7 +373,7 @@
     TraceId: Id_1,
     SpanId: Id_28,
     Name: overridden.attribute,
-    Resource: TestTypeGeneric_ReturnGenericMethodAttribute,
+    Resource: TestTypeGeneric_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -387,7 +387,7 @@
     TraceId: Id_1,
     SpanId: Id_29,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeGeneric,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeGeneric,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -401,7 +401,7 @@
     TraceId: Id_1,
     SpanId: Id_30,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStruct.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -415,7 +415,7 @@
     TraceId: Id_1,
     SpanId: Id_31,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -429,7 +429,7 @@
     TraceId: Id_1,
     SpanId: Id_32,
     Name: trace.annotation,
-    Resource: TestTypeStruct_VoidMethod,
+    Resource: TestTypeStruct_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -443,7 +443,7 @@
     TraceId: Id_1,
     SpanId: Id_33,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStruct.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -457,7 +457,7 @@
     TraceId: Id_1,
     SpanId: Id_34,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStruct.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -471,7 +471,7 @@
     TraceId: Id_1,
     SpanId: Id_35,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStruct.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -485,7 +485,7 @@
     TraceId: Id_1,
     SpanId: Id_36,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -499,7 +499,7 @@
     TraceId: Id_1,
     SpanId: Id_37,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStruct.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -513,7 +513,7 @@
     TraceId: Id_1,
     SpanId: Id_38,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStruct.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -527,7 +527,7 @@
     TraceId: Id_1,
     SpanId: Id_39,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStruct.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -541,7 +541,7 @@
     TraceId: Id_1,
     SpanId: Id_40,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStruct.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -555,7 +555,7 @@
     TraceId: Id_1,
     SpanId: Id_41,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStruct.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -569,7 +569,7 @@
     TraceId: Id_1,
     SpanId: Id_42,
     Name: overridden.attribute,
-    Resource: TestTypeStruct_ReturnGenericMethodAttribute,
+    Resource: TestTypeStruct_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -583,7 +583,7 @@
     TraceId: Id_1,
     SpanId: Id_43,
     Name: trace.annotation,
-    Resource: ExtensionMethodForTestTypeTypeStruct,
+    Resource: ExtensionMethods.ExtensionMethodForTestTypeTypeStruct,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -597,7 +597,7 @@
     TraceId: Id_1,
     SpanId: Id_44,
     Name: trace.annotation,
-    Resource: get_Name,
+    Resource: TestTypeStatic.get_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -611,7 +611,7 @@
     TraceId: Id_1,
     SpanId: Id_45,
     Name: overridden.attribute,
-    Resource: set_Name,
+    Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -625,7 +625,7 @@
     TraceId: Id_1,
     SpanId: Id_46,
     Name: trace.annotation,
-    Resource: TestTypeStatic_VoidMethod,
+    Resource: TestTypeStatic_ResourceNameOverride_VoidMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -639,7 +639,7 @@
     TraceId: Id_1,
     SpanId: Id_47,
     Name: trace.annotation,
-    Resource: ReturnValueMethod,
+    Resource: TestTypeStatic.ReturnValueMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -653,7 +653,7 @@
     TraceId: Id_1,
     SpanId: Id_48,
     Name: trace.annotation,
-    Resource: ReturnReferenceMethod,
+    Resource: TestTypeStatic.ReturnReferenceMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -667,7 +667,7 @@
     TraceId: Id_1,
     SpanId: Id_49,
     Name: trace.annotation,
-    Resource: ReturnNullMethod,
+    Resource: TestTypeStatic.ReturnNullMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -681,7 +681,7 @@
     TraceId: Id_1,
     SpanId: Id_50,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -695,7 +695,7 @@
     TraceId: Id_1,
     SpanId: Id_51,
     Name: trace.annotation,
-    Resource: ReturnGenericMethod,
+    Resource: TestTypeStatic.ReturnGenericMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -709,7 +709,7 @@
     TraceId: Id_1,
     SpanId: Id_52,
     Name: trace.annotation,
-    Resource: ReturnTaskMethod,
+    Resource: TestTypeStatic.ReturnTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -723,7 +723,7 @@
     TraceId: Id_1,
     SpanId: Id_53,
     Name: trace.annotation,
-    Resource: ReturnTaskTMethod,
+    Resource: TestTypeStatic.ReturnTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -737,7 +737,7 @@
     TraceId: Id_1,
     SpanId: Id_54,
     Name: trace.annotation,
-    Resource: ReturnValueTaskMethod,
+    Resource: TestTypeStatic.ReturnValueTaskMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -751,7 +751,7 @@
     TraceId: Id_1,
     SpanId: Id_55,
     Name: trace.annotation,
-    Resource: ReturnValueTaskTMethod,
+    Resource: TestTypeStatic.ReturnValueTaskTMethod,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -765,7 +765,7 @@
     TraceId: Id_1,
     SpanId: Id_56,
     Name: overridden.attribute,
-    Resource: TestTypeStatic_ReturnGenericMethodAttribute,
+    Resource: TestTypeStatic_ResourceNameOverride_ReturnGenericMethodAttribute,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {
@@ -779,7 +779,7 @@
     TraceId: Id_1,
     SpanId: Id_57,
     Name: trace.annotation,
-    Resource: set_Method,
+    Resource: HttpRequestMessage.set_Method,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
     Tags: {

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
@@ -36,7 +36,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestType.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
@@ -232,7 +232,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_18,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeGeneric`1.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
@@ -414,7 +414,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_31,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStruct.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,
@@ -610,7 +610,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_45,
-    Name: overridden.attribute,
+    Name: trace.annotation,
     Resource: TestTypeStatic.set_Name,
     Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
     ParentId: Id_2,

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Samples.TraceAnnotations.VersionMismatch.NewerNuGet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Samples.TraceAnnotations.VersionMismatch.NewerNuGet.csproj
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="255.1.1-dev2.7.0-build01-ddtracemethods" />
+    <PackageReference Include="Datadog.Trace" Version="255.1.1-dev2.8.0-build01-ddtracemethods" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
@@ -31,7 +31,7 @@ namespace Samples.TraceAnnotations
             // Non-finalizer code
         }
 
-        [Trace(ResourceName = "TestType_VoidMethod")]
+        [Trace(ResourceName = "TestType_ResourceNameOverride_VoidMethod")]
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg, int arg21, object arg3) => "Hello World";
@@ -42,7 +42,7 @@ namespace Samples.TraceAnnotations
         public ValueTask ReturnValueTaskMethod(string arg1, int arg2, object arg3) => new ValueTask(Task.Delay(100));
         public ValueTask<bool> ReturnValueTaskTMethod(string arg1, int arg2, object arg3) => new ValueTask<bool>(true);
 
-        [Trace(OperationName = "overridden.attribute", ResourceName = "TestType_ReturnGenericMethodAttribute")]
+        [Trace(OperationName = "overridden.attribute", ResourceName = "TestType_ResourceNameOverride_ReturnGenericMethodAttribute")]
         public T ReturnGenericMethodAttribute<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
     class TestTypeGeneric<T>
@@ -73,7 +73,7 @@ namespace Samples.TraceAnnotations
             // Non-finalizer code
         }
 
-        [Trace(ResourceName = "TestTypeGeneric_VoidMethod")]
+        [Trace(ResourceName = "TestTypeGeneric_ResourceNameOverride_VoidMethod")]
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
@@ -84,7 +84,7 @@ namespace Samples.TraceAnnotations
         public ValueTask ReturnValueTaskMethod(string arg1, int arg2, object arg3) => new ValueTask(Task.Delay(100));
         public ValueTask<bool> ReturnValueTaskTMethod(string arg1, int arg2, object arg3) => new ValueTask<bool>(true);
 
-        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeGeneric_ReturnGenericMethodAttribute")]
+        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeGeneric_ResourceNameOverride_ReturnGenericMethodAttribute")]
         public T ReturnGenericMethodAttribute<TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
     struct TestTypeStruct
@@ -108,7 +108,7 @@ namespace Samples.TraceAnnotations
             return this.Name == other.Name;
         }
 
-        [Trace(ResourceName = "TestTypeStruct_VoidMethod")]
+        [Trace(ResourceName = "TestTypeStruct_ResourceNameOverride_VoidMethod")]
         public void VoidMethod(string arg1, int arg2, object arg3) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
@@ -119,7 +119,7 @@ namespace Samples.TraceAnnotations
         public ValueTask ReturnValueTaskMethod(string arg1, int arg2, object arg3) => new ValueTask(Task.Delay(100));
         public ValueTask<bool> ReturnValueTaskTMethod(string arg1, int arg2, object arg3) => new ValueTask<bool>(true);
 
-        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeStruct_ReturnGenericMethodAttribute")]
+        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeStruct_ResourceNameOverride_ReturnGenericMethodAttribute")]
         public T ReturnGenericMethodAttribute<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
     static class TestTypeStatic
@@ -127,7 +127,7 @@ namespace Samples.TraceAnnotations
         static TestTypeStatic() { }
         public static string Name { get; [Trace(OperationName = "overridden.attribute")] set; }
 
-        [Trace(ResourceName = "TestTypeStatic_VoidMethod")]
+        [Trace(ResourceName = "TestTypeStatic_ResourceNameOverride_VoidMethod")]
         public static void VoidMethod(string arg1, int arg2, object arg3) { }
         public static int ReturnValueMethod(string arg1, int arg2, object arg3) => 42;
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
@@ -138,7 +138,7 @@ namespace Samples.TraceAnnotations
         public static ValueTask ReturnValueTaskMethod(string arg1, int arg2, object arg3) => new ValueTask(Task.Delay(100));
         public static ValueTask<bool> ReturnValueTaskTMethod(string arg1, int arg2, object arg3) => new ValueTask<bool>(true);
 
-        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeStatic_ReturnGenericMethodAttribute")]
+        [Trace(OperationName = "overridden.attribute", ResourceName = "TestTypeStatic_ResourceNameOverride_ReturnGenericMethodAttribute")]
         public static T ReturnGenericMethodAttribute<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
 

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/TestType.cs
@@ -7,7 +7,7 @@ namespace Samples.TraceAnnotations
     {
         static TestType() { }
         public TestType() { }
-        public string Name { get; [Trace(OperationName = "overridden.attribute")] set; }
+        public string Name { get; [Trace] set; }
         public override string ToString() => Name;
         public override int GetHashCode()
         {
@@ -49,7 +49,7 @@ namespace Samples.TraceAnnotations
     {
         static TestTypeGeneric() { }
         public TestTypeGeneric() { }
-        public string Name { get; [Trace(OperationName = "overridden.attribute")] set; }
+        public string Name { get; [Trace] set; }
         public override string ToString() => Name;
         public override int GetHashCode()
         {
@@ -92,7 +92,7 @@ namespace Samples.TraceAnnotations
         private string _name;
         static TestTypeStruct() { }
         public TestTypeStruct() { _name = null; }
-        public string Name { get => _name; [Trace(OperationName = "overridden.attribute")] set => _name = value; }
+        public string Name { get => _name; [Trace] set => _name = value; }
         public override string ToString() => Name;
         public override int GetHashCode()
         {
@@ -125,7 +125,7 @@ namespace Samples.TraceAnnotations
     static class TestTypeStatic
     {
         static TestTypeStatic() { }
-        public static string Name { get; [Trace(OperationName = "overridden.attribute")] set; }
+        public static string Name { get; [Trace] set; }
 
         [Trace(ResourceName = "TestTypeStatic_ResourceNameOverride_VoidMethod")]
         public static void VoidMethod(string arg1, int arg2, object arg3) { }


### PR DESCRIPTION
## Summary of changes
The default resource name is being updated from `<METHOD_NAME>` to `<TYPE_NAME>.<METHOD_NAME>`. This occurs When `[Trace]` does not specify a `ResourceName` property or a method is instrumented via `DD_TRACE_METHODS`.

## Reason for change
Specifying both the type name and method name is what the Java tracer does and it is more descriptive, so users can more easily filter the operations by resource name.

## Implementation details
The type name is populated by the method's `DeclaringType` (as opposed to the `ReflectedType`). This seemed to me like the better choice between the two since it may be more stable and more descriptive of the original base class or interface, but this choice is up for debate.

## Test coverage
Update test snapshots for Samples.TraceAnnotations application and update `[Trace]` resource name overrides so they're easier to spot.

## Other details
N/A
