### PR TITLE
Upload linux-native-symbols artifacts and add to release artifacts

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -97,6 +97,7 @@ variables:
   profilerSrcDirectory: $(System.DefaultWorkingDirectory)/../dd-continuous-profiler-dotnet
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
+  symbols: $(System.DefaultWorkingDirectory)/tracer/bin/symbols
   relativeRunnerTool: tracer/src/bin/runnerTool
   relativeRunnerStandalone: tracer/src/bin/runnerStandalone
   ddApiKey: $(DD_API_KEY)
@@ -369,6 +370,10 @@ stages:
       displayName: Upload linux-x64 packages
       artifact: linux-packages-$(baseImage)
 
+    - publish: $(symbols)
+      displayName: Upload linux-x64 symbols
+      artifact: linux-symbols-$(baseImage)
+
     - publish: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
       displayName: Upload linux-x64 monitoring home
       artifact: linux-monitoring-home-$(baseImage)
@@ -407,6 +412,10 @@ stages:
     - publish: $(artifacts)/linux-arm64
       displayName: Upload linux-arm64 packages
       artifact: linux-packages-arm64
+
+    - publish: $(symbols)
+      displayName: Upload linux-arm64 symbols
+      artifact: linux-symbols-arm64
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
@@ -2016,6 +2025,7 @@ stages:
             echo "##vso[task.setvariable variable=tracer_version]$VERSION_NUMBER"
           displayName: Extract version number
 
+        # Linux packages
         - task: DownloadPipelineArtifact@2
           displayName: Download linux Alpine packages
           inputs:
@@ -2034,12 +2044,38 @@ stages:
             artifact: linux-packages-arm64
             path: $(Build.ArtifactStagingDirectory)
 
+        # Linux symbols
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Alpine symbols
+          inputs:
+            artifact: linux-symbols-alpine
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
+  
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Debian symbols
+          inputs:
+            artifact: linux-symbols-debian
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
+  
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Arm64 symbols
+          inputs:
+            artifact: linux-symbols-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
+
+        - bash: |
+            tar -xcf  $(Build.ArtifactStagingDirectory)/linux-native-symbols.tar.gz $(Build.ArtifactStagingDirectory)/symbols
+            rm -rf $(Build.ArtifactStagingDirectory)/symbols
+          displayName: Tar native linux symbols
+
+        # NuGet
         - task: DownloadPipelineArtifact@2
           displayName: Download distribution nuget package
           inputs:
             artifact: distribution-nuget-package
             path: $(Build.ArtifactStagingDirectory)
 
+        # runner tool
         - task: DownloadPipelineArtifact@2
           displayName: Download runner dotnet tool
           inputs:
@@ -2068,6 +2104,7 @@ stages:
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
 
+        # release artifacts
         - publish: "$(Build.ArtifactStagingDirectory)"
           displayName: Publish release artifacts
           artifact: $(tracer_version)-release-artifacts


### PR DESCRIPTION
## Summary of changes

Uploads the native symbols that were extracted to a separate directory in #2874 

## Reason for change

We want to include the native symbols in the release artifacts

## Implementation details

Uploads the files we extracts as artifacts, then bundles them into a single tar for simplicity and includes them in the release artifacts

## Test coverage
N/A

## Other details
N/A