### PR TITLE
Try using local git configuration instead of global

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -14,7 +14,7 @@ steps:
       git version
       git lfs version
       echo "Updating git config"
-      git config --global init.defaultBranch master
+      git config init.defaultBranch master
       git init "$BUILD_REPOSITORY_LOCALPATH"
       git remote add origin "$BUILD_REPOSITORY_URI"
       git config gc.auto 0
@@ -27,8 +27,8 @@ steps:
       git checkout --force $prBranch
     displayName: checkout
   - bash: |
-      git config --global user.email "gitfun@example.com"
-      git config --global user.name "Automatic Merge"
+      git config user.email "gitfun@example.com"
+      git config user.name "Automatic Merge"
       git merge ${{ parameters.masterCommitId }}
       git status
     displayName: merge


### PR DESCRIPTION
## Summary of changes
Use `git config` without `--global` to do local configuration

## Reason for change
We were getting issues with `$HOME` when using `--global` with the AWS ARM64 scale set. This seems like a "bug" in the AWS configuration, but if this works around it then that should be sufficient.

## Implementation details
Using `git config` without `--global` sets the configuration in the current directory instead of in `$HOME`

## Test coverage
Ran a direct test, we'll see if this PR works too.

## Other details
Closes #2754 if it works, as we can keep using the scale set!
