### PR TITLE
[Profiler] Rework the linux stack frames collectors

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -17,20 +17,19 @@
 #include "StackFrameCodeKind.h"
 #include "StackSnapshotResultReusableBuffer.h"
 
+std::mutex LinuxStackFramesCollector::s_signalHandlerInitLock;
 std::mutex LinuxStackFramesCollector::s_stackWalkInProgressMutex;
+bool LinuxStackFramesCollector::s_isSignalHandlerSetup = false;
+int LinuxStackFramesCollector::s_signalToSend = -1;
 LinuxStackFramesCollector* LinuxStackFramesCollector::s_pInstanceCurrentlyStackWalking = nullptr;
 
-LinuxStackFramesCollector::LinuxStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* managedThreadList) :
-    StackFramesCollectorBase(managedThreadList),
+LinuxStackFramesCollector::LinuxStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo) :
     _pCorProfilerInfo(_pCorProfilerInfo),
-    _signalToSend{-1},
-    _isSignalHandlerSetup{false},
     _lastStackWalkErrorCode{0}
 {
     _pCorProfilerInfo->AddRef();
-    _isSignalHandlerSetup = SetupSignalHandler();
+    InitializeSignalHandler();
 }
-
 LinuxStackFramesCollector::~LinuxStackFramesCollector()
 {
     _pCorProfilerInfo->Release();
@@ -41,29 +40,30 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
                                                                                        uint32_t* pHR,
                                                                                        bool selfCollect)
 {
-    // For now we ignore isTargetThreadSameAsCurrentThread.
-    // However, we should probably look at it, and if it is True, and do the stack walk synchronously, rather than using a signal.
-
-    if (!_isSignalHandlerSetup)
-    {
-        Log::Debug("LinuxStackFramesCollector::CollectStackSampleImplementation:"
-                   " Signal handler not set up. Cannot collect callstacks."
-                   " (Earlier log entry may contain additinal details.)");
-
-        *pHR = E_FAIL;
-
-        return GetStackSnapshotResult();
-    }
-
     long errorCode;
+
+    if (selfCollect)
     {
+        errorCode = CollectCallStackCurrentThread();
+    }
+    else
+    {
+        if (!s_isSignalHandlerSetup)
+        {
+            Log::Debug("LinuxStackFramesCollector::CollectStackSampleImplementation: Signal handler not set up. Cannot collect callstacks."
+                       " (Earlier log entry may contain additinal details.)");
+
+            *pHR = E_FAIL;
+
+            return GetStackSnapshotResult();
+        }
+
         std::unique_lock<std::mutex> stackWalkInProgressLock(s_stackWalkInProgressMutex);
 
         const DWORD osThreadId = pThreadInfo->GetOsThreadId();
 
-        Log::Debug("LinuxStackFramesCollector::CollectStackSampleImplementation:"
-                   " Sending signal ",
-                   _signalToSend, " to thread with osThreadId=", osThreadId, ".");
+        Log::Debug("LinuxStackFramesCollector::CollectStackSampleImplementation: Sending signal ",
+                   s_signalToSend, " to thread with osThreadId=", osThreadId, ".");
 
         s_pInstanceCurrentlyStackWalking = this;
         auto scopeFinalizer = CreateScopeFinalizer(
@@ -71,27 +71,19 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
                 s_pInstanceCurrentlyStackWalking = nullptr;
             });
 
-        if (selfCollect)
+        errorCode = syscall(SYS_tgkill, static_cast<::pid_t>(getpid()), static_cast<::pid_t>(osThreadId), s_signalToSend);
+
+        if (errorCode == -1)
         {
-            CollectStackSampleSignalHandler(0);
-            errorCode = _lastStackWalkErrorCode;
+            Log::Warn("LinuxStackFramesCollector::CollectStackSampleImplementation:"
+                      " Unable to send signal USR1 to thread with osThreadId=",
+                      osThreadId, ". Error code: ",
+                      strerror(errno));
         }
         else
         {
-            errorCode = syscall(SYS_tgkill, static_cast<::pid_t>(getpid()), static_cast<::pid_t>(osThreadId), _signalToSend);
-
-            if (errorCode == -1)
-            {
-                Log::Warn("LinuxStackFramesCollector::CollectStackSampleImplementation:"
-                          " Unable to send signal USR1 to thread with osThreadId=",
-                          osThreadId, ". Error code: ",
-                          strerror(errno));
-            }
-            else
-            {
-                _stackWalkInProgressWaiter.wait(stackWalkInProgressLock);
-                errorCode = _lastStackWalkErrorCode;
-            }
+            _stackWalkInProgressWaiter.wait(stackWalkInProgressLock);
+            errorCode = _lastStackWalkErrorCode;
         }
     }
 
