### PR TITLE
Instrument custom methods using New Relic attributes

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -16,8 +16,14 @@ namespace trace
 {
 
 const size_t kPublicKeySize = 8;
+
 const shared::WSTRING traceattribute_typename = WStr("Datadog.Trace.Annotations.TraceAttribute");
+const shared::WSTRING newrelic_traceattribute_typename = WStr("NewRelic.Api.Agent.TraceAttribute");
+const shared::WSTRING newrelic_transactionattribute_typename = WStr("NewRelic.Api.Agent.TransactionAttribute");
 static LPCWSTR traceAttribute_typename_cstring = traceattribute_typename.c_str();
+static LPCWSTR newrelic_traceattribute_typename_cstring = newrelic_traceattribute_typename.c_str();
+static LPCWSTR newrelic_transactionattribute_typename_cstring = newrelic_transactionattribute_typename.c_str();
+
 const shared::WSTRING tracemethodintegration_assemblyname = WStr("#TraceMethodFeature");
 const std::unordered_set<shared::WSTRING> tracemethodintegration_wildcard_ignored_methods(
     {WStr(".ctor"), WStr(".cctor"), WStr("Equals"), WStr("Finalize"), WStr("GetHashCode"), WStr("ToString")});

--- a/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsAutomaticOnlyTests._.verified.txt
@@ -816,5 +816,33 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTransactionMethodAsync,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchAfterFeatureTests._.verified.txt
@@ -816,5 +816,33 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTransactionMethodAsync,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.AfterFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchBeforeFeatureTests._.verified.txt
@@ -816,5 +816,33 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTransactionMethodAsync,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.BeforeFeature,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
+++ b/tracer/test/snapshots/TraceAnnotationsVersionMismatchNewerNuGetTests._.verified.txt
@@ -816,5 +816,33 @@
       language: dotnet,
       version: 1.0.0
     }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTransactionMethodAsync,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: trace.annotation,
+    Resource: ProgramHelpers.NewRelicTraceMethod,
+    Service: Samples.TraceAnnotations.VersionMismatch.NewerNuGet,
+    ParentId: Id_2,
+    Tags: {
+      component: trace,
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
   }
 ]

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Samples.TraceAnnotations.VersionMismatch.AfterFeature.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/Samples.TraceAnnotations.VersionMismatch.AfterFeature.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="2.5.0" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Samples.TraceAnnotations.VersionMismatch.BeforeFeature.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/Samples.TraceAnnotations.VersionMismatch.BeforeFeature.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="2.4.4" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Samples.TraceAnnotations.VersionMismatch.NewerNuGet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/Samples.TraceAnnotations.VersionMismatch.NewerNuGet.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Datadog.Trace" Version="255.1.1-dev2.8.0-build01-ddtracemethods" />
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/ProgramHelpers.cs
@@ -3,7 +3,9 @@ extern alias OfficialDatadogAlias;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using NewRelic.Api.Agent;
 using CustomTraceAttribute = Datadog.Trace.Annotations.TraceAttribute;
+using NewRelicTraceAttribute = NewRelic.Api.Agent.TraceAttribute;
 using OfficialTraceAttribute = OfficialDatadogAlias::Datadog.Trace.Annotations.TraceAttribute;
 
 namespace Samples.TraceAnnotations
