### PR TITLE
Fix flaky `LambdaRequestBuilderTests`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
     public class ApiWebRequestFactoryTests
     {
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
+    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
     public class ApiWebRequestFactoryTests
     {
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection))]
     public class ApiWebRequestFactoryTests
     {
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -17,6 +17,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
+    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
     public class LambdaRequestBuilderTests
     {
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection))]
     public class LambdaRequestBuilderTests
     {
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
     public class LambdaRequestBuilderTests
     {
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
+    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
     public class SpanContextPropagatorTests_ExtractHeaderTags
     {
         private static readonly string TestPrefix = "test.prefix";

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
     public class SpanContextPropagatorTests_ExtractHeaderTags
     {
         private static readonly string TestPrefix = "test.prefix";

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests_ExtractHeaderTags.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection))]
     public class SpanContextPropagatorTests_ExtractHeaderTags
     {
         private static readonly string TestPrefix = "test.prefix";

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
     public class TracerTests
     {
         private readonly Tracer _tracer;

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
-    [Collection(nameof(WebRequestCollection), DisableParallelization = true)]
+    [Collection(nameof(WebRequestCollection))]
     public class TracerTests
     {
         private readonly Tracer _tracer;

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
+    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
     public class TracerTests
     {
         private readonly Tracer _tracer;

--- a/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="WebRequestCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    /// <summary>
+    /// If you're using WebRequest (directly or indirectly), use must use this attribute
+    /// As we have tests that modify the static prefixes.
+    /// Or, you know, stop using WebRequest  
+    /// </summary>
+    [CollectionDefinition(nameof(TracerInstanceTestCollection), DisableParallelization = true)]
+    public class WebRequestCollection
+    {
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Tests
     /// <summary>
     /// If you're using WebRequest (directly or indirectly), use must use this attribute
     /// As we have tests that modify the static prefixes.
-    /// Or, you know, stop using WebRequest  
+    /// Or, you know, stop using WebRequest
     /// </summary>
     [CollectionDefinition(nameof(TracerInstanceTestCollection), DisableParallelization = true)]
     public class WebRequestCollection

--- a/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Tests
     /// As we have tests that modify the static prefixes.
     /// Or, you know, stop using WebRequest
     /// </summary>
-    [CollectionDefinition(nameof(TracerInstanceTestCollection), DisableParallelization = true)]
+    [CollectionDefinition(nameof(WebRequestCollection), DisableParallelization = true)]
     public class WebRequestCollection
     {
     }

--- a/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/WebRequestCollection.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace Datadog.Trace.Tests
 {
     /// <summary>
-    /// If you're using WebRequest (directly or indirectly), use must use this attribute
+    /// If you're using WebRequest (directly or indirectly), you must use this attribute
     /// As we have tests that modify the static prefixes.
     /// Or, you know, stop using WebRequest
     /// </summary>


### PR DESCRIPTION
## Summary of changes

Fixes 🤞  the flakiness introduced by `LambdaRequestBuilderTests`

## Reason for change

We have been seeing flaky behaviour from the recent merge of `LamdbdaRequestBuilderTests`, failing with the following error:

```
System.NotImplementedException : This property is not implemented by this class.
  at System.Net.WebRequest.set_Method(String value)
  at Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS.LambdaRequestBuilder.Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS.ILambdaExtensionRequest.GetEndInvocationRequest(Scope scope, Boolean isError)
```

This is quite a strange error, as it implies we're running with a `WebRequest` _not_ an `HttpWebRequest` as you'd expect.

My assumption is that this is a parallelization issue with the `ApiWebRequestFactoryTests` which overrides the `http://` prefix for WebRequest. If any test that uses `WebRequest` is running at the same time at `ApiWebRequestFactoryTests` we will get flaky behaviour. We've just been lucky up to now AFAICT.

## Implementation details

To work around it, added a `[WebRequestCollection]` collection, and disabled parallelization. Any test in _Datadog.Trace.Tests_ that uses `WebRequest` (directly or indirectly) should be part of this collection.

## Test coverage
I'll trigger a few runs to make sure it looks ok

## Other details
If you can avoid using WebRequest, please do 😉 
