### PR TITLE
[Pipeline Monitoring] Works better with an agent

### DIFF
--- a/.azure-pipelines/monitoring.yml
+++ b/.azure-pipelines/monitoring.yml
@@ -1,19 +1,38 @@
 trigger: none
 pr: none
 
+variables:
+  ddApiKey: $(DD_API_KEY)
+
 resources:
   pipelines:
   - pipeline: consolidated-pipeline
     source: consolidated-pipeline
     trigger: true # Run when any run of consolidated-pipeline completes
 
+  containers:
+  - container: dd_agent
+    image: datadog/agent
+    ports:
+    - 8126:8126
+    env:
+      DD_API_KEY: $(ddApiKey)
+      DD_INSIDE_CI: true
+
+# Enable the Datadog Agent service for this job
+services:
+  dd_agent: dd_agent
+
 steps:
 
 - bash: dotnet build
   displayName: "Build"
   workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
-    
+
 
 - bash: dotnet run $(resources.pipeline.consolidated-pipeline.runID)
   displayName: "Run"
   workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
+
+- bash: sleep 20
+  displayName: Wait 20 seconds to agent flush before finishing pipeline

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -9,14 +9,16 @@ trigger:
       - refs/tags/*
   paths:
     exclude:
+      - .azure-pipelines/noop-pipeline.yml
+      - .azure-pipelines/monitoring.yml
+      - .github/
       - docs/
       - tracer/README.MD
-      - .github/
       - tracer/dependabot/
+      - tracer/tools/PipelineMonitor
       - LICENSE
       - LICENSE-3rdparty.csv
       - NOTICE
-      - .azure-pipelines/noop-pipeline.yml
       - .vsconfig
 # The following is a list of shared asset locations.
 # This is the config for the Tracer CI pipeline,
@@ -52,20 +54,22 @@ pr:
       - '*' # default
   paths:
     exclude:
-      - tracer/dependabot/
+      - .azure-pipelines/noop-pipeline.yml
+      - .azure-pipelines/monitoring.yml
+      - .github/
+      - .gitlab-ci.yml
       - blog/
       - docs/
+      - tracer/dependabot/
       - tracer/README.MD
       - tracer/src/Datadog.Trace/DuckTyping/README.md
       - tracer/samples
-      - .github/
+      - tracer/build/_build/Build.GitHub.cs
+      - tracer/build/_build/Build.Gitlab.cs
+      - tracer/tools/PipelineMonitor
       - LICENSE
       - LICENSE-3rdparty.csv
       - NOTICE
-      - .gitlab-ci.yml
-      - tracer/build/_build/Build.GitHub.cs
-      - tracer/build/_build/Build.Gitlab.cs
-      - .azure-pipelines/noop-pipeline.yml
       - profiler/
 
 schedules:
@@ -913,8 +917,8 @@ stages:
 - stage: exploration_tests_windows
   condition: >
     and(
-      succeeded(), 
-      eq(variables['isScheduledBuild'], 'False'), 
+      succeeded(),
+      eq(variables['isScheduledBuild'], 'False'),
       or(
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'],'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
@@ -1907,7 +1911,7 @@ stages:
         condition: always()
         displayName: System tests logs
         artifact: system-tests_$(System.JobAttempt)
-        
+
       - script: ./run.sh UDS
         workingDirectory: system-tests
         displayName: Run tests over UDS

--- a/tracer/tools/PipelineMonitor/Program.cs
+++ b/tracer/tools/PipelineMonitor/Program.cs
@@ -64,6 +64,7 @@ try
     var processor = new BuildProcessor(buildData, timeline);
     processor.Process();
     Console.WriteLine("Build " + buildId + " has been processed successfully. It should be visible at: https://ddstaging.datadoghq.com/apm/services/consolidated-pipeline/operations/ci_run/resources");
+    await Tracer.Instance.ForceFlushAsync();
 }
 catch (Exception ex)
 {


### PR DESCRIPTION
## Summary of changes
Adding the agent container within the new pipeline.
Also excluding this tool and new workflow from consolidate-pipeline 

## Reason for change
Because it works better with an agent/

## Test coverage
Retested on a fork. I hadn't validated this part the first time unfortunately.