### PR TITLE
[Profiler] Disable debug logging for throughput tests

### DIFF
--- a/profiler/build/crank/os.profiles.yml
+++ b/profiler/build/crank/os.profiles.yml
@@ -19,7 +19,6 @@ profiles:
           DD_DOTNET_PROFILER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\continousprofiler"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
-          DD_TRACE_DEBUG: 1
           DD_TRACE_ENABLED: 0
           DD_ENV: throughput-profiler-windows
         options:
@@ -47,7 +46,6 @@ profiles:
           DD_DOTNET_PROFILER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/profiler-home-linux"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
-          DD_TRACE_DEBUG: 1
           DD_TRACE_ENABLED: 0
           DD_ENV: throughput-profiler-linux
           LD_LIBRARY_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/profiler-home-linux"


### PR DESCRIPTION
## Summary of changes

Disable debug logging in throughput tests. I initially enabled it to understand why some stuff wasn't working as expected, it is not needed anymore.