### PR TITLE
[Release] Trigger AAS release automatically

### DIFF
--- a/.github/workflows/auto-trigger-aas-release.yml
+++ b/.github/workflows/auto-trigger-aas-release.yml
@@ -1,0 +1,18 @@
+name: Auto trigger AAS version bump
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger_aas_release:
+    runs-on: ubuntu-latest
+
+    steps:        
+      - name: Trigger AAS release
+        run: |
+          curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+          https://api.github.com/repos/pierotibou/datadog-aas-extension/dispatches \
+          -d '{"event_type": "dd-trace-dotnet-release", "client_payload": {"is_prerelease":"${{github.event.release.prerelease}}", "version":"${{github.event.release.tag_name}}" } }'


### PR DESCRIPTION
## Summary of changes
On release publication, triggers a repository dispatch event to trigger the release creation on aas repo.
This works in pair with this PR in ass repo.

## Reason for change
Removing one manual step in the release workflow

## Implementation details
On trigger, calls github api to dispatch the repo event onto datadog-aas-extension repo.
Added a GH token as we need repo rights. 

## Test coverage
On a fork. Note that the release trigger never worked on my fork strangely (I've tested with a push trigger). I hope it will work here cause I don't see what could be the issue.

## Other details
AIT-389
