### PR TITLE
Speed up native compilation on Linux (profiler, tracer, native loader)

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -279,7 +279,7 @@ jobs:
       - name: Build Native Profiler Engine
         run: |
           CXX=clang++ CC=clang cmake -S profiler -B __build -DRUN_UBSAN=ON
-          cmake --build __build --config Release --parallel
+          cmake --build __build --config Release
 
       - name: Build sample applications
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -54,8 +54,7 @@ jobs:
       - name: Build Native Profiler Engine and Tests
         run: |
           CXX=clang++ CC=clang cmake -S profiler -B __build
-          cd __build
-          make
+          cmake --build __build --config Release --parallel
 
       - name: Run Managed Unit tests
         shell: bash
@@ -223,8 +222,7 @@ jobs:
       - name: Build Native Profiler Engine
         run: |
           CXX=clang++ CC=clang cmake -S profiler -B __build -DRUN_ASAN=ON
-          cd __build
-          make
+          cmake --build __build --config Release --parallel
 
       - name: Build sample applications
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
@@ -281,8 +279,7 @@ jobs:
       - name: Build Native Profiler Engine
         run: |
           CXX=clang++ CC=clang cmake -S profiler -B __build -DRUN_UBSAN=ON
-          cd __build
-          make
+          cmake --build __build --config Release --parallel
 
       - name: Build sample applications
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64

--- a/profiler/build/cmake/FindLibunwind.cmake
+++ b/profiler/build/cmake/FindLibunwind.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(libunwind
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND <SOURCE_DIR>/autogen.sh && <SOURCE_DIR>/configure CXXFLAGS=-fPIC CFLAGS=-fPIC && make
+    BUILD_COMMAND <SOURCE_DIR>/autogen.sh && <SOURCE_DIR>/configure CXXFLAGS=-fPIC CFLAGS=-fPIC && make -j
     BUILD_ALWAYS false
 )
 

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -83,10 +83,10 @@ partial class Build
             EnsureExistingDirectory(ProfilerLinuxBuildDirectory);
 
             CMake.Value(
-                arguments: $"-S {ProfilerDirectory}",
-                workingDirectory: ProfilerLinuxBuildDirectory);
+                arguments: $"-B {ProfilerLinuxBuildDirectory} -S {ProfilerDirectory}");
 
-            Make.Value(workingDirectory: ProfilerLinuxBuildDirectory);
+            CMake.Value(
+                arguments: $"--build {ProfilerLinuxBuildDirectory} --parallel");
 
             if (IsAlpine)
             {

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -48,10 +48,11 @@ partial class Build
         {
             var buildDirectory = NativeLoaderProject.Directory;
 
+            const string nativeLoaderBuildDir = "native_loader_cmake";
             CMake.Value(
-                arguments: "-S .",
-                workingDirectory: buildDirectory);
-            Make.Value(workingDirectory: buildDirectory);
+                arguments: $"-B {nativeLoaderBuildDir} -S {buildDirectory}");
+            CMake.Value(
+                arguments: $"--build {nativeLoaderBuildDir} --parallel");
         });
 
     Target CompileNativeLoaderOsx => _ => _

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -48,11 +48,12 @@ partial class Build
         {
             var buildDirectory = NativeLoaderProject.Directory;
 
-            const string nativeLoaderBuildDir = "native_loader_cmake";
             CMake.Value(
-                arguments: $"-B {nativeLoaderBuildDir} -S {buildDirectory}");
+                arguments: $"-S .",
+                workingDirectory: buildDirectory);
             CMake.Value(
-                arguments: $"--build {nativeLoaderBuildDir} --parallel");
+                arguments: $"--build . --parallel",
+                workingDirectory: buildDirectory);
         });
 
     Target CompileNativeLoaderOsx => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -185,12 +185,13 @@ partial class Build
         .Executes(() =>
         {
             var buildDirectory = NativeProfilerProject.Directory / "build";
-            EnsureExistingDirectory(buildDirectory);
 
             CMake.Value(
-                arguments: $"-B {buildDirectory} -S ../ -DCMAKE_BUILD_TYPE=Release");
+                arguments: $"../ -DCMAKE_BUILD_TYPE=Release",
+                workingDirectory: buildDirectory);
             CMake.Value(
-                arguments: $"--build {buildDirectory} --parallel");
+                arguments: $"--build . --parallel",
+                workingDirectory: buildDirectory);
         });
 
     Target CompileNativeSrcMacOs => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -188,9 +188,9 @@ partial class Build
             EnsureExistingDirectory(buildDirectory);
 
             CMake.Value(
-                arguments: "../ -DCMAKE_BUILD_TYPE=Release",
-                workingDirectory: buildDirectory);
-            Make.Value(workingDirectory: buildDirectory);
+                arguments: $"-B {buildDirectory} -S ../ -DCMAKE_BUILD_TYPE=Release");
+            CMake.Value(
+                arguments: $"--build {buildDirectory} --parallel");
         });
 
     Target CompileNativeSrcMacOs => _ => _

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -105,7 +105,7 @@ SET(DOTNET_TRACER_REPO_ROOT_PATH ${CMAKE_SOURCE_DIR}/../../../)
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/re2)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/re2
-        COMMAND git clone --quiet --depth 1 --branch 2018-10-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-O3 -g -fPIC -D_GLIBCXX_USE_CXX11_ABI=0\" make
+        COMMAND git clone --quiet --depth 1 --branch 2018-10-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-O3 -g -fPIC -D_GLIBCXX_USE_CXX11_ABI=0\" make -j
         WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
     )
 endif()
@@ -113,7 +113,7 @@ endif()
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/fmt)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/fmt
-        COMMAND git clone --quiet --depth 1 --branch 5.3.0 https://github.com/fmtlib/fmt.git && cd fmt && CXXFLAGS=\"-D_GLIBCXX_USE_CXX11_ABI=0\" && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0 . && make
+        COMMAND git clone --quiet --depth 1 --branch 5.3.0 https://github.com/fmtlib/fmt.git && cd fmt && CXXFLAGS=\"-D_GLIBCXX_USE_CXX11_ABI=0\" && cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0 . && make -j
         WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
     )
 endif()


### PR DESCRIPTION
## Summary of changes

## Reason for change

Building the native artifact is currently done sequentially. By building in parallel, we would speed up the building

### Profiler 
In Github CI, 
```
3min42 => 2min20
```
Locally,
```
14min to 6min
```

### Native loader
Locally,
```
1min 36 =>  55s
```

### Tracer
Locally,
```
4min => 2min
```

## Implementation details

- Use `-parallel` CMake flag

## Test coverage

## Other details
<!-- Fixes #{issue} -->
