### PR TITLE
[Profiler] Activate log message only in debug build

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -61,9 +61,10 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
 
         const DWORD osThreadId = pThreadInfo->GetOsThreadId();
 
+#ifndef NDEBUG
         Log::Debug("LinuxStackFramesCollector::CollectStackSampleImplementation: Sending signal ",
                    s_signalToSend, " to thread with osThreadId=", osThreadId, ".");
-
+#endif
         s_pInstanceCurrentlyStackWalking = this;
         auto scopeFinalizer = CreateScopeFinalizer(
             [] {


### PR DESCRIPTION
## Summary of changes

## Reason for change

This message is print 5 times every 9ms. Even with debug log this floods the log file.

So we will activate it only in debug build.

## Implementation details

use `NDEBUG` preprocessor (same in cmake and msbuild)

## Test coverage

## Other details
<!-- Fixes #{issue} -->