@@ -117,6 +109,19 @@ void LinuxStackFramesCollector::NotifyStackWalkCompleted(std::int32_t resultErro
 {
     _lastStackWalkErrorCode = resultErrorCode;
     _stackWalkInProgressWaiter.notify_one();
+}
+
+void LinuxStackFramesCollector::InitializeSignalHandler()
+{
+    if (s_isSignalHandlerSetup)
+        return;
+
+    std::unique_lock<std::mutex> lock{s_signalHandlerInitLock};
+
+    if (s_isSignalHandlerSetup)
+        return;
+
+    s_isSignalHandlerSetup = SetupSignalHandler();
 }
 
 bool LinuxStackFramesCollector::TrySetHandlerForSignal(int signal, struct sigaction& action)
@@ -168,14 +173,14 @@ bool LinuxStackFramesCollector::SetupSignalHandler()
 
     if (TrySetHandlerForSignal(SIGUSR1, sampleAction))
     {
-        _signalToSend = SIGUSR1;
+        s_signalToSend = SIGUSR1;
         Log::Info("LinuxStackFramesCollector::SetupSignalHandler: Successfully setup signal handler for SIGUSR1 signal.");
         return true;
     }
 
     if (TrySetHandlerForSignal(SIGUSR2, sampleAction))
     {
-        _signalToSend = SIGUSR2;
+        s_signalToSend = SIGUSR2;
         Log::Info("LinuxStackFramesCollector::SetupSignalHandler: Successfully setup signal handler for SIGUSR2 signal.");
         return true;
     }
@@ -216,40 +221,13 @@ char const* LinuxStackFramesCollector::ErrorCodeToString(int errorCode)
     }
 }
 
