### PR TITLE
Refactor Windows Build and clean Beta Msi related code

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -675,7 +675,7 @@ stages:
         patterns: '**/*-$(targetPlatform).msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
-    - script: tracer\build.cmd BuildWindowsIntegrationTests -Framework $(framework)
+    - script: tracer\build.cmd BuildWindowsIntegrationTests PublishIisSamples -Framework $(framework)
       displayName: BuildWindowsIntegrationTests
 
     - script: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -202,6 +202,10 @@ stages:
     - script: tracer\build.cmd BuildNativeLoader
       displayName: Build monitoring home
 
+    - publish: $(System.DefaultWorkingDirectory)
+      displayName: Upload working directory after the managed build
+      artifact: build-windows-working-directory
+
     - script: tracer\build.cmd BuildProfilerHome
       displayName: Build profiler home
 
@@ -214,10 +218,6 @@ stages:
     - publish: $(tracerHome)
       displayName: Upload Windows tracer home directory
       artifact: windows-tracer-home
-
-    - publish: $(System.DefaultWorkingDirectory)
-      displayName: Upload working directory after the managed build
-      artifact: build-windows-working-directory
 
     - publish: $(artifacts)/windows-tracer-home.zip
       displayName: Publish tracer-home.zip
@@ -234,7 +234,6 @@ stages:
     - publish: $(artifacts)/nuget
       displayName: Publish NuGet packages
       artifact: nuget-packages
-
 
 - stage: build_linux
   dependsOn: [master_commit_id]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -176,10 +176,12 @@ stages:
       displayName: Generate Matrices
       name: generate_variables_step
 
-- stage: build_windows_tracer
+- stage: build_and_package_windows
   dependsOn: [master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+    # Temporarily use the profiling repo's commit hash for the beta MSI's filename
+    BetaMsiSuffix: $[ stageDependencies.build_windows_profiler.build.outputs['SetMsiSuffix.BetaMsiSuffix']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -193,11 +195,21 @@ stages:
       parameters:
         masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
+
     - script: tracer\build.cmd BuildTracerHome
       displayName: Build tracer home
 
     - script: tracer\build.cmd BuildNativeLoader
       displayName: Build monitoring home
+
+    - script: tracer\build.cmd BuildProfilerHome
+      displayName: Build profiler home
+
+    - script: tracer\build.cmd PackageTracerHome --ProfilerHome $(System.DefaultWorkingDirectory)/profiler/_build/DDProf-Deploy
+      displayName: Build MSI and Tracer home
+
+    - script: tracer\build.cmd PackageMonitoringHomeBeta
+      displayName: Build beta MSI
 
     - publish: $(tracerHome)
       displayName: Upload Windows tracer home directory
@@ -207,30 +219,22 @@ stages:
       displayName: Upload working directory after the managed build
       artifact: build-windows-working-directory
 
-- stage: build_windows_profiler
-  dependsOn: [master_commit_id]
-  variables:
-    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-  jobs:
-  - template: steps/update-github-status-jobs.yml
-    parameters:
-      jobs: [build]
+    - publish: $(artifacts)/windows-tracer-home.zip
+      displayName: Publish tracer-home.zip
+      artifact: windows-tracer-home.zip
 
-  - job: build
-    pool:
-      vmImage: windows-2019
-    steps:
-    - template: steps/clone-repo.yml
-      parameters:
-        masterCommitId: $(masterCommitId)
-    - template: steps/install-latest-dotnet-sdk.yml
+    - publish: $(artifacts)/x86/en-us
+      displayName: Publish Windows x86 MSI
+      artifact: windows-msi-x86
 
-    - script: tracer\build.cmd BuildProfilerHome
-      displayName: Build profiler home
+    - publish: $(artifacts)/x64/en-us
+      displayName: Publish Windows x64 MSI
+      artifact: windows-msi-x64
 
-    - publish: $(System.DefaultWorkingDirectory)/profiler/_build/DDProf-Deploy
-      displayName: Upload Windows profiler home directory
-      artifact: windows-profiler-home
+    - publish: $(artifacts)/nuget
+      displayName: Publish NuGet packages
+      artifact: nuget-packages
+
 
 - stage: build_linux
   dependsOn: [master_commit_id]
@@ -344,61 +348,9 @@ stages:
       displayName: Upload working directory after the build
       artifact: build-macos-working-directory
 
-- stage: package_windows
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [ build_windows_tracer, build_windows_profiler, master_commit_id]
-  variables:
-    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-  pool:
-    vmImage: windows-2019
-  jobs:
-  - template: steps/update-github-status-jobs.yml
-    parameters:
-      jobs: [msi_and_pack]
-
-  - job: msi_and_pack
-    variables:
-      # Temporarily use the profiling repo's commit hash for the beta MSI's filename
-      BetaMsiSuffix: $[ stageDependencies.build_windows_profiler.build.outputs['SetMsiSuffix.BetaMsiSuffix']]
-    steps:
-      - template: steps/clone-repo.yml
-        parameters:
-          masterCommitId: $(masterCommitId)
-      - template: steps/install-latest-dotnet-sdk.yml
-      - template: steps/restore-working-directory.yml
-      - script: echo $(BetaMsiSuffix) # TODO Remove
-
-      - task: DownloadPipelineArtifact@2
-        displayName: Download windows profiler home
-        inputs:
-          artifact: windows-profiler-home
-          path: $(profilerHome)
-
-      - script: tracer\build.cmd PackageTracerHome
-        displayName: Build MSI and Tracer home
-
-      - script: tracer\build.cmd PackageMonitoringHomeBeta
-        displayName: Build beta MSI
-
-      - publish: $(artifacts)/windows-tracer-home.zip
-        displayName: Publish tracer-home.zip
-        artifact: windows-tracer-home.zip
-
-      - publish: $(artifacts)/x86/en-us
-        displayName: Publish Windows x86 MSI
-        artifact: windows-msi-x86
-
-      - publish: $(artifacts)/x64/en-us
-        displayName: Publish Windows x64 MSI
-        artifact: windows-msi-x64
-
-      - publish: $(artifacts)/nuget
-        displayName: Publish NuGet packages
-        artifact: nuget-packages
-
 - stage: unit_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows_tracer, master_commit_id]
+  dependsOn: [build_and_package_windows, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
@@ -571,7 +523,7 @@ stages:
 
 - stage: integration_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows_tracer, generate_variables, master_commit_id]
+  dependsOn: [build_and_package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -640,7 +592,7 @@ stages:
 
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows_tracer, package_windows, generate_variables, master_commit_id]
+  dependsOn: [build_and_package_windows, build_and_package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
 
@@ -925,7 +877,7 @@ stages:
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
       )
     )
