### PR TITLE
Add Redis obfuscator

### DIFF
--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTagsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTagsProcessor.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="ObfuscatorTagsProcessor.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Processors
+{
+    internal class ObfuscatorTagsProcessor : ITagProcessor
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ObfuscatorTagsProcessor>();
+        private readonly bool _redisObfuscationEnabled;
+
+        public ObfuscatorTagsProcessor(bool redisObfuscationEnabled)
+        {
+            _redisObfuscationEnabled = redisObfuscationEnabled;
+        }
+
+        public void ProcessMeta(ref string key, ref string value)
+        {
+            // https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis.go#L91
+            if (_redisObfuscationEnabled && key == Trace.Tags.RedisRawCommand)
+            {
+                value = RedisObfuscationUtil.Obfuscate(value);
+                Log.Debug("span.obfuscate: obfuscating `redis.raw_command` value");
+            }
+        }
+
+        public void ProcessMetric(ref string key, ref double value)
+        {
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.TraceProcessors
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ObfuscatorTraceProcessor>();
         private static readonly BitArray NumericLiteralPrefix = new BitArray(256, false);
         private static readonly BitArray Splitters = new BitArray(256, false);
+        private readonly ObfuscatorTagsProcessor _tagsProcessor;
 
         static ObfuscatorTraceProcessor()
         {
@@ -42,9 +43,10 @@ namespace Datadog.Trace.TraceProcessors
             }
         }
 
-        public ObfuscatorTraceProcessor()
+        public ObfuscatorTraceProcessor(bool redisTagObfuscationEnabled)
         {
-            Log.Information("ObfuscatorTraceProcessor initialized.");
+            _tagsProcessor = new(redisTagObfuscationEnabled);
+            Log.Information("ObfuscatorTraceProcessor initialized. Redis tag obfuscation enabled: {RedisObfuscation}", redisTagObfuscationEnabled);
         }
 
         public ArraySegment<Span> Process(ArraySegment<Span> trace)
@@ -71,10 +73,7 @@ namespace Datadog.Trace.TraceProcessors
             return span;
         }
 
-        public ITagProcessor GetTagProcessor()
-        {
-            return null;
-        }
+        public ITagProcessor GetTagProcessor() => _tagsProcessor;
 
         internal static string ObfuscateSqlResource(string sqlQuery)
         {

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -63,6 +63,10 @@ namespace Datadog.Trace.TraceProcessors
             {
                 span.ResourceName = ObfuscateSqlResource(span.ResourceName);
             }
+            else if (span.Type == SpanTypes.Redis)
+            {
+                span.ResourceName = ObfuscateRedisResource(span.ResourceName);
+            }
 
             return span;
         }
@@ -133,6 +137,16 @@ namespace Datadog.Trace.TraceProcessors
             }
 
             return sqlQuery;
+        }
+
+        internal static string ObfuscateRedisResource(string redisResource)
+        {
+            if (string.IsNullOrEmpty(redisResource))
+            {
+                return string.Empty;
+            }
+
+            return RedisObfuscationUtil.Quantize(redisResource);
         }
 
         private static BitArray FindSplitterPositions(char[] sqlChars)