-void LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal)
+std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread()
 {
-    LinuxStackFramesCollector* pCollectorInstanceCurrentlyStackWalking;
     std::int32_t resultErrorCode;
 
-    std::unique_lock<std::mutex> stackWalkInProgressLock(s_stackWalkInProgressMutex);
-
-    pCollectorInstanceCurrentlyStackWalking = s_pInstanceCurrentlyStackWalking;
-
-    // Fail fast in DEBUG builds:
-    assert(pCollectorInstanceCurrentlyStackWalking != nullptr);
-
-    // Bail out in RELEASE builds:
-    if (pCollectorInstanceCurrentlyStackWalking == nullptr)
     {
-        return;
-    }
-
-    {
-        auto scopeFinalizer = CreateScopeFinalizer(
-            [&pCollectorInstanceCurrentlyStackWalking, &stackWalkInProgressLock, resultErrorCode] {
-                // @ToDo: Is resultErrorCode used correctly, so that its later value change applies to the inside of this lambda?
-
-                if (pCollectorInstanceCurrentlyStackWalking != nullptr)
-                {
-                    stackWalkInProgressLock.unlock();
-                    pCollectorInstanceCurrentlyStackWalking->NotifyStackWalkCompleted(resultErrorCode);
-                }
-            });
-
         // Collect data for TraceContext tracking:
-
-        bool traceContextDataCollected = pCollectorInstanceCurrentlyStackWalking->TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
-        assert(true == traceContextDataCollected);
+        bool traceContextDataCollected = TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
 
         // Now walk the stack:
 
@@ -260,40 +238,47 @@ void LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal)
         unw_init_local(&cursor, &uc);
 
         // After every lib call that touches non-local state, check if the StackSamplerLoopManager requested this walk to abort:
-        if (pCollectorInstanceCurrentlyStackWalking->IsCurrentCollectionAbortRequested())
+        if (IsCurrentCollectionAbortRequested())
         {
-            pCollectorInstanceCurrentlyStackWalking->TryAddFrame(StackFrameCodeKind::MultipleMixed, 0, 0, 0);
-            resultErrorCode = E_ABORT;
-            return;
+            TryAddFrame(StackFrameCodeKind::MultipleMixed, 0, 0, 0);
+            return E_ABORT;
         }
 
         resultErrorCode = unw_step(&cursor);
 
-        // @ToDo: when do we stop? How do we signal normal vs abnormal completion via error codes here?
         while (resultErrorCode > 0)
         {
             // After every lib call that touches non-local state, check if the StackSamplerLoopManager requested this walk to abort:
-            if (pCollectorInstanceCurrentlyStackWalking->IsCurrentCollectionAbortRequested())
+            if (IsCurrentCollectionAbortRequested())
             {
-                pCollectorInstanceCurrentlyStackWalking->TryAddFrame(StackFrameCodeKind::MultipleMixed, 0, 0, 0);
-                resultErrorCode = E_ABORT;
-                return;
+                TryAddFrame(StackFrameCodeKind::MultipleMixed, 0, 0, 0);
+                return E_ABORT;
             }
 
             unw_word_t nativeInstructionPointer;
             resultErrorCode = unw_get_reg(&cursor, UNW_REG_IP, &nativeInstructionPointer);
             if (resultErrorCode != 0)
             {
-                return;
+                return resultErrorCode;
             }
 
-            if (!pCollectorInstanceCurrentlyStackWalking->TryAddFrame(StackFrameCodeKind::NotDetermined, 0, nativeInstructionPointer, 0))
+            if (!TryAddFrame(StackFrameCodeKind::NotDetermined, 0, nativeInstructionPointer, 0))
             {
-                resultErrorCode = S_FALSE;
-                return;
+                return S_FALSE;
             }
 
             resultErrorCode = unw_step(&cursor);
         }
     }
+    return resultErrorCode;
+}
+
+void LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal)
+{
+    std::unique_lock<std::mutex> stackWalkInProgressLock(s_stackWalkInProgressMutex);
+    LinuxStackFramesCollector* pCollectorInstanceCurrentlyStackWalking = s_pInstanceCurrentlyStackWalking;
+
+    std::int32_t resultErrorCode = pCollectorInstanceCurrentlyStackWalking->CollectCallStackCurrentThread();
+    stackWalkInProgressLock.unlock();
+    pCollectorInstanceCurrentlyStackWalking->NotifyStackWalkCompleted(resultErrorCode);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -20,7 +20,7 @@ class IManagedThreadList;
 class LinuxStackFramesCollector : public StackFramesCollectorBase
 {
 public:
-    explicit LinuxStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* managedThreadList);
+    explicit LinuxStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo);
     ~LinuxStackFramesCollector() override;
     LinuxStackFramesCollector(LinuxStackFramesCollector const&) = delete;
     LinuxStackFramesCollector& operator=(LinuxStackFramesCollector const&) = delete;
@@ -37,11 +37,10 @@ protected:
                                                                 bool selfCollect) override;
 
 private:
+    void InitializeSignalHandler();
     bool SetupSignalHandler();
     void NotifyStackWalkCompleted(std::int32_t resultErrorCode);
 
-    int _signalToSend;
-    bool _isSignalHandlerSetup;
 
     std::int32_t _lastStackWalkErrorCode;
     std::condition_variable _stackWalkInProgressWaiter;
@@ -50,10 +49,15 @@ private:
 
 private:
     static bool TrySetHandlerForSignal(int signal, struct sigaction& action);
-    static char const* ErrorCodeToString(int errorCode);
-
     static void CollectStackSampleSignalHandler(int signal);
 
+    static char const* ErrorCodeToString(int errorCode);
     static std::mutex s_stackWalkInProgressMutex;
+    static std::mutex s_signalHandlerInitLock;
+    static bool s_isSignalHandlerSetup;
+    static int s_signalToSend;
+
     static LinuxStackFramesCollector* s_pInstanceCurrentlyStackWalking;
