### PR TITLE
[Profiler] Rename `pid` tag into `process id`

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -112,7 +112,7 @@ LibddprofExporter::Tags LibddprofExporter::CreateTags(IConfiguration* configurat
         tags.Add(name, value);
     }
 
-    tags.Add("pid", ProcessId);
+    tags.Add("process_id", ProcessId);
     tags.Add("host", configuration->GetHostname());
 
     // TODO get


### PR DESCRIPTION
## Summary of changes

## Reason for change

Recently a move to have the same tag name between profiler(s) and tracer(s) started.

## Implementation details

rename the string
