### PR TITLE
Split benchmarks between 6 different agents

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1023,45 +1023,57 @@ stages:
   #### Windows
 
   - job: Windows
-    timeoutInMinutes: 100
-    pool: Benchmarks
+    strategy:
+      matrix:
+        BenchmarkAgent1:
+          agent: "BenchmarkAgent1"
+        BenchmarkAgent2:
+          agent: "BenchmarkAgent2"
+        BenchmarkAgent3:
+          agent: "BenchmarkAgent3"
+        BenchmarkAgent4:
+          agent: "BenchmarkAgent4"
+        BenchmarkAgent5:
+          agent: "BenchmarkAgent5"
+        BenchmarkAgent6:
+          agent: "BenchmarkAgent6"
+
+    timeoutInMinutes: 30
+    pool:
+      name: $(agent)
 
     # Enable the Datadog Agent service for this job
     services:
       dd_agent: dd_agent
 
     steps:
-#    NOTE: doing a "normal" clone instead of using the template.
-#    For pull requests this MAY mean we're testing a different
-#    merge commit here, but it's a small risk, and the benchmark server
-#    doesn't have bash installed, so suck it up
-#    - template: steps/clone-repo.yml
-#      parameters:
-#        masterCommitId: $(masterCommitId)
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
 
-    - template: steps/install-latest-dotnet-sdk.yml
+    - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
 
     - script: tracer\build.cmd RunBenchmarks
       displayName: RunBenchmarks
 
     - publish: tracer/build_data/benchmarks
-      artifact: benchmarks_results
+      artifact: benchmarks_results_$(agent)
 
-    - script: tracer\build.cmd CompareBenchmarksResults
-      continueOnError: true
-      displayName: Compare Benchmarks
-      condition: and(succeeded(), eq(variables.isPullRequest, true))
-      env:
-        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
-        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
+#    - script: tracer\build.cmd CompareBenchmarksResults
+#      continueOnError: true
+#      displayName: Compare Benchmarks
+#      condition: and(succeeded(), eq(variables.isPullRequest, true))
+#      env:
+#        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+#        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+#        GITHUB_TOKEN: $(GITHUB_TOKEN)
 
     ## Is this really necessary?
     - task: PowerShell@2
       inputs:
         targetType: 'inline'
-        script: 'Start-Sleep -s 120'
+        script: 'Start-Sleep -s 30'
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1042,10 +1042,6 @@ stages:
     pool:
       name: $(agent)
 
-    # Enable the Datadog Agent service for this job
-    services:
-      dd_agent: dd_agent
-
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -1056,6 +1052,9 @@ stages:
 
     - script: tracer\build.cmd RunBenchmarks
       displayName: RunBenchmarks
+      env:
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+        DD_API_KEY: $(ddApiKey)
 
     - publish: tracer/build_data/benchmarks
       artifact: benchmarks_results_$(agent)
@@ -1069,11 +1068,6 @@ stages:
 #        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
 #        GITHUB_TOKEN: $(GITHUB_TOKEN)
 
-    ## Is this really necessary?
-    - task: PowerShell@2
-      inputs:
-        targetType: 'inline'
-        script: 'Start-Sleep -s 30'
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1018,7 +1018,7 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Windows]
+      jobs: [Windows, compare_benchmarks]
 
   #### Windows
 
@@ -1059,14 +1059,66 @@ stages:
     - publish: tracer/build_data/benchmarks
       artifact: benchmarks_results_$(agent)
 