--- a/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
+++ b/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
@@ -10,8 +10,6 @@ namespace Datadog.Trace.Processors
 {
     internal class RedisObfuscationUtil
     {
-        private const string RedisTruncationMark = "...";
-
         private const int MaxRedisNbCommands = 3;
 
         /// <summary>
@@ -238,6 +236,196 @@ namespace Datadog.Trace.Processors
             }
 
             return false;
+        }
+
+        public class RedisTokenizer
+        {
+            private readonly string _query;
+            private int _offset;
+            private int _finalOffset;
+            private bool _done;
+            private TokenType _state = TokenType.Command;
+
+            public RedisTokenizer(string query)
+            {
+                _query = query;
+                _offset = 0;
+                _finalOffset = _query.Length - 1;
+
+                // skip final whitespace
+                while (_finalOffset > 0 && query[_finalOffset] is ' ' or '\t' or '\r' or '\n')
+                {
+                    _finalOffset--;
+                }
+
+                // skip initial whitespace
+                while (_offset < _finalOffset && query[_offset] is ' ' or '\t' or '\r' or '\n')
+                {
+                    _offset++;
+                }
+
+                _done = _offset > _finalOffset;
+            }
+
+            public enum TokenType
+            {
+                Command,
+                Argument,
+            }
+
+            /// <summary>
+            /// Returns the next token. Returns true if we're finished
+            /// </summary>
+            public bool Scan(out Token token) =>
+                _state == TokenType.Command
+                    ? ScanCommand(out token)
+                    : ScanArgument(out token);
+
+            private bool ScanCommand(out Token token)
+            {
+                var initialOffset = _offset;
+                var started = false;
+                while (!_done)
+                {
+                    switch (_query[_offset])
+                    {
+                        case '\n':
+                            token = new Token(initialOffset, _offset - initialOffset, TokenType.Command);
+                            // increment offset past this token
+                            Next();
+                            return _done;
+                        case ' ':
+                            if (!started)
+                            {
+                                // skip spaces preceding token
+                                SkipSpace(skipTrailingLineBreak: false);
+                                initialOffset = _offset;
+                                break;
+                            }
+
+                            // done scanning command, next word is an argument
+                            _state = TokenType.Argument;
+                            token = new Token(initialOffset, _offset - initialOffset, TokenType.Command);
+                            // don't include the subsequent white space in the token
+                            SkipSpace(skipTrailingLineBreak: true);
+
+                            return _done;
+
+                        default:
+                            started = true;
+                            Next();
+                            break;
+                    }
+                }
+
+                // We're done, so return final token
+                token = new Token(initialOffset, _offset - initialOffset, TokenType.Command);
+                return true;
+            }
+
+            private bool ScanArgument(out Token token)
+            {
+                var initialOffset = _offset;
+
+                var quoted = false;
+                var escape = false;
+                while (!_done)
+                {
+                    switch (_query[_offset])
+                    {
+                        case '\\':
+                            escape = !escape;
+                            Next();
+                            break;
+                        case '\n':
+                            if (!quoted)
+                            {
+                                // last argument, new command follows
+                                _state = TokenType.Command;
+                                token = new Token(initialOffset, _offset - initialOffset, TokenType.Argument);
+                                // increment offset past this token
+                                Next();
+                                return _done;
+                            }
+
+                            escape = false;
+                            Next();
+                            break;
+                        case '"':
+                            if (!escape)
+                            {
+                                // this quote wasn't escaped, toggle quoted mode
+                                quoted = !quoted;
+                            }
+
+                            escape = false;
+                            Next();
+                            break;
+                        case ' ':
+                            if (!quoted)
+                            {
+                                token = new Token(initialOffset, _offset - initialOffset, TokenType.Argument);
+                                SkipSpace(skipTrailingLineBreak: true);
+                                return _done;
+                            }
+
+                            escape = false;
+                            Next();
+                            break;
+                        default:
+                            escape = false;
+                            Next();
+                            break;
+                    }
+                }
+
+                // We're done, so return final token
+                token = new Token(initialOffset, _offset - initialOffset, TokenType.Argument);
+                return true;
+            }
+
+            private void SkipSpace(bool skipTrailingLineBreak)
+            {
+                while (!_done && (_query[_offset] == ' ' || _query[_offset] == '\t' || _query[_offset] == '\r'))
+                {
+                    Next();
+                }
+
+                if (!_done && _query[_offset] == '\n')
+                {
+                    // next token is a command
+                    _state = TokenType.Command;
+
+                    // if we have advanced to a line break, skip over it
+                    if (skipTrailingLineBreak)
+                    {
+                        Next();
+                    }
+                }
+            }
+
+            private void Next()
+            {
+                _offset++;
+                if (_offset > _finalOffset)
+                {
+                    _done = true;
+                }
+            }
+
+            public readonly struct Token
+            {
+                public readonly int Offset;
+                public readonly int Length;
+                public readonly TokenType TokenType;
+
+                public Token(int offset, int length, TokenType tokenType)
+                {
+                    Offset = offset;
+                    Length = length;
+                    TokenType = tokenType;
+                }
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
+++ b/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
@@ -1,0 +1,243 @@
+﻿// <copyright file="RedisObfuscationUtil.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Processors
+{
+    internal class RedisObfuscationUtil
+    {
+        private const string RedisTruncationMark = "...";
+
+        private const int MaxRedisNbCommands = 3;
+
+        /// <summary>
+        /// "Quantizes" (obfuscates) a redis Span's resource name
+        /// Based on https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis.go#L28
+        /// </summary>
+        public static string Quantize(string query)
+        {
+            if (string.IsNullOrEmpty(query))
+            {
+                return string.Empty;
+            }
+
+            var truncated = false;
+            var commandCount = 0;
+
+            var builder = StringBuilderCache.Acquire(query.Length);
+            var startIndex = 0;
+            var endIndex = query.Length;
+
+            // skip initial whitespace
+            while (startIndex < endIndex && char.IsWhiteSpace(query[startIndex]))
+            {
+                startIndex++;
+            }
+
+            while (startIndex < query.Length && commandCount < MaxRedisNbCommands)
+            {
+                // Get next command (separated by line break)
+                endIndex = query.IndexOf('\n', startIndex: startIndex);
+                if (endIndex == -1)
+                {
+                    // only 1 command, use whole string
+                    endIndex = query.Length;
+                }
+
+                // skip whitespace
+                while (startIndex < endIndex && char.IsWhiteSpace(query[startIndex]))
+                {
+                    startIndex++;
+                }
+
+                if (startIndex >= endIndex)
+                {
+                    startIndex = endIndex + 1;
+                    continue;
+                }
+
+                // Get first argument
+                var arg1EndIndex = query.IndexOf(' ', startIndex: startIndex, count: (endIndex - startIndex));
+                if (arg1EndIndex == -1)
+                {
+                    // whole command only has one argument
+                    arg1EndIndex = endIndex;
+                }
+                else
+                {
+                    // remove whitespace from end of arg
+                    while (arg1EndIndex > startIndex && char.IsWhiteSpace(query[arg1EndIndex - 1]))
+                    {
+                        arg1EndIndex--;
+                    }
+                }
+
+                // Does the argument have the truncation mark '...'
+                if (IsTruncated(query, startIndex, arg1EndIndex))
+                {
+                    truncated = true;
+                    startIndex = endIndex + 1;
+                    continue;
+                }
+
+                var arg2StartIndex = arg1EndIndex;
+
+                // skip whitespace
+                while (arg2StartIndex < endIndex && char.IsWhiteSpace(query[arg2StartIndex]))
+                {
+                    arg2StartIndex++;
+                }
+
+                var isCompoundCommand = false;
+                var arg2EndIndex = endIndex;
+
+                // Do we have a second argument?
+                if (arg2StartIndex < endIndex)
+                {
+                    // we have more left in the command
+                    arg2EndIndex = query.IndexOf(' ', startIndex: arg2StartIndex, count: endIndex - arg2StartIndex);
+                    if (arg2EndIndex == -1)
+                    {
+                        arg2EndIndex = endIndex;
+                    }
+
+                    // if yes, is the first argument a compound command?
+                    if (IsCompoundCommand(query, startIndex, arg1EndIndex))
+                    {
+                        isCompoundCommand = true;
+
+                        // remove whitespace from end of arg
+                        while (arg2EndIndex > arg2StartIndex && char.IsWhiteSpace(query[arg2EndIndex - 1]))
+                        {
+                            arg2EndIndex--;
+                        }
+
+                        // is the second command truncated?
+                        if (IsTruncated(query, arg2StartIndex, arg2EndIndex))
+                        {
+                            truncated = true;
+                            startIndex = endIndex + 1;
+                            continue;
+                        }
+                    }
+                }
+
+                if (builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+
+                // add the command to the builder
+                while (startIndex < arg1EndIndex)
+                {
+                    builder.Append(char.ToUpperInvariant(query[startIndex]));
+                    startIndex++;
+                }
+
+                if (isCompoundCommand)
+                {
+                    builder.Append(' ');
+                    while (arg2StartIndex < arg2EndIndex)
+                    {
+                        builder.Append(char.ToUpperInvariant(query[arg2StartIndex]));
+                        arg2StartIndex++;
+                    }
+                }
+
+                commandCount++;
+                truncated = false;
+                startIndex = endIndex + 1;
+            }
+
+            if (commandCount == MaxRedisNbCommands || truncated)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+
+                builder.Append('.', 3);
+            }
+
+            return StringBuilderCache.GetStringAndRelease(builder);
+        }
+
+        private static bool IsTruncated(string query, int startIndex, int endIndex)
+        {
+            return endIndex > startIndex + 3
+                && query[endIndex - 1] == '.'
+                && query[endIndex - 2] == '.'
+                && query[endIndex - 3] == '.';
+        }
+
+        /// <summary>
+        /// Is the redis command a compound command (consists of 2 works)?
+        /// </summary>
+        internal static bool IsCompoundCommand(string query, int startIndex, int endIndex)
+        {
+            // The following commands are 2-part commands, so check if the full argument matches this
+            // "CLIENT", "CLUSTER", "CONFIG", "COMMAND", "DEBUG", "SCRIPT"
+            if (endIndex - startIndex is < 5 or > 7)
+            {
+                return false;
+            }
+
+            var firstLetter = char.ToUpperInvariant(query[startIndex]);
+
+            if (firstLetter == 'C')
+            {
+                if (char.ToUpperInvariant(query[startIndex + 1]) == 'L')
+                {
+                    return (endIndex == startIndex + 6
+                         && char.ToUpperInvariant(query[startIndex + 2]) == 'I'
+                         && char.ToUpperInvariant(query[startIndex + 3]) == 'E'
+                         && char.ToUpperInvariant(query[startIndex + 4]) == 'N'
+                         && char.ToUpperInvariant(query[startIndex + 5]) == 'T')
+                        || (endIndex == startIndex + 7
+                         && char.ToUpperInvariant(query[startIndex + 2]) == 'U'
+                         && char.ToUpperInvariant(query[startIndex + 3]) == 'S'
+                         && char.ToUpperInvariant(query[startIndex + 4]) == 'T'
+                         && char.ToUpperInvariant(query[startIndex + 5]) == 'E'
+                         && char.ToUpperInvariant(query[startIndex + 6]) == 'R');
+                }
+                else if (char.ToUpperInvariant(query[startIndex + 1]) == 'O')
+                {
+                    return (endIndex == startIndex + 6
+                         && char.ToUpperInvariant(query[startIndex + 2]) == 'N'
+                         && char.ToUpperInvariant(query[startIndex + 3]) == 'F'
+                         && char.ToUpperInvariant(query[startIndex + 4]) == 'I'
+                         && char.ToUpperInvariant(query[startIndex + 5]) == 'G')
+                        || (endIndex == startIndex + 7
+                         && char.ToUpperInvariant(query[startIndex + 2]) == 'M'
+                         && char.ToUpperInvariant(query[startIndex + 3]) == 'M'
+                         && char.ToUpperInvariant(query[startIndex + 4]) == 'A'
+                         && char.ToUpperInvariant(query[startIndex + 5]) == 'N'
+                         && char.ToUpperInvariant(query[startIndex + 6]) == 'D');
+                }
+            }
+            else if (firstLetter == 'D')
+            {
+                return (endIndex == startIndex + 5)
+                    && char.ToUpperInvariant(query[startIndex + 1]) == 'E'
+                    && char.ToUpperInvariant(query[startIndex + 2]) == 'B'
+                    && char.ToUpperInvariant(query[startIndex + 3]) == 'U'
+                    && char.ToUpperInvariant(query[startIndex + 4]) == 'G';
+            }
+            else if (query[startIndex] is 's' or 'S')
+            {
+                return (endIndex == startIndex + 6)
+                    && char.ToUpperInvariant(query[startIndex + 1]) == 'C'
+                    && char.ToUpperInvariant(query[startIndex + 2]) == 'R'
+                    && char.ToUpperInvariant(query[startIndex + 3]) == 'I'
+                    && char.ToUpperInvariant(query[startIndex + 4]) == 'P'
+                    && char.ToUpperInvariant(query[startIndex + 5]) == 'T';
+            }
+
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
+++ b/tracer/src/Datadog.Trace/Processors/RedisObfuscationUtil.cs
@@ -457,7 +457,7 @@ namespace Datadog.Trace.Processors
                     && char.ToUpperInvariant(query[startIndex + 3]) == 'U'
                     && char.ToUpperInvariant(query[startIndex + 4]) == 'G';
             }
-            else if (query[startIndex] is 's' or 'S')
+            else if (firstLetter == 'S')
             {
                 return (endIndex == startIndex + 6)
                     && char.ToUpperInvariant(query[startIndex + 1]) == 'C'

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
@@ -41,6 +41,9 @@ namespace Datadog.Trace.Tests.TraceProcessors
             { "CLIENT...", "..." },
             { "CLIENT LIST...", "..." },
             { "罿", "罿" },
+            { string.Empty, string.Empty },
+            { null, string.Empty },
+            { "CONFIG SET parameter\t\t value\t\nCONFIG SET parameter\t\t value\t value \n", "CONFIG SET CONFIG SET" },
         };
 
         public static TheoryData<string, int, int, bool> RedisCompoundCommands() => new()
@@ -174,6 +177,19 @@ SET k v
                 @"CONFIG command
 SET k ?"
             },
+            // These are some extra ones to catch some edge cases
+            { null, null },
+            { string.Empty, string.Empty },
+            { "\n  \n", "\n  \n" },
+            { "\n  \n", "\n  \n" },
+            { "EEK key value1 value2", "EEK key value1 value2" },
+            { "YIKES key value1 value2", "YIKES key value1 value2" },
+            { "OOPSEY key value1 value2", "OOPSEY key value1 value2" },
+            { "IMSORRY key value1 value2", "IMSORRY key value1 value2" },
+            { "WHOOPSEY key value1 value2", "WHOOPSEY key value1 value2" },
+            { "IMSOSORRY key value1 value2", "IMSOSORRY key value1 value2" },
+            { "YOUTRYDOINGITTHEN key value1 value2", "YOUTRYDOINGITTHEN key value1 value2" },
+            { "ALRIGHTIMOUT key value1 value2", "ALRIGHTIMOUT key value1 value2" },
         };
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="RedisObfuscationUtilTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Processors;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.TraceProcessors
+{
+    public class RedisObfuscationUtilTests
+    {
+        // Test cases from https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L31
+        public static TheoryData<string, string> GetRedisQuantizedQuery() => new()
+        {
+            { "CLIENT", "CLIENT" },
+            { "CLIENT LIST", "CLIENT LIST" },
+            { "get my_key", "GET" },
+            { "SET le_key le_value", "SET" },
+            { "\n\n  \nSET foo bar  \n  \n\n  ", "SET" },
+            { "CONFIG SET parameter value", "CONFIG SET" },
+            { "SET toto tata \n \n  EXPIRE toto 15  ", "SET EXPIRE" },
+            { "MSET toto tata toto tata toto tata \n ", "MSET" },
+            { "MULTI\nSET k1 v1\nSET k2 v2\nSET k3 v3\nSET k4 v4\nDEL to_del\nEXEC", "MULTI SET SET ..." },
+            { "DEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"", "DEL DEL HMSET ..." },
+            { "GET...", "..." },
+            { "GET k...", "GET" },
+            { "GET k1\nGET k2\nG...", "GET GET ..." },
+            { "GET k1\nGET k2\nDEL k3\nGET k...", "GET GET DEL ..." },
+            { "GET k1\nGET k2\nHDEL k3 a\nG...", "GET GET HDEL ..." },
+            { "GET k...\nDEL k2\nMS...", "GET DEL ..." },
+            { "GET k...\nDE...\nMS...", "GET ..." },
+            { "GET k1\nDE...\nGET k2", "GET GET" },
+            { "GET k1\nDE...\nGET k2\nHDEL k3 a\nGET k4\nDEL k5", "GET GET HDEL ..." },
+            { "UNKNOWN 123", "UNKNOWN" },
+            // These are some extra edge cases
+            { "  \n \n  ", string.Empty },
+            { "GET ...", "GET" },
+            { "CLIENT...", "..." },
+            { "CLIENT LIST...", "..." },
+            { "罿", "罿" },
+        };
+
+        public static TheoryData<string, int, int, bool> RedisCompoundCommands() => new()
+        {
+            { "CLIENT foo", 0, 6, true },
+            { "CLUSTER foo", 0, 7, true },
+            { "COMMAND foo", 0, 7, true },
+            { "CONFIG foo", 0, 6, true },
+            { "DEBUG foo", 0, 5, true },
+            { "SCRIPT foo", 0, 6, true },
+            { "client foo", 0, 6, true },
+            { "cluSTER foo", 0, 7, true },
+            { "commanD foo", 0, 7, true },
+            { "Config foo", 0, 6, true },
+            { "debug foo", 0, 5, true },
+            { "sCrIpT foo", 0, 6, true },
+            { "foo blah SCRIPT baz", 9, 15, true },
+            { "CLINT foo", 0, 5, false },
+            { "foo CLINT", 4, 9, false },
+            { "foo DEBOG", 4, 9, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(GetRedisQuantizedQuery))]
+        public void RedisQuantizerTest(string inValue, string expectedValue)
+        {
+            var actualValue = RedisObfuscationUtil.Quantize(inValue);
+            actualValue.Should().Be(expectedValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(RedisCompoundCommands))]
+        public void RedisCompoundCommandsTest(string query, int startIndex, int endIndex, bool expected)
+        {
+            var actual = RedisObfuscationUtil.IsCompoundCommand(query, startIndex, endIndex);
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/RedisObfuscationUtilTests.cs
@@ -99,6 +99,83 @@ namespace Datadog.Trace.Tests.TraceProcessors
             { "CMD arg1 \n\n  \n CMD2 arg2\n ", new[] { ("CMD", nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Command), false), ("arg1", nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Argument), false), (string.Empty, nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Command), false), (string.Empty, nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Command), false), ("CMD2", nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Command), false), ("arg2", nameof(RedisObfuscationUtil.RedisTokenizer.TokenType.Argument), true), } },
         };
 