@@ -13,6 +15,7 @@ namespace Samples.TraceAnnotations
         [CustomTrace]
         public static async Task RunTestsAsync()
         {
+            // Invoke instrumented methods for reference type
             var testType = new TestType();
             var testTypeName = testType.Name;
             testType.Name = null;
@@ -32,14 +35,14 @@ namespace Samples.TraceAnnotations
             testType.Finalize(0);
 
             // Release the reference to testType
-            testType = null;
-
             // Force a garbage collection, try to invoke finalizer on previous testType object
+            testType = null;
             GC.Collect();
 
             // Delay
             await Task.Delay(500);
 
+            // Invoke instrumented methods for generic reference type
             var testTypeGenericString = new TestTypeGeneric<string>();
             var testTypeGenericStringName = testTypeGenericString.Name;
             testTypeGenericString.Name = null;
@@ -59,14 +62,14 @@ namespace Samples.TraceAnnotations
             testTypeGenericString.Finalize(0);
 
             // Release the reference to testTypeGenericString
-            testTypeGenericString = null;
-
             // Force a garbage collection, try to invoke finalizer on previous testTypeGenericString object
+            testTypeGenericString = null;
             GC.Collect();
 
             // Delay
             await Task.Delay(500);
 
+            // Invoke instrumented methods for value type
             var testTypeStruct = new TestTypeStruct();
             var testTypeStructName = testTypeStruct.Name;
             testTypeStruct.Name = null;
@@ -84,9 +87,10 @@ namespace Samples.TraceAnnotations
             testTypeStruct.ReturnGenericMethodAttribute<string, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2));
             testTypeStruct.ExtensionMethodForTestTypeTypeStruct();
 
-            // Do not try to invoke finalizer for struct as it does not have a finalizer
+            // Delay
             await Task.Delay(500);
 
+            // Invoke instrumented methods for static type
             var testTypeStaticName = TestTypeStatic.Name;
             TestTypeStatic.Name = null;
             TestTypeStatic.VoidMethod("Hello World", 42, Tuple.Create(1, 2));
@@ -101,22 +105,30 @@ namespace Samples.TraceAnnotations
             await TestTypeStatic.ReturnValueTaskTMethod("Hello world", 42, Tuple.Create(1, 2));
             TestTypeStatic.ReturnGenericMethodAttribute<string, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2));
 
+            // Delay
             await Task.Delay(500);
-            
+
+            // Invoke instrumented methods on framework types
             HttpRequestMessage message = new HttpRequestMessage();
             message.Method = HttpMethod.Get;
 
+            // Delay
             await Task.Delay(500);
 
+            // Invoke instrumented methods only from attributes
             await AttributeOnlyStatic.ReturnTaskTMethod("Hello World", 42, Tuple.Create(1, 2));
-
             await WaitUsingOfficialAttribute();
+            await NewRelicTransactionMethodAsync("Hello World");
+            NewRelicTraceMethod(42);
         }
 
         [OfficialTrace(OperationName = "overridden.attribute", ResourceName = "Program_WaitUsingOfficialAttribute")]
-        private static Task WaitUsingOfficialAttribute()
-        {
-            return Task.Delay(500);
-        }
+        private static Task WaitUsingOfficialAttribute() => Task.Delay(500);
+
+        [Transaction]
+        private static Task NewRelicTransactionMethodAsync(string input) => Task.Delay(500);
+
+        [NewRelicTrace]
+        private static void NewRelicTraceMethod(int input) { }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Samples.TraceAnnotations.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TraceAnnotations/Samples.TraceAnnotations.csproj
@@ -6,6 +6,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NewRelic.Agent.Api" Version="9.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj">
       <Aliases>OfficialDatadogAlias</Aliases>
     </ProjectReference>


### PR DESCRIPTION
## Summary of changes
Improves the discovery of trace attributes in an application to also consider New Relic attributes, in addition to the Datadog attribute (`Datadog.Trace.Annotations.TraceAttribute`)

## Reason for change
We want to make it easier for users to add custom instrumentation to their applications. If the application already used the attributes from New Relic, no code changes are needed to instrument those same methods using Datadog.

## Implementation details
During the module load event, we first check whether the assembly has defined a TypeDef/TypeRef to to `Datadog.Trace.Annotations.TraceAttribute` and if that succeeds then we iterate through all custom attributes in the assembly to find the attribute types we care about and instrument the methods that they decorate. This PR adds the New Relic attributes `NewRelic.Api.Agent.TraceAttribute` and `NewRelic.Api.Agent.TransactionAttribute` to the set of included types when checking for TypeRefs (not TypeDefs) and for attribute usage.

## Test coverage
The `Samples.TraceAnnotations` applications have been updated with usage of New Relic attributes and snapshot tests confirm that the new methods are instrumented.

## Other details
N/A