### PR TITLE
[Profiler] Remove dependency to Datadog.AutoInstrumentation.Profiler.Managed

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/BuggyBitsTest.cs
@@ -13,7 +13,7 @@ using Datadog.Profiler.SmokeTests;
 using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 using MessagePack;
-using Perftools.Profiles.Tests;
+using Perftools.Profiles;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuProfiler/CpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuProfiler/CpuProfilerTest.cs
@@ -6,7 +6,7 @@
 using System.IO;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using Datadog.Profiler.SmokeTests;
-using Perftools.Profiles.Tests;
+using Perftools.Profiles;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Google.Protobuf" Version="3.20.1" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
@@ -45,9 +46,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\ProfilerEngine\Datadog.Profiler.Managed\Datadog.Profiler.Managed.csproj" />
   </ItemGroup>
 </Project>

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/Pprof/Pprof.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/Pprof/Pprof.cs
@@ -9,7 +9,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace Perftools.Profiles.Tests {
+namespace Perftools.Profiles {
 
   /// <summary>Holder for reflection information generated from pprof.proto</summary>
   public static partial class PprofReflection {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/PprofHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/PprofHelper.cs
@@ -4,7 +4,7 @@
 // </copyright>
 
 using System.Collections.Generic;
-using Perftools.Profiles.Tests;
+using Perftools.Profiles;
 
 namespace Datadog.Profiler.IntegrationTests.Helpers
 {


### PR DESCRIPTION
## Summary of changes

## Reason for change

2 things:
 - We are cleaning up profiler code: removing the old pipeline.
 - We want to run the profiler integration tests in AzDo

## Implementation details

Remove the dependency to the profiler managed project and add one to Google Protobuf

## Test coverage

## Other details
<!-- Fixes #{issue} -->
