### PR TITLE
[CiApp] - Avoid setting env:none if not environment variable has been set

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -7,9 +7,7 @@
 
 using System;
 using Datadog.Trace.Ci.Agent.Payloads;
-using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Ci.Agent.MessagePack
@@ -30,7 +28,11 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
         public CIEventMessagePackFormatter(TracerSettings tracerSettings)
         {
-            _environmentValueBytes = StringEncoding.UTF8.GetBytes(tracerSettings.Environment ?? "none");
+            if (!string.IsNullOrEmpty(tracerSettings.Environment))
+            {
+                _environmentValueBytes = StringEncoding.UTF8.GetBytes(tracerSettings.Environment);
+            }
+
             _envelopBytes = GetEnvelopeArraySegment();
         }
 
@@ -92,8 +94,14 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             // Key
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _asteriskBytes);
 
-            // Value (RuntimeId, Language, Env)
-            offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 3);
+            // Value (RuntimeId, Language, Env?)
+            int valuesCount = 2;
+            if (_environmentValueBytes is not null)
+            {
+                valuesCount++;
+            }
+
+            offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, valuesCount);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdValueBytes);
@@ -101,14 +109,10 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameBytes);
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _languageNameValueBytes);
 
-            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentBytes);
             if (_environmentValueBytes is not null)
             {
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentBytes);
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentValueBytes);
-            }
-            else
-            {
-                offset += MessagePackBinary.WriteNil(ref bytes, offset);
             }
 
             // # Events

--- a/tracer/src/Datadog.Trace/Processors/TraceUtil.cs
+++ b/tracer/src/Datadog.Trace/Processors/TraceUtil.cs
@@ -57,6 +57,11 @@ namespace Datadog.Trace.Processors
         // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/traceutil/normalize.go#L98-L209
         public static string NormalizeTag(string value)
         {
+            if (value is null)
+            {
+                return null;
+            }
+
             if (string.IsNullOrEmpty(value) || Encoding.GetByteCount(value) == 0)
             {
                 return string.Empty;


### PR DESCRIPTION
## Summary of changes

This PR remove defaulting back to `env:none` in case an environment variable is not set. With these changes, we stop sending the `env` tag in the CI Visibility Agentless mode.

Note: This change doesn't affect the normal APM tracer behaviour, only affecting the Agentless CI Visibility mode.

## Reason for change

The CI Visibility backend added and improves this logic by defaulting to `none` or `ci` (in case a CI is detected). So there's no reason to have this in the tracer now.