### PR TITLE
Use a separate agent pool for running status updates

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -6,7 +6,7 @@ parameters:
 jobs:
   - job: set_pending
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-task-scale-set
     steps:
     - checkout: none
     - template: update-github-status.yml
@@ -17,7 +17,7 @@ jobs:
 
   - job: set_succeeded
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-task-scale-set
     dependsOn:
     - set_pending
     - ${{ each job in parameters.jobs }}:
@@ -33,7 +33,7 @@ jobs:
 
   - job: set_failed
     pool:
-      vmImage: ubuntu-18.04
+      name: azure-linux-task-scale-set
     dependsOn:
       - set_pending
       - ${{ each job in parameters.jobs }}:


### PR DESCRIPTION
To try and avoid getting blocked, and "using up" hosted agents

## Summary of changes

- Use a new Azure VMSS pool for running the GitHub update tasks

## Reason for change

Currently we're using the hosted agents for running these tasks, but as we are competing with other tasks as well as other projects (e.g. integrations-core), then we can sometimes get blocked waiting for an agent. Using a small, cheap, distinct agent pool means these are never blocked (and never block other jobs), reducing the hold-up after a stage completes.

## Implementation details

Created a simple VMSS using the latest Ubuntu 20.04 LTS image, on Standard_A1_v2 VMs. These are v. small and cheap, but as we are literally just running a curl command, it's plenty. 

For the agent pool, I configured it to _not_ wipe the machines between runs. This should improve availability, and shouldn't cause any issues as we're not even persisting anything on the machines.

## Test coverage
Did a trial run, looks good to me.

## Other details
There's no reason we can't use this _and_ #2748, but if this one works well enough, then it may be easiest to only have this one (as you don't need to consider which approach to use, consistency etc)
