### PR TITLE
[Build] Add timeout to dotnet installs

### DIFF
--- a/.azure-pipelines/steps/install-dotnet-sdk-32bit.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdk-32bit.yml
@@ -20,6 +20,7 @@ steps:
       CHANNEL: ${{ parameters.channel }}
       SDKVERSION: ${{ parameters.sdkVersion }}
     displayName: Validate parameters
+    timeoutInMinutes: 3
     retryCountOnTaskFailure: 5
 
   - ${{if ne(parameters.sdkVersion, '') }}:
@@ -32,6 +33,7 @@ steps:
         echo "Exporting path to DOTNET_EXE_32"
         echo "##vso[task.setvariable variable=DOTNET_EXE_32]$path\dotnet.exe"
       displayName: install dotnet core sdk ${{ parameters.sdkVersion }} (x86)
+      timeoutInMinutes: 3
       retryCountOnTaskFailure: 5
   - ${{if ne(parameters.channel, '') }}:
     - powershell: |
@@ -43,4 +45,5 @@ steps:
         echo "Exporting path to DOTNET_EXE_32"
         echo "##vso[task.setvariable variable=DOTNET_EXE_32]$path\dotnet.exe"
       displayName: install dotnet core sdk ${{ parameters.channel }} (x86)
+      timeoutInMinutes: 3
       retryCountOnTaskFailure: 5

--- a/.azure-pipelines/steps/install-dotnet-sdks.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdks.yml
@@ -9,6 +9,7 @@ steps:
   inputs:
     packageType: sdk
     version: 2.1.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -16,6 +17,7 @@ steps:
   inputs:
     packageType: sdk
     version: 3.0.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -23,6 +25,7 @@ steps:
   inputs:
     packageType: sdk
     version: 3.1.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -30,6 +33,7 @@ steps:
   inputs:
     packageType: sdk
     version: 5.0.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -38,6 +42,7 @@ steps:
     packageType: sdk
     version: $(dotnetCoreSdkLatestVersion)
     includePreviewVersions: true
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - ${{ if eq(parameters.includeX86, true) }}:

--- a/.azure-pipelines/steps/install-dotnet.yml
+++ b/.azure-pipelines/steps/install-dotnet.yml
@@ -4,6 +4,7 @@ steps:
   inputs:
     packageType: runtime
     version: 2.1.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -11,6 +12,7 @@ steps:
   inputs:
     packageType: runtime
     version: 3.0.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -18,6 +20,7 @@ steps:
   inputs:
     packageType: runtime
     version: 3.1.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
@@ -25,11 +28,13 @@ steps:
   inputs:
     packageType: runtime
     version: 5.0.x
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
-    
+
 - task: UseDotNet@2
   displayName: install latest dotnet core sdk
   inputs:
     packageType: sdk
     version: $(dotnetCoreSdkLatestVersion)
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5

--- a/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
+++ b/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
@@ -10,6 +10,7 @@ steps:
     packageType: sdk
     version: $(dotnetCoreSdkLatestVersion)
     includePreviewVersions: true
+  timeoutInMinutes: 3
   retryCountOnTaskFailure: 5
 
 - ${{ if eq(parameters.includeX86, true) }}:


### PR DESCRIPTION
## Summary of changes
Adding a 3 minutes timeout on dotnet install tasks.

## Reason for change
[One build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=98003&view=logs&j=79d4ae43-b0e6-5bea-a939-b9b728cca996&t=ccf9d6eb-a627-53e1-aec1-777ad6ff8fea&s=532dcea1-9aaf-5cc0-829d-fa83095908cf) failed after 6hours. Hopefully, the timeout is considered as a normal failure and the retry would fix the issue.

