### PR TITLE
[ALL] Add overload to create std::string from WCHAR* (+ size)

### DIFF
--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -11,21 +11,26 @@ namespace shared {
     std::string ToString(const std::string& str) { return str; }
     std::string ToString(const char* str) { return std::string(str); }
     std::string ToString(const uint64_t i) { return std::to_string(i); }
-    std::string ToString(const WSTRING& wstr) {
-#ifdef _WIN32
-        if (wstr.empty()) return std::string();
 
-        std::string tmpStr(tmp_buffer_size, 0);
-        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &tmpStr[0], tmp_buffer_size, NULL, NULL);
-        if (size_needed < tmp_buffer_size) {
-            return tmpStr.substr(0, size_needed);
+    std::string ToString(const WSTRING& wstr) { return ToString(wstr.data(), wstr.size()); }
+
+    std::string ToString(const WCHAR* wstr, std::size_t size)
+    {
+#ifdef _WIN32
+        if (size == 0) return std::string();
+
+        char tmpStr[tmp_buffer_size] = {0};
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) size, &tmpStr[0], tmp_buffer_size, NULL, NULL);
+        if (size_needed < tmp_buffer_size)
+        {
+            return std::string(tmpStr, size_needed);
         }
 
         std::string strTo(size_needed, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) size, &strTo[0], size_needed, NULL, NULL);
         return strTo;
 #else
-        std::u16string ustr(reinterpret_cast<const char16_t*>(wstr.c_str()));
+        std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), size);
         return miniutf::to_utf8(ustr);
 #endif
     }
@@ -34,10 +39,10 @@ namespace shared {
 #ifdef _WIN32
         if (str.empty()) return std::wstring();
 
-        std::wstring tmpStr(tmp_buffer_size, 0);
+        wchar_t tmpStr[tmp_buffer_size] = {0};
         int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &tmpStr[0], tmp_buffer_size);
         if (size_needed < tmp_buffer_size) {
-            return tmpStr.substr(0, size_needed);
+            return std::wstring(tmpStr, size_needed);
         }
 
         std::wstring wstrTo(size_needed, 0);

--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -14,23 +14,23 @@ namespace shared {
 
     std::string ToString(const WSTRING& wstr) { return ToString(wstr.data(), wstr.size()); }
 
-    std::string ToString(const WCHAR* wstr, std::size_t size)
+    std::string ToString(const WCHAR* wstr, std::size_t nbChars)
     {
 #ifdef _WIN32
-        if (size == 0) return std::string();
+        if (nbChars == 0) return std::string();
 
         char tmpStr[tmp_buffer_size] = {0};
-        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) size, &tmpStr[0], tmp_buffer_size, NULL, NULL);
+        int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &tmpStr[0], tmp_buffer_size, NULL, NULL);
         if (size_needed < tmp_buffer_size)
         {
             return std::string(tmpStr, size_needed);
         }
 
         std::string strTo(size_needed, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) size, &strTo[0], size_needed, NULL, NULL);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &strTo[0], size_needed, NULL, NULL);
         return strTo;
 #else
-        std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), size);
+        std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), nbChars);
         return miniutf::to_utf8(ustr);
 #endif
     }

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -24,6 +24,7 @@ namespace shared {
     std::string ToString(const char* str);
     std::string ToString(const uint64_t i);
     std::string ToString(const WSTRING& wstr);
+    std::string ToString(const WCHAR* wstr, std::size_t size);
 
     WSTRING ToWSTRING(const std::string& str);
     WSTRING ToWSTRING(const uint64_t i);

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -24,7 +24,7 @@ namespace shared {
     std::string ToString(const char* str);
     std::string ToString(const uint64_t i);
     std::string ToString(const WSTRING& wstr);
-    std::string ToString(const WCHAR* wstr, std::size_t size);
+    std::string ToString(const WCHAR* wstr, std::size_t nbChars);
 
     WSTRING ToWSTRING(const std::string& str);
     WSTRING ToWSTRING(const uint64_t i);


### PR DESCRIPTION
## Summary of changes

## Reason for change

In the profiler code, we have a many places where we create a `std::string` from `WCHAR*` like this:
`shared::ToString(shared::ToWSTRING(wstr))` 
In all the places we also have the size of the `WCHAR*`.

This code does 3 string allocations.

## Implementation details

We add a new overload `std::string ToString(const WCHAR* wstr, std::size_t size)`  and reducing the allocation to only 1 string.

