### PR TITLE
Improve git checkout to handle rebases on Benchmark VMs

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -32,12 +32,23 @@ steps:
       git reset origin/$prBranch --hard
     displayName: checkout
   - bash: |
-      echo "Merging $prBranch with ${{ parameters.masterCommitId }} ..."
+      echo "Updating credentials ..."
       git config user.email "gitfun@example.com"
       git config user.name "Automatic Merge"
+
+      echo "Merging $prBranch with ${{ parameters.masterCommitId }} ..."
       git merge ${{ parameters.masterCommitId }}
+      
+      mergeInProgress=$?
+      if [ $mergeInProgress -ne 0 ]
+      then
+        echo "Merge failed, rolling back ..."
+        git merge --abort
+        exit 1;
+      fi
+
+      echo "Merge successful"
       git status
     displayName: merge
-    failOnStderr: true
 - ${{ else }}:
   - checkout: self

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -8,14 +8,15 @@ steps:
   - bash: |
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
-      set +x
       prBranch=$SYSTEM_PULLREQUEST_SOURCEBRANCH
       echo "Checking out merge commit for ${{ parameters.masterCommitId }} and $prBranch"
       git version
       git lfs version
-      echo "Updating git config"
+      echo "Updating git config ..."
       git config init.defaultBranch master
+      echo "Initializing repository at $BUILD_REPOSITORY_LOCALPATH ..."
       git init "$BUILD_REPOSITORY_LOCALPATH"
+      echo "Adding remote $BUILD_REPOSITORY_URI ..."
       git remote add origin "$BUILD_REPOSITORY_URI"
       git config gc.auto 0
       git config --get-all http.$BUILD_REPOSITORY_URI.extraheader
@@ -23,10 +24,15 @@ steps:
       git config --get-regexp .*extraheader
       git config --get-all http.proxy
       git config http.version HTTP/1.1
+      echo "Force fetching master and $prBranch ..."
       git fetch --force --tags --prune --prune-tags --progress --no-recurse-submodules origin +refs/heads/master:refs/remotes/origin/master +refs/heads/$prBranch:refs/remotes/origin/$prBranch
+      echo "Checking out $prBranch..."
       git checkout --force $prBranch
+      echo "Resetting $prBranch to origin/$prBranch ..."
+      git reset origin/$prBranch --hard
     displayName: checkout
   - bash: |
+      echo "Merging $prBranch with ${{ parameters.masterCommitId }} ..."
       git config user.email "gitfun@example.com"
       git config user.name "Automatic Merge"
       git merge ${{ parameters.masterCommitId }}


### PR DESCRIPTION
## Summary of changes

Fix checkout on benchmark VMs

## Reason for change

When a branch had been merged using GitHub's "merge" button, we were seeing silent failures in the checkout stages on the Benchmark VMS

## Implementation details

The benchmarks etc VMs are long-lived, so we re-clone the git repo. However, this can cause issues when references change (e.g. rebasing/merges) and can [cause the merge to fail](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=98855&view=logs&j=8e30da06-6f63-5e55-9ded-896e7f06c2ab&t=0172328a-49a2-5487-0ae3-0b3a4fbbcdb6). Previously, this would "silently" fail.

There are two fixes in this PR, in addition to some extra logging:
- Run `git reset origin/$prBranch --hard`. That ensures we are correctly mirroring the remote before we do the merge.
- Check whether the merge process succeeded. If not, then abort the merge and fail the step.