+
+    std::int32_t CollectCallStackCurrentThread();
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -14,8 +14,8 @@ void InitializeLoaderResourceMonikerIDs(shared::LoaderResourceMonikerIDs*)
 {
 }
 
-StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IManagedThreadList* managedThreadList)
+StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo)
 {
-    return new LinuxStackFramesCollector(const_cast<ICorProfilerInfo4* const>(pCorProfilerInfo), managedThreadList);
+    return new LinuxStackFramesCollector(const_cast<ICorProfilerInfo4* const>(pCorProfilerInfo));
 }
 } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -26,14 +26,14 @@ void InitializeLoaderResourceMonikerIDs(shared::LoaderResourceMonikerIDs* loader
     loaderResourceMonikerIDs->NetCoreApp20_Datadog_AutoInstrumentation_ManagedLoader_pdb = NETCOREAPP20_Datadog_AutoInstrumentation_ManagedLoader_pdb;
 }
 
-StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IManagedThreadList* managedThreadList)
+StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo)
 {
 #ifdef BIT64
     static_assert(8 * sizeof(void*) == 64);
-    return new Windows64BitStackFramesCollector(pCorProfilerInfo, managedThreadList);
+    return new Windows64BitStackFramesCollector(pCorProfilerInfo);
 #else
     assert(8 * sizeof(void*) == 32);
-    return new Windows32BitStackFramesCollector(pCorProfilerInfo, managedThreadList);
+    return new Windows32BitStackFramesCollector(pCorProfilerInfo);
 #endif
 }
 } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
@@ -15,8 +15,7 @@
 // This method is called from the CLR so we need to use STDMETHODCALLTYPE macro to match the CLR declaration
 HRESULT STDMETHODCALLTYPE StackSnapshotCallbackHandlerImpl(FunctionID funcId, UINT_PTR ip, COR_PRF_FRAME_INFO frameInfo, ULONG32 contextSize, BYTE context[], void* clientData);
 
-Windows32BitStackFramesCollector::Windows32BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* const managedThreadList) :
-    StackFramesCollectorBase(managedThreadList),
+Windows32BitStackFramesCollector::Windows32BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo) :
     _pCorProfilerInfo(_pCorProfilerInfo)
 {
     _pCorProfilerInfo->AddRef();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.h
@@ -17,7 +17,7 @@ class IManagedThreadList;
 class Windows32BitStackFramesCollector : public StackFramesCollectorBase
 {
 public:
-    Windows32BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* const managedThreadList);
+    Windows32BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo);
     ~Windows32BitStackFramesCollector() override;
 
     void OnDeadlock() override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
@@ -76,8 +76,7 @@ void UnsafeLogDebugIfEnabledDuringStackwalk(const Args... args)
 
 Windows64BitStackFramesCollector::NtQueryInformationThreadDelegate_t Windows64BitStackFramesCollector::s_ntQueryInformationThreadDelegate = nullptr;
 
