### PR TITLE
Minor UDS support updates

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Agent.StreamFactories;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
@@ -23,14 +24,14 @@ namespace Datadog.Trace.Agent
             {
                 case TracesTransportType.WindowsNamedPipe:
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), DatadogHttpClient.CreateTraceAgentClient());
+                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), DatadogHttpClient.CreateTraceAgentClient(), new Uri("http://localhost"));
                 case TracesTransportType.UnixDomainSocket:
 #if NET5_0_OR_GREATER
                     Log.Information("Using {FactoryType} for trace transport, with UDS path {Path}.", nameof(SocketHandlerRequestFactory), settings.TracesUnixDomainSocketPath);
-                    return new SocketHandlerRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), AgentHttpHeaderNames.DefaultHeaders);
+                    return new SocketHandlerRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), AgentHttpHeaderNames.DefaultHeaders, new Uri("http://localhost"));
 #elif NETCOREAPP3_1_OR_GREATER
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with Unix Domain Sockets path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), DatadogHttpClient.CreateTraceAgentClient());
+                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), DatadogHttpClient.CreateTraceAgentClient(), new Uri("http://localhost"));
 #else
                     Log.Error("Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
                     goto case TracesTransportType.Default;

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Agent.Transports
 
         public Uri GetEndpoint(string relativePath) => UriHelpers.Combine(_baseEndpoint, relativePath);
 
-        public string Info(Uri endpoint)
+        public virtual string Info(Uri endpoint)
         {
             return endpoint.ToString();
         }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequestFactory.cs
@@ -14,11 +14,13 @@ namespace Datadog.Trace.Agent.Transports
     {
         private readonly IStreamFactory _streamFactory;
         private readonly DatadogHttpClient _httpClient;
+        private readonly Uri _baseEndpoint;
 
-        public HttpStreamRequestFactory(IStreamFactory streamFactory, DatadogHttpClient httpClient)
+        public HttpStreamRequestFactory(IStreamFactory streamFactory, DatadogHttpClient httpClient, Uri baseEndpoint)
         {
             _streamFactory = streamFactory;
             _httpClient = httpClient;
+            _baseEndpoint = baseEndpoint;
         }
 
         public Uri GetEndpoint(string relativePath)
@@ -29,7 +31,7 @@ namespace Datadog.Trace.Agent.Transports
             // https://github.com/grpc/grpc-go/issues/2628 and issue/discussion in aspnetcore here:
             // https://github.com/dotnet/aspnetcore/issues/18522.
             // To play it safe, use localhost as the host instead of the UDS socket name/ named pipe
-            return UriHelpers.Combine(new Uri("http://localhost"), relativePath);
+            return UriHelpers.Combine(_baseEndpoint, relativePath);
         }
 
         public string Info(Uri endpoint)

--- a/tracer/src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
@@ -13,6 +13,8 @@ namespace Datadog.Trace.Agent.Transports
 {
     internal class SocketHandlerRequestFactory : HttpClientRequestFactory
     {
+        private readonly IStreamFactory _streamFactory;
+
         public SocketHandlerRequestFactory(IStreamFactory streamFactory, KeyValuePair<string, string>[] defaultHeaders, Uri baseEndpoint, TimeSpan? timeout = null)
             : base(
                 // HttpClient requires a "valid" host header, and will only accept http:// or https:// schemes
@@ -26,6 +28,12 @@ namespace Datadog.Trace.Agent.Transports
                     ConnectCallback = async (_, token) => await streamFactory.GetBidirectionalStreamAsync(token).ConfigureAwait(false)
                 })
         {
+            _streamFactory = streamFactory;
+        }
+
+        public override string Info(Uri endpoint)
+        {
+            return $"{base.Info(endpoint)} to {_streamFactory.Info()}";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
@@ -13,12 +13,12 @@ namespace Datadog.Trace.Agent.Transports
 {
     internal class SocketHandlerRequestFactory : HttpClientRequestFactory
     {
-        public SocketHandlerRequestFactory(IStreamFactory streamFactory, KeyValuePair<string, string>[] defaultHeaders, TimeSpan? timeout = null)
+        public SocketHandlerRequestFactory(IStreamFactory streamFactory, KeyValuePair<string, string>[] defaultHeaders, Uri baseEndpoint, TimeSpan? timeout = null)
             : base(
                 // HttpClient requires a "valid" host header, and will only accept http:// or https:// schemes
                 // The host part of the endpoint is irrelevant, as we're using the UDS socket/named pipe
                 // See also HttpStreamRequestFactory
-                baseEndpoint: new Uri("http://localhost"),
+                baseEndpoint: baseEndpoint,
                 defaultHeaders: defaultHeaders,
                 timeout: timeout,
                 handler: new SocketsHttpHandler

--- a/tracer/src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
+++ b/tracer/src/Datadog.Trace/Util/System.Diagnostics.CodeAnalysis.Attributes.cs
@@ -16,11 +16,10 @@
 #pragma warning disable SA1649 // file name should match first type name
 #pragma warning disable SA1402 // file may only contain a single type
 
-#if !NETCOREAPP3_0_OR_GREATER
-
 // ReSharper disable once CheckNamespace
 namespace System.Diagnostics.CodeAnalysis
 {
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property)]
     internal sealed class AllowNullAttribute : Attribute
@@ -127,6 +126,8 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets field or property member names.</summary>
         public string[] Members { get; }
     }
+#endif
+#if !NET5_0_OR_GREATER
 
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values when returning with the specified return value condition.</summary>
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
@@ -164,9 +165,8 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets field or property member names.</summary>
         public string[] Members { get; }
     }
-}
-
 #endif
+}
 
 #pragma warning restore SA1402
 #pragma warning restore SA1649

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -502,11 +502,11 @@ namespace Datadog.Trace.TestHelpers
 
         public void EnableUnixDomainSockets()
         {
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             TransportType = TestTransports.Uds;
 #else
             // Unsupported
-            throw new NotSupportedException("UDS is not supported in non-netcore applications");
+            throw new NotSupportedException("UDS is not supported in non-netcore applications or < .NET Core 3.1 ");
 #endif
         }
 
@@ -518,9 +518,13 @@ namespace Datadog.Trace.TestHelpers
             // Decide between transports
             if (TransportType == TestTransports.Uds)
             {
+#if NETCOREAPP3_1_OR_GREATER
                 var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 var metricsUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, metricsUdsPath) { UseDogstatsD = useStatsD });
