### PR TITLE
Don't check agent connectivity when tracing is disabled

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -230,10 +230,12 @@ namespace Datadog.Trace
             }
 
             string agentError = null;
+            var instanceSettings = instance.Settings;
 
             // In AAS, the trace agent is deployed alongside the tracer and managed by the tracer
             // Disable this check as it may hit the trace agent before it is ready to receive requests and give false negatives
-            if (!AzureAppServices.Metadata.IsRelevant)
+            // Also disable if tracing is not enabled (as likely to be in an environment where agent is not available)
+            if (instanceSettings.TraceEnabled && !AzureAppServices.Metadata.IsRelevant)
             {
                 try
                 {
@@ -252,7 +254,6 @@ namespace Datadog.Trace
 
             try
             {
-                var instanceSettings = instance.Settings;
                 var stringWriter = new StringWriter();
 
                 using (var writer = new JsonTextWriter(stringWriter))


### PR DESCRIPTION
## Summary of changes

Don't check connectivity if `DD_TRACE_ENABLED=false`

## Reason for change

There is no expectation that the agent should be available if tracing is disabled. Doing so will write a spurious error to the logs.

## Implementation details

If tracing is disabled, don't run the agent check.

## Test coverage
None, because we can't easily test logging stuff atm. I considered refactoring to add it, but this seems simple enough not to bother, plus we are looking to rework the whole log infrastructure soon anyway

## Other details
N/A