+        // Test cases from https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L103
+        public static TheoryData<string, string> GetRedisObfuscatedQuery() => new()
+        {
+            { "AUTH my-secret-password", "AUTH ?" },
+            { "AUTH james my-secret-password", "AUTH ?" },
+            { "AUTH", "AUTH" },
+            { "APPEND key value", "APPEND key ?" },
+            { "GETSET key value", "GETSET key ?" },
+            { "LPUSHX key value", "LPUSHX key ?" },
+            { "GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]", "GEORADIUSBYMEMBER key ? radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]" },
+            { "RPUSHX key value", "RPUSHX key ?" },
+            { "SET key value", "SET key ?" },
+            { "SET key value [expiration EX seconds|PX milliseconds] [NX|XX]", "SET key ? [expiration EX seconds|PX milliseconds] [NX|XX]" },
+            { "SETNX key value", "SETNX key ?" },
+            { "SISMEMBER key member", "SISMEMBER key ?" },
+            { "ZRANK key member", "ZRANK key ?" },
+            { "ZREVRANK key member", "ZREVRANK key ?" },
+            { "ZSCORE key member", "ZSCORE key ?" },
+            { "BITFIELD key GET type offset SET type offset value INCRBY type", "BITFIELD key GET type offset SET type offset ? INCRBY type" },
+            { "BITFIELD key SET type offset value INCRBY type", "BITFIELD key SET type offset ? INCRBY type" },
+            { "BITFIELD key GET type offset INCRBY type", "BITFIELD key GET type offset INCRBY type" },
+            { "BITFIELD key SET type offset", "BITFIELD key SET type offset" },
+            { "CONFIG SET parameter value", "CONFIG SET parameter ?" },
+            { "CONFIG foo bar baz", "CONFIG foo bar baz" },
+            { "GEOADD key longitude latitude member longitude latitude member longitude latitude member", "GEOADD key longitude latitude ? longitude latitude ? longitude latitude ?" },
+            { "GEOADD key longitude latitude member longitude latitude member", "GEOADD key longitude latitude ? longitude latitude ?" },
+            { "GEOADD key longitude latitude member", "GEOADD key longitude latitude ?" },
+            { "GEOADD key longitude latitude", "GEOADD key longitude latitude" },
+            { "GEOADD key", "GEOADD key" },
+            { "GEOHASH key\nGEOPOS key\n GEODIST key", "GEOHASH key\nGEOPOS key\nGEODIST key" },
+            { "GEOHASH key member\nGEOPOS key member\nGEODIST key member\n", "GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?" },
+            { "GEOHASH key member member member\nGEOPOS key member member \n  GEODIST key member member member", "GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?" },
+            { "GEOPOS key member [member ...]", "GEOPOS key ?" },
+            { "SREM key member [member ...]", "SREM key ?" },
+            { "ZREM key member [member ...]", "ZREM key ?" },
+            { "SADD key member [member ...]", "SADD key ?" },
+            { "GEODIST key member1 member2 [unit]", "GEODIST key ?" },
+            { "LPUSH key value [value ...]", "LPUSH key ?" },
+            { "RPUSH key value [value ...]", "RPUSH key ?" },
+            { "HSET key field value \nHSETNX key field value\nBLAH", "HSET key field ?\nHSETNX key field ?\nBLAH" },
+            { "HSET key field value", "HSET key field ?" },
+            { "HSETNX key field value", "HSETNX key field ?" },
+            { "LREM key count value", "LREM key count ?" },
+            { "LSET key index value", "LSET key index ?" },
+            { "SETBIT key offset value", "SETBIT key offset ?" },
+            { "SETRANGE key offset value", "SETRANGE key offset ?" },
+            { "SETEX key seconds value", "SETEX key seconds ?" },
+            { "PSETEX key milliseconds value", "PSETEX key milliseconds ?" },
+            { "ZINCRBY key increment member", "ZINCRBY key increment ?" },
+            { "SMOVE source destination member", "SMOVE source destination ?" },
+            { "RESTORE key ttl serialized-value [REPLACE]", "RESTORE key ttl ? [REPLACE]" },
+            { "LINSERT key BEFORE pivot value", "LINSERT key BEFORE pivot ?" },
+            { "LINSERT key AFTER pivot value", "LINSERT key AFTER pivot ?" },
+            { "HMSET key field value field value", "HMSET key field ? field ?" },
+            { "HMSET key field value \n HMSET key field value\n\n ", "HMSET key field ?\nHMSET key field ?" },
+            { "HMSET key field", "HMSET key field" },
+            { "MSET key value key value", "MSET key ? key ?" },
+            { "MSET\nMSET key value", "MSET\nMSET key ?" },
+            { "MSET key value", "MSET key ?" },
+            { "MSETNX key value key value", "MSETNX key ? key ?" },
+            { "ZADD key score member score member", "ZADD key score ? score ?" },
+            { "ZADD key NX score member score member", "ZADD key NX score ? score ?" },
+            { "ZADD key NX CH score member score member", "ZADD key NX CH score ? score ?" },
+            { "ZADD key NX CH INCR score member score member", "ZADD key NX CH INCR score ? score ?" },
+            { "ZADD key XX INCR score member score member", "ZADD key XX INCR score ? score ?" },
+            { "ZADD key XX INCR score member", "ZADD key XX INCR score ?" },
+            { "ZADD key XX INCR score", "ZADD key XX INCR score" },
+            {
+                @"
+CONFIG command
+SET k v
+			",
+                @"CONFIG command
+SET k ?"
+            },
+        };
+
         [Theory]
         [MemberData(nameof(GetRedisQuantizedQuery))]
         public void RedisQuantizerTest(string inValue, string expectedValue)
