### PR TITLE
[Profiler] Run profiler benchmark tests with monitoring home instead for windows

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -486,8 +486,8 @@ jobs:
       - name: Download profiler artifact
         uses: actions/download-artifact@v2
         with:
-          name: profiler-home.Windows.Release
-          path: DDProf-Deploy
+          name: monitoring-home.Windows.Release
+          path: shared/bin/monitoring-home
 
       - name: Setup Go 1.16.8
         uses: actions/setup-go@v2
@@ -508,12 +508,24 @@ jobs:
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
 
       - name: Execute PiComputation benchmark
+        env:
+          DD_PROFILING_LOG_DIR: '${{ github.workspace }}/tests_output_dir/${{ matrix.framework }}'
+          DD_TRACE_LOG_DIRECTORY: '${{ github.workspace }}/tests_output_dir/${{ matrix.framework }}' # for the loader
         run: |
           cd profiler\build
           .\run.cmd ${{ matrix.framework }}
 
       - name: Wait 20 seconds to agent flush before finishing pipeline
         run: Start-Sleep -s 20
+
+      - name: 'Publish Benchmark log files'
+        uses: actions/upload-artifact@v2
+        if: '${{ always() }}'
+        with:
+          if-no-files-found: error
+          name: Benchmark.tests.windows.x64.${{ matrix.framework }}.logs
+          path: '${{ github.workspace }}/tests_output_dir'
+          retention-days: 7
 
   deploy_windows_profiler:
     name: Deploying Windows Profiler to AWS S3 bucket

--- a/profiler/build/PiComputation.windows.net45.json
+++ b/profiler/build/PiComputation.windows.net45.json
@@ -14,7 +14,8 @@
       "name": "Profiler",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1"
+        "DD_PROFILING_ENABLED": "1",
+        "DD_TRACE_ENABLED" : "0"
       }
     }
   ],
@@ -24,12 +25,12 @@
   "workingDirectory": "$(CWD)\\..\\_build\\bin\\Release-x64\\profiler\\src\\Demos\\Samples.Computer01\\net45",
   "environmentVariables": {
     "COR_ENABLE_PROFILING": "1",
-    "COR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "CORECLR_ENABLE_PROFILING": "1",
-    "CORECLR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\DDProf-Deploy",
+    "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
+    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\continuousprofiler",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },
   "tags": {

--- a/profiler/build/PiComputation.windows.net50.json
+++ b/profiler/build/PiComputation.windows.net50.json
@@ -14,7 +14,8 @@
       "name": "Profiler",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1"
+        "DD_PROFILING_ENABLED": "1",
+        "DD_TRACE_ENABLED" : "0"
       }
     }
   ],
@@ -24,12 +25,12 @@
   "workingDirectory": "$(CWD)\\..\\_build\\bin\\Release-x64\\profiler\\src\\Demos\\Samples.Computer01\\net5.0",
   "environmentVariables": {
     "COR_ENABLE_PROFILING": "1",
-    "COR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "CORECLR_ENABLE_PROFILING": "1",
-    "CORECLR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\DDProf-Deploy\\",
+    "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
+    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\continuousprofiler",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },
   "tags": {

--- a/profiler/build/PiComputation.windows.netcoreapp31.json
+++ b/profiler/build/PiComputation.windows.netcoreapp31.json
@@ -14,7 +14,8 @@
       "name": "Profiler",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
-        "DD_PROFILING_ENABLED": "1"
+        "DD_PROFILING_ENABLED": "1",
+        "DD_TRACE_ENABLED" : "0"
       }
     }
   ],
@@ -24,12 +25,12 @@
   "workingDirectory": "$(CWD)\\..\\_build\\bin\\Release-x64\\profiler\\src\\Demos\\Samples.Computer01\\netcoreapp3.1",
   "environmentVariables": {
     "COR_ENABLE_PROFILING": "1",
-    "COR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "CORECLR_ENABLE_PROFILING": "1",
-    "CORECLR_PROFILER": "{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}",
-    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\DDProf-Deploy\\Datadog.AutoInstrumentation.Profiler.Native.x64.dll",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\DDProf-Deploy\\",
+    "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
+    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\continuousprofiler",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },
   "tags": {


### PR DESCRIPTION
## Summary of changes

## Reason for change

On windows the native loader is used to load the profiler. We should launch the benchmark tests with the same packaging as our customers.

## Implementation details

Use the monitoring and fix the json file for windows
## Test coverage

## Other details
<!-- Fixes #{issue} -->
