### PR TITLE
[Profiler] Allow stack sampler metrics for Linux

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -84,10 +84,7 @@ const char* StackSamplerLoopManager::GetName()
 bool StackSamplerLoopManager::Start()
 {
     this->RunStackSampling();
-    if (AllowDeadlockIntervention)
-    {
-        this->RunWatcher();
-    }
+    this->RunWatcher();
 
     return true;
 }
@@ -102,10 +99,7 @@ bool StackSamplerLoopManager::Stop()
     _isStopped = true;
 
     GracefulShutdownStackSampling();
-    if (AllowDeadlockIntervention)
-    {
-        ShutdownWatcher();
-    }
+    ShutdownWatcher();
 
     return true;
 }
@@ -285,7 +279,10 @@ void StackSamplerLoopManager::WatcherLoopIteration()
 
     _currentStatistics->IncrDeadlockCount();
 
-    PerformDeadlockIntervention(collectionDurationNs);
+    if (AllowDeadlockIntervention)
+    {
+        PerformDeadlockIntervention(collectionDurationNs);
+    }
 }
 
 bool StackSamplerLoopManager::HasMadeProgress(FILETIME userTime, FILETIME kernelTime)


### PR DESCRIPTION
## Summary of changes
Enable stack sampler metrics for Linux

## Reason for change
Currently only available on Windows
 
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
