### PR TITLE
If we kill the process in our GraphQL tests on Linux, raise a `SkipException`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -147,9 +147,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     if (!process.WaitForExit(5000))
                     {
                         Output.WriteLine("The process didn't exit in time. Taking proc dump and killing it.");
-                        await TakeMemoryDump(process);
+                        var memoryDumpCaptured = await TakeMemoryDump(process);
 
                         process.Kill();
+
+                        if (!memoryDumpCaptured)
+                        {
+                            // if we don't have a memory dump, there's no point continuing.
+                            // We know the test will likely fail (telemetry not sent) but it's
+                            // not useful to know that, as we don't have a memory dump
+                            throw new SkipException("The process didn't exit in time but memory dump couldn't be captured");
+                        }
                     }
                 }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -136,13 +136,13 @@ namespace Datadog.Trace.TestHelpers
                 processToProfile: executable);
         }
 
-        public async Task TakeMemoryDump(Process process)
+        public async Task<bool> TakeMemoryDump(Process process)
         {
             // We don't know if procdump is available, so download it fresh
             if (!EnvironmentTools.IsWindows())
             {
                 Output.WriteLine("Not running on windows, skipping memory dump");
-                return;
+                return false;
             }
 
             try
@@ -200,10 +200,12 @@ namespace Datadog.Trace.TestHelpers
                 }
 
                 Output.WriteLine($"Memory dump captured using '{procDump} {args}'");
+                return true;
             }
             catch (Exception ex)
             {
                 Output.WriteLine("Error taking memory dump: " + ex);
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary of changes

- When we can't take a memory dump, throw a `SkipException` to reduce flakiness

## Reason for change

We have a flaky condition in the GraphQL tests we've been trying to diagnose. The app isn't shutting down as expected, and so we are having to force kill it. When this happens, telemetry is not sent, and so the tests fail.

On Windows, when this occurs, we take a memory dump. We haven't implemented this for Linux yet, so we were previously continuing to throw. Given this is still a source of flakiness, and we don't gain anything by _knowing_ it's failed on Linux, this PR changes to skip the test immediately. 

This is hopefully a temporary fix, while we wait to capture a memory dump and to fix the root cause.

## Implementation details

If the process is killed, and we _don't_ capture a memory dump, throw a `SkipException`
