### PR TITLE
Fix SamplingPriority in B3 and W3C headers

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/B3ContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3ContextPropagator.cs
@@ -33,7 +33,8 @@ namespace Datadog.Trace.Propagators
         {
             var traceId = IsValidTraceId(context.RawTraceId) ? context.RawTraceId : context.TraceId.ToString("x16");
             var spanId = IsValidSpanId(context.RawSpanId) ? context.RawSpanId : context.SpanId.ToString("x16");
-            var sampled = context.SamplingPriority > 0 ? "1" : "0";
+            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var sampled = samplingPriority > 0 ? "1" : "0";
 
             carrierSetter.Set(carrier, TraceId, traceId);
             carrierSetter.Set(carrier, SpanId, spanId);

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -22,7 +22,8 @@ namespace Datadog.Trace.Propagators
         {
             var traceId = IsValidTraceId(context.RawTraceId) ? context.RawTraceId : context.TraceId.ToString("x16");
             var spanId = IsValidSpanId(context.RawSpanId) ? context.RawSpanId : context.SpanId.ToString("x16");
-            var sampled = context.SamplingPriority > 0 ? "1" : "0";
+            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var sampled = samplingPriority > 0 ? "1" : "0";
             carrierSetter.Set(carrier, B3, $"{traceId}-{spanId}-{sampled}");
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CContextPropagator.cs
@@ -22,7 +22,8 @@ namespace Datadog.Trace.Propagators
         {
             var traceId = IsValidTraceId(context.RawTraceId) ? context.RawTraceId : context.TraceId.ToString("x32");
             var spanId = IsValidSpanId(context.RawSpanId) ? context.RawSpanId : context.SpanId.ToString("x16");
-            var sampled = context.SamplingPriority > 0 ? "01" : "00";
+            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var sampled = samplingPriority > 0 ? "01" : "00";
             carrierSetter.Set(carrier, TraceParent, $"00-{traceId}-{spanId}-{sampled}");
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderSpanContextPropagatorTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Reflection;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -33,6 +34,20 @@ namespace Datadog.Trace.Tests.Propagators
 
             headers.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
+
+            // Extract sampling from trace context
+            var newContext = new SpanContext(null, new TraceContext(null, null), null, traceId, spanId);
+            var newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object);
+            newHeaders.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-0"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
+
+            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
+            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
+            newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object);
+            newHeaders.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-1"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -50,6 +65,20 @@ namespace Datadog.Trace.Tests.Propagators
 
             headers.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
+
+            // Extract sampling from trace context
+            var newContext = new SpanContext(null, new TraceContext(null, null), null, traceId, spanId);
+            var newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            newHeaders.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-0"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
+
+            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
+            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
+            newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            newHeaders.Verify(h => h.Set(B3SingleHeaderContextPropagator.B3, "00000000075bcd15-000000003ade68b1-1"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SpanContextPropagatorTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Reflection;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -35,6 +36,24 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
             headers.Verify(h => h.Set(B3ContextPropagator.Sampled, "1"), Times.Once());
             headers.VerifyNoOtherCalls();
+
+            // Extract sampling from trace context
+            var newContext = new SpanContext(null, new TraceContext(null, null), null, traceId, spanId);
+            var newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object);
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.TraceId, "00000000075bcd15"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.Sampled, "0"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
+
+            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
+            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
+            newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object);
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.TraceId, "00000000075bcd15"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.Sampled, "1"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
         }
 
         [Fact]
@@ -54,6 +73,24 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
             headers.Verify(h => h.Set(B3ContextPropagator.Sampled, "1"), Times.Once());
             headers.VerifyNoOtherCalls();
+
+            // Extract sampling from trace context
+            var newContext = new SpanContext(null, new TraceContext(null, null), null, traceId, spanId);
+            var newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.TraceId, "00000000075bcd15"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.Sampled, "0"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
+
+            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
+            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
+            newHeaders = new Mock<IHeadersCollection>();
+            B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.TraceId, "00000000075bcd15"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.SpanId, "000000003ade68b1"), Times.Once());
+            newHeaders.Verify(h => h.Set(B3ContextPropagator.Sampled, "1"), Times.Once());
+            newHeaders.VerifyNoOtherCalls();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes
Adds missing `TraceContext.SamplingPriority` in `B3ContextPropagator`, `B3SingleHeaderContextPropagator` and `W3CContextPropagator` (as is being used in the `DatadogContextPropagator`)

## Reason for change
The current implementation misses the `TraceContext` sampling priority.

## Other details
Fixes #2826 
