### PR TITLE
Fix `StackOverflowException` issues when an application uses custom `AssemblyLoadContext`'s and has a manual/automatic tracer version mismatch

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -38,6 +38,7 @@ private:
     RuntimeInformation runtime_information_;
     std::vector<IntegrationDefinition> integration_definitions_;
     std::deque<std::pair<ModuleID, std::vector<MethodReference>>> rejit_module_method_pairs;
+    std::deque<ModuleID> deferred_integration_modules;
 
     std::unordered_set<shared::WSTRING> definitions_ids_;
     std::mutex definitions_ids_lock_;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Internal/AssemblyLoadContext_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Internal/AssemblyLoadContext_Integration.cs
@@ -1,0 +1,49 @@
+// <copyright file="AssemblyLoadContext_Integration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+#if !NETFRAMEWORK
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal
+{
+    /// <summary>
+    /// System.Web.ThreadContext.DisassociateFromCurrentThread calltarget instrumentation
+    /// </summary>
+    /*
+    [InstrumentMethod(
+        AssemblyName = "System.Private.CoreLib",
+        TypeName = "System.Runtime.Loader.AssemblyLoadContext",
+        MethodName = "ResolveUsingEvent",
+        ReturnTypeName = "System.Reflection.Assembly",
+        ParameterTypeNames = new string[] { "System.Reflection.AssemblyName" },
+        MinimumVersion = "4.0.0",
+        MaximumVersion = "*.*.*",
+        IntegrationName = IntegrationName)]
+    */
+    [InstrumentMethod(
+        AssemblyName = "System.Private.CoreLib",
+        TypeName = "System.Runtime.Loader.AssemblyLoadContext",
+        MethodName = "ResolveUsingLoad",
+        ReturnTypeName = "System.Reflection.Assembly",
+        ParameterTypeNames = new string[] { "System.Reflection.AssemblyName" },
+        MinimumVersion = "4.0.0",
+        MaximumVersion = "*.*.*",
+        IntegrationName = IntegrationName)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class AssemblyLoadContext_Integration
+    {
+        private const string IntegrationName = nameof(Configuration.IntegrationId.Internal);
+        internal static readonly Assembly InstrumentationAssembly = Assembly.GetExecutingAssembly();
+        internal static readonly AssemblyName InstrumentationAssemblyName = InstrumentationAssembly.GetName();
+    }
+}
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -57,6 +57,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, TArg1 arg1)
         {
+#if !NETFRAMEWORK
+            // Insert special-case handling for AssemblyLoadContext events,
+            // which all have one method paramater.
+            // Skip CallTarget infrastructure to avoid StackOverflowExceptions when
+            // some of the Datadog.Trace dependencies have not been loaded yet
+            if (typeof(TIntegration) == typeof(Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration))
+            {
+                return new CallTargetState(scope: null, state: arg1);
+            }
+#endif
+
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
@@ -281,6 +292,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, ref TArg1 arg1)
         {
+#if !NETFRAMEWORK
+            // Insert special-case handling for AssemblyLoadContext events,
+            // which all have one method paramater.
+            // Skip CallTarget infrastructure to avoid StackOverflowExceptions when
+            // some of the Datadog.Trace dependencies have not been loaded yet
+            if (typeof(TIntegration) == typeof(Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration))
+            {
+                return new CallTargetState(scope: null, state: arg1);
+            }
+#endif
+
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
@@ -548,6 +570,29 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetReturn<TReturn> EndMethod<TIntegration, TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
+#if !NETFRAMEWORK
+            // Insert special-case handling for AssemblyLoadContext events,
+            // which all have one method paramater.
+            // Skip CallTarget infrastructure to avoid StackOverflowExceptions when
+            // some of the Datadog.Trace dependencies have not been loaded yet
+            if (typeof(TIntegration) == typeof(Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration))
+            {
+                var assemblyName = state.State as System.Reflection.AssemblyName;
+                if (assemblyName is not null
+                    && assemblyName.Name == Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssemblyName.Name
+                    && assemblyName.Version <= Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssemblyName.Version
+                    && !object.ReferenceEquals(returnValue, Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssembly)
+                    && returnValue is System.Reflection.Assembly assembly)
+                {
+                    return new CallTargetReturn<TReturn>((TReturn)((object)Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssembly));
+                }
+                else
+                {
+                    return new CallTargetReturn<TReturn>(returnValue);
+                }
+            }
+#endif
+
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
@@ -592,6 +637,29 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetReturn<TReturn> EndMethod<TIntegration, TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
         {
+#if !NETFRAMEWORK
+            // Insert special-case handling for AssemblyLoadContext events,
+            // which all have one method paramater.
+            // Skip CallTarget infrastructure to avoid StackOverflowExceptions when
+            // some of the Datadog.Trace dependencies have not been loaded yet
+            if (typeof(TIntegration) == typeof(Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration))
+            {
+                var assemblyName = state.State as System.Reflection.AssemblyName;
+                if (assemblyName is not null
+                    && assemblyName.Name == Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssemblyName.Name
+                    && assemblyName.Version <= Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssemblyName.Version
+                    && !object.ReferenceEquals(returnValue, Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssembly)
+                    && returnValue is System.Reflection.Assembly assembly)
+                {
+                    return new CallTargetReturn<TReturn>((TReturn)((object)Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration.InstrumentationAssembly));
+                }
+                else
+                {
+                    return new CallTargetReturn<TReturn>(returnValue);
+                }
+            }
+#endif
+
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void RecordTelemetry()
         {
-            if (_integrationId.Value is not null)
+            if (_integrationId.Value is not null && _integrationId.Value != IntegrationId.Internal)
             {
                 Tracer.Instance.TracerManager.Telemetry.IntegrationRunning(_integrationId.Value.Value);
             }

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
@@ -47,5 +47,6 @@ namespace Datadog.Trace.Configuration
         NLog,
         TraceAnnotations,
         Grpc,
+        Internal,
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -156,6 +156,9 @@ namespace Datadog.Trace.ClrProfiler
                new ("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactoryScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"),
                new ("Microsoft.Extensions.Logging.Abstractions", "Microsoft.Extensions.Logging.LoggerExternalScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"),
 
+                // Internal
+               new ("System.Private.CoreLib", "System.Runtime.Loader.AssemblyLoadContext", "ResolveUsingLoad",  new[] { "System.Reflection.Assembly", "System.Reflection.AssemblyName" }, 4, 0, 0, 65535, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"),
+
                 // Kafka
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Close",  new[] { "System.Void" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"),
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Consume",  new[] { "Confluent.Kafka.ConsumeResult`2[!0,!1]", "System.Int32" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"),
@@ -544,6 +547,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.ILogger,
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"
+                    => Datadog.Trace.Configuration.IntegrationId.Internal,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerDisposeIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -156,6 +156,9 @@ namespace Datadog.Trace.ClrProfiler
                new ("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactoryScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"),
                new ("Microsoft.Extensions.Logging.Abstractions", "Microsoft.Extensions.Logging.LoggerExternalScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"),
 
+                // Internal
+               new ("System.Private.CoreLib", "System.Runtime.Loader.AssemblyLoadContext", "ResolveUsingLoad",  new[] { "System.Reflection.Assembly", "System.Reflection.AssemblyName" }, 4, 0, 0, 65535, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"),
+
                 // Kafka
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Close",  new[] { "System.Void" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"),
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Consume",  new[] { "Confluent.Kafka.ConsumeResult`2[!0,!1]", "System.Int32" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"),
@@ -544,6 +547,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.ILogger,
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"
+                    => Datadog.Trace.Configuration.IntegrationId.Internal,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerDisposeIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -156,6 +156,9 @@ namespace Datadog.Trace.ClrProfiler
                new ("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactoryScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"),
                new ("Microsoft.Extensions.Logging.Abstractions", "Microsoft.Extensions.Logging.LoggerExternalScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"),
 
+                // Internal
+               new ("System.Private.CoreLib", "System.Runtime.Loader.AssemblyLoadContext", "ResolveUsingLoad",  new[] { "System.Reflection.Assembly", "System.Reflection.AssemblyName" }, 4, 0, 0, 65535, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"),
+
                 // Kafka
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Close",  new[] { "System.Void" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"),
                new ("Confluent.Kafka", "Confluent.Kafka.Consumer`2", "Consume",  new[] { "Confluent.Kafka.ConsumeResult`2[!0,!1]", "System.Int32" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"),
@@ -544,6 +547,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.ILogger,
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.Internal.AssemblyLoadContext_Integration"
+                    => Datadog.Trace.Configuration.IntegrationId.Internal,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerCloseIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerDisposeIntegration"


### PR DESCRIPTION
## Summary of changes
Add a new integration to insert ourselves into the AssemblyLoadContext loading process to prevent `StackOverflowException`'s from occurring when there is a manual/automatic tracer version mismatch and the application contains custom AssemblyLoadContexts.

## Reason for change
In a manual/automatic tracer version mismatch scenario, the "manual" instrumentation assembly is rewritten so that `DistributedTracer.GetDistributedTracer()` calls the `DistributedTracer.GetDistributedTracer()` method from the instrumentation assembly. This is done by injecting a method invocation using a new set of AssemblyRef/TypeRef/MemberRef tokens to the new assembly and letting the runtime resolve the assembly. However, custom AssemblyLoadContexts and assembly-resolving event handlers may force the assembly reference to resolve to itself, causing the method to call itself and eventually raise a `StackOverflowException`.

## Implementation details
The proposed solution is to inject ourselves into `AssemblyLoadContext` methods to force the `Datadog.Trace` assembly references to resolve to the automatic instrumentation assembly. Changes include:

- Adding a new integrations to rewrite `System.Runtime.Loader.AssemblyLoadContext.ResolveUsingLoad`, which is responsible for invoking `AssemblyLoadContext.Load`. This will interrupt all ALC's so we can return the automatic instrumentation's copy of `Datadog.Trace` if the requested assembly is `Datadog.Trace` and it has a version less than or equal to the instrumentation's version.
- Adding a new integration category `Internal`
- Adding an event handler for `System.Runtime.Loader.AssemblyLoadContext.Default.Resolving`

> Note: Assemblies loaded via AssemblyRefs and TypeRefs and loaded from the Default AssemblyLoadContext do not invoke the methods we instrument, so the application may still load a lower version of `Datadog.Trace` if directly referenced from the application code.

## Test coverage
Tested the following scenarios locally:
- Application running on (local) Azure Functions Runtime v3 with tracer version mismatch
- xUnit test project with tracer version mismatch
- Console application with tracer version mismatch

## Other details
<!-- Fixes #{issue} -->

Remaining items:
- [ ] Ensure the `Internal` integration cannot be selectively disabled
- [ ] For whatever reason, trying to rewrite `System.Runtime.Loader.AssemblyLoadContext.ResolveUsingEvent` causes issues with the Azure Functions runtime. Ideally, we'd understand WHY we can't do that, before merging.
- [ ] For some reason we need to add a Resolving event to the Default ALC. Make sure to understand why
- [ ] Add automated tests, not just local one-off tests