### PR TITLE
[Tests] Allow updating snapshots from an AzDo build

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1468,29 +1468,6 @@ partial class Build
                 .EnableTrxLogOutput(GetResultsDirectory(project)));
         });
 
-    Target UpdateSnapshots => _ => _
-        .Description("Updates verified snapshots files with received ones")
-        .Executes(() =>
-        {
-            var snapshotsDirectory = Path.Combine(TestsDirectory, "snapshots");
-            var directory = new DirectoryInfo(snapshotsDirectory);
-            var files = directory.GetFiles("*.received*");
-
-            var suffixLength = "received".Length;
-            foreach (var file in files)
-            {
-                var source = file.FullName;
-                var fileName = Path.GetFileNameWithoutExtension(source);
-                if (!fileName.EndsWith("received"))
-                {
-                    Logger.Warn($"Skipping file '{source}' as filename did not end with 'received'");
-                    continue;
-                }
-                var trimmedName = fileName.Substring(0, fileName.Length - suffixLength);
-                var dest = Path.Combine(directory.FullName, $"{trimmedName}verified{Path.GetExtension(source)}");
-                file.MoveTo(dest, overwrite: true);
-            }
-        });
 
     Target CheckBuildLogsForErrors => _ => _
        .Unlisted()


### PR DESCRIPTION
## Summary of changes
Added a nuke target to update snapshots given an Azure Devops buildid.

## Reason for change
As Lucas, a few weeks back, I had to update all snapshots for one PR. In that case being able to run the pipeline, get the snapshots and check them in your diff tool is actually way easier.

## Implementation details
It extends the target I had already created to do this locally. 
Given a buildId, we call the AzDo Api to get artifacts, download and unzip the artifacts one, copy all received files to the snapshots directory and rename them. 

## Test coverage
Ran it once for #2836 

