### PR TITLE
Improve profiler logging in the tracer

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -42,7 +42,6 @@ namespace Datadog.Trace.ContinuousProfiler
             _status = status;
             _isCodeHotspotsEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.CodeHotspotsEnabled)?.ToBoolean() ?? true;
             _traceContextPtr = new ThreadLocal<IntPtr>();
-            Log.Information("CodeHotspots feature is {IsEnabled}.", _isCodeHotspotsEnabled ? "enabled" : "disabled");
         }
 
         public bool IsEnabled

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -13,11 +13,11 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ContinuousProfiler
 {
-    internal class ContextTracker
+    internal class ContextTracker : IContextTracker
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContextTracker));
 
-        private readonly ProfilerStatus _status;
+        private readonly IProfilerStatus _status;
         private readonly bool _isCodeHotspotsEnabled;
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ContinuousProfiler
         /// </summary>
         private readonly ThreadLocal<IntPtr> _traceContextPtr;
 
-        public ContextTracker(ProfilerStatus status)
+        public ContextTracker(IProfilerStatus status)
         {
             _status = status;
             _isCodeHotspotsEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.CodeHotspotsEnabled)?.ToBoolean() ?? true;

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/IContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/IContextTracker.cs
@@ -1,0 +1,16 @@
+// <copyright file="IContextTracker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal interface IContextTracker
+    {
+        bool IsEnabled { get; }
+
+        void Set(ulong localRootSpanId, ulong spanId);
+
+        void Reset();
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/IProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/IProfilerStatus.cs
@@ -1,0 +1,12 @@
+// <copyright file="IProfilerStatus.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ContinuousProfiler
+{
+    internal interface IProfilerStatus
+    {
+        bool IsProfilerReady { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.ContinuousProfiler
     {
         private static Profiler _instance;
 
-        private Profiler(ContextTracker contextTracker, ProfilerStatus status)
+        internal Profiler(IContextTracker contextTracker, IProfilerStatus status)
         {
             ContextTracker = contextTracker;
             Status = status;
@@ -22,9 +22,9 @@ namespace Datadog.Trace.ContinuousProfiler
             get { return LazyInitializer.EnsureInitialized(ref _instance, () => Create()); }
         }
 
-        public ProfilerStatus Status { get; }
+        public IProfilerStatus Status { get; }
 
-        public ContextTracker ContextTracker { get; }
+        public IContextTracker ContextTracker { get; }
 
         private static Profiler Create()
         {

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/Profiler.cs
@@ -11,11 +11,10 @@ namespace Datadog.Trace.ContinuousProfiler
     {
         private static Profiler _instance;
 
-        private readonly ContextTracker _contextTracker;
-
-        private Profiler(ContextTracker contextTracker)
+        private Profiler(ContextTracker contextTracker, ProfilerStatus status)
         {
-            _contextTracker = contextTracker;
+            ContextTracker = contextTracker;
+            Status = status;
         }
 
         public static Profiler Instance
@@ -23,16 +22,15 @@ namespace Datadog.Trace.ContinuousProfiler
             get { return LazyInitializer.EnsureInitialized(ref _instance, () => Create()); }
         }
 
-        public ContextTracker ContextTracker
-        {
-            get { return _contextTracker; }
-        }
+        public ProfilerStatus Status { get; }
+
+        public ContextTracker ContextTracker { get; }
 
         private static Profiler Create()
         {
             var status = new ProfilerStatus();
             var contextTracker = new ContextTracker(status);
-            return new Profiler(contextTracker);
+            return new Profiler(contextTracker, status);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -11,7 +11,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ContinuousProfiler
 {
-    internal class ProfilerStatus
+    internal class ProfilerStatus : IProfilerStatus
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ProfilerStatus));
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Telemetry
         private int _hasChangesFlag = 0;
         private volatile CurrentSettings _settings;
         private volatile SecuritySettings _securitySettings;
+        private volatile Profiler _profiler;
         private volatile bool _isTracerInitialized = false;
         private AzureAppServices _azureApServicesMetadata;
         private HostTelemetryData _hostData = null;
@@ -70,6 +71,12 @@ namespace Datadog.Trace.Telemetry
         public void RecordSecuritySettings(SecuritySettings securitySettings)
         {
             _securitySettings = securitySettings;
+            SetHasChanges();
+        }
+
+        public void RecordProfilerSettings(Profiler profiler)
+        {
+            _profiler = profiler;
             SetHasChanges();
         }
 
@@ -133,8 +140,8 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted),
                 new(ConfigTelemetryData.TraceMethods, value: settings.TraceMethods),
                 new(ConfigTelemetryData.ActivityListenerEnabled, value: settings.IsActivityListenerEnabled),
-                new(ConfigTelemetryData.ProfilerLoaded, value: Profiler.Instance.Status.IsProfilerReady),
-                new(ConfigTelemetryData.CodeHotspotsEnabled, value: Profiler.Instance.ContextTracker.IsEnabled),
+                new(ConfigTelemetryData.ProfilerLoaded, value: _profiler?.Status.IsProfilerReady),
+                new(ConfigTelemetryData.CodeHotspotsEnabled, value: _profiler?.ContextTracker.IsEnabled),
             };
 
             if (_azureApServicesMetadata.IsRelevant)

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.PlatformHelpers;
 
 namespace Datadog.Trace.Telemetry
@@ -132,6 +133,8 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted),
                 new(ConfigTelemetryData.TraceMethods, value: settings.TraceMethods),
                 new(ConfigTelemetryData.ActivityListenerEnabled, value: settings.IsActivityListenerEnabled),
+                new(ConfigTelemetryData.ProfilerLoaded, value: Profiler.Instance.Status.IsProfilerReady),
+                new(ConfigTelemetryData.CodeHotspotsEnabled, value: Profiler.Instance.ContextTracker.IsEnabled),
             };
 
             if (_azureApServicesMetadata.IsRelevant)

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -35,5 +35,8 @@ namespace Datadog.Trace.Telemetry
         public const string AasFunctionsRuntimeVersion = "aas_functions_runtime_version";
 
         public const string ActivityListenerEnabled = "activity_listener_enabled";
+
+        public const string ProfilerLoaded = "profiler_loaded";
+        public const string CodeHotspotsEnabled = "code_hotspots_enabled";
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.PlatformHelpers;
 
 namespace Datadog.Trace.Telemetry
@@ -38,6 +39,11 @@ namespace Datadog.Trace.Telemetry
         /// Called when app sec security is enabled to record the security settings
         /// </summary>
         public void RecordSecuritySettings(SecuritySettings settings);
+
+        /// <summary>
+        /// Called to record profiler-related telemetry
+        /// </summary>
+        public void RecordProfilerSettings(Profiler profiler);
 
         /// <summary>
         /// Dispose resources for sending telemetry

--- a/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
@@ -6,6 +6,7 @@
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.PlatformHelpers;
 
 namespace Datadog.Trace.Telemetry
@@ -31,6 +32,10 @@ namespace Datadog.Trace.Telemetry
         }
 
         public void RecordSecuritySettings(SecuritySettings settings)
+        {
+        }
+
+        public void RecordProfilerSettings(Profiler profiler)
         {
         }
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
 
@@ -75,6 +76,9 @@ namespace Datadog.Trace.Telemetry
 
         public void RecordSecuritySettings(SecuritySettings settings)
             => _configuration.RecordSecuritySettings(settings);
+
+        public void RecordProfilerSettings(Profiler profiler)
+            => _configuration.RecordProfilerSettings(profiler);
 
         public void IntegrationRunning(IntegrationId integrationId)
             => _integrations.IntegrationRunning(integrationId);

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -400,6 +401,12 @@ namespace Datadog.Trace
 
                     writer.WritePropertyName("activity_listener_enabled");
                     writer.WriteValue(instanceSettings.IsActivityListenerEnabled);
+
+                    writer.WritePropertyName("profiler_enabled");
+                    writer.WriteValue(Profiler.Instance.Status.IsProfilerReady);
+
+                    writer.WritePropertyName("code_hotspots_enabled");
+                    writer.WriteValue(Profiler.Instance.ContextTracker.IsEnabled);
 
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -53,7 +53,10 @@ namespace Datadog.Trace
 
             try
             {
-                NativeInterop.SetApplicationInfoForAppDomain(RuntimeId.Get(), tracer.DefaultServiceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion);
+                if (Profiler.Instance.Status.IsProfilerReady)
+                {
+                    NativeInterop.SetApplicationInfoForAppDomain(RuntimeId.Get(), tracer.DefaultServiceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion);
+                }
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -111,6 +111,7 @@ namespace Datadog.Trace
             telemetry ??= TelemetryFactory.CreateTelemetryController(settings);
             telemetry.RecordTracerSettings(settings, defaultServiceName, AzureAppServices.Metadata);
             telemetry.RecordSecuritySettings(Security.Instance.Settings);
+            telemetry.RecordProfilerSettings(Profiler.Instance);
 
             SpanContextPropagator.Instance = ContextPropagators.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 

--- a/tracer/src/Datadog.Trace/Util/RuntimeId.cs
+++ b/tracer/src/Datadog.Trace/Util/RuntimeId.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Util
                 // We failed to retrieve the runtime from native this can be because:
                 // - P/Invoke issue (unknown dll, unknown entrypoint...)
                 // - We are running in a partial trust environment
-                Log.Warning("Failed to get the runtime-id from native: {Reason}", e.Message);
+                Log.Information("Failed to get the runtime-id from native: {Reason}", e.Message);
             }
 
             runtimeId = default;

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Sampling;
@@ -114,6 +115,10 @@ namespace Datadog.Trace.Tests.Telemetry
             }
 
             public void RecordSecuritySettings(SecuritySettings settings)
+            {
+            }
+
+            public void RecordProfilerSettings(Profiler profiler)
             {
             }
 


### PR DESCRIPTION
## Summary of changes

- Don't try p/invoking into the profiler if it's not loaded (thus removing the warning in the logs)
- Lower the runtime id log to info
- Add values to the diagnostic log and the telemetry

## Reason for change

The extra logs were triggering Andrew's OCDs.

