### PR TITLE
Remove dependency to libuuid

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
@@ -5,6 +5,7 @@
 
 #include "Log.h"
 #include "shared/src/native-src/string.h"
+#include "shared/src/native-src/util.h"
 
 #ifdef _WINDOWS
 #define LIBRARY_FILE_EXTENSION ".dll"
@@ -24,18 +25,6 @@ const char* const RuntimeIdStore::NativeLoaderFilename =
 #else
     "Datadog.AutoInstrumentation.NativeLoader.x86" LIBRARY_FILE_EXTENSION;
 #endif
-
-extern "C"
-{
-#ifdef _WINDOWS
-#include <Rpc.h>
-#pragma comment(lib, "Rpcrt4.lib")
-#else
-#include <uuid/uuid.h>
-#endif
-}
-
-static std::string GenerateRuntimeId();
 
 bool RuntimeIdStore::Start()
 {
@@ -99,7 +88,7 @@ const std::string& RuntimeIdStore::GetId(AppDomainID appDomainId)
 
     if (rid.empty())
     {
-        rid = GenerateRuntimeId();
+        rid = ::shared::GenerateRuntimeId();
     }
 
     return rid;
@@ -184,25 +173,4 @@ bool RuntimeIdStore::FreeDynamicLibrary(void* handle)
 #else
     return dlclose(handle) == 0;
 #endif
-}
-
-static std::string GenerateRuntimeId()
-{
-#ifdef _WINDOWS
-    UUID uuid;
-    UuidCreate(&uuid);
-
-    unsigned char* str;
-    UuidToStringA(&uuid, &str);
-
-    std::string s((char*)str);
-
-    RpcStringFreeA(&str);
-#else
-    uuid_t uuid;
-    uuid_generate_random(uuid);
-    char s[37];
-    uuid_unparse(uuid, s);
-#endif
-    return s;
 }

--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -17,6 +17,11 @@
 #include <utility>
 #include <set>
 
+#ifdef WIN32
+#include <Rpc.h>
+#pragma comment(lib, "Rpcrt4.lib")
+#endif
+
 namespace shared
 {
     template <typename In, typename Out>
@@ -92,6 +97,8 @@ namespace shared
     }
 
     WSTRING WHexStr(const void* pData, int len);
+
+    std::string GenerateRuntimeId();
 
     template <class Container>
     bool Contains(const Container& items, const typename Container::value_type& value)

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/runtimeid_store.cpp
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/runtimeid_store.cpp
@@ -4,7 +4,7 @@
 RuntimeIdStore::RuntimeIdStore()
 {
     m_isIis = IsRunningOnIIS();
-    m_process_runtime_id = GenerateRuntimeId();
+    m_process_runtime_id = ::shared::GenerateRuntimeId();
 }
 
 const std::string& RuntimeIdStore::Get(AppDomainID app_domain)
@@ -15,7 +15,7 @@ const std::string& RuntimeIdStore::Get(AppDomainID app_domain)
     auto& rid = m_appDomainToRuntimeId[app_domain];
     if (rid.empty())
     {
-        rid = GenerateRuntimeId();
+        rid = ::shared::GenerateRuntimeId();
     }
 
     return rid;

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/util.h
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/util.h
@@ -14,15 +14,6 @@ EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #include "../../../shared/src/native-src/pal.h"
 #include "../../../shared/src/native-src/string.h"
 
-extern "C"
-{
-#ifdef WIN32
-#include <Rpc.h>
-#else
-#include <uuid/uuid.h>
-#endif
-}
-
 using namespace datadog::shared::nativeloader;
 
 const std::string conf_filename = "loader.conf";
@@ -58,27 +49,6 @@ static fs::path GetConfigurationFilePath()
     {
         return GetCurrentModuleFolderPath() / conf_filename;
     }
-}
-
-static std::string GenerateRuntimeId()
-{
-#ifdef WIN32
-    UUID uuid;
-    UuidCreate(&uuid);
-
-    unsigned char* str;
-    UuidToStringA(&uuid, &str);
-
-    std::string s((char*) str);
-
-    RpcStringFreeA(&str);
-#else
-    uuid_t uuid;
-    uuid_generate_random(uuid);
-    char s[37];
-    uuid_unparse(uuid, s);
-#endif
-    return s;
 }
 
 inline bool IsRunningOnIIS()


### PR DESCRIPTION
## Summary of changes

## Reason for change

While working on this [PR](https://github.com/DataDog/dd-trace-dotnet/pull/2777), I discovered that `libuuid` is not installed by default on Alpine docker image. Which means that, if we ship the APM artifact (profiler, tracer and native loader) to customers, it won't work.

## Implementation details

Reuse a simple way to generate UUID string from https://stackoverflow.com/a/60198074 + few adjustments. This is based on 
`std::mt19937_64` which is a [Mersenne Twister pseudo-random generator](https://www.cplusplus.com/reference/random/mt19937/). 

For our current use of uuid, this is enough.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
