### PR TITLE
Avoid calling AsyncLocal.Value twice when GetSpanContextRaw() is null

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
@@ -42,7 +42,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -43,7 +43,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -44,7 +44,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -45,7 +45,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -46,7 +46,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -47,7 +47,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -48,7 +48,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -49,7 +49,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -50,7 +50,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -41,7 +41,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, object[] arguments)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, arguments));
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw();
+            var activeScope = Tracer.Instance.InternalActiveScope;
+            return new CallTargetState(activeScope, spanContextRaw ?? activeScope?.Span?.Context, _invokeDelegate(instance, arguments));
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR is an optimization to the CallTarget machinery to avoid calling the `AsyncLocal.Value` getter twice when the `GetSpanContextRaw()` is null.

## Reason for change
Simple optimization, this is hotpath and calling `AsyncLocal.Value` is not cheap.

## Implementation details
Move the `Tracer.Instance.DistributedSpanContext` getter code to the caller to reuse the `Tracer.Instance.InternalActiveScope`

