### PR TITLE
Increase timeout in ASP.NET Core diagnostic observer

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -443,7 +443,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
                 // The diagnostic observer runs on a separate thread
                 // This gives time for the Stop event to run and to be flushed to the writer
-                const int timeoutInMilliseconds = 10000;
+                const int timeoutInMilliseconds = 30_000;
 
                 var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
                 while (DateTime.Now < deadline)


### PR DESCRIPTION
## Summary of changes

- Increase the timeout in the ASP.NET Core diagnostic observer tests

## Reason for change

We occasionally see flakiness in these tests where we don't receive the expected spans.

## Implementation details

`10s -> 30s`. Yes, I know. But otherwise I think we have to refactor the whole `AspNetCoreDiagnosticObserver`, and this is much lower risk

## Test coverage
N/A
