### PR TITLE
[Profiler] Fix error reported by UBSAN

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.cpp
@@ -7,19 +7,16 @@
 std::mutex ProfilerEngineStatus::s_updateLock;
 bool* ProfilerEngineStatus::s_pIsProfilerEngineActive = nullptr;
 
-bool ProfilerEngineStatus::WriteIsProfilerEngineActive(bool newValue)
+void ProfilerEngineStatus::WriteIsProfilerEngineActive(bool newValue)
 {
     bool* pIsProfilerEngineActive = GetPtrIsProfilerEngineActive();
 
     {
         std::lock_guard<std::mutex> lock(s_updateLock);
 
-        bool prevValue = *pIsProfilerEngineActive;
         *pIsProfilerEngineActive = newValue;
 
         OpSysTools::MemoryBarrierProcessWide();
-
-        return prevValue;
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.h
@@ -35,7 +35,7 @@ public:
         return const_cast<const bool*>(GetPtrIsProfilerEngineActive());
     }
 
-    static bool WriteIsProfilerEngineActive(bool newValue);
+    static void WriteIsProfilerEngineActive(bool newValue);
 
 private:
     static std::mutex s_updateLock;


### PR DESCRIPTION
## Summary of changes

## Reason for change
Our Undefined-Behavior Sanitizer found an issue (read from uninitialized memory):
```
/home/runner/work/dd-trace-dotnet/dd-trace-dotnet/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.cpp:17:26: runtime error: load of value 240, which is not a valid value for type 'bool'
    #0 0x7fac29681286 in ProfilerEngineStatus::WriteIsProfilerEngineActive(bool) /home/runner/work/dd-trace-dotnet/dd-trace-dotnet/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.cpp:17
    #1 0x7fac295acc1e in CorProfilerCallback::Initialize(IUnknown*) /home/runner/work/dd-trace-dotnet/dd-trace-dotnet/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp:555
    #2 0x7facbd4d1[14](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:14)a  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x1e814a)
    #3 0x7facbd5475ac  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x25e5ac)
    #4 0x7facbd54719e  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x25e19e)
    #5 0x7facbd546fe9  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x25dfe9)
    #6 0x7facbd78e104  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x4a5104)
    #7 0x7facbd78d608  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x4a4608)
    #8 0x7facbd78d46c  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x4a446c)
    #9 0x7facbd3b32ed  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0xca2ed)
    #10 0x7facbd35de5f in coreclr_initialize (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libcoreclr.so+0x74e5f)
    #11 0x7facbd9eee0f  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libhostpolicy.so+0x8e0f)
    #12 0x7facbd9fefb4  (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libhostpolicy.so+0x18fb4)
    #13 0x7facbd9fe9da in corehost_main (/usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.16/libhostpolicy.so+0x189da)
    #14 0x7facbdc54d03  (/usr/share/dotnet/host/fxr/6.0.4/libhostfxr.so+0x13d03)
    #[15](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:15) 0x7facbdc53408  (/usr/share/dotnet/host/fxr/6.0.4/libhostfxr.so+0x12408)
    #[16](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:16) 0x7facbdc4e8fa in hostfxr_main_startupinfo (/usr/share/dotnet/host/fxr/6.0.4/libhostfxr.so+0xd8fa)
    #[17](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:17) 0x561f9828efa9  (/usr/share/dotnet/dotnet+0xffa9)
    #[18](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:18) 0x561f9828f41f  (/usr/share/dotnet/dotnet+0x1041f)
    #[19](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:19) 0x7facbdcd10b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #[20](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:20) 0x561f98[28](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:28)3d[29](https://github.com/DataDog/dd-trace-dotnet/runs/6422788637?check_suite_focus=true#step:7:29)  (/usr/share/dotnet/dotnet+0x4d29)

```

## Implementation details

Remove the useless read of the uninitialized memory.

## Test coverage

## Other details
<!-- Fixes #{issue} -->