### PR TITLE
Use ARM64 AWS auto scale group

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -287,7 +287,7 @@ stages:
   - job: build
     dependsOn: []
     pool:
-      name: Arm64
+      name: aws-arm64-auto-scaling
     workspace:
       clean: all
     steps:
@@ -540,7 +540,7 @@ stages:
 
     - job: test
       pool:
-        name: Arm64
+        name: aws-arm64-auto-scaling
       workspace:
         clean: all
       steps:
@@ -839,7 +839,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: Arm64
+        name: aws-arm64-auto-scaling
 
       steps:
         - template: steps/clone-repo.yml
@@ -1344,7 +1344,7 @@ stages:
           baseImage: debian
           artifactSuffix: linux-arm64
           poolImage:
-          poolName: Arm64
+          poolname: aws-arm64-auto-scaling
 
     pool:
       vmImage: $(poolImage)
@@ -1982,7 +1982,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: Arm64
+        name: aws-arm64-auto-scaling
 
       steps:
         - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## Summary of changes
Use ARM64  AWS auto scale group, instead of having a fixed amount of agents.

## Reason for change
Currently we are using 3 ARM64 build agents.
Each build takes 1 (build) + 5 (unit and integration tests) + 2 (artifacts tests) = 8 agents
Each step takes 10 - 40 minutes to run.
It very fast leads to agents stagnation.

## Implementation details
There are 2 parts of configured CI.

1. 3 continuously running agents ready to pick any job (similar to the way it configured now)
2. Autoscaling group, which will gradually add/remove additional agents depending on the load.

Thresholds are
- 10 waiting jobs in queue (not picked by agent) for 5 minutes - add 10 agents
- 5 waiting jobs in queue (not picked by agent) for 5 minutes - add 5 agents
- 1 waiting job in queue (not picked by agent) for 5 minutes - add agent
- 0 waiting jobs in queue for 15 minutes - remove agent
- Maximum 30 agents.

Agents in auto scale group are configured to run once, afterward machine is destroyed, and another agent is created instead.

As base image, I've used one of currently available agents.

See 'AWS ARM64 Auto Scaling' document in Confluence for more details of implementation.

