### PR TITLE
[Profiler] Use uws_backtrace for stackwalking on Linux

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -24,7 +24,7 @@ error("unsupported architecture")
 #include "ManagedThreadInfo.h"
 #include "OpSysTools.h"
 #include "ScopeFinalizer.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 using namespace std::chrono_literals;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -304,7 +304,6 @@ std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread()
 
         if (count == 0)
         {
-            AddFakeFrame();
             return S_FALSE;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
@@ -8,7 +8,7 @@
 
 #include "Log.h"
 #include "ManagedThreadInfo.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 // This method is called from the CLR so we need to use STDMETHODCALLTYPE macro to match the CLR declaration
 HRESULT STDMETHODCALLTYPE StackSnapshotCallbackHandlerImpl(FunctionID funcId, UINT_PTR ip, COR_PRF_FRAME_INFO frameInfo, ULONG32 contextSize, BYTE context[], void* clientData);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.h
@@ -10,9 +10,8 @@
 
 #include "StackFramesCollectorBase.h"
 
-class StackSnapshotResultReusableBuffer;
+class StackSnapshotResultBuffer;
 struct ManagedThreadInfo;
-class IManagedThreadList;
 
 class Windows32BitStackFramesCollector : public StackFramesCollectorBase
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
@@ -11,7 +11,7 @@
 #include "Log.h"
 #include "ManagedThreadInfo.h"
 #include "StackSamplerLoopManager.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 #endif // matches the '#ifdef BIT64' above
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.h
@@ -12,9 +12,8 @@
 #include "StackFramesCollectorBase.h"
 #include <winternl.h>
 
-class StackSnapshotResultReusableBuffer;
+class StackSnapshotResultBuffer;
 struct ManagedThreadInfo;
-class IManagedThreadList;
 
 class Windows64BitStackFramesCollector : public StackFramesCollectorBase
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -288,7 +288,7 @@
     <ClInclude Include="StackFramesCollectorBase.h" />
     <ClInclude Include="StackSamplerLoop.h" />
     <ClInclude Include="StackSamplerLoopManager.h" />
-    <ClInclude Include="StackSnapshotResultReusableBuffer.h" />
+    <ClInclude Include="StackSnapshotResultBuffer.h" />
     <ClInclude Include="TagsHelper.h" />
     <ClInclude Include="ThreadCpuInfo.h" />
     <ClInclude Include="ThreadsCpuManager.h" />
@@ -332,7 +332,7 @@
     <ClCompile Include="StackFramesCollectorBase.cpp" />
     <ClCompile Include="StackSamplerLoop.cpp" />
     <ClCompile Include="StackSamplerLoopManager.cpp" />
-    <ClCompile Include="StackSnapshotResultReusableBuffer.cpp" />
+    <ClCompile Include="StackSnapshotResultBuffer.cpp" />
     <ClCompile Include="TagsHelper.cpp" />
     <ClCompile Include="ThreadCpuInfo.cpp" />
     <ClCompile Include="ThreadsCpuManager.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -80,7 +80,7 @@
     <ClInclude Include="StackSamplerLoopManager.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
-    <ClInclude Include="StackSnapshotResultReusableBuffer.h">
+    <ClInclude Include="StackSnapshotResultBuffer.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
     <ClInclude Include="ThreadCpuInfo.h">
@@ -254,7 +254,7 @@
     <ClCompile Include="StackSamplerLoopManager.cpp">
       <Filter>Profiler-Driver</Filter>
     </ClCompile>
-    <ClCompile Include="StackSnapshotResultReusableBuffer.cpp">
+    <ClCompile Include="StackSnapshotResultBuffer.cpp">
       <Filter>Profiler-Driver</Filter>
     </ClCompile>
     <ClCompile Include="ThreadCpuInfo.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -8,7 +8,7 @@
 #include "corprof.h"
 #include "ExceptionSampler.h"
 #include "OsSpecificApi.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 class ExceptionsProvider
     : public CollectorBase<RawExceptionSample>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -12,9 +12,6 @@ namespace shared {
 struct LoaderResourceMonikerIDs;
 }
 
-class StackSnapshotResultReusableBuffer;
-class IManagedThreadList;
-
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
@@ -14,28 +14,28 @@
 StackFramesCollectorBase::StackFramesCollectorBase()
 {
     _isRequestedCollectionAbortSuccessful = false;
-    _pReusableStackSnapshotResult = new StackSnapshotResultReusableBuffer();
+    _pStackSnapshotResult = new StackSnapshotResultBuffer();
     _pCurrentCollectionThreadInfo = nullptr;
 }
 
 StackFramesCollectorBase::~StackFramesCollectorBase()
 {
-    StackSnapshotResultReusableBuffer* pReusableStackSnapshotResult = _pReusableStackSnapshotResult;
+    const auto* pReusableStackSnapshotResult = _pStackSnapshotResult;
     if (pReusableStackSnapshotResult != nullptr)
     {
         delete pReusableStackSnapshotResult;
-        _pReusableStackSnapshotResult = nullptr;
+        _pStackSnapshotResult = nullptr;
     }
 }
 
 bool StackFramesCollectorBase::AddFrame(std::uintptr_t ip)
 {
-    return _pReusableStackSnapshotResult->AddFrame(ip);
+    return _pStackSnapshotResult->AddFrame(ip);
 }
 
 void StackFramesCollectorBase::AddFakeFrame()
 {
-    _pReusableStackSnapshotResult->AddFakeFrame();
+    _pStackSnapshotResult->AddFakeFrame();
 }
 
 void StackFramesCollectorBase::RequestAbortCurrentCollection(void)
@@ -112,8 +112,8 @@ bool StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThre
         std::uint64_t localRootSpanId = pCurrentCollectionThreadInfo->GetLocalRootSpanId();
         std::uint64_t spanId = pCurrentCollectionThreadInfo->GetSpanId();
 
-        _pReusableStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
-        _pReusableStackSnapshotResult->SetSpanId(spanId);
+        _pStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
+        _pStackSnapshotResult->SetSpanId(spanId);
 
         return true;
     }
