### PR TITLE
[Release] Changes following last release

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -5,8 +5,8 @@ labels:
   - name: "area:serverless"
     title: "^\\[?(?i)serverless"
 
-  - name: "area:app-sec"
-    title: "^\\[?(?i)appsec"
+  - name: "area:asm"
+    title: "^\\[?(?i)ASM"
 
   - name: "area:profiler"
     title: "^\\[?(?i)profiler"

--- a/.github/workflows/auto-trigger-aas-release.yml
+++ b/.github/workflows/auto-trigger-aas-release.yml
@@ -8,11 +8,11 @@ jobs:
   trigger_aas_release:
     runs-on: ubuntu-latest
 
-    steps:        
+    steps:
       - name: Trigger AAS release
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
-          https://api.github.com/repos/pierotibou/datadog-aas-extension/dispatches \
+          https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
           -d '{"event_type": "dd-trace-dotnet-release", "client_payload": {"is_prerelease":"${{github.event.release.prerelease}}", "version":"${{github.event.release.tag_name}}" } }'

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -445,7 +445,7 @@ partial class Build
             const string misc = "Miscellaneous";
             const string tracer = "Tracer";
             const string ciApp = "CI App";
-            const string appSec = "AppSec";
+            const string appSecMonitoring = "ASM";
             const string profiler = "Continuous Profiler";
             const string debugger = "Debugger";
             const string serverless = "Serverless";
@@ -536,7 +536,7 @@ partial class Build
                 var areaLabelToComponentMap = new Dictionary<string, string>() {
                     { "area:tracer", tracer },
                     { "area:ci-app", ciApp },
-                    { "area:app-sec", appSec },
+                    { "area:asm", appSecMonitoring },
                     { "area:profiler", profiler },
                     { "area:debugger", debugger },
                     { "area:serverless", serverless }
@@ -581,7 +581,7 @@ partial class Build
             {
                 tracer => 0,
                 ciApp => 1,
-                appSec => 2,
+                appSecMonitoring => 2,
                 profiler => 3,
                 debugger => 4,
                 serverless => 5,


### PR DESCRIPTION
## Summary of changes

Renaming AppSec to ASM in release notes. Also updates the labeller to forget use a `area:asm` label.
Trigger the AAS release on Datadog repo, instead of my fork 🤦 

## Reason for change

To avoid a few manual actions that I had to do during the last release.

