### PR TITLE
Exclude dynamic assemblies from telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
@@ -20,17 +21,36 @@ namespace Datadog.Trace.Telemetry
         /// <summary>
         /// Called when an assembly is loaded
         /// </summary>
-        public void AssemblyLoaded(AssemblyName assembly)
+        public void AssemblyLoaded(Assembly assembly)
         {
-            if (assembly.Name is null or "Anonymously Hosted DynamicMethods Assembly"
-             || assembly.Name.StartsWith(DuckTypeConstants.DuckTypeAssemblyPrefix)
-             || assembly.Name.StartsWith(DuckTypeConstants.DuckTypeNotVisibleAssemblyPrefix)
-             || assembly.Name.StartsWith(DuckTypeConstants.DuckTypeGenericTypeAssemblyPrefix))
+            if (!assembly.IsDynamic)
+            {
+                AssemblyLoaded(assembly.GetName());
+            }
+        }
+
+        // Internal for testing
+        internal void AssemblyLoaded(AssemblyName assembly)
+        {
+            // exclude dlls we're not interested in which have a "random" component
+            // ASP.NET sites generate an App_Web_*.dll with a random string for
+            var assemblyName = assembly.Name;
+            if (assemblyName is null or "Anonymously Hosted DynamicMethods Assembly"
+             || assemblyName.StartsWith("App_Web_", StringComparison.Ordinal)
+             || assemblyName.StartsWith("App_Theme_", StringComparison.Ordinal)
+             || assemblyName.StartsWith("App_GlobalResources.", StringComparison.Ordinal)
+             || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
+             || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
+             || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)
+             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeAssemblyPrefix, StringComparison.Ordinal)
+             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeNotVisibleAssemblyPrefix, StringComparison.Ordinal)
+             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeGenericTypeAssemblyPrefix, StringComparison.Ordinal)
+             || IsTempPathPattern(assemblyName))
             {
                 return;
             }
 
-            var key = new DependencyTelemetryData(name: assembly.Name) { Version = assembly.Version?.ToString() };
+            var key = new DependencyTelemetryData(name: assemblyName) { Version = assembly.Version?.ToString() };
             if (_assemblies.TryAdd(key, true))
             {
                 SetHasChanges();
@@ -55,6 +75,33 @@ namespace Datadog.Trace.Telemetry
             }
 
             return _assemblies.Keys;
+        }
+
+        private static bool IsTempPathPattern(string assemblyName)
+        {
+            return assemblyName.Length == 12 // (8 + 1 + 3)
+                && assemblyName[8] == '.'
+                && IsBase32Char(assemblyName[0])
+                && IsBase32Char(assemblyName[1])
+                && IsBase32Char(assemblyName[2])
+                && IsBase32Char(assemblyName[3])
+                && IsBase32Char(assemblyName[4])
+                && IsBase32Char(assemblyName[5])
+                && IsBase32Char(assemblyName[6])
+                && IsBase32Char(assemblyName[7])
+                && IsBase32Char(assemblyName[9])
+                && IsBase32Char(assemblyName[10])
+                && IsBase32Char(assemblyName[11]);
+
+            static bool IsBase32Char(char c)
+            {
+                return c switch
+                {
+                    >= 'a' and <= 'z' => true,
+                    >= '0' and <= '5' => true,
+                    _ => false
+                };
+            }
         }
 
         private void SetHasChanges()

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -8,7 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
-using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.Telemetry
 {
@@ -35,17 +34,15 @@ namespace Datadog.Trace.Telemetry
             // exclude dlls we're not interested in which have a "random" component
             // ASP.NET sites generate an App_Web_*.dll with a random string for
             var assemblyName = assembly.Name;
-            if (assemblyName is null or "Anonymously Hosted DynamicMethods Assembly"
-             || assemblyName.StartsWith("App_Web_", StringComparison.Ordinal)
-             || assemblyName.StartsWith("App_Theme_", StringComparison.Ordinal)
-             || assemblyName.StartsWith("App_GlobalResources.", StringComparison.Ordinal)
-             || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
-             || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
-             || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)
-             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeAssemblyPrefix, StringComparison.Ordinal)
-             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeNotVisibleAssemblyPrefix, StringComparison.Ordinal)
-             || assemblyName.StartsWith(DuckTypeConstants.DuckTypeGenericTypeAssemblyPrefix, StringComparison.Ordinal)
-             || IsTempPathPattern(assemblyName))
+            if (assemblyName is null or ""
+             || IsTempPathPattern(assemblyName)
+             || (assemblyName[0] == 'A'
+              && (assemblyName.StartsWith("App_Web_", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_Theme_", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_GlobalResources.", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal))))
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Telemetry
         {
             try
             {
-                _dependencies.AssemblyLoaded(assembly.GetName());
+                _dependencies.AssemblyLoaded(assembly);
             }
             catch (Exception ex)
             {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -92,6 +92,7 @@ namespace Datadog.Trace.Tests.Telemetry
         {
             var currentAssemblyNames = AppDomain.CurrentDomain
                                                 .GetAssemblies()
+                                                .Where(x => !x.IsDynamic)
                                                 .Select(x => x.GetName())
                                                 .Where(x => x.Name != "Anonymously Hosted DynamicMethods Assembly"
                                                          && !x.Name.StartsWith("DuckType"))

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -94,8 +94,6 @@ namespace Datadog.Trace.Tests.Telemetry
                                                 .GetAssemblies()
                                                 .Where(x => !x.IsDynamic)
                                                 .Select(x => x.GetName())
-                                                .Where(x => x.Name != "Anonymously Hosted DynamicMethods Assembly"
-                                                         && !x.Name.StartsWith("DuckType"))
                                                 .Select(name => new { name.Name, Version = name.Version.ToString() });
 
             // creating a new controller so we have the same list of assemblies


### PR DESCRIPTION
## Summary of changes

- Exclude dynamic assemblies from telemetry collection.

## Reason for change

These assemblies significantly increase the cardinality and are generally not useful.

## Implementation details

We exclude both dynamically generated assemblies and assemblies created by ASP.NET (and similar) which are written to disk at runtime (e.g. App_Web_xxxx), and assemblies who's name matches the format of Path.GetRandomFileName()

## Test coverage

Unit test coverage

## Other details
Prerequisite for enabling by default
