### PR TITLE
Add named pipe support to the mock agent + convert telemetry tests to Snapshot

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -142,7 +142,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.UserAgent, "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36");
             }
 
-            public MockTracerAgent Agent { get; private set; }
+            public MockTracerAgent.TcpUdpAgent Agent { get; private set; }
 
             public int HttpPort { get; private set; }
 
@@ -160,7 +160,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         var initialAgentPort = TcpPortProvider.GetOpenPort();
                         HttpPort = TcpPortProvider.GetOpenPort();
 
-                        Agent = new MockTracerAgent(initialAgentPort);
+                        Agent = MockTracerAgent.Create(initialAgentPort);
                         Agent.SpanFilters.Add(IsNotServerLifeCheck);
                         output.WriteLine($"Starting OWIN sample, agentPort: {Agent.Port}, samplePort: {HttpPort}");
                         _process = helper.StartSample(Agent, arguments: null, packageVersion: string.Empty, aspNetCorePort: HttpPort);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                 _httpClient.DefaultRequestHeaders.Add(HeaderName2, HeaderValue2);
             }
 
-            public MockTracerAgent Agent { get; private set; }
+            public MockTracerAgent.TcpUdpAgent Agent { get; private set; }
 
             public int HttpPort { get; private set; }
 
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                         var initialAgentPort = TcpPortProvider.GetOpenPort();
                         HttpPort = TcpPortProvider.GetOpenPort();
 
-                        Agent = new MockTracerAgent(initialAgentPort);
+                        Agent = MockTracerAgent.Create(initialAgentPort);
                         Agent.SpanFilters.Add(IsNotServerLifeCheck);
                         WriteToOutput($"Starting aspnetcore sample, agentPort: {Agent.Port}, samplePort: {HttpPort}");
                         _process = helper.StartSample(Agent, arguments: null, packageVersion: string.Empty, aspNetCorePort: HttpPort);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.ILogger), hostName);
 
             var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = new MockTracerAgent(agentPort);
+            using var agent = MockTracerAgent.Create(agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, aspNetCorePort: 0);
 
             Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -159,7 +159,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Log4Net), hostName);
 
             var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = new MockTracerAgent(agentPort);
+            using var agent = MockTracerAgent.Create(agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -119,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.NLog), hostName);
 
             var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = new MockTracerAgent(agentPort);
+            using var agent = MockTracerAgent.Create(agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
             SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
 
-            using ProcessResult processResult = RunSampleAndWaitForExit(new MockTracerAgent(9696, doNotBindPorts: true));
+            using ProcessResult processResult = RunSampleAndWaitForExit(MockTracerAgent.Create(9696, doNotBindPorts: true));
             string[] logFileContent = File.ReadAllLines(tmpFile);
             int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));
             Assert.Equal(1, numOfLoadersLoad);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -62,6 +62,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void NamedPipesSubmitsMetrics()
         {
+            if (!EnvironmentTools.IsWindows())
+            {
+                throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
+            }
+
             EnvironmentHelper.EnableWindowsNamedPipes();
             RunTest();
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -68,7 +68,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             EnvironmentHelper.EnableWindowsNamedPipes();
-            RunTest();
+            // The server implementation of named pipes is flaky so have 3 attempts
+            var attemptsRemaining = 3;
+            while (true)
+            {
+                try
+                {
+                    attemptsRemaining--;
+                    RunTest();
+                    return;
+                }
+                catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
+                {
+                    Output.WriteLine($"Error executing test. {attemptsRemaining} attempts remaining. {ex}");
+                }
+            }
         }
 
         private void RunTest()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -57,6 +57,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 #endif
 
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void NamedPipesSubmitsMetrics()
+        {
+            EnvironmentHelper.EnableWindowsNamedPipes();
+            RunTest();
+        }
+
         private void RunTest()
         {
             var inputServiceName = "12_$#Samples.$RuntimeMetrics";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), hostName);
 
             var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = new MockTracerAgent(agentPort);