-#    - script: tracer\build.cmd CompareBenchmarksResults
-#      continueOnError: true
-#      displayName: Compare Benchmarks
-#      condition: and(succeeded(), eq(variables.isPullRequest, true))
-#      env:
-#        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
-#        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
-#        GITHUB_TOKEN: $(GITHUB_TOKEN)
+  - job: compare_benchmarks
+    dependsOn: [ Windows ]
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - template: steps/install-latest-dotnet-sdk.yml
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent1
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent2
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent2
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent3
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent3
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent4
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent4
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent5
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent5
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent6
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent6
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    # upload the combined results for simplicity in other pipelines
+    - publish: tracer/build_data/benchmarks
+      artifact: benchmarks_results
+
+    - script: tracer\build.cmd CompareBenchmarksResults
+      continueOnError: true
+      displayName: Compare Benchmarks
+      condition: and(succeeded(), eq(variables.isPullRequest, true))
+      env:
+        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 
 - stage: dotnet_tool

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentFilterAttribute.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentFilterAttribute.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Benchmarks.Trace
+{
+    public class BenchmarkAgent1Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent1Attribute() : base(Agent.BenchmarkAgent1)
+        {
+        }
+    }
+    public class BenchmarkAgent2Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent2Attribute() : base(Agent.BenchmarkAgent2)
+        {
+        }
+    }
+    public class BenchmarkAgent3Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent3Attribute() : base(Agent.BenchmarkAgent3)
+        {
+        }
+    }
+    public class BenchmarkAgent4Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent4Attribute() : base(Agent.BenchmarkAgent4)
+        {
+        }
+    }
+    public class BenchmarkAgent5Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent5Attribute() : base(Agent.BenchmarkAgent5)
+        {
+        }
+    }
+    public class BenchmarkAgent6Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent6Attribute() : base(Agent.BenchmarkAgent6)
+        {
+        }
+    }
+
+    public abstract class AgentFilterAttribute : Attribute
+    {
+        public AgentFilterAttribute(Agent agent)
+        {
+            RunOn = agent;
+        }
+
+        public Agent RunOn { get; }
+
+        public enum Agent
+        {
+            BenchmarkAgent1,
+            BenchmarkAgent2,
+            BenchmarkAgent3,
+            BenchmarkAgent4,
+            BenchmarkAgent5,
+            BenchmarkAgent6,
+        }
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Util;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent1]
     public class AgentWriterBenchmark
     {
         private const int SpanCount = 1000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AppSecBodyBenchmark.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Http.Features;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent2]
     public class AppSecBodyBenchmark
     {
         private static readonly Security security;

--- a/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent1]
     public class AspNetCoreBenchmark
     {
         private static readonly HttpClient Client;

--- a/tracer/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.Configuration;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent1]
     public class DbCommandBenchmark
     {
         private static readonly CustomDbCommand CustomCommand = new CustomDbCommand();

--- a/tracer/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
@@ -10,6 +10,7 @@ using Elasticsearch.Net;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent5]
     public class ElasticsearchBenchmark
     {
         private static readonly RequestPipeline Pipeline = new RequestPipeline();

--- a/tracer/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
@@ -9,6 +9,7 @@ using GraphQL.Execution;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent3]
     public class GraphQLBenchmark
     {
         private static readonly Task<ExecutionResult> Result = Task.FromResult(new ExecutionResult { Value = 42 });

--- a/tracer/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Configuration;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent3]
     public class HttpClientBenchmark
     {
         private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };

--- a/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -12,6 +12,7 @@ using IExternalScopeProvider = Microsoft.Extensions.Logging.IExternalScopeProvid
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent4]
     public class ILoggerBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
@@ -13,6 +13,7 @@ using log4net.Repository.Hierarchy;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent4]
     public class Log4netBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
@@ -11,6 +11,7 @@ using NLog.Targets;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent3]
     public class NLogBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -29,7 +29,7 @@ namespace Benchmarks.Trace
                     .AddExporter(JsonExporter.FullCompressed);
 
                 var agentName = Environment.GetEnvironmentVariable("AGENT_NAME");
