### PR TITLE
Change code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,9 @@
 .github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
 
 # Debugger
-/debugger                                 @DataDog/debugger-dotnet-agent
+/tracer/src/Datadog.Trace/Debugger        @DataDog/debugger-dotnet-agent
+/tracer/test/Datadog.Trace.Tests/Debugger @DataDog/debugger-dotnet-agent
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger @DataDog/debugger-dotnet-agent
 
 # Shared code we could move to the root folder
-/tracer/build                             @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
+/tracer/build/                            @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,3 @@
 
 # Shared code we could move to the root folder
 /tracer/build                             @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
-
-# Those do not exist yet, but I suggest we use that structure
-/docs/tracer/                             @DataDog/apm-dotnet
-/samples/tracer/                          @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,10 @@
 
 # Debugger
 /debugger                                 @DataDog/debugger-dotnet-agent
+
+# Shared code we could move to the root folder
+/tracer/build                             @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
+
 # Those do not exist yet, but I suggest we use that structure
 /docs/tracer/                             @DataDog/apm-dotnet
 /samples/tracer/                          @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,16 @@
 
 # Tracer
 /tracer/                                  @DataDog/apm-dotnet
+
+# CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/apm-dotnet @DataDog/ci-app-tracers
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/ @DataDog/ci-app-tracers
-# /tracer/src/Datadog.Trace/AppSec/       @DataDog/apm-dotnet @DataDog/appsec-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-tracers
+
+# ASM
+/tracer/src/Datadog.Trace/AppSec/         @DataDog/apm-dotnet @DataDog/asm-dotnet
+/tracer/test/test-applications/security   @DataDog/apm-dotnet @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.IntegrationTests @DataDog/apm-dotnet @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.Unit.Tests       @DataDog/apm-dotnet @DataDog/asm-dotnet
 
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet
@@ -19,4 +26,4 @@
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger @DataDog/debugger-dotnet
 
 # Shared code we could move to the root folder
-/tracer/build/                            @DataDog/apm-dotnet @DataDog/debugger-dotnet @DataDog/profiling-dotnet
+/tracer/build/                            @DataDog/apm-dotnet @DataDog/debugger-dotnet @DataDog/profiling-dotnet @DataDog/asm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet
 .github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
+/tracer/src/Datadog.Trace/ContinuousProfiler @DataDog/apm-dotnet @DataDog/profiling-dotnet
 
 # Debugger
 /tracer/src/Datadog.Trace/Debugger        @DataDog/debugger-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,20 @@
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
-*                                         @DataDog/apm-dotnet
-.github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
-/shared/                                  @DataDog/apm-dotnet @DataDog/profiling-dotnet
+# By default every team is owner
+*                                         @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
+
+# Tracer
 /tracer/                                  @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Ci/             @DataDog/apm-dotnet @DataDog/ci-app-tracers
-# /tracer/src/Datadog.Trace/AppSec/       @DataDog/apm-dotnet @DataDog/appsec-dotnet
-/profiler/                                @DataDog/profiling-dotnet
-
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/ @DataDog/ci-app-tracers
+# /tracer/src/Datadog.Trace/AppSec/       @DataDog/apm-dotnet @DataDog/appsec-dotnet
+
+# Profiler
+/profiler/                                @DataDog/profiling-dotnet
+.github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
+
+# Debugger
+/debugger                                 @DataDog/debugger-dotnet-agent
+# Those do not exist yet, but I suggest we use that structure
+/docs/tracer/                             @DataDog/apm-dotnet
+/samples/tracer/                          @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 # By default every team is owner
-*                                         @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
+*                                         @DataDog/apm-dotnet @DataDog/debugger-dotnet @DataDog/profiling-dotnet
 
 # Tracer
 /tracer/                                  @DataDog/apm-dotnet
@@ -14,9 +14,9 @@
 .github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
 
 # Debugger
-/tracer/src/Datadog.Trace/Debugger        @DataDog/debugger-dotnet-agent
-/tracer/test/Datadog.Trace.Tests/Debugger @DataDog/debugger-dotnet-agent
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger @DataDog/debugger-dotnet-agent
+/tracer/src/Datadog.Trace/Debugger        @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.Tests/Debugger @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger @DataDog/debugger-dotnet
 
 # Shared code we could move to the root folder
-/tracer/build/                            @DataDog/apm-dotnet @DataDog/debugger-dotnet-agent @DataDog/profiling-dotnet
+/tracer/build/                            @DataDog/apm-dotnet @DataDog/debugger-dotnet @DataDog/profiling-dotnet


### PR DESCRIPTION
## Summary of changes
Give ownership to all teams by default and specify more precisely ownership by folder. This allows everyone to have ownership on shared files (CI, github pipelines, shared folder...). 

## Reason for change
3 teams now own this repository

## Other details
Proposal open to discussion.
Gave write access to [debugger-dotnet-agent](https://github.com/orgs/DataDog/teams/debugger-dotnet-agent) team on the repository and the `asm-dotnet` team as well

- [x] ~~Need to check locally if I'm not breaking CI CodeOwners tests~~ they have their own test file 