### PR TITLE
Write integration test logs directly to `build_data` directory

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -129,6 +129,7 @@ partial class Build
                .After(Clean, BuildTracerHome, SetUpExplorationTests)
                .Executes(() =>
                 {
+                    FileSystemTasks.EnsureExistingDirectory(TestLogsDirectory);
                     try
                     {
                         var envVariables = GetEnvironmentVariables();
@@ -137,7 +138,7 @@ partial class Build
                     }
                     finally
                     {
-                        MoveLogsToBuildData();
+                        CopyDumpsToBuildData();
                     }
                 })
         ;
@@ -146,6 +147,7 @@ partial class Build
     {
         var envVariables = new Dictionary<string, string>
         {
+            ["DD_TRACE_LOG_DIRECTORY"] = TestLogsDirectory,
             ["DD_SERVICE"] = "exploration_tests",
             ["DD_VERSION"] = Version
         };

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -67,6 +67,12 @@ internal static partial class DotNetSettingsExtensions
     {
         return settings.SetProcessEnvironmentVariable("DD_SERVICE_NAME", serviceName);
     }
+
+    public static T SetLogsDirectory<T>(this T settings, AbsolutePath logsDirectory)
+        where T: ToolSettings
+    {
+        return settings.SetProcessEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", logsDirectory);
+    }
     
     public static T SetProcessEnvironmentVariables<T>(this T settings, IEnumerable<KeyValuePair<string, string>> variables)
         where T: ToolSettings

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
+using DiffEngine;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -26,7 +27,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public void SingleLoaderTest()
         {
             string tmpFile = Path.GetTempFileName();
+            // Using obsolete variable so we can be sure it will only
+            // contain logs from this sample
             SetEnvironmentVariable("DD_TRACE_LOG_PATH", tmpFile);
+
+            // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
+
             using ProcessResult processResult = RunSampleAndWaitForExit(new MockTracerAgent(9696, doNotBindPorts: true));
             string[] logFileContent = File.ReadAllLines(tmpFile);
             int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));


### PR DESCRIPTION
## Summary of changes

Writes logs directly to `build_data` in integration tests, instead of writing to system logs folder and then copying them across.

## Reason for change

We've seen some _really_ weird things, where log files from other branches seem to be polluting a pipeline run. This _shouldn't_ happen. I can't find an explanation as to how it _can_ happen. Yet, happen it does. This should definitely avoid the issue.

## Implementation details

Previously we were writing log files to the default "system" directory (e.g. `/var/logs/datadog/dotnet` etc), and then copying them across to `build_data` as the final step in the Nuke targets. 

Instead, we set `DD_TRACE_LOG_DIRECTORY` to the `build_data` folder initially, so we don't need to copy anything. This is within the "repository" structure, so is _definitely_ cleaned between runs, and as a bonus this is on the temp drive, so it should be faster. 

I've left the "copy memory dumps" as-is for now, as those get written to the system temp drive so harder work to fix (plus we've never actually captured one afaict!)

## Test coverage

Confirmed we are still capturing and uploading the log files in our CI runs. No evidence of cross-run pollution. 

## Other details
Had to tweak the `NoMultiLoaderTests`, as this is relying on the deprecated `DD_TRACE_LOG_PATH` variable, to override the log path, but that's ignored when `DD_TRACE_LOG_DIRECTORY` is set, so removed `DD_TRACE_LOG_DIRECTORY` for that single test.
