### PR TITLE
Rework RabbitMQ sample to try avoid race condition

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.RabbitMQ), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
         public void SubmitsTraces(string packageVersion)
         {
 #if NET6_0_OR_GREATER


### PR DESCRIPTION
## Summary of changes

Tries to fix a race condition in the RabbitMQ sample that was causing integration tests to hang indefinitely

## Reason for change

CI is upset.

## Implementation details

Use a `BlockingCollection` to avoid race condition. Add missing `Reset` to `_sendFinished`, and `Interlocked` for fun

## Test coverage

## Other details
Related to #2735 