-  dependsOn: [build_windows_tracer, generate_variables, master_commit_id]
+  dependsOn: [build_and_package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
 
@@ -1066,7 +1018,7 @@ stages:
 
 - stage: benchmarks
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_windows_tracer, master_commit_id]
+  dependsOn: [build_and_package_windows, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1119,7 +1071,7 @@ stages:
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
-  dependsOn: [build_windows_tracer, build_linux, build_arm64, build_macos, master_commit_id]
+  dependsOn: [build_and_package_windows, build_linux, build_arm64, build_macos, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1394,7 +1346,7 @@ stages:
 
 - stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, build_linux, build_arm64, master_commit_id]
+  dependsOn: [build_and_package_windows, build_linux, build_arm64, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1493,7 +1445,7 @@ stages:
 
 - stage: upload_to_azure
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool, master_commit_id]
+  dependsOn: [build_and_package_windows, build_linux, build_arm64, dotnet_tool, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1629,7 +1581,7 @@ stages:
 
 - stage: throughput
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_linux, build_arm64, build_windows_tracer, master_commit_id]
+  dependsOn: [build_linux, build_arm64, build_and_package_windows, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool: Throughput
@@ -1790,7 +1742,7 @@ stages:
 
 - stage: execution_benchmarks
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [build_windows_tracer, master_commit_id]
+  dependsOn: [build_and_package_windows, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -180,8 +180,6 @@ stages:
   dependsOn: [master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-    # Temporarily use the profiling repo's commit hash for the beta MSI's filename
-    BetaMsiSuffix: $[ stageDependencies.build_windows_profiler.build.outputs['SetMsiSuffix.BetaMsiSuffix']]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -211,9 +209,6 @@ stages:
 
     - script: tracer\build.cmd PackageTracerHome --ProfilerHome $(System.DefaultWorkingDirectory)/profiler/_build/DDProf-Deploy
       displayName: Build MSI and Tracer home
-
-    - script: tracer\build.cmd PackageMonitoringHomeBeta
-      displayName: Build beta MSI
 
     - publish: $(tracerHome)
       displayName: Upload Windows tracer home directory
@@ -591,7 +586,7 @@ stages:
 
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_and_package_windows, build_and_package_windows, generate_variables, master_commit_id]
+  dependsOn: [build_and_package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
 

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -18,7 +18,6 @@
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <OutputName>datadog-dotnet-apm-2.8.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
-    <OutputName Condition=" '$(BetaMsiSuffix)' != '' ">$(OutputName)-$(BetaMsiSuffix)</OutputName>
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
     <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\windows-tracer-home</TracerHomeDirectory>
     <ProfilerHomeDirectory Condition="'$(ProfilerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\bin\DDProf-Deploy</ProfilerHomeDirectory>

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -510,7 +510,6 @@ partial class Build
                     .SetProperty("LibDdwafDirectory", LibDdwafDirectory)
                     .SetProperty("ProfilerHomeDirectory", ProfilerHomeDirectory)
                     .SetProperty("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                    .SetProperty("BetaMsiSuffix", BetaMsiSuffix)
                     .SetMaxCpuCount(null)
                     .CombineWith(ArchitecturesForPlatform, (o, arch) => o
                         .SetProperty("MsiOutputPath", ArtifactsDirectory / arch.ToString())

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -201,7 +201,6 @@ partial class Build : NukeBuild
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CreatePlatformlessSymlinks)
         .DependsOn(CompileSamples)
-        .DependsOn(PublishIisSamples)
         .DependsOn(CompileIntegrationTests)
         .DependsOn(BuildNativeLoader)
         .DependsOn(BuildRunnerTool);

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -50,8 +50,6 @@ partial class Build : NukeBuild
     readonly AbsolutePath DDTracerHome;
     [Parameter("The location to place NuGet packages and other packages. Default is ./bin/artifacts ")]
     readonly AbsolutePath Artifacts;
-    [Parameter("An optional suffix for the beta profiler-tracer MSI. Default is '' ")]
-    readonly string BetaMsiSuffix = string.Empty;
 
     [Parameter("The location to the find the profiler build artifacts. Default is ./profiler/_build/DDProf-Deploy")]
     readonly AbsolutePath ProfilerHome;
@@ -166,17 +164,12 @@ partial class Build : NukeBuild
         .DependsOn(PublishNativeLoader);
 
     Target PackageTracerHome => _ => _
-        .Description("Packages the already built src")
-        .After(Clean, BuildTracerHome)
+        .Description("Builds NuGet packages, MSIs, and zip files, from already built source")
+        .After(Clean, BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(ZipTracerHome)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
-
-    Target PackageMonitoringHomeBeta => _ => _
-        .Description("Packages the already built src")
-        .After(Clean, BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
-        .DependsOn(BuildMsi);
 
     Target BuildAndRunManagedUnitTests => _ => _
         .Description("Builds the managed unit tests and runs them")

--- a/tracer/build/_build/gitlab.bat
+++ b/tracer/build/_build/gitlab.bat
@@ -11,7 +11,7 @@ mklink /d dd-trace-dotnet C:\mnt
 mklink /d _build C:\_build
 SET ProfilerSrcDirectory=C:\mnt\dd-continuous-profiler-dotnet
 
-dotnet run --project tracer/build/_build/_build.csproj -- Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader PackageTracerHome PackageMonitoringHomeBeta ZipSymbols SignDlls SignMsiAndNupkg --Artifacts "build-out\%CI_JOB_ID%"
+dotnet run --project tracer/build/_build/_build.csproj -- Info Clean BuildTracerHome BuildProfilerHome BuildNativeLoader PackageTracerHome ZipSymbols SignDlls SignMsiAndNupkg --Artifacts "build-out\%CI_JOB_ID%"
 
 IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
 


### PR DESCRIPTION
## Summary of changes
Build the Tracer, Profiler and package it in one stage on Windows.
Also removed some beta MSI related code as it isn't generated anymore.

## Reason for change
Building the MSI actually takes <1min, but with all the extra delay introduced from having a separate stage, it can take anywhere up to 10mins. Building the profiler takes 5 minutes. So building the profiler and the MSI in this step make it ~6 minutes longer. Which is still better than the current situation as IIS tests will start faster. Removing those stages also removes the set_pending, set_success jobs, so a bit more availability for the other jobs (even though we shall fix that independently).

## Implementation details
Move those steps into one.
Upload working directory before building profiler home and the packaging, to reduce the size of the artifacts.
And also, I've removed the PublishIISSamples step from building the integration tests on windows to have them only on WindowsIIS tests

## Other details
I'll need to rename the blocking step `package_windows` in the repo settings once I have validation for that PR
AIT-1943
