### PR TITLE
Add snapshot tests for ASP.NET virtual applications

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -72,6 +72,42 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
     }
 
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsModuleOnlyClassic : AspNetMvc5ModuleOnlyTests
+    {
+        public AspNetMvc5TestsModuleOnlyClassic(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, virtualApp: false, classicMode: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsModuleOnlyIntegrated : AspNetMvc5ModuleOnlyTests
+    {
+        public AspNetMvc5TestsModuleOnlyIntegrated(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, virtualApp: false, classicMode: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsModuleOnlyVirtualAppIntegrated : AspNetMvc5ModuleOnlyTests
+    {
+        public AspNetMvc5TestsModuleOnlyVirtualAppIntegrated(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetMvc5TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag : AspNetMvc5ModuleOnlyTests
+    {
+        public AspNetMvc5TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
     [UsesVerify]
     public abstract class AspNetMvc5Tests : TestHelper, IClassFixture<IisFixture>
     {
@@ -148,6 +184,67 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Ensures that we get nice file nesting in Solution Explorer
             await Verifier.Verify(spans, settings)
                           .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+
+    [UsesVerify]
+    public abstract class AspNetMvc5ModuleOnlyTests : TestHelper, IClassFixture<IisFixture>
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetMvc5ModuleOnlyTests(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableRouteTemplateResourceNames, bool virtualApp = false)
+            : base("AspNetMvc5", @"test\test-applications\aspnet", output)
+        {
+            SetServiceVersion("1.0.0");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, enableRouteTemplateResourceNames.ToString());
+
+            // Disable the MVC part, so we can't back propagate any details to the tracing module
+            SetEnvironmentVariable(ConfigurationKeys.DisabledIntegrations, nameof(Configuration.IntegrationId.AspNetMvc));
+
+            _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
+            if (virtualApp)
+            {
+                _iisFixture.VirtualApplicationPath = "/my-app";
+            }
+
+            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+            _testName = nameof(AspNetMvc5Tests)
+                      + "ModuleOnly"
+                      + (virtualApp ? ".VirtualApp" : string.Empty)
+                      + (classicMode ? ".Classic" : ".Integrated");
+        }
+
+        public static TheoryData<string, int> Data() => new()
+        {
+            { "/Home/Index", 200 },
+            { "/Home/Get", 500 },
+            { "/badrequest", 500 },
+            { "/statuscode/503", 503 },
+            { "/BadRequestWithStatusCode/401", 500 }, // the exception thrown here overrides the status code set
+        };
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsTraces(string path, HttpStatusCode statusCode)
+        {
+            // Append virtual directory if there is one
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .DisableRequireUniquePrefix()
                           .UseTypeName(_testName);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc5TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag : AspNetMvc5ModuleOnlyTests
     {
         public AspNetMvc5TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: false)
+            : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: true)
         {
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public class AspNetWebApi2TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag : AspNetWebApi2ModuleOnlyTests
         {
             public AspNetWebApi2TestsModuleOnlyVirtualAppIntegratedWithFeatureFlag(IisFixture iisFixture, ITestOutputHelper output)
-                : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: false)
+                : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: true)
             {
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
@@ -158,6 +158,7 @@
         <application path="/" applicationPool="[POOL]">
           <virtualDirectory path="/" physicalPath="[PATH]" />
         </application>
+        [VIRTUAL_APPLICATION]
         <bindings>
           <binding protocol="http" bindingInformation="*:[PORT]:localhost" />
         </bindings>

--- a/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/IisFixture.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace.TestHelpers
 
         public string ShutdownPath { get; set; }
 
+        public string VirtualApplicationPath { get; set; } = string.Empty;
+
         public void TryStartIis(TestHelper helper, IisAppType appType)
         {
             lock (this)
@@ -32,7 +34,7 @@ namespace Datadog.Trace.TestHelpers
                     Agent = new MockTracerAgent(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
-                    IisExpress = helper.StartIISExpress(Agent, HttpPort, appType);
+                    IisExpress = helper.StartIISExpress(Agent, HttpPort, appType, VirtualApplicationPath);
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -300,7 +300,7 @@ namespace Datadog.Trace.TestHelpers
 
             var virtualAppSection = subAppPath switch
             {
-                null or "" or "/" => "/",
+                null or "" or "/" => string.Empty,
                 _ when !subAppPath.StartsWith("/") => throw new ArgumentException("Application path must start with '/'", nameof(subAppPath)),
                 _ when subAppPath.EndsWith("/") => throw new ArgumentException("Application path must not end with '/'", nameof(subAppPath)),
                 _ => $"<application path=\"{subAppPath}\" applicationPool=\"{appPool}\"><virtualDirectory path=\"/\" physicalPath=\"{appPath}\" /></application>",

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -272,7 +272,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public (Process Process, string ConfigFile) StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType)
+        public (Process Process, string ConfigFile) StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
         {
             var iisExpress = EnvironmentHelper.GetIisExpressPath();
 
@@ -298,10 +298,19 @@ namespace Datadog.Trace.TestHelpers
 
             var newConfig = Path.GetTempFileName();
 
+            var virtualAppSection = subAppPath switch
+            {
+                null or "" or "/" => "/",
+                _ when !subAppPath.StartsWith("/") => throw new ArgumentException("Application path must start with '/'", nameof(subAppPath)),
+                _ when subAppPath.EndsWith("/") => throw new ArgumentException("Application path must not end with '/'", nameof(subAppPath)),
+                _ => $"<application path=\"{subAppPath}\" applicationPool=\"{appPool}\"><virtualDirectory path=\"/\" physicalPath=\"{appPath}\" /></application>",
+            };
+
             configTemplate = configTemplate
                             .Replace("[PATH]", appPath)
                             .Replace("[PORT]", iisPort.ToString())
-                            .Replace("[POOL]", appPool);
+                            .Replace("[POOL]", appPool)
+                            .Replace("[VIRTUAL_APPLICATION]", virtualAppSection);
 
             var isAspNetCore = appType == IisAppType.AspNetCoreInProcess || appType == IisAppType.AspNetCoreOutOfProcess;
             if (isAspNetCore)

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -1,0 +1,102 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: error,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: aspnet-mvc.request,
+    Resource: GET /badrequestwithstatuscode/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      aspnet.action: badrequestwithstatuscode,
+      aspnet.controller: home,
+      aspnet.route: BadRequestWithStatusCode/{statuscode},
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -1,0 +1,106 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: error,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: aspnet-mvc.request,
+    Resource: GET /badrequestwithstatuscode/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      aspnet.action: badrequestwithstatuscode,
+      aspnet.controller: home,
+      aspnet.route: BadRequestWithStatusCode/{statuscode},
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_DogHouse_Woof_statusCode=200.verified.txt
@@ -1,0 +1,50 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /datadog/doghouse/woof,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: woof,
+      aspnet.area: datadog,
+      aspnet.controller: doghouse,
+      aspnet.route: Datadog/{controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog/doghouse/woof,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /datadog/doghouse/woof,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog/doghouse/woof,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_DogHouse_statusCode=200.verified.txt
@@ -1,0 +1,72 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request.child-action,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: hellofromchild,
+      aspnet.controller: doghouse,
+      aspnet.route: Datadog/{controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog/doghouse,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Tags: {
+      aspnet.action: index,
+      aspnet.area: datadog,
+      aspnet.controller: doghouse,
+      aspnet.route: Datadog/{controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog/doghouse,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog/doghouse,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_DataDog_statusCode=200.verified.txt
@@ -1,0 +1,72 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request.child-action,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: hellofromchild,
+      aspnet.controller: doghouse,
+      aspnet.route: Datadog/{controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Tags: {
+      aspnet.action: index,
+      aspnet.area: datadog,
+      aspnet.controller: doghouse,
+      aspnet.route: Datadog/{controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /datadog/doghouse/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/datadog,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Get_3_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /home/get/{id},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: get,
+      aspnet.controller: home,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home/get/3,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /home/get/{id},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home/get/3,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Get_statusCode=500.verified.txt
@@ -1,0 +1,67 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /home/get,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg:
+The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters,
+      error.stack:
+System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters
+at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/home/get,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /home/get,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_2,
+    Error: 1,
+    Tags: {
+      aspnet.action: get,
+      aspnet.controller: home,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      error.msg:
+The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters,
+      error.stack:
+System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters
+at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/home/get,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_Index_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: home,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home/index,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home/index,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_Home_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: home,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: home,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /home/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_badrequest-TransferRequest=true_statusCode=500.verified.txt
@@ -1,0 +1,106 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.action: index,
+      aspnet.controller: error,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /badrequest,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: aspnet-mvc.request,
+    Resource: GET /badrequest,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      aspnet.action: badrequest,
+      aspnet.controller: home,
+      aspnet.route: badrequest,
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/badrequest?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_badrequest_statusCode=500.verified.txt
@@ -1,0 +1,61 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequest,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /badrequest,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_2,
+    Error: 1,
+    Tags: {
+      aspnet.action: badrequest,
+      aspnet.controller: home,
+      aspnet.route: badrequest,
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-async_0_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /delay-async/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: delayasync,
+      aspnet.controller: home,
+      aspnet.route: delay-async/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-async/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /delay-async/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-async/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-optional_1_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: optional,
+      aspnet.controller: home,
+      aspnet.route: delay-optional/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-optional/1,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-optional/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay-optional_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: optional,
+      aspnet.controller: home,
+      aspnet.route: delay-optional/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-optional,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay-optional,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: delay,
+      aspnet.controller: home,
+      aspnet.route: delay/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /delay/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_graphql_GetAllFoo_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /graphql/{*slug},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: query,
+      aspnet.controller: graphql,
+      aspnet.route: graphql/{*slug},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/graphql/getallfoo,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /graphql/{*slug},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/graphql/getallfoo,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_statuscode_201_statusCode=201.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: home,
+      aspnet.route: statuscode/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/statuscode/201,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/statuscode/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5Tests.VirtualApp.Integrated.WithFF.__path=_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-mvc.request,
+    Resource: GET /statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: home,
+      aspnet.route: statuscode/{value},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/statuscode/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /badrequestwithstatuscode/401,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_Home_Get_statusCode=500.verified.txt
@@ -1,0 +1,36 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /home/get,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg:
+The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters,
+      error.stack:
+System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters
+at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /home/get,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_Home_Index_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /home/index,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /home/index,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_badrequest_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequest,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /badrequest,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Classic.__path=_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /statuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -1,0 +1,52 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /error/index,
+    Service: sample,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /badrequestwithstatuscode/401,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /error/index,
+    Service: sample,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /badrequestwithstatuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_Home_Get_statusCode=500.verified.txt
@@ -1,0 +1,36 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /home/get,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg:
+The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters,
+      error.stack:
+System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters
+at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /home/get,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_Home_Index_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /home/index,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /home/index,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_badrequest_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /badrequest,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /badrequest,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.Integrated.__path=_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /statuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_401-TransferRequest=true_statusCode=401.verified.txt
@@ -1,0 +1,52 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/badrequestwithstatuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/badrequestwithstatuscode/401?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_401_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/badrequestwithstatuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequestwithstatuscode/401,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_BadRequestWithStatusCode_503-TransferRequest=true_statusCode=503.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/error/index,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/badrequestwithstatuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequestWithStatusCode(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/badrequestwithstatuscode/503?transferrequest=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_Home_Get_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_Home_Get_statusCode=500.verified.txt
@@ -1,0 +1,36 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/home/get,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg:
+The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters,
+      error.stack:
+System.ArgumentException: The parameters dictionary contains a null entry for parameter 'id' of non-nullable type 'System.Int32' for method 'System.Web.Mvc.ActionResult Get(Int32)' in 'Samples.AspNetMvc5.Controllers.HomeController'. An optional parameter must be a reference type, a nullable type, or be declared as an optional parameter.
+Parameter name: parameters
+at System.Web.Mvc.ActionDescriptor.ExtractParameterFromDictionary(ParameterInfo parameterInfo, IDictionary`2 parameters, MethodInfo methodInfo),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/home/get,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_Home_Index_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_Home_Index_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/home/index,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/home/index,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_badrequest_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_badrequest_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/badrequest,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke.,
+      error.stack:
+System.Exception: Oops, it broke.
+at Samples.AspNetMvc5.Controllers.HomeController.BadRequest(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/badrequest,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetMvc5TestsModuleOnly.VirtualApp.Integrated.__path=_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_delayAsync_0_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/delayasync/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: delayasync,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api2/delayasync/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/delayasync/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api2/delayasync/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/delay/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: delay,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api2/delay/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/delay/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api2/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_optional_1_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/optional/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: optional,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api2/optional/1,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/optional/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api2/optional/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_optional_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/optional/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: optional,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api2/optional,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/optional/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api2/optional,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/api2/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api2/statuscode/201?ps=false&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/api2/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api2/statuscode/201?ps=false&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=false_statusCode=201.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: http://localhost:00000/my-app/api2/statuscode/201?ps=true&ts=false,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api2/statuscode/201?ps=true&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201-ps=true&ts=true_statusCode=201.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: http://localhost:00000/my-app/api2/statuscode/201?ps=true&ts=true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api2/statuscode/201?ps=true&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: http://localhost:00000/my-app/api2/statuscode/201,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api2/statuscode/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.action: statuscode,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: http://localhost:00000/my-app/api2/statuscode/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api2/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -1,0 +1,75 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/transientfailure/{value},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api2/transientfailure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/transientfailure/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.action: transientfailure,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/my-app/api2/transientfailure/false,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api2_transientfailure_true_statusCode=200.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api2/transientfailure/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.action: transientfailure,
+      aspnet.controller: conventions,
+      aspnet.route: api2/{action}/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api2/transientfailure/true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/transientfailure/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api2/transientfailure/true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_TransferRequest_401_statusCode=401.verified.txt
@@ -1,0 +1,98 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/statuscode/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: http://localhost:00000/my-app/api/statuscode/401,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/api/transferrequest/401,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /api/transferrequest/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTransferRequest(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 401,
+      http.url: /my-app/api/transferrequest/401,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/transferrequest/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      aspnet.route: api/TransferRequest/{statuscode},
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 401,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 401
+at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTransferRequest(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/my-app/api/transferrequest/401,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_TransferRequest_503_statusCode=503.verified.txt
@@ -1,0 +1,102 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.route: api/statuscode/{value},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: http://localhost:00000/my-app/api/statuscode/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api/transferrequest/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet.request,
+    Resource: GET /api/transferrequest/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTransferRequest(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api/transferrequest/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/transferrequest/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_4,
+    Error: 1,
+    Tags: {
+      aspnet.route: api/TransferRequest/{statuscode},
+      env: integration_tests,
+      error.msg: Oops, it broke. Specified status code was: 503,
+      error.stack:
+System.Exception: Oops, it broke. Specified status code was: 503
+at Samples.AspNetMvc5.Controllers.ApiController.BadRequestWithStatusCodeAndTransferRequest(Int32 statuscode),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/my-app/api/transferrequest/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/absolute-route,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/absolute-route,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/absolute-route,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/absolute-route,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/absolute-route,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_constraints_201_statusCode=201.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/constraints/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/constraints/{statuscode},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: http://localhost:00000/my-app/api/constraints/201,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/constraints/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api/constraints/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_constraints_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_constraints_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/constraints/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/constraints/{statuscode},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/constraints,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/constraints/{statuscode},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/constraints,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-async_0_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/delay-async/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/delay-async/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/delay-async/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/delay-async/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/delay-async/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-optional_1_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/delay-optional/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/delay-optional/1,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/delay-optional/1,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay-optional_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/delay-optional/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/delay-optional,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/delay-optional/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/delay-optional,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/delay/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/delay/{seconds},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/delay/0,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/delay/{seconds},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_environment_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/environment,
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/environment,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/environment,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/environment,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/environment,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_statuscode_201_statusCode=201.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/statuscode/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: http://localhost:00000/my-app/api/statuscode/201,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api/statuscode/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.route: api/statuscode/{value},
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: http://localhost:00000/my-app/api/statuscode/503,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/statuscode/{value},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -1,0 +1,73 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/transient-failure/{value},
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api/transient-failure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/transient-failure/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Error: 1,
+    Tags: {
+      aspnet.route: api/transient-failure/{value},
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/my-app/api/transient-failure/false,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet-webapi.request,
+    Resource: GET /api/transient-failure/{value},
+    Service: sample/my-app,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet.route: api/transient-failure/{value},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/my-app/api/transient-failure/true,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/transient-failure/{value},
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/transient-failure/true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=false&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=false&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=true&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.VirtualApp.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/handler-api/api?ps=true&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/api2/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /my-app/api2/statuscode/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/api2/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api2/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/api2/transientfailure/false,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api2/transientfailure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/api/absolute-route,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/absolute-route,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/api/statuscode/?,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /my-app/api/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/api/transient-failure/false,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/api/transient-failure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/api/transient-failure/true,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/api/transient-failure/true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=false&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=false&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample/my-app,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /my-app/handler-api/api?ps=true&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.VirtualApp.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /my-app/handler-api/api,
+    Service: sample/my-app,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /my-app/handler-api/api?ps=true&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_statuscode_201_statusCode=201.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_statuscode_201_statusCode=201.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/?,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 201,
+      http.url: /api2/statuscode/201,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /api2/statuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /api2/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api2/transientfailure/false,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /api2/transientfailure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_absolute-route_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_absolute-route_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /api/absolute-route,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /api/absolute-route,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_statuscode_503_statusCode=503.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_statuscode_503_statusCode=503.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /api/statuscode/?,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: The HTTP response has status code 503.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 503,
+      http.url: /api/statuscode/503,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /api/transient-failure/false,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Passed in value was not 'true': false,
+      error.stack:
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /api/transient-failure/false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_transient-failure_true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_api_transient-failure_true_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /api/transient-failure/true,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /api/transient-failure/true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /handler-api/api,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /handler-api/api?ps=false&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /handler-api/api,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /handler-api/api?ps=false&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: CustomTracingExceptionHandler.handle-async,
+    Resource: CustomTracingExceptionHandler.handle-async,
+    Service: sample,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet.request,
+    Resource: GET /handler-api/api,
+    Service: sample,
+    Type: web,
+    Error: 1,
+    Tags: {
+      env: integration_tests,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack:
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: /handler-api/api?ps=true&ts=false,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2TestsModuleOnly.__path=_handler-api_api-ps=true&ts=true_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /handler-api/api,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: /handler-api/api?ps=true&ts=true,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

- Adds tests + snapshots for 2 currently untested scenarios
  - Virtual applications
  - Tracing module _only_ (no MVC/WebAPI integration) +/- virtual applications
- Identifies several bugs 

## Reason for change

A recent escalation flagged that we are using the wrong resource name in some cases when an app is hosted in IIS as a virtual/sub app. We want to fix the bug, but we currently don't have any tests covering this scenario.

## Implementation details

This PR doesn't actually fix the bugs, it just documents them. I'll make follow up PRs to fix them. The bugs identified are: 

### Virtual app name in `aspnet.request` resource names when `TracingHttpModule` only

> Fixed in #2852

In some cases we are including the ASP.NET virtual application name in the `aspnet.request` span's resource name. This only occurs when the MVC/WebApi integration doesn't run (e.g. there's an error somewhere in the pipeline, before it executes). In that case we can't "back propagate" the resource name (which is based on the routing information). This leads to incorrect grouping of resources.

i.e. for an app called `my-app`
- successful requests: `POST /some/path`
- failing requests: `POST /my-app/some/path`

### Virtual app name in `aspnet.request` resource names when global handler used with WebApi2

> Fixed in #2852

In #1772 and #1734 we added support for global/per-route message handlers. If these run when the app is a virtual application, we incorrectly append the application name to the resource name, for the same reason as above - the WebApi2 integration doesn't run so can't back-propagate the correct resource name.

### Classic mode MVC doesn't set the status code correctly

> Fixed in #2854

While generating the snapshots, I noticed that when running in Classic mode, with the MVC/WebApi2 integration disabled, and the server returns an error, we are not setting the status code. It remains as 200, even though the server returns 500 etc.

### `aspnet-webapi.request` and `aspnet-mvc.request` spans differ in `http.url` tag

There's inconsistency in the format used for the `http.url` spans across the various web requests:

- `aspnet.request`: path only
- `aspnet-mvc.request`: path only
- `aspnet-webapi.request`: full URL
- `aspnet_core.request`: full URL
- `aspnet_core_mvc.request`: (not set)

## Test coverage

I just added tests for MVC5 and WebAPI2, as we reuse the same code paths with MVC4 and don't want to blow up the number of tests too much. Also didn't try all combinations of classic/feature flag/virtual app, just the pertinent ones.

## Other details
The WebApi project was referring to an unknown project AspNetWebApi2, where it should have been referencing AspNetMvc5.

Relates to APMS-7278 and AIT-2676