-Windows64BitStackFramesCollector::Windows64BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* const managedThreadList) :
-    StackFramesCollectorBase(managedThreadList),
+Windows64BitStackFramesCollector::Windows64BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo) :
     _pCorProfilerInfo(_pCorProfilerInfo)
 {
     _pCorProfilerInfo->AddRef();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.h
@@ -23,7 +23,7 @@ class Windows64BitStackFramesCollector : public StackFramesCollectorBase
     // ----------- 64 bit specific implementation: -----------
 
 public:
-    explicit Windows64BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo, IManagedThreadList* const managedThreadList);
+    explicit Windows64BitStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo);
     ~Windows64BitStackFramesCollector() override;
 
     bool SuspendTargetThreadImplementation(ManagedThreadInfo* pThreadInfo,
@@ -51,8 +51,7 @@ private:
     // (This collector is not meant for 32 bit builds. Use the 32 bit collector instead.)
 
 public:
-    Windows64BitStackFramesCollector(ICorProfilerInfo4* const _, IManagedThreadList* managedThreadList) :
-        StackFramesCollectorBase(managedThreadList)
+    Windows64BitStackFramesCollector(ICorProfilerInfo4* const _)
     {
         Log::Error("Windows64BitStackFramesCollector used in a 32 bit build."
                    " This was not intended. Use Windows32BitStackFramesCollector instead.");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -67,7 +67,7 @@ int OpSysTools::GetThreadId()
 #ifdef _WINDOWS
     return ::GetCurrentThreadId();
 #else
-    return pthread_self();
+    return (SIZE_T)syscall(SYS_gettid);
 #endif
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -20,5 +20,5 @@ class IManagedThreadList;
 namespace OsSpecificApi {
 void InitializeLoaderResourceMonikerIDs(shared::LoaderResourceMonikerIDs* moniker);
 
-StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IManagedThreadList* managedThreadList);
+StackFramesCollectorBase* CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
@@ -165,8 +165,6 @@ StackSnapshotResultBuffer* StackFramesCollectorBase::GetStackSnapshotResult()
 
 void StackFramesCollectorBase::PrepareForNextCollection(void)
 {
-    std::unique_lock<std::mutex> lk(_collectionLock);
-
     // We cannot allocate memory once a thread is suspended.
     // This is because malloc() uses a lock and so if we suspend a thread that was allocating, we will deadlock.
     // So we pre-allocate the memory buffer and reset it before suspending the target thread.
@@ -195,8 +193,6 @@ void StackFramesCollectorBase::ResumeTargetThreadIfRequired(ManagedThreadInfo* p
 
 StackSnapshotResultBuffer* StackFramesCollectorBase::CollectStackSample(ManagedThreadInfo* pThreadInfo, uint32_t* pHR)
 {
-    std::unique_lock<std::mutex> lk(_collectionLock);
-
     // Update state with the info for the thread that we are collecting:
     _pCurrentCollectionThreadInfo = pThreadInfo;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
@@ -55,8 +55,5 @@ private:
     std::atomic<bool> _isCurrentCollectionAbortRequested;
     std::condition_variable _collectionAbortPerformedSignal;
     std::mutex _collectionAbortNotificationLock;
-    // this prevents from multiple concurrent calls to the same instance of the collector (ex: Exception profiling)
-    // since there is shared state (StackSnapshotResultBuffer)
-    std::mutex _collectionLock;
     bool _isRequestedCollectionAbortSuccessful;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
@@ -10,12 +10,10 @@
 #include "ManagedThreadInfo.h"
 #include "StackSnapshotResultReusableBuffer.h"
 
-class IManagedThreadList;
-
 class StackFramesCollectorBase
 {
 protected:
-    StackFramesCollectorBase(IManagedThreadList* const managedThreadList);
+    StackFramesCollectorBase();
 
     bool TryAddFrame(StackFrameCodeKind codeKind,
                      FunctionID clrFunctionId,
@@ -57,6 +55,8 @@ private:
     std::atomic<bool> _isCurrentCollectionAbortRequested;
     std::condition_variable _collectionAbortPerformedSignal;
     std::mutex _collectionAbortNotificationLock;
+    // this prevents from multiple concurrent calls to the same instance of the collector (ex: Exception profiling)
+    // since there is shared state (StackSnapshotResultBuffer)
+    std::mutex _collectionLock;
     bool _isRequestedCollectionAbortSuccessful;
-    IManagedThreadList* _managedThreadsList;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -62,7 +62,7 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _deadlockInterventionInProgress{0}
 {
     _pCorProfilerInfo->AddRef();
-    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, _pManagedThreadList);
+    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo);
 
     _currentStatistics = std::make_unique<Statistics>();
     _statisticCollectionStartNs = OpSysTools::GetHighPrecisionNanoseconds();


### PR DESCRIPTION
## Summary of changes

## Reason for change

The linux stack frames collector was stuck thank to that  [PR](https://github.com/DataDog/dd-trace-dotnet/pull/2743).
The issue was that the locking strategy was not adequate for the `self-collect` use-case.

## Implementation details

- For a thread to collect its own stack, we check that the current thread id is the same as the one passed in parameter
- Fix GetThreadId: The CLR use `gettid` which is different from `pthread_self`
- For the linux collector, we ensure that the signal handler is initialized once.

## Test coverage

For the self-collect case, this will be tested in another [PR](https://github.com/DataDog/dd-trace-dotnet/pull/2743)

## Other details
<!-- Fixes #{issue} -->
