### PR TITLE
Stripping out unneeded information from native `so` library files

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -363,7 +363,7 @@ stages:
         build: true
         target: builder
         baseImage: $(baseImage)
-        command: "BuildNativeLoader ZipMonitoringHome"
+        command: "BuildNativeLoader ZipMonitoringHome ExtractDebugInfoAndStripSymbols"
 
     - publish: $(artifacts)/linux-x64
       displayName: Upload linux-x64 packages
@@ -398,7 +398,7 @@ stages:
         build: true
         target: builder
         baseImage: debian
-        command: "Clean BuildTracerHome ZipMonitoringHome"
+        command: "Clean BuildTracerHome ZipMonitoringHome ExtractDebugInfoAndStripSymbols"
 
     - publish: $(tracerHome)
       displayName: Uploading linux tracer home artifact

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -373,6 +373,10 @@ stages:
       displayName: Upload linux-x64 monitoring home
       artifact: linux-monitoring-home-$(baseImage)
 
+    - publish: $(System.DefaultWorkingDirectory)/shared/symbols
+      displayName: Upload linux-x64 symbols
+      artifact: linux-symbols-home-$(baseImage)
+
 - stage: build_arm64
   dependsOn: [master_commit_id]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -373,10 +373,6 @@ stages:
       displayName: Upload linux-x64 monitoring home
       artifact: linux-monitoring-home-$(baseImage)
 
-    - publish: $(System.DefaultWorkingDirectory)/shared/symbols
-      displayName: Upload linux-x64 symbols
-      artifact: linux-symbols-home-$(baseImage)
-
 - stage: build_arm64
   dependsOn: [master_commit_id]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -363,7 +363,7 @@ stages:
         build: true
         target: builder
         baseImage: $(baseImage)
-        command: "BuildNativeLoader ZipMonitoringHome ExtractDebugInfoAndStripSymbols"
+        command: "BuildNativeLoader ZipMonitoringHome"
 
     - publish: $(artifacts)/linux-x64
       displayName: Upload linux-x64 packages
@@ -398,7 +398,7 @@ stages:
         build: true
         target: builder
         baseImage: debian
-        command: "Clean BuildTracerHome ZipMonitoringHome ExtractDebugInfoAndStripSymbols"
+        command: "Clean BuildTracerHome ZipMonitoringHome"
 
     - publish: $(tracerHome)
       displayName: Uploading linux tracer home artifact

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -594,7 +594,7 @@ partial class Build
         .Executes(() =>
         {
             var directory = new DirectoryInfo(MonitoringHomeDirectory);
-            var files = directory.GetFiles("*.so");
+            var files = directory.GetFiles("*.so", SearchOption.AllDirectories);
 
             var symbolsDirectory = SharedDirectory / "symbols";
             EnsureExistingDirectory(symbolsDirectory);
@@ -603,7 +603,7 @@ partial class Build
             {
                 var outputFile = Path.Combine(symbolsDirectory, Path.GetFileNameWithoutExtension(file.Name));
 
-                Logger.Info($"Extracting debug symbol for {file.FullName} to {outputFile}");
+                Logger.Info($"Extracting debug symbol for {file.FullName} to {outputFile}.debug");
                 ExtractDebugInfo.Value(arguments: $"--only-keep-debug {file.FullName} {outputFile}.debug");
 
                 Logger.Info($"Stripping out unneeded information from {file.FullName}");

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -596,12 +596,11 @@ partial class Build
             var directory = new DirectoryInfo(MonitoringHomeDirectory);
             var files = directory.GetFiles("*.so", SearchOption.AllDirectories);
 
-            var symbolsDirectory = SharedDirectory / "symbols";
-            EnsureExistingDirectory(symbolsDirectory);
+            EnsureExistingDirectory(SymbolsDirectory);
 
             foreach (var file in files)
             {
-                var outputFile = Path.Combine(symbolsDirectory, Path.GetFileNameWithoutExtension(file.Name));
+                var outputFile = Path.Combine(SymbolsDirectory, Path.GetFileNameWithoutExtension(file.Name));
 
                 Logger.Info($"Extracting debug symbol for {file.FullName} to {outputFile}.debug");
                 ExtractDebugInfo.Value(arguments: $"--only-keep-debug {file.FullName} {outputFile}.debug");

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -593,14 +593,13 @@ partial class Build
         .OnlyWhenStatic(() => IsLinux)
         .Executes(() =>
         {
-            var directory = new DirectoryInfo(MonitoringHomeDirectory);
-            var files = directory.GetFiles("*.so", SearchOption.AllDirectories);
+            var files = MonitoringHomeDirectory.GlobFiles("*.so");
 
             EnsureExistingDirectory(SymbolsDirectory);
 
             foreach (var file in files)
             {
-                var outputFile = Path.Combine(SymbolsDirectory, Path.GetFileNameWithoutExtension(file.Name));
+                var outputFile = SymbolsDirectory / Path.GetFileNameWithoutExtension(file.Name);
 
                 Logger.Info($"Extracting debug symbol for {file.FullName} to {outputFile}.debug");
                 ExtractDebugInfo.Value(arguments: $"--only-keep-debug {file.FullName} {outputFile}.debug");

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -86,7 +86,7 @@ partial class Build : NukeBuild
 
     [Parameter("The directory to install the tool to")]
     readonly AbsolutePath ToolDestination;
-    
+
     [Parameter("Should we build and run tests that require docker. true = only docker integration tests, false = no docker integration tests, null = all", List = false)]
     readonly bool? IncludeTestsRequiringDocker;
 
@@ -180,6 +180,7 @@ partial class Build : NukeBuild
         .After(Clean, BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(ZipMonitoringHome)
+        .DependsOn(ExtractDebugInfoAndStripSymbols)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -180,7 +180,6 @@ partial class Build : NukeBuild
         .After(Clean, BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(ZipMonitoringHome)
-        .DependsOn(ExtractDebugInfoAndStripSymbols)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
 


### PR DESCRIPTION
## Summary of changes

## Reason for change

Today the profiler on linux is 52MB on disk. This is mainly du to the fact that we have not stripped out debug symbols and unneeded information.

For reference:
- Tracer: 6.8MB
- Native loader: 6.4MB

After stripping out the unneeded information we are at:
- Profiler: 17MB
- Tracer: 3.5MB
- Native Loader: 4.6MB

## Implementation details

When creating the package for linux, we extract the debug info in a `*.debug` file and we strip out unneeded information (debug ...)

## Test coverage

## Other details
<!-- Fixes #{issue} -->
