### PR TITLE
Fix crash in exection benchmark tests

### DIFF
--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net461.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net461.json
@@ -25,11 +25,11 @@
     "DD_TRACE_CALLTARGET_ENABLED": "true",
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "DD_DOTNET_TRACER_HOME": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer",
     "COR_ENABLE_PROFILING": "1",
     "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "COR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+    "COR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll"
   },
   "tags": {
     "runtime.architecture": "x64",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -25,7 +25,7 @@
     "DD_TRACE_CALLTARGET_ENABLED": "true",
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "DD_DOTNET_TRACER_HOME": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer",
     "COR_ENABLE_PROFILING": "1",
     "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -25,7 +25,7 @@
     "DD_TRACE_CALLTARGET_ENABLED": "true",
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "DD_DOTNET_TRACER_HOME": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\tracer",
     "COR_ENABLE_PROFILING": "1",
     "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/cor_profiler.cpp
@@ -977,6 +977,12 @@ namespace datadog::shared::nativeloader
 
     AppDomainID CorProfiler::GetCurrentAppDomainId()
     {
+        if (m_this == nullptr)
+        {
+            Log::Warn("The native loader library is not properly initialized. We cannot get the current AppDomain Id.");
+            return (AppDomainID)0;
+        }
+
         ThreadID threadId;
         auto hr = m_this->m_info->GetCurrentThreadID(&threadId);
 
@@ -1002,6 +1008,12 @@ namespace datadog::shared::nativeloader
 
     const char* CorProfiler::GetRuntimeId(AppDomainID appDomain)
     {
+        if (m_this == nullptr)
+        {
+            Log::Warn("The native loader library is not properly initialized. We cannot get the runtime id for the AppDomain ID #", appDomain);
+            return nullptr;
+        }
+
         return m_this->m_runtimeIdStore.Get(appDomain).c_str();
     }
 


### PR DESCRIPTION
## Summary of changes

## Reason for change

Execution benchmark tests are crashing. The test does not use the native loader, but there are P/Invoke calls toward the native loader library.
The issue is that the native loader is not correctly initialized and crash when getting the runtime id.

## Implementation details

- Add checks when accessing function that compute the runtime id.
- Run the tests with the native loader

## Test coverage

## Other details
<!-- Fixes #{issue} -->