@@ -132,6 +209,14 @@ namespace Datadog.Trace.Tests.TraceProcessors
                 var commandArg = query.Substring(token.Offset, token.Length);
                 commandArg.Should().Be(expected.Token);
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRedisObfuscatedQuery))]
+        public void RedisObfuscatorTest(string inValue, string expectedValue)
+        {
+            var actualValue = RedisObfuscationUtil.Obfuscate(inValue);
+            Assert.Equal(expectedValue, actualValue);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Add quantization (obfuscation) of Redis span resource names
- Add obfuscation of `redis.raw_command` tag.
- Required for stats computation in the tracer

## Reason for change

As part of computing stats in the tracer, we need to provide the same bucketing and obfuscation as the agent. This PR adds both the quantization applied to resource names, and the obfuscation applied to the `redis.raw_command` tag.

## Implementation details

Closely follows the agent implementation [here](https://github.dev/DataDog/datadog-agent/blob/3cc240ddd18a77b0cbb9761de1f98fd0c299a067/pkg/trace/obfuscate/redis.go). Reworked a bit to simplify it (it's still not very simple!) and removed all the allocations (apart from the final string, or when the query is too large for the `StringBuilderCache`).

The `ITagProcessor` and `ITraceProcessor` implementations aren't used yet, but are available for stats in the tracer. 

> I'm just realising now, we probably don't need to the tag processing at all for stats in the tracer? In which case, I've made additional headway towards "agentless" 😄 

The Quantizer (obfuscator for resource names) uses a relatively naïve algorithm, which has known issues with string literals that contain line breaks. However, as the agent is using this approach, I figured it was best to continue with that approach. The Quantizer implementation is also a lot faster than the Obfuscator implementation (as you can see below in the benchmarks)

## Test coverage
Includes all the test cases from the agent implementation, [the `Tokenizer` tests](https://github.dev/DataDog/datadog-agent/blob/1c76b8381a195a0b0f629011a6225e936fe1d37a/pkg/trace/obfuscate/redis_tokenizer_test.go#L2), [the quantizer tests](https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L31), and [the obfuscator tests](https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L103).

I added a few extra edge cases in to be sure.

I also ran some property-based fuzz-testing to confirm that the implementations don't throw for weird inputs (couldn't add it to the project as FSCheck isn't strong-named, and didn't want to faff with that). Something we should consider if we change the implementation later. 

I also ran some benchmarks based on the ones in the agent (but haven't added them to the solution as I don't think they're super-useful)

``` ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
Intel Core i7-8750H CPU 2.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=6.0.300
  [Host]     : .NET Core 3.1.25 (CoreCLR 4.700.22.21202, CoreFX 4.700.22.21303), X64 RyuJIT
  DefaultJob : .NET Core 3.1.25 (CoreCLR 4.700.22.21202, CoreFX 4.700.22.21303), X64 RyuJIT
```

|    Method |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------- |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|  Quantize |   231.9 ns |  2.48 ns |  2.20 ns | 0.0007 |     - |     - |      56 B |
| Obfuscate | 1,867.6 ns | 18.95 ns | 16.80 ns | 0.0076 |     - |     - |     616 B |

- `Quantize` is the `Quantize()` function using [this string](https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L395) from the agent tests
- `Obfuscate` is the `Obfuscate()` function using [this string](https://github.dev/DataDog/datadog-agent/blob/712c7a7835e0f5aaa47211c4d75a84323eed7fd9/pkg/trace/obfuscate/redis_test.go#L395) from the agent tests, only concatenated 4 times instead of 5, to avoid going over the `StringBuilderCache` max size limit.

All of the allocations are from the final `string` output allocation. If I tweak the methods so that we just clear the `StringBuilder` at the end instead of allocating, then we get the following results:

|     Method |       Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |-----------:|---------:|---------:|------:|------:|------:|----------:|
|   Quantize |   224.7 ns |  4.34 ns |  4.06 ns |     - |     - |     - |         - |
|  Obfuscate | 1,888.5 ns | 10.47 ns |  9.29 ns |     - |     - |     - |         - |
| Obfuscate2 | 3,225.5 ns | 41.50 ns | 36.79 ns |     - |     - |     - |         - |

The `Obfuscate2` row in the table above shows the results of running the `Obfuscate()` function on the same data as the `Quantize` method. As you can see, it's a lot slower than `Quantize()`, as it needs to do a lot more work.

## Other details
Relates to #2591 
Closes AIT-2646
