### PR TITLE
Don't try and get runtime ID from the native loader on ARM64

### DIFF
--- a/tracer/src/Datadog.Trace/Util/RuntimeId.cs
+++ b/tracer/src/Datadog.Trace/Util/RuntimeId.cs
@@ -28,7 +28,8 @@ namespace Datadog.Trace.Util
 
         private static string GetImpl()
         {
-            if (TryGetRuntimeIdFromNative(out var runtimeId))
+            if (FrameworkDescription.Instance.OSArchitecture != ProcessArchitecture.Arm64
+             && TryGetRuntimeIdFromNative(out var runtimeId))
             {
                 Log.Information("Runtime id retrieved from native: " + runtimeId);
                 return runtimeId;
@@ -72,7 +73,7 @@ namespace Datadog.Trace.Util
                 // We failed to retrieve the runtime from native this can be because:
                 // - P/Invoke issue (unknown dll, unknown entrypoint...)
                 // - We are running in a partial trust environment
-                Log.Information("Failed to get the runtime-id from native: {Reason}", e.Message);
+                Log.Warning("Failed to get the runtime-id from native: {Reason}", e.Message);
             }
 
             runtimeId = default;


### PR DESCRIPTION
## Summary of changes

Don't try and get runtime ID from the native loader on ARM64

## Reason for change

We don't ship the native loader on ARM64 yet, so no point trying to fetch it, as just adds a log that can confuse customers.

## Implementation details

Added a runtime check for ARM64. Also Changed the "failed to get runtimeid" log back to a warning, as we _shouldn't_ hit it now.

## Test coverage

- [ ] Checked smoke test logs that log isn't there

## Other details
This assumes that we ship the native loader on Linux before the next release. If not, we should add that check in here too.
