### PR TITLE
Use azure scale-sets for more jobs (#2806)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -529,6 +529,7 @@ stages:
     - job: native
       timeoutInMinutes: 60 #default value
       pool:
+        # not using the VMSS here as there's an issue with the profiler building currently  
         vmImage: windows-2019
       steps:
       - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -168,7 +168,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -193,7 +193,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -225,7 +225,7 @@ stages:
 
   - job: build
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -450,7 +450,7 @@ stages:
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
-    vmImage: windows-2019
+    name: azure-windows-scale-set
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -494,8 +494,7 @@ stages:
   dependsOn: [build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-  pool:
-    vmImage: windows-2019
+  
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -503,6 +502,8 @@ stages:
 
     - job: managed
       timeoutInMinutes: 60 #default value
+      pool:
+        name: azure-windows-scale-set
       steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -527,6 +528,8 @@ stages:
 
     - job: native
       timeoutInMinutes: 60 #default value
+      pool:
+        vmImage: windows-2019
       steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1554,7 +1557,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -1705,7 +1708,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -1759,21 +1762,17 @@ stages:
         debian:
           baseImage: debian
           artifactSuffix: linux-x64
-          poolImage: ubuntu-18.04
-          poolName:
+          poolName: azure-linux-scale-set
         alpine:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-          poolImage: ubuntu-18.04
-          poolName:
+          poolName: azure-linux-scale-set
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolImage:
           poolname: aws-arm64-auto-scaling
 
     pool:
-      vmImage: $(poolImage)
       name: $(poolName)
 
     steps:


### PR DESCRIPTION
> This PR attempts to reinstate #2806. There was an issue on all the Windows VMs when I merged that PR (`error NETSDK1127: The targeting pack Microsoft.NETCore.App is not installed. Please restore and try again.`), so trying again to see if it was a transient issue or something else

## Summary of changes

Use the VMSS for more jobs

## Reason for change

Using the VMSS agents will hopefully speed up the build (as they're more powerful).

I didn't use them on some of the small non-critical jobs initially (coverage, trace pipeline) as don't want to over tax the scale set for now and unlikely to see much improvement there.

They're also not used in tasks that aren't designed primarily for running in Docker or have other dependencies (e.g. master_commit_id, upload to s3). We can review those in a subsequent PR if required.

Also there's an issue with building the native profiler on the windows scale set currently, as it makes assumptions about the NuGet.exe call. I need to fix the way the profiler does a restore to use the built-in helpers instead, then we can use it!

## Implementation details
Cherry-picked the previous commit