@@ -123,7 +123,7 @@ bool StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThre
 
 StackSnapshotResultBuffer* StackFramesCollectorBase::GetStackSnapshotResult()
 {
-    return _pReusableStackSnapshotResult;
+    return _pStackSnapshotResult;
 }
 
 // ----------- Inline stubs for APIs that are specific to overriding implementations: -----------
@@ -135,7 +135,7 @@ void StackFramesCollectorBase::PrepareForNextCollection(void)
     // We cannot allocate memory once a thread is suspended.
     // This is because malloc() uses a lock and so if we suspend a thread that was allocating, we will deadlock.
     // So we pre-allocate the memory buffer and reset it before suspending the target thread.
-    _pReusableStackSnapshotResult->Reset();
+    _pStackSnapshotResult->Reset();
 
     // Clear the current collection thread pointer:
     _pCurrentCollectionThreadInfo = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
@@ -38,6 +38,16 @@ void StackFramesCollectorBase::AddFakeFrame()
     _pStackSnapshotResult->AddFakeFrame();
 }
 
+void StackFramesCollectorBase::SetFrameCount(std::uint16_t count)
+{
+    _pStackSnapshotResult->SetFramesCount(count);
+}
+
+std::pair<uintptr_t*, std::uint16_t> StackFramesCollectorBase::Data()
+{
+    return {_pStackSnapshotResult->Data(), StackSnapshotResultBuffer::MaxSnapshotStackDepth_Limit};
+}
+
 void StackFramesCollectorBase::RequestAbortCurrentCollection(void)
 {
     std::lock_guard<std::mutex> lock(_collectionAbortNotificationLock);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
@@ -18,6 +18,9 @@ protected:
     bool TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot(void);
     bool AddFrame(std::uintptr_t ip);
     void AddFakeFrame();
+    void SetFrameCount(std::uint16_t count);
+
+    std::pair<uintptr_t*, std::uint16_t> Data();
 
     StackSnapshotResultBuffer* GetStackSnapshotResult(void);
     bool IsCurrentCollectionAbortRequested();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
@@ -8,7 +8,7 @@
 #include <mutex>
 
 #include "ManagedThreadInfo.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 class StackFramesCollectorBase
 {
@@ -48,7 +48,7 @@ protected:
     ManagedThreadInfo* _pCurrentCollectionThreadInfo;
 
 private:
-    StackSnapshotResultReusableBuffer* _pReusableStackSnapshotResult;
+    StackSnapshotResultBuffer* _pStackSnapshotResult;
     std::atomic<bool> _isCurrentCollectionAbortRequested;
     std::condition_variable _collectionAbortPerformedSignal;
     std::mutex _collectionAbortNotificationLock;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
@@ -25,7 +25,7 @@ StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
     _spanId = 0;
 }
 
-void StackSnapshotResultBuffer::Reset(void)
+void StackSnapshotResultBuffer::Reset()
 {
     _localRootSpanId = 0;
     _spanId = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
@@ -1,19 +1,18 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
-StackSnapshotResultBuffer::StackSnapshotResultBuffer(std::uint16_t initialCapacity) :
+StackSnapshotResultBuffer::StackSnapshotResultBuffer() :
     _unixTimeUtc{0},
     _representedDurationNanoseconds{0},
     _appDomainId{0},
-    _currentCapacity{0},
-    _nextResetCapacity{initialCapacity},
-    _currentFramesCount{0},
-    _localRootSpanId{0},
+    _instructionPointers(),
+    _currentFramesCount{0},    
+    _localRootSpanId{0},    
     _spanId{0}
+    
 {
-    _instructionPointers.reserve(initialCapacity);
 }
 
 StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
@@ -21,18 +20,13 @@ StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
     _unixTimeUtc = 0;
     _representedDurationNanoseconds = 0;
     _appDomainId = static_cast<AppDomainID>(0);
-    _currentCapacity = 0;
-    _nextResetCapacity = 0;
     _currentFramesCount = 0;
     _localRootSpanId = 0;
     _spanId = 0;
 }
 
-void StackSnapshotResultReusableBuffer::Reset(void)
+void StackSnapshotResultBuffer::Reset(void)
 {
-    _instructionPointers.clear();
-    _instructionPointers.reserve(_nextResetCapacity);
-
     _localRootSpanId = 0;
     _spanId = 0;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
@@ -23,13 +23,13 @@ class StackSnapshotResultBuffer
 public:
     static constexpr std::uint16_t MaxSnapshotStackDepth_Limit = 2049;
 
-    inline std::uint64_t GetUnixTimeUtc(void) const;
+    inline std::uint64_t GetUnixTimeUtc() const;
     inline std::uint64_t SetUnixTimeUtc(std::uint64_t value);
 
-    inline std::uint64_t GetRepresentedDurationNanoseconds(void) const;
+    inline std::uint64_t GetRepresentedDurationNanoseconds() const;
     inline std::uint64_t SetRepresentedDurationNanoseconds(std::uint64_t value);
 
-    inline AppDomainID GetAppDomainId(void) const;
+    inline AppDomainID GetAppDomainId() const;
     inline AppDomainID SetAppDomainId(AppDomainID appDomainId);
 
     inline std::uint64_t GetLocalRootSpanId() const;
@@ -38,15 +38,18 @@ public:
     inline std::uint64_t GetSpanId() const;
     inline std::uint64_t SetSpanId(std::uint64_t value);
 
-    inline std::size_t GetFramesCount(void) const;
+    inline std::uint16_t GetFramesCount() const;
+    inline void SetFramesCount(std::uint16_t count);
     inline void CopyInstructionPointers(std::vector<std::uintptr_t>& ips) const;
 
     inline void DetermineAppDomain(ThreadID threadId, ICorProfilerInfo4* pCorProfilerInfo);
     
-    void Reset(void);
+    void Reset();
 
     inline bool AddFrame(std::uintptr_t ip);
     inline bool AddFakeFrame();
+
+    inline uintptr_t* Data();
 
     StackSnapshotResultBuffer();
     ~StackSnapshotResultBuffer();
@@ -66,7 +69,7 @@ protected:
 
 // ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
 
-inline std::uint64_t StackSnapshotResultBuffer::GetUnixTimeUtc(void) const
+inline std::uint64_t StackSnapshotResultBuffer::GetUnixTimeUtc() const
 {
     return _unixTimeUtc;
 }
@@ -78,7 +81,7 @@ inline std::uint64_t StackSnapshotResultBuffer::SetUnixTimeUtc(std::uint64_t val
     return prevValue;
 }
 
-inline std::uint64_t StackSnapshotResultBuffer::GetRepresentedDurationNanoseconds(void) const
+inline std::uint64_t StackSnapshotResultBuffer::GetRepresentedDurationNanoseconds() const
 {
     return _representedDurationNanoseconds;
 }
@@ -90,7 +93,7 @@ inline std::uint64_t StackSnapshotResultBuffer::SetRepresentedDurationNanosecond
     return prevValue;
 }
 
-inline AppDomainID StackSnapshotResultBuffer::GetAppDomainId(void) const
+inline AppDomainID StackSnapshotResultBuffer::GetAppDomainId() const
 {
     return _appDomainId;
 }
@@ -126,9 +129,14 @@ inline std::uint64_t StackSnapshotResultBuffer::SetSpanId(std::uint64_t value)
     return prevValue;
 }
 
