### PR TITLE
Add workaround for race condition in GRPC library

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -263,9 +263,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var assert = new AssertionScope();
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
+            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(totalExpectedSpans, 500);
+
+                // There is a race condition in GRPC version < v2.43.0 that can cause ObjectDisposedException
+                // when a deadline is exceeded. Skip the test if we hit it: https://github.com/grpc/grpc-dotnet/pull/1550
+                if (processResult.ExitCode != 0
+                    && (string.IsNullOrEmpty(packageVersion) || new Version(packageVersion) < new Version("2.43.0")))
+                {
+                    if (processResult.StandardError.Contains("ObjectDisposedException"))
+                    {
+                        throw new SkipException("Hit race condition in GRPC deadline exceeded");
+                    }
+                }
 
                 using var scope = new AssertionScope();
                 spans.Count.Should().Be(totalExpectedSpans);


### PR DESCRIPTION
## Summary of changes

- If we get an `ObjectDisposedException` in an affected version, skip the test.

## Reason for change

[There is a race condition in versions of GRPC < 2.43.0. ](https://github.com/grpc/grpc-dotnet/pull/1550) when the deadline is exceeded. We hit it occasionally in our tests and it causes flake.

## Implementation details

If we exit with a non-zero code, we're using an affected package, and the error contains `ObjectDisposedException`, then skip the test. Will hopefully avoid skipping any real issues.

## Test coverage
N/A

## Other details
Original PR that fixed the bug https://github.com/grpc/grpc-dotnet/pull/1550
