### PR TITLE
[Build] Do not update Pipeline Monitoring nuget version

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -326,7 +326,6 @@ partial class Build
                 "tracer/src/Datadog.Trace/Datadog.Trace.csproj",
                 "tracer/src/Datadog.Trace/TracerConstants.cs",
                 "tracer/test/test-applications/regression/AutomapperTest/Dockerfile",
-                "tracer/tools/PipelineMonitor/PipelineMonitor.csproj",
             };
 
             if (ExpectChangelogUpdate)

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -189,10 +189,6 @@ namespace PrepareRelease
                 "../shared/src/msi-installer/WindowsInstaller.wixproj",
                 WixProjReplace);
 
-            SynchronizeVersion(
-                "tools/PipelineMonitor/PipelineMonitor.csproj",
-                DatadogTraceNugetDependencyVersionReplace);
-
             Console.WriteLine($"Completed synchronizing versions to {VersionString()}");
         }
 

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+      <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of changes
Removed the Pipeline Monitor project from version update

## Reason for change
This package doesn't exist. It just doesn't make sense to add this project to the version update.
