### PR TITLE
Fix number of spans in telemetry tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
 
-                var spans = agent.WaitForSpans(2);
+                var spans = agent.WaitForSpans(3);
 
                 Assert.Contains(spans, span => span.Name == expectedOperationName);
                 Assert.Contains(spans, span => span.Name == spanFromActivityOperationName);
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
 
-                var spans = agent.WaitForSpans(2);
+                var spans = agent.WaitForSpans(3);
 
                 Assert.Contains(spans, span => span.Name == expectedOperationName);
                 Assert.Contains(spans, span => span.Name == spanFromActivityOperationName);
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
 
-                var spans = agent.WaitForSpans(2);
+                var spans = agent.WaitForSpans(3);
 
                 Assert.Contains(spans, span => span.Name == expectedOperationName);
                 Assert.Contains(spans, span => span.Name == spanFromActivityOperationName);


### PR DESCRIPTION
## Summary of changes

Following https://github.com/DataDog/dd-trace-dotnet/pull/2446, the sample app is producing one extra span but the tests weren't updated accordingly. Now waiting for 3 spans instead of 2.

## Reason for change

I like my CI green. 🟢 📗 💚 

## Implementation details

Changed the literal 2 to 3.