+            using var agent = MockTracerAgent.Create(agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
@@ -120,6 +121,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             EnvironmentHelper.EnableWindowsNamedPipes();
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            agent.Output = Output;
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task Telemetry_Agentless_IsSentOnAppClose()
         {
-            using var agent = new MockTracerAgent(useTelemetry: true);
+            using var agent = MockTracerAgent.Create(useTelemetry: true);
             Output.WriteLine($"Assigned port {agent.Port} for the agentPort.");
 
             using var telemetry = new MockTelemetryAgent<TelemetryData>();
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task Telemetry_WithAgentProxy_IsSentOnAppClose()
         {
-            using var agent = new MockTracerAgent(useTelemetry: true);
+            using var agent = MockTracerAgent.Create(useTelemetry: true);
             Output.WriteLine($"Assigned port {agent.Port} for the agentPort.");
 
             EnableTelemetry();
@@ -88,7 +88,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenDisabled_DoesntSendTelemetry()
         {
-            using var agent = new MockTracerAgent(useTelemetry: true);
+            using var agent = MockTracerAgent.Create(useTelemetry: true);
             Output.WriteLine($"Assigned port {agent.Port} for the agentPort.");
 
             EnableTelemetry(enabled: false);
@@ -114,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingUdsAgent_UsesUdsTelemetry()
         {
-            EnvironmentHelper.TransportType = TestTransports.Uds;
+            EnvironmentHelper.EnableUnixDomainSockets();
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
             int httpPort = TcpPortProvider.GetOpenPort();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -113,6 +113,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task WhenUsingNamedPipesAgent_UsesNamedPipesTelemetry()
         {
+            if (!EnvironmentTools.IsWindows())
+            {
+                throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
+            }
+
             EnvironmentHelper.EnableWindowsNamedPipes();
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -43,6 +43,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             const int expectedSpanCount = 2;
             var transportType = (TracesTransportType)transport;
+
+            if (transportType == TracesTransportType.WindowsNamedPipe && !EnvironmentTools.IsWindows())
+            {
+                throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
+            }
+
             EnvironmentHelper.EnableTransport(GetTransport(transportType));
 
             using var telemetry = this.ConfigureTelemetry();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -53,6 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = GetAgent(transportType);
+            agent.Output = Output;
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -30,7 +30,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public static IEnumerable<object[]> Data =>
             Enum.GetValues(typeof(TracesTransportType))
                 .Cast<TracesTransportType>()
-                .Where(x => x != TracesTransportType.WindowsNamedPipe)
 #if !NETCOREAPP3_1_OR_GREATER
                 .Where(x => x != TracesTransportType.UnixDomainSocket)
 #endif
@@ -67,6 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 => type switch
                 {
                     TracesTransportType.Default => MockTracerAgent.Create(),
+                    TracesTransportType.WindowsNamedPipe => MockTracerAgent.Create(new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}")),
 #if NETCOREAPP3_1_OR_GREATER
                     TracesTransportType.UnixDomainSocket
                         => MockTracerAgent.Create(new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), null)),

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             const int expectedSpanCount = 2;
             var transportType = (TracesTransportType)transport;
-            EnvironmentHelper.TransportType = GetTransport(transportType);
+            EnvironmentHelper.EnableTransport(GetTransport(transportType));
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = GetAgent(transportType);
@@ -66,10 +66,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             MockTracerAgent GetAgent(TracesTransportType type)
                 => type switch
                 {
-                    TracesTransportType.Default => new MockTracerAgent(),
+                    TracesTransportType.Default => MockTracerAgent.Create(),
 #if NETCOREAPP3_1_OR_GREATER
                     TracesTransportType.UnixDomainSocket
-                        => new MockTracerAgent(new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), null)),
+                        => MockTracerAgent.Create(new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), null)),
 #endif
                     _ => throw new InvalidOperationException("Unsupported transport type " + type),
                 };

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var expectedCorrelatedSpanCount = 8;
 
             int agentPort = TcpPortProvider.GetOpenPort();
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             using (RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.IntegrationTests
             string actualContainerId = null;
             var agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 agent.RequestReceived += (sender, args) =>
                 {

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.IntegrationTests
         {
             var waitEvent = new AutoResetEvent(false);
 
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort());
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
 
             agent.StatsDeserialized += (_, _) => waitEvent.Set();
 

--- a/tracer/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
         {
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 var settings = new TracerSettings
                 {
@@ -48,7 +48,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
         {
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 var settings = new TracerSettings
                 {
@@ -80,7 +80,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
         {
             int agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 var settings = new TracerSettings
                 {

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             if (_agent == null)
             {
                 var agentPort = TcpPortProvider.GetOpenPort();
-                _agent = new MockTracerAgent(agentPort);
+                _agent = MockTracerAgent.Create(agentPort);
             }
 
             StartSample(

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -62,6 +62,7 @@ namespace Datadog.Trace.TestHelpers
             settings.AddRegexScrubber(LoopBackRegex, "localhost:00000");
             settings.AddRegexScrubber(KeepRateRegex, "_dd.tracer_kr: 1.0");
             settings.AddRegexScrubber(ProcessIdRegex, "process_id: 0");
+            settings.ScrubInlineGuids();
             return settings;
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -504,6 +504,11 @@ namespace Datadog.Trace.TestHelpers
 
         public void EnableWindowsNamedPipes(string tracePipeName = null, string statsPipeName = null)
         {
+            if (!EnvironmentTools.IsWindows())
+            {
+                throw new NotSupportedException("Windows named pipes is only supported on Windows");
+            }
+
             _transportType = TestTransports.WindowsNamedPipe;
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.TestHelpers
         private readonly bool _isCoreClr;
         private readonly string _samplesDirectory;
         private readonly TargetFrameworkAttribute _targetFramework;
+        private TestTransports _transportType = TestTransports.Tcp;
 
         public EnvironmentHelper(
             string sampleName,
@@ -61,8 +62,6 @@ namespace Datadog.Trace.TestHelpers
                           ? "Samples."
                           : string.Empty;
         }
-
-        public TestTransports TransportType { get; set; } = TestTransports.Tcp;
 
         public bool AutomaticInstrumentationEnabled { get; private set; } = true;
 
@@ -294,31 +293,37 @@ namespace Datadog.Trace.TestHelpers
 
         public void ConfigureTransportVariables(IDictionary<string, string> environmentVariables, MockTracerAgent agent)
         {
-            if (TransportType == TestTransports.Uds)
+            var envVars = agent switch
             {
-                string apmKey = "DD_APM_RECEIVER_SOCKET";
-                string dsdKey = "DD_DOGSTATSD_SOCKET";
-
-                environmentVariables.Add(apmKey, agent.TracesUdsPath);
-                environmentVariables.Add(dsdKey, agent.StatsUdsPath);
-            }
-            else if (TransportType == TestTransports.WindowsNamedPipe)
-            {
-                string apmKey = "DD_TRACE_PIPE_NAME";
-                string dsdKey = "DD_DOGSTATSD_PIPE_NAME";
-
-                environmentVariables.Add(apmKey, agent.TracesUdsPath);
-                environmentVariables.Add(dsdKey, agent.StatsUdsPath);
-            }
-            else if (TransportType == TestTransports.Tcp)
-            {
-                environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "127.0.0.1";
-                environmentVariables["DD_TRACE_AGENT_PORT"] = agent.Port.ToString();
-
-                if (agent.StatsdPort != default(int))
+#if NETCOREAPP3_1_OR_GREATER
+                MockTracerAgent.UdsAgent uds => new Dictionary<string, string>
                 {
-                    environmentVariables["DD_DOGSTATSD_PORT"] = agent.StatsdPort.ToString();
-                }
+                    { "DD_APM_RECEIVER_SOCKET", uds.TracesUdsPath },
+                    { "DD_DOGSTATSD_SOCKET", uds.StatsUdsPath },
+                },
+#endif
+                MockTracerAgent.NamedPipeAgent np => new Dictionary<string, string>
+                {
+                    { "DD_TRACE_PIPE_NAME", np.TracesWindowsPipeName },
+                    { "DD_DOGSTATSD_PIPE_NAME", np.StatsWindowsPipeName },
+                },
+                MockTracerAgent.TcpUdpAgent { StatsdPort: not 0 } tcp => new Dictionary<string, string>
+                {
+                    { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
+                    { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
+                    { "DD_DOGSTATSD_PORT", tcp.StatsdPort.ToString() },
+                },
+                MockTracerAgent.TcpUdpAgent tcp => new Dictionary<string, string>
+                {
+                    { "DD_TRACE_AGENT_HOSTNAME", "127.0.0.1" },
+                    { "DD_TRACE_AGENT_PORT", tcp.Port.ToString() },
+                },
+                _ => throw new InvalidOperationException($"Unknown MockTracerAgent type {agent?.GetType()}")
+            };
+
+            foreach (var envVar in envVars)
+            {
+                environmentVariables[envVar.Key] = envVar.Value;
             }
         }
 
@@ -499,62 +504,67 @@ namespace Datadog.Trace.TestHelpers
 
         public void EnableWindowsNamedPipes(string tracePipeName = null, string statsPipeName = null)
         {
-            TransportType = TestTransports.WindowsNamedPipe;
+            _transportType = TestTransports.WindowsNamedPipe;
         }
 
         public void EnableDefaultTransport()
         {
-            TransportType = TestTransports.Tcp;
+            _transportType = TestTransports.Tcp;
         }
 
         public void EnableUnixDomainSockets()
         {
 #if NETCOREAPP3_1_OR_GREATER
-            TransportType = TestTransports.Uds;
+            _transportType = TestTransports.Uds;
 #else
             // Unsupported
             throw new NotSupportedException("UDS is not supported in non-netcore applications or < .NET Core 3.1 ");
 #endif
         }
 
+        public void EnableTransport(TestTransports transport)
+        {
+            switch (transport)
+            {
+                case TestTransports.Tcp:
+                    EnableDefaultTransport();
+                    break;
+                case TestTransports.Uds:
+                    EnableUnixDomainSockets();
+                    break;
+                case TestTransports.WindowsNamedPipe:
+                    EnableWindowsNamedPipes();
+                    break;
+                default:
+                    throw new InvalidOperationException("Unknown transport " + transport.ToString());
+            }
+        }
+
         public MockTracerAgent GetMockAgent(bool useStatsD = false, int? fixedPort = null, bool useTelemetry = false)
         {
             MockTracerAgent agent = null;
 
-#if NETCOREAPP
             // Decide between transports
-            if (TransportType == TestTransports.Uds)
+            if (_transportType == TestTransports.Uds)
             {
 #if NETCOREAPP3_1_OR_GREATER
                 var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 var metricsUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, metricsUdsPath) { UseDogstatsD = useStatsD, UseTelemetry = useTelemetry });
+                agent = MockTracerAgent.Create(new UnixDomainSocketConfig(tracesUdsPath, metricsUdsPath) { UseDogstatsD = useStatsD, UseTelemetry = useTelemetry });
 #else
             throw new NotSupportedException("UDS is not supported in non-netcore applications or < .NET Core 3.1 ");
 #endif
             }
-            else if (TransportType == TestTransports.WindowsNamedPipe)
+            else if (_transportType == TestTransports.WindowsNamedPipe)
             {
-                agent = new MockTracerAgent(new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = useStatsD, UseTelemetry = useTelemetry });
+                agent = MockTracerAgent.Create(new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = useStatsD, UseTelemetry = useTelemetry });
             }
             else
             {
                 // Default
                 var agentPort = fixedPort ?? TcpPortProvider.GetOpenPort();
-                agent = new MockTracerAgent(agentPort, useStatsd: useStatsD, useTelemetry: useTelemetry);
+                agent = MockTracerAgent.Create(agentPort, useStatsd: useStatsD, useTelemetry: useTelemetry);
             }
-#else
-            if (TransportType == TestTransports.WindowsNamedPipe)
-            {
-                agent = new MockTracerAgent(new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = useStatsD, UseTelemetry = useTelemetry });
-            }
-            else
-            {
-                // Default
-                var agentPort = fixedPort ?? TcpPortProvider.GetOpenPort();
-                agent = new MockTracerAgent(agentPort, useStatsd: useStatsD, useTelemetry: useTelemetry);
-            }
-#endif
 
             _output.WriteLine($"Agent listener info: {agent.ListenerInfo}");
 

--- a/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.TestHelpers
                     AddAssembliesToGac();
 
                     var initialAgentPort = TcpPortProvider.GetOpenPort();
-                    Agent = new MockTracerAgent(initialAgentPort);
+                    Agent = MockTracerAgent.Create(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
                     IisExpress = helper.StartIISExpress(Agent, HttpPort, appType, VirtualApplicationPath);

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -21,8 +21,8 @@ using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers.Stats;
 using Datadog.Trace.Util;
-using MessagePack;
-using Xunit.Abstractions; // use nuget MessagePack to deserialize
+using MessagePack; // use nuget MessagePack to deserialize
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
 {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -757,6 +757,7 @@ namespace Datadog.Trace.TestHelpers
 
             internal class PipeServer : IDisposable
             {
+                private const int ConcurrentInstanceCount = 5;
                 private readonly CancellationTokenSource _cancellationTokenSource;
                 private readonly string _pipeName;
                 private readonly PipeDirection _pipeDirection;
@@ -784,12 +785,16 @@ namespace Datadog.Trace.TestHelpers
 
                 public Task Start()
                 {
-                    _log("Starting PipeServer " + _pipeName);
-                    using var mutex = new ManualResetEventSlim();
-                    var startPipe = StartNamedPipeServer(mutex);
-                    _tasks.Add(startPipe);
-                    mutex.Wait(5_000);
-                    return startPipe;
+                    for (var i = 0; i < ConcurrentInstanceCount; i++)
+                    {
+                        _log("Starting PipeServer " + _pipeName);
+                        using var mutex = new ManualResetEventSlim();
+                        var startPipe = StartNamedPipeServer(mutex);
+                        _tasks.Add(startPipe);
+                        mutex.Wait(5_000);
+                    }
+
+                    return Task.CompletedTask;
                 }
 
                 public void Dispose()

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -397,7 +397,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void SetEnvironmentVariable(string key, string value)
         {
-            EnvironmentHelper.CustomEnvironmentVariables.Add(key, value);
+            EnvironmentHelper.CustomEnvironmentVariables[key] = value;
         }
 
         protected void ValidateSpans<T>(IEnumerable<MockSpan> spans, Func<MockSpan, T> mapper, IEnumerable<T> expected)

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.Tests
             IImmutableList<MockSpan> spans;
             var agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 var settings = new TracerSettings
                 {

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
         {
             var agentPort = TcpPortProvider.GetOpenPort();
 
-            using (var agent = new MockTracerAgent(agentPort))
+            using (var agent = MockTracerAgent.Create(agentPort))
             {
                 var oldSettings = new TracerSettings
                 {

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             };
 
             // CI visibility mode checks if there's a running agent
-            using var agent = EnableCiVisibilityMode ? new MockTracerAgent(TcpPortProvider.GetOpenPort()) : null;
+            using var agent = EnableCiVisibilityMode ? MockTracerAgent.Create(TcpPortProvider.GetOpenPort()) : null;
 
             var agentUrl = $"http://localhost:{agent?.Port ?? 1111}";
 
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             };
 
             // CI visibility mode checks if there's a running agent
-            using var agent = EnableCiVisibilityMode ? new MockTracerAgent(TcpPortProvider.GetOpenPort()) : null;
+            using var agent = EnableCiVisibilityMode ? MockTracerAgent.Create(TcpPortProvider.GetOpenPort()) : null;
 
             var agentUrl = $"http://localhost:{agent?.Port ?? 1111}";
 
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             };
 
             // CI visibility mode checks if there's a running agent
-            using var agent = EnableCiVisibilityMode ? new MockTracerAgent(TcpPortProvider.GetOpenPort()) : null;
+            using var agent = EnableCiVisibilityMode ? MockTracerAgent.Create(TcpPortProvider.GetOpenPort()) : null;
 
             var agentUrl = $"http://localhost:{agent?.Port ?? 1111}";
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task DetectTransportHttp()
         {
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort());
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
 
             var url = $"http://127.0.0.1:{agent.Port}/";
 
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             var url = $"unix://{tracesUdsPath}";
             var uri = new System.Uri(url);
 
-            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, null));
+            using var agent = MockTracerAgent.Create(new UnixDomainSocketConfig(tracesUdsPath, null));
             using var helper = await StartConsole(enableProfiler: false, ("DD_TRACE_AGENT_URL", url));
             using var console = ConsoleHelper.Redirect();
 
@@ -113,7 +113,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             using var console = ConsoleHelper.Redirect();
 
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort());
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
 
             agent.RequestReceived += (_, e) => e.Value.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
 
@@ -131,10 +131,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             using var console = ConsoleHelper.Redirect();
 
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort())
-            {
-                Version = expectedVersion
-            };
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
+            agent.Version = expectedVersion;
 
             var result = await AgentConnectivityCheck.RunAsync(CreateSettings($"http://localhost:{agent.Port}/"));
 
@@ -153,10 +151,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
-            using var agent = new MockTracerAgent(new UnixDomainSocketConfig(tracesUdsPath, null))
-            {
-                Version = expectedVersion
-            };
+            using var agent = MockTracerAgent.Create(new UnixDomainSocketConfig(tracesUdsPath, null));
+            agent.Version = expectedVersion;
 
             var settings = new ExporterSettings
             {
@@ -176,10 +172,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         {
             using var console = ConsoleHelper.Redirect();
 
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort())
-            {
-                Version = null
-            };
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
+            agent.Version = null;
 
             var result = await AgentConnectivityCheck.RunAsync(CreateSettings($"http://localhost:{agent.Port}/"));
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ConsoleTestHelper.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             if (enableProfiler)
             {
-                agent = new MockTracerAgent();
+                agent = MockTracerAgent.Create();
 
                 environmentHelper.SetEnvironmentVariables(
                     agent,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             };
 
             // CI visibility mode checks if there's a running agent
-            using var agent = new MockTracerAgent(TcpPortProvider.GetOpenPort());
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
 
             var agentUrl = $"http://localhost:{agent.Port}";
 

--- a/tracer/test/snapshots/TelemetryTests.verified.txt
+++ b/tracer/test/snapshots/TelemetryTests.verified.txt
@@ -13,6 +13,7 @@
     },
     Metrics: {
       process_id: 0,
+      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
@@ -55,6 +56,7 @@
     },
     Metrics: {
       process_id: 0,
+      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/TelemetryTests.verified.txt
+++ b/tracer/test/snapshots/TelemetryTests.verified.txt
@@ -1,0 +1,63 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: GetAsync,
+    Resource: GetAsync,
+    Service: Samples.Telemetry,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.Telemetry-http-client,
+    Type: http,
+    ParentId: Id_2,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_4,
+    SpanId: Id_5,
+    Name: HttpListener.ReceivedRequest,
+    Resource: HttpListener.ReceivedRequest,
+    Service: Samples.Telemetry,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/TransportTests.verified.txt
+++ b/tracer/test/snapshots/TransportTests.verified.txt
@@ -1,0 +1,42 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: GetAsync,
+    Resource: GetAsync,
+    Service: Samples.Telemetry,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.Telemetry-http-client,
+    Type: http,
+    ParentId: Id_2,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/TransportTests.verified.txt
+++ b/tracer/test/snapshots/TransportTests.verified.txt
@@ -12,6 +12,7 @@
     },
     Metrics: {
       process_id: 0,
+      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0


### PR DESCRIPTION
## Summary of changes

- Add support for named pipes to MockTracerAgent (including for telemetry)
- Refactor MockTracerAgent
- Convert `TelemetryTests` and `TransportTests` to use snapshots for spans

## Reason for change

We want to make sure we test over named pipes. Also, we've seen some flakiness in the telemetry tests which are related to the spans returned, so using snapshots to make the issue clearer.

## Implementation details

- Move `MockTracerAgent` UDS and TCP/UDS/Named pipe implementations to nested classes - the implementations are very separate in a lot of ways, and this makes that distinction clearer
- The above also adds clearer typing, e.g. you can no longer check the "port" of the agent when using UDS (it doesn't make sense to)
- Add helper `Create()` static function for creating the mock agent (required for simplicity after the above move) and update callsites
- Refactor `EnvironmentHelper` to encapsulate the selected transport better and to infer the env vars based on the actual agent passed in. This has bitten me previously, when I couldn't work out why the UDS mock agent I was passing to RunSample wasn't setting the right env vars. The changes ensure that doesn't happen
- Update Transport tests to test Windows Named Pipes
- Add tests for telemetry over named pipes
- Add tests for RuntimeMetrics over named pipes

## Test coverage
Added.

## Other details
Interesting to see that runtime metrics over UDS on Windows does not work apparently (creating the socket errors)? We should presumably be handling this in `ExporterSettings` too?
