### PR TITLE
[Profiler] Set _GLIBCXX_USE_CXX11_ABI to 0 and remove liblzma dependency

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -83,6 +83,8 @@ if (DEFINED RUN_ANALYSIS AND RUN_ANALYSIS EQUAL 1)
     endif()
 endif()
 
+add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+
 # ******************************************************
 # Output folders
 # ******************************************************

--- a/profiler/build/cmake/FindLibunwind.cmake
+++ b/profiler/build/cmake/FindLibunwind.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(libunwind
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND <SOURCE_DIR>/autogen.sh && <SOURCE_DIR>/configure CXXFLAGS=-fPIC CFLAGS=-fPIC && make -j
+    BUILD_COMMAND <SOURCE_DIR>/autogen.sh && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 CFLAGS=-fPIC --disable-minidebuginfo && make -j
     BUILD_ALWAYS false
 )
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -175,7 +175,6 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -static-libstdc++
     -lstdc++fs
     -pthread
-    -llzma
     -ldl
 )
 


### PR DESCRIPTION
## Summary of changes

## Reason for change

In the past, the tracer suffered from a bug where the customer application got stuck due to an `ABI`  issue.
By setting the flag `_GLIBCXX_USE_CXX11_ABI` to 0, the problem was solved.

In that case, we compile the profiler and its dependency with that flag set to `0`.

We also remove the `liblzma` dependency, to avoid having the profiler not working on alpine (base/default installation)
## Implementation details

Set the flag `_GLIBCXX_USE_CXX11_ABI` to 0
Deactivate `minidebuginfo` in libunwind to remove the liblzma dependency

## Test coverage

## Other details
<!-- Fixes #{issue} -->