-inline std::size_t StackSnapshotResultBuffer::GetFramesCount(void) const
+inline std::uint16_t StackSnapshotResultBuffer::GetFramesCount() const
 {
     return _currentFramesCount;
+}
+
+inline void StackSnapshotResultBuffer::SetFramesCount(std::uint16_t count)
+{
+    _currentFramesCount = count;
 }
 
 inline void StackSnapshotResultBuffer::CopyInstructionPointers(std::vector<std::uintptr_t>& ips) const
@@ -190,4 +198,9 @@ inline bool StackSnapshotResultBuffer::AddFrame(std::uintptr_t ip)
 inline bool StackSnapshotResultBuffer::AddFakeFrame()
 {
     return AddFrame(0);
+}
+
+inline uintptr_t* StackSnapshotResultBuffer::Data()
+{
+    return _instructionPointers.data();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -58,7 +58,7 @@
     <ClCompile Include="SamplesCollectorTest.cpp" />
     <ClCompile Include="SamplesProviderTest.cpp" />
     <ClCompile Include="SamplesAggregatorTest.cpp" />
-    <ClCompile Include="StackSnapshotResultReusableBufferTest.cpp" />
+    <ClCompile Include="StackSnapshotResultBufferTest.cpp" />
     <ClCompile Include="TagsHelperTest.cpp" />
     <ClCompile Include="ProviderTest.cpp" />
     <ClCompile Include="ThreadsCpuManagerHelper.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -83,7 +83,7 @@
     <ClCompile Include="ManagedThreadListTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="StackSnapshotResultReusableBufferTest.cpp">
+    <ClCompile Include="StackSnapshotResultBufferTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="RuntimeIdTest.cpp">

--- a/profiler/test/Datadog.Profiler.Native.Tests/StackSnapshotResultBufferTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/StackSnapshotResultBufferTest.cpp
@@ -3,11 +3,11 @@
 
 #include "gtest/gtest.h"
 
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
-TEST(StackSnapshotResultReusableBufferTest, CheckAddedFrames)
+TEST(StackSnapshotResultBufferTest, CheckAddedFrames)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     std::vector<std::uintptr_t> expectedIps = {42, 21, 11, 4};
     for (auto ip : expectedIps)
@@ -23,9 +23,9 @@ TEST(StackSnapshotResultReusableBufferTest, CheckAddedFrames)
     ASSERT_EQ(expectedIps, ips);
 }
 
-TEST(StackSnapshotResultReusableBufferTest, CheckAddedFakeFrame)
+TEST(StackSnapshotResultBufferTest, CheckAddedFakeFrame)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     std::vector<std::uintptr_t> expectedIps = {42, 21, 11, 4};
 
@@ -46,9 +46,9 @@ TEST(StackSnapshotResultReusableBufferTest, CheckAddedFakeFrame)
     ASSERT_EQ(expectedIps, ips);
 }
 
-TEST(StackSnapshotResultReusableBufferTest, CheckIfWeReachTheBufferLimitTheLastFrameIsFake)
+TEST(StackSnapshotResultBufferTest, CheckIfWeReachTheBufferLimitTheLastFrameIsFake)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     for (auto i = 1; i < 2049; i++)
     {


### PR DESCRIPTION
## Summary of changes

Use libunwind `uws_backtrace` for stackwalking instead of manually using the cursor.

`uws_backtrace` is supposed to be significantly faster because it relies on an internal cache.

## Implementation details

Since `uws_backtrace` directly writes to the buffer, this PR also changes the underlying storage of `StackSnapshotResultBuffer` to use a `std::array` instead of a `std::vector`, so we can safely get a pointer to the underlying array.
