### PR TITLE
[Profiler] Prevent from blocking the application

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -35,7 +35,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DEPLOY_DIR})
 # ******************************************************
 
 add_library(${API_WRAPPER_SHARED_LIB_NAME} SHARED
-    dl_iterate_phdr_wrapper.c
+    functions_to_wrap.c
 )
 
 # Define linker libraries

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <mutex>
 #include <signal.h>
+#include <atomic>
 
 class IManagedThreadList;
 
@@ -44,6 +45,11 @@ private:
 
     std::int32_t _lastStackWalkErrorCode;
     std::condition_variable _stackWalkInProgressWaiter;
+    // since we wait for a specific amount of time, if a call to notify_one
+    // is done while we are not waiting, we will miss it and
+    // we will block for ever.
+    // This flag is used to prevent blocking on successfull (but long) stackwalking
+    std::atomic<bool> _stackWalkFinished;
 
     ICorProfilerInfo4* const _pCorProfilerInfo;
 


### PR DESCRIPTION
## Summary of changes

## Reason for change

Here we have two cases:
- on alpine dlopen has a lock which is not recursive and if the application thread is hijacked while holding the lock, the thread will stay blocked. By wrapping we prevent the thread from being hijacked while in a dlopen call.
- There are times in AzDo when the sampler thread was blocked, waiting for the application thread. But the application thread was dead (no notification from the CLR).

## Implementation details

For the first case, we just replace dlopen by our implementation (which just wrap and prevent signals from interrupting its execution)
For the second case, we check if the thread is alive by sending a  `0` signal. In reality, no signal is sent to the thread, only sanity check (is the thread alive?) 

## Test coverage

## Other details
<!-- Fixes #{issue} -->