+#else
+            throw new NotSupportedException("UDS is not supported in non-netcore applications or < .NET Core 3.1 ");
+#endif
             }
             else if (TransportType == TestTransports.WindowsNamedPipe)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.TestHelpers
         private readonly Task _statsdTask;
         private readonly CancellationTokenSource _cancellationTokenSource;
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
         private readonly UnixDomainSocketEndPoint _tracesEndpoint;
         private readonly Socket _udsTracesSocket;
         private readonly UnixDomainSocketEndPoint _statsEndpoint;
@@ -305,7 +305,7 @@ namespace Datadog.Trace.TestHelpers
             _listener?.Close();
             _cancellationTokenSource.Cancel();
             _udpClient?.Close();
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
             if (_udsTracesSocket != null)
             {
                 IgnoreException(() => _udsTracesSocket.Shutdown(SocketShutdown.Both));
@@ -394,7 +394,7 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-#if NETCOREAPP
+#if NETCOREAPP3_1_OR_GREATER
         private byte[] GetResponseBytes()
         {
             var responseBody = Encoding.UTF8.GetBytes("{}");


### PR DESCRIPTION
## Summary of changes

- Fix some System.Diagnostics.CodeAnalysis `#if`
- Fix supported UDS version in MockTracerAgent
- Allow specifying the `baseEndpoint` used by `HttpStreamRequestFactory` in requests
- Provide more endpoint data in error messages for SocketHandlerRequestFactory (UDS on .NET 6)

## Reason for change

These are minor things I found while implementing #2617 but aren't strictly related to telemetry, so makes sense to extract them I think.

## Test coverage
Covered by existing tests

## Other details
Blocker for #2617
