### PR TITLE
Fix all sample package versions and `UpdateVersion` task

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -57,8 +57,8 @@ jobs:
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion UpdateMsiContents
         env:
-          Version: ${{ steps.versions.outputs.version }}
-          IsPrerelease: ${{ steps.versions.outputs.isprerelease }}
+          NewVersion: ${{ steps.versions.outputs.version }}
+          NewIsPrerelease: ${{ steps.versions.outputs.isprerelease }}
 
       - name: "Verify Changes"
         id: changes

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      Version: "${{ github.event.inputs.version }}"
-      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
+      NewVersion: "${{ github.event.inputs.version }}"
+      NewIsPrerelease: "${{ github.event.inputs.is_prerelease }}"
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      Version: "${{ github.event.inputs.version }}"
-      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
+      NewVersion: "${{ github.event.inputs.version }}"
+      NewIsPrerelease: "${{ github.event.inputs.is_prerelease }}"
 
     steps:
       - name: Support longpaths

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -191,9 +191,19 @@ partial class Build
        .Before(Clean, BuildTracerHome)
        .Before(Clean, BuildProfilerHome)
        .Requires(() => Version)
+       .Requires(() => NewVersion)
+       .Requires(() => NewIsPrerelease)
        .Executes(() =>
         {
-            new SetAllVersions(TracerDirectory, Version, IsPrerelease).Run();
+            if (NewVersion == Version)
+            {
+                throw new Exception($"Cannot set versions, new version {NewVersion} was the same as {Version}");
+            }
+
+            // Samples need to use the latest version (i.e. the _current_ build version, before updating)
+            new SetAllVersions.Samples(TracerDirectory, Version, IsPrerelease).Run();
+            // Source needs to use the _actual_ version
+            new SetAllVersions.Source(TracerDirectory, NewVersion, NewIsPrerelease.Value!).Run();
         });
 
     Target UpdateMsiContents => _ => _

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -60,11 +60,17 @@ partial class Build : NukeBuild
     [Parameter("Is the build running on Alpine linux? Default is 'false'")]
     readonly bool IsAlpine = false;
 
-    [Parameter("The build version. Default is latest")]
+    [Parameter("The current version of the source and build")]
     readonly string Version = "2.9.0";
 
-    [Parameter("Whether the build version is a prerelease(for packaging purposes). Default is latest")]
+    [Parameter("Whether the current build version is a prerelease(for packaging purposes)")]
     readonly bool IsPrerelease = false;
+
+    [Parameter("The new build version to set")]
+    readonly string NewVersion;
+
+    [Parameter("Whether the new build version is a prerelease(for packaging purposes)")]
+    readonly bool? NewIsPrerelease;
 
     [Parameter("Prints the available drive space before executing each target. Defaults to false")]
     readonly bool PrintDriveSpace = false;

--- a/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" />
   </ItemGroup>

--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Datadog.Monitoring.Distribution" Version="1.28.6-beta01" />
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.18" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.5.0-beta01" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.0.0" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+    <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.9.0
+ARG TRACER_VERSION=2.8.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.9.0
+ARG TRACER_VERSION=2.8.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Debian.dockerfile
+++ b/tracer/samples/ConsoleApp/Debian.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=2.9.0
+ARG TRACER_VERSION=2.8.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/tracer/samples/WindowsContainer/Dockerfile
+++ b/tracer/samples/WindowsContainer/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2019 AS base
 WORKDIR /app
 
-ARG TRACER_VERSION=2.9.0
+ARG TRACER_VERSION=2.8.0
 ENV DD_TRACER_VERSION=$TRACER_VERSION
 ENV ASPNETCORE_URLS=http://*.80
 

--- a/tracer/test/test-applications/regression/AutomapperTest/Dockerfile
+++ b/tracer/test/test-applications/regression/AutomapperTest/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim AS base
-ARG TRACER_VERSION=2.9.0
+ARG TRACER_VERSION=2.8.0
 RUN mkdir -p /opt/datadog
 RUN mkdir -p /var/log/datadog/dotnet
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACER_VERSION/datadog-dotnet-apm-$TRACER_VERSION.tar.gz | tar xzf - -C /opt/datadog

--- a/tracer/test/test-applications/regression/MismatchedTracerVersions/Build-Tracer.ps1
+++ b/tracer/test/test-applications/regression/MismatchedTracerVersions/Build-Tracer.ps1
@@ -27,7 +27,7 @@ foreach ($TracerVersion in $TracerVersions) {
     }
 
     Write-Host "Changing tracer version to ${TracerVersion}"
-    & "$SolutionDirectory/build.ps1" UpdateVersion -Version $TracerVersion -IsPrerelease $false -NoLogo -Verbosity minimal
+    & "$SolutionDirectory/build.ps1" UpdateVersion -NewVersion $TracerVersion -NewIsPrerelease $false -NoLogo -Verbosity minimal
 
     Write-Host "Building tracer ${TracerVersion} into ${TracerHomeDirectory}"
     & "$SolutionDirectory/build.ps1" Clean BuildTracerHome PackageTracerHome -Version $TracerVersion -TracerHome $TracerHomeDirectory -NoLogo -Verbosity minimal

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Datadog.Trace" Version="2.9.0" />
+      <PackageReference Include="Datadog.Trace" Version="2.8.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of changes

- A more complete version of #2764
- Updates all samples (and pipeline monitoring tool) to use the latest version of Datadog.Trace NuGet
- Updates the `UpdateVersion` task to use the _previous_ version of the Datadog.Trace NuGet

## Reason for change

Our samples all reference the Datadog.Trace NuGet with the same version as the current source. This worked fine when were updating the version just _before_ a release, but now that we update the versions just _after_ a release, it means the samples all reference a non-existent NuGet package

## Implementation details

- Manually updated the samples to the correct version initially
- Add separate parameters `NewVersion` and `NewIsPrerelease` so that we can access the "current" values in `Version` and `IsPrerelease`
- When running `UpdateVersion` task (which happens automatically in build scripts)
  - Update the sample apps to use the existing `Version` values
  - Update the source build to use the new `NewVersion` values

## Test coverage
I ran `UpdateVersion` locally a couple of times and verified the behaviour was as expected, i.e. the samples "track behind" the source version

## Other details
Closes #2764 (as this incorporates it)
Only downside is when reviewing the version bump PR we need to be aware that we expect to see two different versions. We _could_ run this as two separate tasks, create separate commits etc, but I don't think that's necessary right now. I suggest we see how it goes and do that later if we want to (it's a bit of a pain)
