### PR TITLE
Revert "use aws auto scale group (#2734)"

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -287,7 +287,7 @@ stages:
   - job: build
     dependsOn: []
     pool:
-      name: aws-arm64-auto-scaling
+      name: Arm64
     workspace:
       clean: all
     steps:
@@ -540,7 +540,7 @@ stages:
 
     - job: test
       pool:
-        name: aws-arm64-auto-scaling
+        name: Arm64
       workspace:
         clean: all
       steps:
@@ -839,7 +839,7 @@ stages:
       workspace:
         clean: all
       pool:
-        name: aws-arm64-auto-scaling
+        name: Arm64
 
       steps:
         - template: steps/clone-repo.yml
@@ -1344,7 +1344,7 @@ stages:
           baseImage: debian
           artifactSuffix: linux-arm64
           poolImage:
-          poolname: aws-arm64-auto-scaling
+          poolName: Arm64
 
     pool:
       vmImage: $(poolImage)
@@ -2029,7 +2029,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        name: aws-arm64-auto-scaling
+        name: Arm64
 
       steps:
         - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## Summary of changes

Go back to using the old ARM64 hosted agents

## Reason for change

There's an issue with some of the agents related to `$HOME`

## Implementation details

## Test coverage

## Other details
Azure VMSS apparently don't support ARM64 agents 🙁 
