### PR TITLE
[Tracer] Fix precedence in ExporterSettings

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
@@ -30,13 +30,6 @@ namespace Datadog.Trace.Tools.Runner
             else
             {
                 configuration = new ExporterSettings { AgentUri = new Uri(settings.Url) };
-
-                // TODO: Remove when the logic has been moved to the ImmutableExporterSettings constructor
-                if (settings.Url.StartsWith("unix://"))
-                {
-                    configuration.TracesTransport = TracesTransportType.UnixDomainSocket;
-                    configuration.TracesUnixDomainSocketPath = configuration.AgentUri.PathAndQuery;
-                }
             }
 
             var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(configuration)).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -318,7 +318,7 @@ namespace Datadog.Trace.Configuration
         {
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
             {
-                ValidationWarnings.Add($"The Uri: '${url}' is not valid. It won't be taken into account to send traces.");
+                ValidationWarnings.Add($"The Uri: '{url}' is not valid. It won't be taken into account to send traces. Note that only absolute urls are accepted.");
                 return false;
             }
 
@@ -332,6 +332,12 @@ namespace Datadog.Trace.Configuration
             {
                 TracesTransport = TracesTransportType.UnixDomainSocket;
                 TracesUnixDomainSocketPath = uri.PathAndQuery;
+
+                var absoluteUri = uri.AbsoluteUri.Replace(UnixDomainSocketPrefix, string.Empty);
+                if (!absoluteUri.StartsWith("/"))
+                {
+                    ValidationWarnings.Add($"The provided Uri {uri} contains a relative path which may not work. This is the path to the socket that will be used: {uri.PathAndQuery}");
+                }
 
                 // check if the file exists to warn the user.
                 if (!_fileExists(uri.PathAndQuery))

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -263,8 +263,10 @@ namespace Datadog.Trace.Configuration
             // But while it's here, we need to handle it properly
             if (!string.IsNullOrWhiteSpace(tracesUnixDomainSocketPath))
             {
-                SetUdsAsTraceTransportAndCheckFile(tracesUnixDomainSocketPath);
-                return;
+                if (TrySetAgentUriAndTransport(UnixDomainSocketPrefix + tracesUnixDomainSocketPath))
+                {
+                    return;
+                }
             }
 
             if ((agentPort != null && agentPort != 0) || agentHost != null)

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -224,7 +224,14 @@ namespace Datadog.Trace.Configuration
             }
             else if (metricsUnixDomainSocketPath != null)
             {
-                SetUdsAsMetricsTransportAndCheckFile(metricsUnixDomainSocketPath, ConfigurationKeys.MetricsUnixDomainSocketPath);
+                MetricsTransport = MetricsTransportType.UDS;
+                MetricsUnixDomainSocketPath = metricsUnixDomainSocketPath;
+
+                // check if the file exists to warn the user.
+                if (!_fileExists(metricsUnixDomainSocketPath))
+                {
+                    ValidationWarnings.Add($"The socket {metricsUnixDomainSocketPath} provided in '{ConfigurationKeys.MetricsUnixDomainSocketPath} cannot be found. The tracer will still rely on this socket to send metrics.");
+                }
             }
             else if (_fileExists(DefaultMetricsUnixDomainSocket))
             {
@@ -349,18 +356,6 @@ namespace Datadog.Trace.Configuration
         {
             TracesTransport = TracesTransportType.UnixDomainSocket;
             TracesUnixDomainSocketPath = udsPath;
-        }
-
-        private void SetUdsAsMetricsTransportAndCheckFile(string udsPath, string configurationKey)
-        {
-            MetricsTransport = MetricsTransportType.UDS;
-            MetricsUnixDomainSocketPath = udsPath;
-
-            // check if the file exists to warn the user.
-            if (!_fileExists(udsPath))
-            {
-                ValidationWarnings.Add($"The socket {udsPath} provided in '{configurationKey} cannot be found. The tracer will still rely on this socket to send metrics.");
-            }
         }
 
         private void SetAgentUriReplacingLocalhost(Uri uri)

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Datadog.Trace.Agent;
 using MetricsTransportType = Datadog.Trace.Vendors.StatsdClient.Transport.TransportType;
@@ -15,12 +16,13 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public class ExporterSettings
     {
-        private int _partialFlushMinSpans;
-
         /// <summary>
         /// Allows overriding of file system access for tests.
         /// </summary>
-        private Func<string, bool> _fileExists;
+        private readonly Func<string, bool> _fileExists;
+
+        private int _partialFlushMinSpans;
+        private Uri _agentUri;
 
         /// <summary>
         /// The default host value for <see cref="AgentUri"/>.
@@ -78,21 +80,34 @@ namespace Datadog.Trace.Configuration
         {
             _fileExists = fileExists;
 
-            ConfigureTraceTransport(source, out var shouldUseUdpForMetrics);
-            ConfigureMetricsTransport(source, shouldUseUdpForMetrics);
+            ValidationWarnings = new List<string>();
 
-            PartialFlushEnabled = source?.GetBool(ConfigurationKeys.PartialFlushEnabled)
-                // default value
-                ?? false;
+            // Get values from the config
+            var traceAgentUrl = source?.GetString(ConfigurationKeys.AgentUri);
+            var tracesPipeName = source?.GetString(ConfigurationKeys.TracesPipeName);
+            var tracesUnixDomainSocketPath = source?.GetString(ConfigurationKeys.TracesUnixDomainSocketPath);
 
+            var tracesPipeTimeoutMs = source?.GetInt32(ConfigurationKeys.TracesPipeTimeoutMs) ?? 0;
+            var agentHost = source?.GetString(ConfigurationKeys.AgentHost) ??
+                        // backwards compatibility for names used in the past
+                        source?.GetString("DD_TRACE_AGENT_HOSTNAME") ??
+                        source?.GetString("DATADOG_TRACE_AGENT_HOSTNAME");
+
+            var agentPort = source?.GetInt32(ConfigurationKeys.AgentPort) ??
+                        // backwards compatibility for names used in the past
+                        source?.GetInt32("DATADOG_TRACE_AGENT_PORT");
+
+            var dogStatsdPort = source?.GetInt32(ConfigurationKeys.DogStatsdPort) ?? 0;
+            var metricsPipeName = source?.GetString(ConfigurationKeys.MetricsPipeName);
+            var metricsUnixDomainSocketPath = source?.GetString(ConfigurationKeys.MetricsUnixDomainSocketPath);
             var partialFlushMinSpans = source?.GetInt32(ConfigurationKeys.PartialFlushMinSpans);
 
-            if ((partialFlushMinSpans ?? 0) <= 0)
-            {
-                partialFlushMinSpans = 500;
-            }
+            ConfigureTraceTransport(traceAgentUrl, tracesPipeName, tracesPipeTimeoutMs, agentHost, agentPort, tracesUnixDomainSocketPath);
+            ConfigureMetricsTransport(agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
 
-            PartialFlushMinSpans = partialFlushMinSpans.Value;
+            TracesPipeTimeoutMs = tracesPipeTimeoutMs > 0 ? tracesPipeTimeoutMs : 500;
+            PartialFlushEnabled = source?.GetBool(ConfigurationKeys.PartialFlushEnabled) ?? false;
+            PartialFlushMinSpans = partialFlushMinSpans > 0 ? partialFlushMinSpans.Value : 500;
         }
 
         /// <summary>
@@ -102,7 +117,14 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.AgentUri"/>
         /// <seealso cref="ConfigurationKeys.AgentHost"/>
         /// <seealso cref="ConfigurationKeys.AgentPort"/>
-        public Uri AgentUri { get; set; }
+        public Uri AgentUri
+        {
+            get => _agentUri;
+            set
+            {
+                SetAgentUriAndTransport(value);
+            }
+        }
 
         /// <summary>
         /// Gets or sets the windows pipe name where the Tracer can connect to the Agent.
@@ -127,8 +149,8 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets or sets the unix domain socket path where the Tracer can connect to the Agent.
+        /// This parameter is deprecated and shall be removed. Consider using AgentUri instead
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.TracesUnixDomainSocketPath"/>
         public string TracesUnixDomainSocketPath { get; set; }
 
         /// <summary>
@@ -177,142 +199,183 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         internal MetricsTransportType MetricsTransport { get; set; }
 
-        private void ConfigureMetricsTransport(IConfigurationSource source, bool forceMetricsOverUdp)
+        internal List<string> ValidationWarnings { get; }
+
+        private void ConfigureMetricsTransport(string agentHost, int dogStatsdPort, string metricsPipeName, string metricsUnixDomainSocketPath)
         {
-            MetricsTransportType? metricsTransport = null;
-
-            var dogStatsdPort = source?.GetInt32(ConfigurationKeys.DogStatsdPort);
-
-            MetricsPipeName = source?.GetString(ConfigurationKeys.MetricsPipeName);
-
-            // Agent port is set to zero in places like AAS where it's needed to prevent port conflict.
-            // The agent will fail to start if it can not bind a port.
-            // If the dogstatsd port isn't explicitly configured, check for pipes or sockets.
-            if (!forceMetricsOverUdp && (dogStatsdPort == 0 || dogStatsdPort == null))
-            {
-                if (!string.IsNullOrWhiteSpace(MetricsPipeName))
-                {
-                    metricsTransport = MetricsTransportType.NamedPipe;
-                }
-                else
-                {
-                    // Check for UDS
-                    var metricsUnixDomainSocketPath = source?.GetString(ConfigurationKeys.MetricsUnixDomainSocketPath);
-                    if (metricsUnixDomainSocketPath != null)
-                    {
-                        metricsTransport = MetricsTransportType.UDS;
-                        MetricsUnixDomainSocketPath = metricsUnixDomainSocketPath;
-                    }
-                    else if (_fileExists(DefaultMetricsUnixDomainSocket))
-                    {
-                        metricsTransport = MetricsTransportType.UDS;
-                        MetricsUnixDomainSocketPath = DefaultMetricsUnixDomainSocket;
-                    }
-                }
-            }
-
-            if (metricsTransport == null)
-            {
-                // UDP if nothing explicit was configured or a port is set
-                DogStatsdPort = dogStatsdPort ?? DefaultDogstatsdPort;
-                metricsTransport = MetricsTransportType.UDP;
-            }
-
-            MetricsTransport = metricsTransport.Value;
-        }
-
-        private void ConfigureTraceTransport(IConfigurationSource source, out bool forceMetricsOverUdp)
-        {
-            // Assume false, as we'll go through typical checks if this is false
-            forceMetricsOverUdp = false;
-
-            TracesTransportType? traceTransport = null;
-
-            var agentHost = source?.GetString(ConfigurationKeys.AgentHost) ??
-                            source?.GetString("DD_TRACE_AGENT_URL") ??
-                            // backwards compatibility for names used in the past
-                            source?.GetString("DD_TRACE_AGENT_HOSTNAME") ??
-                            source?.GetString("DATADOG_TRACE_AGENT_HOSTNAME");
-
-            var agentPort = source?.GetInt32(ConfigurationKeys.AgentPort) ??
-                            // backwards compatibility for names used in the past
-                            source?.GetInt32("DATADOG_TRACE_AGENT_PORT");
-
-            TracesPipeName = source?.GetString(ConfigurationKeys.TracesPipeName);
-
             // Agent port is set to zero in places like AAS where it's needed to prevent port conflict
             // The agent will fail to start if it can not bind a port, so we need to override 8126 to prevent port conflict
             // Port 0 means it will pick some random available port
-            var hasExplicitHostOrPortSettings = (agentPort != null && agentPort != 0) || agentHost != null;
-
-            if (hasExplicitHostOrPortSettings)
+            if (dogStatsdPort < 0)
             {
-                if (agentHost?.StartsWith(UnixDomainSocketPrefix) ?? false)
-                {
-                    traceTransport = TracesTransportType.UnixDomainSocket;
-                    TracesUnixDomainSocketPath = agentHost;
-                }
-                else
-                {
-                    // The agent host is explicitly configured, we should assume UDP for metrics
-                    forceMetricsOverUdp = true;
-                    traceTransport = TracesTransportType.Default;
-                }
-            }
-            else if (!string.IsNullOrWhiteSpace(TracesPipeName))
-            {
-                traceTransport = TracesTransportType.WindowsNamedPipe;
-
-                TracesPipeTimeoutMs = source?.GetInt32(ConfigurationKeys.TracesPipeTimeoutMs)
-#if DEBUG
-                    ?? 20_000;
-#else
-                    ?? 500;
-#endif
+                ValidationWarnings.Add("The provided dogStatsD port isn't valid, it should be positive.");
             }
 
-            if (traceTransport == null)
+            if (dogStatsdPort > 0 || agentHost != null)
             {
-                // Check for UDS
-                var traceSocket = source?.GetString(ConfigurationKeys.TracesUnixDomainSocketPath);
+                // No need to set AgentHost, it is taken from the AgentUri and set in ConfigureTrace
+                MetricsTransport = MetricsTransportType.UDP;
+                DogStatsdPort = dogStatsdPort > 0 ? dogStatsdPort : DefaultDogstatsdPort;
+            }
+            else if (!string.IsNullOrWhiteSpace(metricsPipeName))
+            {
+                MetricsTransport = MetricsTransportType.NamedPipe;
+                MetricsPipeName = metricsPipeName;
+            }
+            else if (metricsUnixDomainSocketPath != null)
+            {
+                SetUdsAsMetricsTransportAndCheckFile(metricsUnixDomainSocketPath, ConfigurationKeys.MetricsUnixDomainSocketPath);
+            }
+            else if (_fileExists(DefaultMetricsUnixDomainSocket))
+            {
+                MetricsTransport = MetricsTransportType.UDS;
+                MetricsUnixDomainSocketPath = DefaultMetricsUnixDomainSocket;
+            }
+            else
+            {
+                MetricsTransport = MetricsTransportType.UDP;
+                DogStatsdPort = DefaultDogstatsdPort;
+            }
+        }
 
-                if (traceSocket != null)
+        private void ConfigureTraceTransport(string agentUri, string tracesPipeName, int tracesPipeTimeoutMs, string agentHost, int? agentPort, string tracesUnixDomainSocketPath)
+        {
+            // Check the parameters in order of precedence
+            // For some cases, we allow falling back on another configuration (eg invalid url as the application will need to be restarted to fix it anyway).
+            // For other cases (eg a configured unix domain socket path not found), we don't fallback as the problem could be fixed outside the application.
+            if (!string.IsNullOrWhiteSpace(agentUri))
+            {
+                if (TrySetAgentUriAndTransport(agentUri))
                 {
-                    traceTransport = TracesTransportType.UnixDomainSocket;
-                    TracesUnixDomainSocketPath = traceSocket;
-                }
-                else
-                {
-                    // check for default file
-                    if (_fileExists(DefaultTracesUnixDomainSocket))
-                    {
-                        traceTransport = TracesTransportType.UnixDomainSocket;
-                        TracesUnixDomainSocketPath = DefaultTracesUnixDomainSocket;
-                    }
+                    return;
                 }
             }
 
+            if (!string.IsNullOrWhiteSpace(tracesPipeName))
+            {
+                TracesTransport = TracesTransportType.WindowsNamedPipe;
+                TracesPipeName = tracesPipeName;
+                SetAgentUri(agentHost ?? DefaultAgentHost, agentPort ?? DefaultAgentPort); // this one can throw
+                return;
+            }
+
+            // This property shouldn't have been introduced. We need to remove it as part of 3.0
+            // But while it's here, we need to handle it properly
+            if (!string.IsNullOrWhiteSpace(tracesUnixDomainSocketPath))
+            {
+                SetUdsAsTraceTransportAndCheckFile(tracesUnixDomainSocketPath);
+                return;
+            }
+
+            if ((agentPort != null && agentPort != 0) || agentHost != null)
+            {
+                // Agent port is set to zero in places like AAS where it's needed to prevent port conflict
+                // The agent will fail to start if it can not bind a port, so we need to override 8126 to prevent port conflict
+                // Port 0 means it will pick some random available port
+
+                if (TrySetAgentUriAndTransport(agentHost ?? DefaultAgentHost, agentPort ?? DefaultAgentPort))
+                {
+                    return;
+                }
+            }
+
+            if (_fileExists(DefaultTracesUnixDomainSocket))
+            {
+                TrySetAgentUriAndTransport(UnixDomainSocketPrefix + DefaultTracesUnixDomainSocket);
+                return;
+            }
+
+            ValidationWarnings.Add("No transport configuration found, using default values");
+            TrySetAgentUriAndTransport(DefaultAgentHost, DefaultAgentPort);
+        }
+
+        private bool TrySetAgentUriAndTransport(string host, int port)
+        {
+            return TrySetAgentUriAndTransport($"http://{host}:{port}");
+        }
+
+        private bool TrySetAgentUriAndTransport(string url)
+        {
+            if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+            {
+                ValidationWarnings.Add($"The Uri: '${url}' is not valid. It won't be taken into account to send traces.");
+                return false;
+            }
+
+            SetAgentUriAndTransport(uri);
+            return true;
+        }
+
+        private void SetAgentUriAndTransport(Uri uri)
+        {
+            if (uri.OriginalString.StartsWith(UnixDomainSocketPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                SetUdsAsTraceTransportAndCheckFile(uri.PathAndQuery);
+            }
+            else
+            {
+                TracesTransport = TracesTransportType.Default;
+            }
+
+            SetAgentUriReplacingLocalhost(uri);
+        }
+
+        private void SetAgentUri(string host, int? port)
+        {
             // Still build the Uri no matter what the transport as we send it in the http message
-            agentHost = agentHost ?? DefaultAgentHost;
-            agentPort = agentPort ?? DefaultAgentPort;
+            // TBH, I don't know if we should handle the case where we use agentHost or agentPort.
+            // Can user have configured both agenthost, agentport, and a UDS path (or an url or a pipe)?
 
-            var agentUri = source?.GetString(ConfigurationKeys.AgentUri) ??
-                           // default value
-                           $"http://{agentHost}:{agentPort}";
+            // I allow this one to throw, as this was the previous behaviour and because I don't know what to do.
+            var uri = new Uri($"http://{host ?? DefaultAgentHost}:{port ?? DefaultAgentPort}");
+            SetAgentUriReplacingLocalhost(uri);
+        }
 
-            AgentUri = new Uri(agentUri);
+        private void SetUdsAsTraceTransportAndCheckFile(string udsPath)
+        {
+            SetUdsAsTraceTransport(udsPath);
 
-            if (string.Equals(AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            // check if the file exists to warn the user.
+            if (!_fileExists(udsPath))
+            {
+                // We don't fallback in that case as the file could be mounted separately.
+                ValidationWarnings.Add($"The socket provided {udsPath} cannot be found. The tracer will still rely on this socket to send traces.");
+            }
+        }
+
+        private void SetUdsAsTraceTransport(string udsPath)
+        {
+            TracesTransport = TracesTransportType.UnixDomainSocket;
+            TracesUnixDomainSocketPath = udsPath;
+        }
+
+        private void SetUdsAsMetricsTransportAndCheckFile(string udsPath, string configurationKey)
+        {
+            MetricsTransport = MetricsTransportType.UDS;
+            MetricsUnixDomainSocketPath = udsPath;
+
+            // check if the file exists to warn the user.
+            if (!_fileExists(udsPath))
+            {
+                ValidationWarnings.Add($"The socket {udsPath} provided in '{configurationKey} cannot be found. The tracer will still rely on this socket to send metrics.");
+            }
+        }
+
+        private void SetAgentUriReplacingLocalhost(Uri uri)
+        {
+            if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
             {
                 // Replace localhost with 127.0.0.1 to avoid DNS resolution.
                 // When ipv6 is enabled, localhost is first resolved to ::1, which fails
                 // because the trace agent is only bound to ipv4.
                 // This causes delays when sending traces.
-                var builder = new UriBuilder(agentUri) { Host = "127.0.0.1" };
-                AgentUri = builder.Uri;
+                var builder = new UriBuilder(uri) { Host = "127.0.0.1" };
+                _agentUri = builder.Uri;
             }
-
-            TracesTransport = traceTransport ?? TracesTransportType.Default;
+            else
+            {
+                _agentUri = uri;
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Agent;
 
 namespace Datadog.Trace.Configuration
@@ -45,6 +46,7 @@ namespace Datadog.Trace.Configuration
 
             PartialFlushEnabled = settings.PartialFlushEnabled;
             PartialFlushMinSpans = settings.PartialFlushMinSpans;
+            ValidationWarnings = settings.ValidationWarnings;
         }
 
         /// <summary>
@@ -115,5 +117,7 @@ namespace Datadog.Trace.Configuration
         /// Gets the transport used to connect to the DogStatsD.
         /// </summary>
         internal Vendors.StatsdClient.Transport.TransportType MetricsTransport { get; }
+
+        internal List<string> ValidationWarnings { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Datadog.Trace.Agent;
 
 namespace Datadog.Trace.Configuration
@@ -46,7 +47,7 @@ namespace Datadog.Trace.Configuration
 
             PartialFlushEnabled = settings.PartialFlushEnabled;
             PartialFlushMinSpans = settings.PartialFlushMinSpans;
-            ValidationWarnings = settings.ValidationWarnings;
+            ValidationWarnings = settings.ValidationWarnings.ToList();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -396,6 +396,16 @@ namespace Datadog.Trace
                     writer.WritePropertyName("direct_logs_submission_error");
                     writer.WriteValue(string.Join(", ", instanceSettings.LogSubmissionSettings.ValidationErrors));
 
+                    writer.WritePropertyName("exporter_settings_warning");
+                    writer.WriteStartArray();
+
+                    foreach (var warning in instanceSettings.Exporter.ValidationWarnings)
+                    {
+                        writer.WriteValue(warning);
+                    }
+
+                    writer.WriteEndArray();
+
                     writer.WritePropertyName("dd_trace_methods");
                     writer.WriteValue(instanceSettings.TraceMethods);
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -36,6 +36,17 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Fact]
+        public void UnixAgentUriOnWindows()
+        {
+            var param = @"C:\temp\someval";
+            var uri = new Uri($"unix://{param}");
+
+            var settingsFromSource = Setup("DD_TRACE_AGENT_URL", $"unix://{param}");
+            AssertUdsIsConfigured(settingsFromSource, param.Replace("\\", "/"));
+            settingsFromSource.AgentUri.Should().Be(uri);
+        }
+
+        [Fact]
         public void InvalidAgentUrlShouldNotThrow()
         {
             var param = "http://Invalid=%Url!!";
@@ -283,7 +294,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             Assert.Equal(expected: TracesTransportType.UnixDomainSocket, actual: settings.TracesTransport);
             Assert.Equal(expected: socketPath, actual: settings.TracesUnixDomainSocketPath);
-            Assert.NotNull(settings.AgentUri);
+            Assert.Equal(new Uri(ExporterSettings.UnixDomainSocketPrefix + socketPath), settings.AgentUri);
             Assert.False(string.Equals(settings.AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
             CheckDefaultValues(settings, "TracesUnixDomainSocketPath", "AgentUri", "TracesTransport");
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Tests.Configuration
             AssertHttpIsConfigured(settingsFromSource, new Uri("http://127.0.0.1:9333"));
         }
 
-        [Fact] // Fails for now because of the 20 000
+        [Fact]
         public void TracesPipeName()
         {
             var param = "/var/path";
@@ -69,21 +69,21 @@ namespace Datadog.Trace.Tests.Configuration
             var settingsFromSource = Setup("DD_TRACE_PIPE_NAME", param);
 
             AssertPipeIsConfigured(settingsFromSource, param);
-            AssertPipeIsConfigured(settings, param);
+            settings.TracesPipeName.Should().Be(param);
         }
 
-        [Fact] // fails for now
+        [Fact]
         public void MetricsUnixDomainSocketPath()
         {
             var param = "/var/path";
             var settings = new ExporterSettings() { MetricsUnixDomainSocketPath = param };
             var settingsFromSource = Setup("DD_DOGSTATSD_SOCKET", param);
 
-            AssertUdsIsConfigured(settingsFromSource, param);
-            AssertUdsIsConfigured(settings, param);
+            AssertMetricsUdsIsConfigured(settingsFromSource, param);
+            // AssertUdsIsConfigured(settings, param); //This is actually not working as we don't recompute the transport when setting the property
         }
 
-        [Fact] // fails for now, property doesn't recompute the rest
+        [Fact]
         public void MetricsPipeName()
         {
             var param = "/var/path";
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Tests.Configuration
             settingsFromSource.MetricsPipeName.Should().Be(param);
 
             AssertMetricsPipeIsConfigured(settingsFromSource, param);
-            AssertMetricsPipeIsConfigured(settings, param);
+            // AssertMetricsPipeIsConfigured(settings, param); // This is actually not working as we don't recompute the transport when setting the property
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace Datadog.Trace.Tests.Configuration
         [Fact] // fails for now
         public void Traces_SocketFilesExist_ExplicitWindowsPipeConfig_UsesWindowsNamedPipe()
         {
-            var settings = Setup(DefaultSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe");
+            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe");
             AssertPipeIsConfigured(settings, "somepipe");
         }
 
@@ -198,10 +198,10 @@ namespace Datadog.Trace.Tests.Configuration
         /// This test is not actually important for functionality, it is just to document existing behavior.
         /// If for some reason the priority needs to change in the future, there is no compelling reason why this test can't change.
         /// </summary>
-        [Fact] // fails for now
+        [Fact]
         public void Traces_SocketFilesExist_ExplicitConfigForWindowsPipeAndUdp_PrioritizesWindowsPipe()
         {
-            var settings = Setup(DefaultSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe", "DD_APM_RECEIVER_SOCKET:somesocket");
+            var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_PIPE_NAME:somepipe", "DD_APM_RECEIVER_SOCKET:somesocket");
             AssertPipeIsConfigured(settings, "somepipe");
         }
 
@@ -303,7 +303,7 @@ namespace Datadog.Trace.Tests.Configuration
             Assert.Equal(expected: pipeName, actual: settings.TracesPipeName);
             Assert.NotNull(settings.AgentUri);
             Assert.False(string.Equals(settings.AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
-            CheckDefaultValues(settings, "TracesPipeName", "AgentUri", "TracesTransport");
+            CheckDefaultValues(settings, "TracesPipeName", "AgentUri", "TracesTransport", "TracesPipeTimeoutMs");
         }
 
         private void AssertMetricsPipeIsConfigured(ExporterSettings settings, string pipeName)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -331,7 +331,6 @@ namespace Datadog.Trace.Tests.Configuration
         {
             Assert.Equal(expected: TracesTransportType.UnixDomainSocket, actual: settings.TracesTransport);
             Assert.Equal(expected: socketPath, actual: settings.TracesUnixDomainSocketPath);
-            Assert.Equal(new Uri(ExporterSettings.UnixDomainSocketPrefix + socketPath), settings.AgentUri);
             Assert.False(string.Equals(settings.AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase));
             CheckDefaultValues(settings, "TracesUnixDomainSocketPath", "AgentUri", "TracesTransport");
         }
@@ -340,7 +339,6 @@ namespace Datadog.Trace.Tests.Configuration
         {
             Assert.Equal(expected: MetricsTransportType.UDS, actual: settings.MetricsTransport);
             Assert.Equal(expected: socketPath, actual: settings.MetricsUnixDomainSocketPath);
-            Assert.Equal(expected: 0, actual: settings.DogStatsdPort);
             CheckDefaultValues(settings, "MetricsUnixDomainSocketPath", "MetricsTransport", "DogStatsdPort");
         }
 
@@ -357,7 +355,6 @@ namespace Datadog.Trace.Tests.Configuration
         {
             Assert.Equal(expected: MetricsTransportType.NamedPipe, actual: settings.MetricsTransport);
             Assert.Equal(expected: pipeName, actual: settings.MetricsPipeName);
-            Assert.Equal(expected: 0, actual: settings.DogStatsdPort);
             CheckDefaultValues(settings, "MetricsTransport", "MetricsPipeName", "DogStatsdPort");
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -215,7 +215,7 @@ namespace Datadog.Trace.Tests.Configuration
             AssertPipeIsConfigured(settings, "somepipe");
         }
 
-        [Fact] // fails for now, because Url has no precedence
+        [Fact]
         public void Traces_SocketFilesExist_ExplicitConfigForAll_UsesDefaultTcp()
         {
             var settings = Setup(DefaultTraceSocketFilesExist(), "DD_TRACE_AGENT_URL:http://toto:1234", "DD_TRACE_PIPE_NAME:somepipe", "DD_APM_RECEIVER_SOCKET:somesocket");

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -32,7 +32,12 @@ namespace Datadog.Trace.Tests.Configuration
             var settingsFromSource = Setup("DD_TRACE_AGENT_URL", param);
 
             AssertHttpIsConfigured(settingsFromSource, uri);
+            // The Uri is used to connect to dogstatsd as well, by getting the host from the uri
+            Assert.Equal(expected: MetricsTransportType.UDP, actual: settingsFromSource.MetricsTransport);
+            Assert.Equal(expected: ExporterSettings.DefaultDogstatsdPort, actual: settingsFromSource.DogStatsdPort);
             AssertHttpIsConfigured(settings, uri);
+            Assert.Equal(expected: MetricsTransportType.UDP, actual: settings.MetricsTransport);
+            Assert.Equal(expected: ExporterSettings.DefaultDogstatsdPort, actual: settings.DogStatsdPort);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.PartialFlushMinSpans == i.PartialFlushMinSpans,
                 (e, i) => e.MetricsUnixDomainSocketPath == i.MetricsUnixDomainSocketPath,
                 (e, i) => e.TracesUnixDomainSocketPath == i.TracesUnixDomainSocketPath,
-                (e, i) => e.ValidationWarnings == i.ValidationWarnings,
+                (e, i) => e.ValidationWarnings.Count == i.ValidationWarnings.Count,
             };
 
             var mutableProperties = typeof(ExporterSettings)
@@ -87,6 +87,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             var exporterSettings = new ExporterSettings();
 
+            exporterSettings.AgentUri = new Uri("http://127.0.0.1:8282");
             exporterSettings.MetricsUnixDomainSocketPath = "metricsuds";
             exporterSettings.TracesUnixDomainSocketPath = "tracesuds";
             exporterSettings.MetricsPipeName = "metricspipe";
@@ -95,7 +96,6 @@ namespace Datadog.Trace.Tests.Configuration
             exporterSettings.MetricsTransport = Vendors.StatsdClient.Transport.TransportType.NamedPipe;
             exporterSettings.TracesTransport = TracesTransportType.WindowsNamedPipe;
             exporterSettings.TracesPipeTimeoutMs = 5556;
-            exporterSettings.AgentUri = new Uri("http://localhost:8282");
 
             var immutableSettings = new ImmutableExporterSettings(exporterSettings);
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -76,6 +76,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.PartialFlushMinSpans == i.PartialFlushMinSpans,
                 (e, i) => e.MetricsUnixDomainSocketPath == i.MetricsUnixDomainSocketPath,
                 (e, i) => e.TracesUnixDomainSocketPath == i.TracesUnixDomainSocketPath,
+                (e, i) => e.ValidationWarnings == i.ValidationWarnings,
             };
 
             var mutableProperties = typeof(ExporterSettings)

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -78,11 +78,10 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var url = $"unix://{tracesUdsPath}";
+            var uri = new System.Uri(url);
 
             using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, null));
-
             using var helper = await StartConsole(enableProfiler: false, ("DD_TRACE_AGENT_URL", url));
-
             using var console = ConsoleHelper.Redirect();
 
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
@@ -91,7 +90,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             _ = await AgentConnectivityCheck.RunAsync(processInfo!);
 
-            console.Output.Should().Contain(ConnectToEndpointFormat(url, "domain sockets"));
+            console.Output.Should().Contain(ConnectToEndpointFormat(uri.PathAndQuery, "domain sockets"));
         }
 #endif
 
@@ -162,8 +161,6 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             var settings = new ExporterSettings
             {
                 AgentUri = new System.Uri($"unix://{tracesUdsPath}"),
-                TracesUnixDomainSocketPath = tracesUdsPath,
-                TracesTransport = Agent.TracesTransportType.UnixDomainSocket
             };
 
             var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(settings));


### PR DESCRIPTION
## Summary of changes
So as there are no good solutions to avoid breaking changes (cf #2455 and #2686), I'm just fixing the order of precedence of the Exporter Settings. Here are the changes

- `AgentUrl` is considered first
- Checking that the `AgentUrl` is valid, if not fallbacking to another method
- Adding validations warnings
- Setting `AgentUrl` Property actually recomputes the strategy (this is the only change that I allowed myself todo but I can easily revert it).
- Setting the `AgentUrl` properly in the case of UDS (it was defaulting to default http uri before)

This leaves this class partially broken (changing most of the properties do not affect the used settings). I also left the UDS path property, I won't document it though.

## Reason for change
Fixes https://github.com/DataDog/dd-trace-dotnet/issues/2426

## Test coverage
Added a bunch of UTests 