-                if (Enum.TryParse(agentName, out Agent benchmarkAgent))
+                if (Enum.TryParse(agentName, out AgentFilterAttribute.Agent benchmarkAgent))
                 {
                     var attributeName = $"{benchmarkAgent}Attribute";
                     Console.WriteLine($"Found agent name {agentName}; executing only benchmarks decorated with '{attributeName}");

--- a/tracer/test/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
@@ -10,6 +10,7 @@ using ServiceStack.Redis;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent4]
     public class RedisBenchmark
     {
         private static readonly RedisNativeClient Client = new RedisNativeClient();

--- a/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
@@ -16,6 +16,7 @@ using Logger = Serilog.Core.Logger;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent5]
     public class SerilogBenchmark
     {
         private static readonly Logger Logger;

--- a/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -10,6 +10,7 @@ namespace Benchmarks.Trace
     /// Span benchmarks
     /// </summary>
     [MemoryDiagnoser]
+    [BenchmarkAgent6]
     public class SpanBenchmark
     {
         private static readonly Tracer Tracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/TraceAnnotationsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/TraceAnnotationsBenchmark.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.Configuration;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
+    [BenchmarkAgent6]
     public class TraceAnnotationsBenchmark
     {
         private static readonly RuntimeMethodHandle MethodHandle;


### PR DESCRIPTION
## Summary of changes

- Adds 6 new benchmarks agents, and divides the benchmarks between them stably.
- Runs the 6 in parallel
- Switched to agentless CI-app

## Reason for change

Our benchmark runs currently take upwards of an hour. As there's only a single agent, that means runs easily get backed-up for 8+ hours. We don't block on the benchmark completion, but it means we also often don't see the results, or get notified of other failures in the build. With this approach we should be able to cut it down to ~15 mins, and we can gain some parallelism between jobs.

## Implementation details

- Created 6 Benchmark agents, based on the existing Windows integration test images (for simplicity) + installed the agent, and that's it.
- Using `Standard_D4ads_v5` VMs which are _similar_ to the `Standard_D2s_v3` we were using, but newer, so may as well take the opportunity to update I think.
- Each benchmark should be decorated with a `[BenchmarkAgent6]` attribute (for example). When running on an agent with the expected name (`AGENT_NAME=BenchmarkAgent6`), only those benchmarks will run. If the agent name env var is not set, all benchmarks will run, as before (good for local testing etc).
- We run the 6 in parallel, then do the benchmark comparison after they've all finished. 

When deciding how to split them up, I compared the durations, and then assigned agents trying to get as even a split as I can

| Benchmark                 | Duration (s) | Agent |
|---------------------------|-------------:|:-----:|
| AgentWriterBenchmark      | 124.68       | 1     |
| AppSecBodyBenchmark       | 688.25       | 2     |
| AspNetCoreBenchmark       | 182.49       | 1     |
| DbCommandBenchmark        | 206.74       | 1     |
| ElasticsearchBenchmark    | 328.25       | 5     |
| GraphQLBenchmark          | 136.22       | 3     |
| HttpClientBenchmark       | 132.05       | 3     |
| ILoggerBenchmark          | 127.92       | 4     |
| Log4netBenchmark          | 180.67       | 4     |
| NLogBenchmark             | 243.76       | 3     |
| RedisBenchmark            | 142.80       | 4     |
| SerilogBenchmark          | 148.19       | 5     |
| SpanBenchmark             | 264.67       | 6     |
| TraceAnnotationsBenchmark | 247.61       | 6     |
| **Total seconds:**        | **3154.30**  |       |

Which gives: 

| Agent Number | Agent totals |
|:------------:|-------------:|
| 1            | 513.91       |
| 2            | 688.25       |
| 3            | 512.03       |
| 4            | 451.39       |
| 5            | 476.44       |
| 6            | 512.28       |
| **Average**  | **525.72**   |

So not perfect, but not too bad

## Test coverage

The PR is the test, but I've confirmed results are coming through on the dashboard with agentless ci-app. This PR is the test that the comparison/commenter etc still works correctly

## Other details
- I'll keep the existing benchmark agent hanging around for now, in case we need to revert.
- I'll document the process of adding a new benchmark agent in Confluence.
- We have a lot of the benchmarks missing from the benchmark dashboard (AppSec, ILogger, Trace Annotations etc). We should update that

