### PR TITLE
Return const char* instead of std::string on C linkage function

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IRuntimeIdStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IRuntimeIdStore.h
@@ -12,5 +12,5 @@ class IRuntimeIdStore
 public:
     virtual ~IRuntimeIdStore() = default;
 
-    virtual const std::string& GetId(AppDomainID appDomainId) = 0;
+    virtual const char* GetId(AppDomainID appDomainId) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
@@ -52,7 +52,7 @@ bool RuntimeIdStore::Start()
 
     // /!\ when casting the function pointer externalFunction, we must not forget the calling convention
     // /!\ otherwise, the profiler will crash.
-    _getIdFn = reinterpret_cast<const std::string&(STDMETHODCALLTYPE*)(AppDomainID)>(externalFunction);
+    _getIdFn = reinterpret_cast<const char*(STDMETHODCALLTYPE*)(AppDomainID)>(externalFunction);
     return _getIdFn != nullptr;
 #endif
 }
@@ -78,7 +78,7 @@ const char* RuntimeIdStore::GetName()
     return RuntimeIdStore::ServiceName;
 }
 
-const std::string& RuntimeIdStore::GetId(AppDomainID appDomainId)
+const char* RuntimeIdStore::GetId(AppDomainID appDomainId)
 {
     if (_getIdFn != nullptr)
     {
@@ -93,7 +93,7 @@ const std::string& RuntimeIdStore::GetId(AppDomainID appDomainId)
         rid = ::shared::GenerateRuntimeId();
     }
 
-    return rid;
+    return rid.c_str();
 }
 
 void* RuntimeIdStore::LoadDynamicLibrary(std::string filePath)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
@@ -18,7 +18,7 @@ public:
     bool Start() override;
     bool Stop() override;
 
-    const std::string& GetId(AppDomainID appDomainId) override;
+    const char* GetId(AppDomainID appDomainId) override;
 
 private:
     static const char* const ServiceName;
@@ -30,7 +30,7 @@ private:
     static bool FreeDynamicLibrary(void* handle);
 
     void* _instance = nullptr;
-    std::function<const std::string&(AppDomainID)> _getIdFn;
+    std::function<const char*(AppDomainID)> _getIdFn;
 
     std::mutex _cacheLock;
     // This is a fallback case when the profiler runs without the native loader

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -49,7 +49,7 @@ enum class SampleValue : size_t
     //ContentionCount = 4,
     //ContentionDuration = 5,
 
-    
+
 };
 //
 static constexpr size_t array_size = sizeof(SampleTypeDefinitions) / sizeof(SampleTypeDefinitions[0]);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -97,7 +97,7 @@ public:
 class MockRuntimeIdStore : public IRuntimeIdStore
 {
 public:
-    MOCK_METHOD(const std::string&, GetId, (AppDomainID appDomainId), (override));
+    MOCK_METHOD(const char*, GetId, (AppDomainID appDomainId), (override));
 };
 
 template <typename T, typename U, typename... Args>

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -89,7 +89,7 @@ TEST(WallTimeProviderTest, CheckNoMissingSample)
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
-    EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::ReturnRef(expectedRuntimeId));
+    EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
     WallTimeProvider provider(configuration.get(), threadscpuManager, frameStore, appDomainStore, &runtimeIdStore);
     provider.Start();
@@ -119,10 +119,10 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     MockRuntimeIdStore runtimeIdStore;
 
     std::string firstExpectedRuntimeId = "MyRid";
-    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::ReturnRef(firstExpectedRuntimeId));
+    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::Return(firstExpectedRuntimeId.c_str()));
 
     std::string secondExpectedRuntimeId = "OtherRid";
-    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(2))).WillRepeatedly(::testing::ReturnRef(secondExpectedRuntimeId));
+    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(2))).WillRepeatedly(::testing::Return(secondExpectedRuntimeId.c_str()));
 
     WallTimeProvider provider(configuration.get(), threadscpuManager, frameStore, appDomainStore, &runtimeIdStore);
     provider.Start();
@@ -201,7 +201,7 @@ TEST(WallTimeProviderTest, CheckFrames)
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
-    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::ReturnRef(expectedRuntimeId));
+    EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
     WallTimeProvider provider(configuration.get(), threadscpuManager, frameStore, appDomainStore, &runtimeIdStore);
     provider.Start();
