### PR TITLE
Run `git clean -ffdx` in checkout code

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -30,6 +30,8 @@ steps:
       git checkout --force $prBranch
       echo "Resetting $prBranch to origin/$prBranch ..."
       git reset origin/$prBranch --hard
+      echo "Running git clean -ffdx ..."
+      git clean -ffdx
     displayName: checkout
   - bash: |
       echo "Updating credentials ..."
@@ -52,3 +54,4 @@ steps:
     displayName: merge
 - ${{ else }}:
   - checkout: self
+    clean: true


### PR DESCRIPTION
## Summary of changes

After checking out the repo, clean it.

## Reason for change

We have been seeing "pollution" of logs between runs due to residual files from previous pipelines. Even though the VMs are "reimaged", this doesn't apply to the temp drive on which the build occurs. This ensures we clean the directory on each fresh checkout, to avoid log pollution/flakiness due to previous builds

## Implementation details

Run `git clean -ffdx` after checkout. This is the same as specifying [`clean: true` in the `checkout` task](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#clean-build). 

## Test coverage
N/A

## Other details
This _may_ have an impact on build throughput, as we may have had leftover obj files that were being reused previously. We could experiment with an in-between approach to get incremental builds, but I'm inclined to stay safe for now and stick with this.
