### PR TITLE
[Profiler] Do not aggregate sample with empty callstack

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.cpp
@@ -87,7 +87,10 @@ void SamplesAggregator::Work()
 
             for (auto const& sample : samples)
             {
-                _exporter->Add(sample);
+                if (!sample.GetCallstack().empty())
+                {
+                    _exporter->Add(sample);
+                }
             }
 
             Export();

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
@@ -21,12 +21,21 @@ using ::testing::Throw;
 
 using namespace std::chrono_literals;
 
+Sample CreateSample(std::string_view rid)
+{
+    Sample s{rid};
+
+    s.AddFrame("My module", "My frame");
+
+    return s;
+}
+
 std::list<Sample> CreateSamples(std::string_view runtimeId, int nbSamples)
 {
     std::list<Sample> samples;
     for (int i = 0; i < nbSamples; i++)
     {
-        samples.push_back({runtimeId});
+        samples.push_back(CreateSample(runtimeId));
     }
     return samples;
 }
@@ -171,4 +180,31 @@ TEST(SamplesAggregatorTest, MustNotFailWhenCollectingSampleThrows)
     aggregator.Stop();
 
     ASSERT_TRUE(metricsSender.WasCounterCalled());
+}
+
+TEST(SamplesAggregatorTest, MustdNotAddSampleInExporterIfEmptyCallstack)
+{
+    auto [configuration, mockConfiguration] = CreateConfiguration();
+    EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(10s));
+
+    std::string runtimeId = "MyRid";
+
+    std::list<Sample> samples;
+    // add sample with empty callstack
+    samples.push_back({runtimeId});
+
+    auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
+    EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Return(ByMove(std::move(samples))));
+
+    auto [exporter, mockExporter] = CreateExporter();
+    EXPECT_CALL(mockExporter, Add(_)).Times(0);
+
+    auto metricsSender = MockMetricsSender();
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &mockExporter, &metricsSender);
+    aggregator.Register(&mockSamplesProvider);
+
+    aggregator.Start();
+    std::this_thread::sleep_for(100ms);
+    aggregator.Stop();
 }


### PR DESCRIPTION
## Summary of changes

## Reason for change

Currently we do not resolve native frames. This leads to samples with empty callstacks and in the dashboard we can have profile with not callstack at all.

## Implementation details

Filter out samples with empty callstack.

## Test coverage

- Added a unit test

## Other details
<!-- Fixes #{issue} -->