@@ -258,7 +258,7 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
-    EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::ReturnRef(expectedRuntimeId));
+    EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
     WallTimeProvider provider(configuration.get(), threadscpuManager, frameStore, appDomainStore, &runtimeIdStore);
     provider.Start();

--- a/profiler/test/Datadog.Profiler.Native.Tests/RuntimeIdStoreHelper.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/RuntimeIdStoreHelper.cpp
@@ -9,7 +9,7 @@ RuntimeIdStoreHelper::RuntimeIdStoreHelper()
 {
 }
 
-const std::string& RuntimeIdStoreHelper::GetId(AppDomainID appDomainId)
+const char* RuntimeIdStoreHelper::GetId(AppDomainID appDomainId)
 {
-    return _guid;
+    return _guid.c_str();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/RuntimeIdStoreHelper.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/RuntimeIdStoreHelper.h
@@ -11,7 +11,7 @@ public:
 
 public:
 // Inherited via IRuntimeIdStore
-    virtual const std::string& GetId(AppDomainID appDomainId) override;
+    virtual const char* GetId(AppDomainID appDomainId) override;
 
 private:
     static std::string _guid;

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
@@ -280,7 +280,7 @@ TEST(SamplesAggregatorTest, MustdNotAddSampleInExporterIfEmptyCallstack)
 
     std::list<Sample> samples;
     // add sample with empty callstack
-    samples.push_back({runtimeId});
+    samples.push_back({runtimeId.c_str()});
 
     auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
     EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Return(ByMove(std::move(samples))));

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
@@ -1000,9 +1000,9 @@ namespace datadog::shared::nativeloader
         return appDomain;
     }
 
-    const std::string& CorProfiler::GetRuntimeId(AppDomainID appDomain)
+    const char* CorProfiler::GetRuntimeId(AppDomainID appDomain)
     {
-        return m_this->m_runtimeIdStore.Get(appDomain);
+        return m_this->m_runtimeIdStore.Get(appDomain).c_str();
     }
 
 } // namespace datadog::shared::nativeloader

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.h
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.h
@@ -170,7 +170,7 @@ namespace datadog::shared::nativeloader
         HRESULT STDMETHODCALLTYPE EventPipeProviderCreated(EVENTPIPE_PROVIDER provider) override;
 
         static AppDomainID GetCurrentAppDomainId();
-        static const std::string& GetRuntimeId(AppDomainID appDomain);
+        static const char* GetRuntimeId(AppDomainID appDomain);
     };
 
 } // namespace datadog::shared::nativeloader

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/exported_functions.cpp
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/exported_functions.cpp
@@ -2,7 +2,7 @@
 #include "cor_profiler.h"
 
 // This function is exported for interoperability with native libraries (e.g.: Profiler)
-extern "C" const std::string& STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain)
+extern "C" const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain)
 {
     return datadog::shared::nativeloader::CorProfiler::GetRuntimeId(appDomain);
 }
@@ -12,6 +12,5 @@ extern "C" const std::string& STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDoma
 extern "C" const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId()
 {
     auto appDomain = datadog::shared::nativeloader::CorProfiler::GetCurrentAppDomainId();
-    auto& rid = GetRuntimeId(appDomain);
-    return rid.c_str();
+    return GetRuntimeId(appDomain);
 }

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/exported_functions.h
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/exported_functions.h
@@ -3,7 +3,5 @@
 #include <corhlpr.h>
 #include <corprof.h>
 
-#include <string>
-
 extern "C" const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId();
-extern "C" const std::string& STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain);
+extern "C" const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain);


### PR DESCRIPTION
## Summary of changes

## Reason for change

When return an user-defined  object from a C linkage function (`extern "C"`), we may end access object with different layout (ex: std::string can be different. If library A compiles with options different from library B, and  library B a function from library A that returns a `std::string` the application may crach).

To avoid that, we return C types 
## Implementation details

Here, we return a `const char*` instead of a `std::string`. 

## Test coverage

## Other details
<!-- Fixes #{issue} -->
