### PR TITLE
Revert "try building samples in parallel (#2709)"

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -892,7 +892,7 @@ partial class Build
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(TargetPlatform)
                 .EnableNoDependencies()
-                .SetProperty("BuildInParallel", "true")
+                .SetProperty("BuildInParallel", "false")
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                 .CombineWith(projects, (s, project) => s
                     // we have to build this one for all frameworks (because of reasons)


### PR DESCRIPTION
Reverts the build in parallel as [it causes flakiness](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=97379&view=logs&j=4fda7d96-9b91-5787-3365-88c00fd727ee&t=cecd2ee3-c908-5a7b-7a4d-fe9655a519df)