### PR TITLE
[Build] Don't build twice docker image in ITests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -701,11 +701,6 @@ stages:
       parameters:
         artifact: build-linux-$(baseImage)-working-directory
 
-    - template: steps/run-in-docker.yml
-      parameters:
-        baseImage: $(baseImage)
-        command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
-
     - task: DownloadPipelineArtifact@2
       displayName: Download linux tracer home
       inputs:
@@ -713,6 +708,19 @@ stages:
         path: $(System.DefaultWorkingDirectory)/tracer/serverlessArtifacts
 
     - script: |
+        docker run --rm \
+            --mount type=bind,source="$(System.DefaultWorkingDirectory)",target=/project \
+            --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
+            --env tracerHome=/project/$(relativeTracerHome) \
+            --env artifacts=/project/$(relativeArtifacts) \
+            --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
+            --env Verify_DisableClipboard=true \
+            --env DiffEngine_Disabled=true \
+            --env TestAllPackageVersions=$(TestAllPackageVersions) \
+            --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
+            --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
+            dd-trace-dotnet/$(baseImage)-tester \
+            dotnet /build/bin/Debug/_build.dll BuildLinuxIntegrationTests --framework $(publishTargetFramework) &
         docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests &
         docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies &
         wait

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -621,12 +621,13 @@ stages:
         patterns: '**/*-$(targetPlatform).msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
+    - script: tracer\build.cmd BuildWindowsIntegrationTests PublishIisSamples -Framework $(framework)
+      displayName: BuildWindowsIntegrationTests
+
     - script: |
-        tracer\build.cmd BuildWindowsIntegrationTests PublishIisSamples -Framework $(framework) &
-        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS &
-        wait &
+        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
         docker-compose up -d IntegrationTests.IIS
-      displayName: BuildWindowsIntegrationTests and docker-compose start IntegrationTests.IIS
+      displayName: docker-compose start IntegrationTests.IIS
       retryCountOnTaskFailure: 5
 
     - script: tracer\build.cmd RunWindowsIisIntegrationTests -Framework $(framework) --code-coverage
@@ -805,25 +806,14 @@ stages:
           parameters:
             artifact: build-linux-arm64-working-directory
 
-        # we build the integration tests in parallel to starting the dependencies
-        # the first command is just a copy past of the run-in-docker template
+        - template: steps/run-in-docker.yml
+          parameters:
+            baseImage: $(baseImage)
+            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
+
         - script: |
-            docker run --rm \
-              --mount type=bind,source="$(System.DefaultWorkingDirectory)",target=/project \
-              --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
-              --env tracerHome=/project/$(relativeTracerHome) \
-              --env artifacts=/project/$(relativeArtifacts) \
-              --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
-              --env Verify_DisableClipboard=true \
-              --env DiffEngine_Disabled=true \
-              --env TestAllPackageVersions=$(TestAllPackageVersions) \
-              --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
-              --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
-              dd-trace-dotnet/$(baseImage)-tester \
-              dotnet /build/bin/Debug/_build.dll BuildLinuxIntegrationTests --framework $(publishTargetFramework) &
-            docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64 &
-            docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64 &
-            wait
+            docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64
+            docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64
           env:
             baseImage: $(baseImage)
             framework: $(publishTargetFramework)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -700,6 +700,13 @@ stages:
       parameters:
         artifact: build-linux-$(baseImage)-working-directory
 
+    # when we build samples separately, we could run this step and the docker-compose one below in //
+    # (currently the docker-compose step relies on serverless samples)
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
+
     - task: DownloadPipelineArtifact@2
       displayName: Download linux tracer home
       inputs:
@@ -707,22 +714,8 @@ stages:
         path: $(System.DefaultWorkingDirectory)/tracer/serverlessArtifacts
 
     - script: |
-        docker run --rm \
-            --mount type=bind,source="$(System.DefaultWorkingDirectory)",target=/project \
-            --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
-            --env tracerHome=/project/$(relativeTracerHome) \
-            --env artifacts=/project/$(relativeArtifacts) \
-            --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
-            --env Verify_DisableClipboard=true \
-            --env DiffEngine_Disabled=true \
-            --env TestAllPackageVersions=$(TestAllPackageVersions) \
-            --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
-            --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
-            dd-trace-dotnet/$(baseImage)-tester \
-            dotnet /build/bin/Debug/_build.dll BuildLinuxIntegrationTests --framework $(publishTargetFramework) &
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests &
-        docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies &
-        wait
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests
+        docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
       env:
         baseImage: $(baseImage)
         framework: $(publishTargetFramework)
@@ -812,12 +805,22 @@ stages:
           parameters:
             artifact: build-linux-arm64-working-directory
 
-        - template: steps/run-in-docker.yml
-          parameters:
-            baseImage: $(baseImage)
-            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
-
+        # we build the integration tests in parallel to starting the dependencies
+        # the first command is just a copy past of the run-in-docker template
         - script: |
+            docker run --rm \
+              --mount type=bind,source="$(System.DefaultWorkingDirectory)",target=/project \
+              --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
+              --env tracerHome=/project/$(relativeTracerHome) \
+              --env artifacts=/project/$(relativeArtifacts) \
+              --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
+              --env Verify_DisableClipboard=true \
+              --env DiffEngine_Disabled=true \
+              --env TestAllPackageVersions=$(TestAllPackageVersions) \
+              --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
+              --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
+              dd-trace-dotnet/$(baseImage)-tester \
+              dotnet /build/bin/Debug/_build.dll BuildLinuxIntegrationTests --framework $(publishTargetFramework) &
             docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64 &
             docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64 &
             wait

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -703,7 +703,6 @@ stages:
 
     - template: steps/run-in-docker.yml
       parameters:
-        build: true
         baseImage: $(baseImage)
         command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
 
@@ -712,9 +711,11 @@ stages:
       inputs:
         artifact: linux-tracer-home-$(baseImage)
         path: $(System.DefaultWorkingDirectory)/tracer/serverlessArtifacts
+
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests
-        docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests &
+        docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies &
+        wait
       env:
         baseImage: $(baseImage)
         framework: $(publishTargetFramework)
@@ -806,13 +807,13 @@ stages:
 
         - template: steps/run-in-docker.yml
           parameters:
-            build: true
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
 
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64
-            docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64
+            docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64 &
+            docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64 &
+            wait
           env:
             baseImage: $(baseImage)
             framework: $(publishTargetFramework)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -621,13 +621,12 @@ stages:
         patterns: '**/*-$(targetPlatform).msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
-    - script: tracer\build.cmd BuildWindowsIntegrationTests PublishIisSamples -Framework $(framework)
-      displayName: BuildWindowsIntegrationTests
-
     - script: |
-        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
+        tracer\build.cmd BuildWindowsIntegrationTests PublishIisSamples -Framework $(framework) &
+        docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS &
+        wait &
         docker-compose up -d IntegrationTests.IIS
-      displayName: docker-compose start IntegrationTests.IIS
+      displayName: BuildWindowsIntegrationTests and docker-compose start IntegrationTests.IIS
       retryCountOnTaskFailure: 5
 
     - script: tracer\build.cmd RunWindowsIisIntegrationTests -Framework $(framework) --code-coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -478,15 +478,6 @@ services:
       - kafka-zookeeper
       - aws_sqs
       - couchbase
-      - serverless-lambda-no-param-sync
-      - serverless-lambda-one-param-sync
-      - serverless-lambda-two-params-sync
-      - serverless-lambda-no-param-async
-      - serverless-lambda-one-param-async
-      - serverless-lambda-two-params-async
-      - serverless-lambda-no-param-void
-      - serverless-lambda-one-param-void
-      - serverless-lambda-two-params-void
       - serverless-integration-trace-context-mock
 
   ExplorationTests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -478,6 +478,15 @@ services:
       - kafka-zookeeper
       - aws_sqs
       - couchbase
+      - serverless-lambda-no-param-sync
+      - serverless-lambda-one-param-sync
+      - serverless-lambda-two-params-sync
+      - serverless-lambda-no-param-async
+      - serverless-lambda-one-param-async
+      - serverless-lambda-two-params-async
+      - serverless-lambda-no-param-void
+      - serverless-lambda-one-param-void
+      - serverless-lambda-two-params-void
       - serverless-integration-trace-context-mock
 
   ExplorationTests:
@@ -499,7 +508,7 @@ services:
       - explorationTestName=${explorationTestName:-eshoponweb}
       - baseImage=${baseImage:-default}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
-      
+
   StartDependencies:
     image: andrewlock/wait-for-dependencies
     depends_on:
@@ -531,7 +540,7 @@ services:
       - serverless-integration-trace-context-mock
     environment:
       - TIMEOUT_LENGTH=120
-    command: aerospike:3000 servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324 couchbase:11210 serverless-lambda-no-param-sync:8080 serverless-lambda-one-param-sync:8080 serverless-lambda-two-params-sync:8080 serverless-lambda-no-param-async:8080 serverless-lambda-one-param-async:8080 serverless-lambda-two-params-async:8080 serverless-integration-trace-context-mock:9003
+    command: aerospike:3000 servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 elasticsearch7:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324 couchbase:11210 serverless-lambda-no-param-sync:8080 serverless-lambda-one-param-sync:8080 serverless-lambda-two-params-sync:8080 serverless-lambda-no-param-async:8080 serverless-lambda-one-param-async:8080 serverless-lambda-two-params-async:8080 serverless-integration-trace-context-mock:9003 serverless-lambda-no-param-void:8080 serverless-lambda-one-param-void:8080 serverless-lambda-two-params-void:8080
 
   IntegrationTests.ARM64:
     build:


### PR DESCRIPTION
## Summary of changes

We seem to gain:
- 45 seconds on linux and ARM ITests by not rebuilding the image

## What we could have gained
- 2 minutes on Windows tests by not installing x86 .NET sdks on x64 tests. 
It seems simple to do. But it isn't actually. This variable is set through a dynamic strategy and used in a template, so I couldn't manage to make it work. If want to gain those 2 minutes, we could split windows tests in 2 stages, duplicating the yaml for x86 and x64 (but that would mean 4 windows stages so it may do more harm than good).

- 2 minutes by parallelizing build and docker-compose on linux ITests.
It's actually not working on netcoreapp3.1 (this is the only target serverless tests) as in that case the docker dependencies are built from Samples. So we need the Samples to do the rest. Once we build samples independently, we will be able to parallelize those tasks.

- 2 minutes on IIS Tests by parallelizing build and docker-compose. We can do it if we want once we compile samples separately.
