### PR TITLE
[Profiler] Add a cache for native frame resolution

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -39,17 +39,36 @@ std::tuple<bool, std::string, std::string> FrameStore::GetFrame(uintptr_t instru
 std::pair<std::string, std::string> FrameStore::GetNativeFrame(uintptr_t instructionPointer)
 {
     static const std::string UnknownNativeFrame("|lm:Unknown-Native-Module |ns:NativeCode |ct:Unknown-Native-Module |fn:Function");
+    static const std::string UnknowNativeModule = "Unknown-Native-Module";
+
     auto moduleName = OpSysTools::GetModuleName(reinterpret_cast<void*>(instructionPointer));
     if (moduleName.empty())
     {
-        return {"Unknown-Native-Module", UnknownNativeFrame};
+        return {UnknowNativeModule, UnknownNativeFrame};
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_nativeLock);
+
+        auto it = _framePerNativeModule.find(moduleName);
+        if (it != _framePerNativeModule.cend())
+        {
+            return {it->first, it->second};
+        }
     }
 
     // moduleName contains the full path: keep only the filename
-    moduleName = fs::path(moduleName).filename().string();
+    auto moduleFilename = fs::path(moduleName).filename().string();
     std::stringstream builder;
-    builder << "|lm:" << moduleName << " |ns:NativeCode |ct:" << moduleName << " |fn:Function";
-    return {moduleName, builder.str()};
+    builder << "|lm:" << moduleFilename << " |ns:NativeCode |ct:" << moduleFilename << " |fn:Function";
+
+    {
+        std::lock_guard<std::mutex> lock(_nativeLock);
+        // emplace returns a pair<iterator, bool>. It returns false if the element was already there
+        // we use the iterator (first element of the pair) to get a reference to the key and the value
+        auto it = _framePerNativeModule.emplace(std::move(moduleName), builder.str()).first;
+        return {it->first, it->second};
+    }
 }
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -78,9 +78,11 @@ private:
 
     std::mutex _methodsLock;
     std::mutex _typesLock;
+    std::mutex _nativeLock;
     // caches functions                      V-- module    V-- full frame
     std::unordered_map<FunctionID, std::pair<std::string, std::string>> _methods;
     std::unordered_map<ClassID, TypeDesc> _types;
+    std::unordered_map<std::string, std::string> _framePerNativeModule;
     // TODO: dump stats about caches size at the end of the application
 
     // TODO: would it be needed to have a cache (moduleId + mdTypeDef) -> TypeDesc?


### PR DESCRIPTION
## Summary of changes

## Reason for change

When resolving native frame, the computation is done at each call even for already seen frames.
This has a significant impact on the performance of the profiler and incurs a non-negligible overhead.

## Implementation details

For native frame, we just resolve module name and build the representation string. We cache the string so the next time, for the same module we will reuse the information.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
