### PR TITLE
Create a Code Freeze bot

### DIFF
--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -1,0 +1,42 @@
+name: Block PR on Code Freeze
+
+on:
+  pull_request:
+
+jobs:
+  check_for_code_freeze:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: octokit/request-action@v2.x
+      name: 'Get Milestones'
+      id: milestones
+      with:
+        route: GET /repos/{owner}/{repo}/milestones
+        owner: Datadog
+        repo: dd-trace-dotnet
+        state: open
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - run: |
+        set -o pipefail
+        sha="${{ github.event.pull_request.head.sha }}"
+        targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_code_freeze_block_pr.yml"
+        state="success"
+        description="No code freeze is in place"
+        
+        if addr=$(${{ steps.milestones.outputs.data }} | jq -er '.[] | select(.title == "Code Freeze")'); then
+          state="failure"
+          description="A code freeze is in place"
+        fi
+        
+        echo "$description, setting check status $state"
+        
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
+            -d '{"state":"$state","context":"code_freeze","description":"$description","target_url":"$targetUrl"}'
+
+      name: 'Check Code Freeze status'

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -26,7 +26,7 @@ jobs:
         state="success"
         description="No code freeze is in place"
         
-        if addr=$(${{ steps.milestones.outputs.data }} | jq -er '.[] | select(.title == "Code Freeze")'); then
+        if addr=$(echo "${{ steps.milestones.outputs.data }}" | jq -er '.[] | select(.title == "Code Freeze")'); then
           state="failure"
           description="A code freeze is in place"
         fi

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -13,7 +13,7 @@ jobs:
       id: milestones
       with:
         route: GET /repos/{owner}/{repo}/milestones
-        owner: Datadog
+        owner: DataDog
         repo: dd-trace-dotnet
         state: open
       env:

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -36,7 +36,7 @@ jobs:
         curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
-            -d '{"state":"$state","context":"code_freeze","description":"$description","target_url":"$targetUrl"}'
+            "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+            -d '{"state":"'"$state"'","context":"code_freeze","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
 
       name: 'Check Code Freeze status'

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -1,4 +1,4 @@
-name: Start code freeze
+name: End code freeze
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ jobs:
   end_code_freeze:
     if: | 
       github.event_name == 'workflow_dispatch' 
-      || (github.event.milestone.title == 'Core Freeze' && github.event.milestone.state == 'closed') 
+      || (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'closed') 
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -21,7 +21,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       with:
         route: POST /repos/{owner}/{repo}/milestones
-        owner: Datadog
+        owner: DataDog
         repo: dd-trace-dotnet
         state: open
         title: 'Code Freeze'
@@ -33,7 +33,7 @@ jobs:
       id: prs
       with:
         route: GET /repos/{owner}/{repo}/pulls
-        owner: Datadog
+        owner: DataDog
         repo: dd-trace-dotnet
         state: open
         base: master
@@ -43,7 +43,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=${{ steps.milestones.outputs.data }}
+        json=${{ steps.prs.outputs.data }}
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze status for $arrayLength PRs" 
 

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -1,0 +1,66 @@
+name: Start code freeze
+
+on:
+  workflow_dispatch:
+  milestone:
+    types: [closed, deleted, edited]
+
+jobs:
+  end_code_freeze:
+    if: | 
+      github.event_name == 'workflow_dispatch' 
+      || (github.event.milestone.title == 'Core Freeze' && github.event.milestone.state == 'closed') 
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+    - uses: octokit/request-action@v2.x
+      name: 'Close Code Freeze Milestone'
+      id: milestones
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        route: POST /repos/{owner}/{repo}/milestones
+        owner: Datadog
+        repo: dd-trace-dotnet
+        state: open
+        title: 'Code Freeze'
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - uses: octokit/request-action@v2.x
+      name: 'Get open PRs'
+      id: prs
+      with:
+        route: GET /repos/{owner}/{repo}/pulls
+        owner: Datadog
+        repo: dd-trace-dotnet
+        state: open
+        base: master
+        per_page: 100 # max value, for simplicity. If we have more than 100 pull requests open, then we need to revisit!
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - run: |
+        set -o pipefail
+        json=${{ steps.milestones.outputs.data }}
+        arrayLength=$(echo $json | jq -r 'length')
+        echo "Updating code freeze status for $arrayLength PRs" 
+
+        arrayLength=$((arrayLength-1))
+        for i in $(seq 1 $arrayLength); do
+          title=$(echo $json | jq -r ".[$i].title")
+          echo "Removing code freeze for '$title'" 
+          sha=$(echo $json | jq -r ".[$i].head.sha")
+          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_end.yml"
+        
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
+              -d '{"state":"success","context":"code_freeze","description":"No code freeze is in place","target_url":"$targetUrl"}'
+        done
+      name: 'Update all PRs with Code Freeze status'
+
+        
+        

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -57,8 +57,8 @@ jobs:
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
-              -d '{"state":"success","context":"code_freeze","description":"No code freeze is in place","target_url":"$targetUrl"}'
+              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+              -d '{"state":"success","context":"code_freeze","description":"No code freeze is in place","target_url":"'"$targetUrl"'"}'
         done
       name: 'Update all PRs with Code Freeze status'
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -58,8 +58,8 @@ jobs:
           curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
-              -d '{"state":"failure","context":"code_freeze","description":"A code freeze is in place","target_url":"$targetUrl"}'
+              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+              -d '{"state":"failure","context":"code_freeze","description":"A code freeze is in place","target_url":"'"$targetUrl"'"}'
         done
       name: 'Update all PRs with Code Freeze status'
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -9,7 +9,7 @@ jobs:
   start_code_freeze:
     if: | 
       github.event_name == 'workflow_dispatch' || 
-      (github.event.milestone.title == 'Core Freeze' && github.event.milestone.state == 'open') 
+      (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open') 
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -21,7 +21,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       with:
         route: POST /repos/{owner}/{repo}/milestones
-        owner: Datadog
+        owner: DataDog
         repo: dd-trace-dotnet
         state: open
         title: 'Code Freeze'
@@ -34,7 +34,7 @@ jobs:
       id: prs
       with:
         route: GET /repos/{owner}/{repo}/pulls
-        owner: Datadog
+        owner: DataDog
         repo: dd-trace-dotnet
         state: open
         base: master
@@ -44,7 +44,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=${{ steps.milestones.outputs.data }}
+        json=${{ steps.prs.outputs.data }}
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze  status for $arrayLength PRs" 
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -1,0 +1,67 @@
+name: Start code freeze
+
+on:
+  workflow_dispatch:
+  milestone:
+    types: [opened, created, edited]
+
+jobs:
+  start_code_freeze:
+    if: | 
+      github.event_name == 'workflow_dispatch' || 
+      (github.event.milestone.title == 'Core Freeze' && github.event.milestone.state == 'open') 
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+    - uses: octokit/request-action@v2.x
+      name: 'Create Code Freeze Milestone'
+      id: milestones
+      if: github.event_name == 'workflow_dispatch'
+      with:
+        route: POST /repos/{owner}/{repo}/milestones
+        owner: Datadog
+        repo: dd-trace-dotnet
+        state: open
+        title: 'Code Freeze'
+        description: 'When opened, indicates a code freeze is in place'
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - uses: octokit/request-action@v2.x
+      name: 'Get open PRs'
+      id: prs
+      with:
+        route: GET /repos/{owner}/{repo}/pulls
+        owner: Datadog
+        repo: dd-trace-dotnet
+        state: open
+        base: master
+        per_page: 100 # max value, for simplicity. If we have more than 100 pull requests open, then we need to revisit!
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - run: |
+        set -o pipefail
+        json=${{ steps.milestones.outputs.data }}
+        arrayLength=$(echo $json | jq -r 'length')
+        echo "Updating code freeze  status for $arrayLength PRs" 
+
+        arrayLength=$((arrayLength-1))
+        for i in $(seq 1 $arrayLength); do
+          title=$(echo $json | jq -r ".[$i].title")
+          echo "Setting code freeze for '$title'" 
+          sha=$(echo $json | jq -r ".[$i].head.sha")
+          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_start.yml"
+
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha \
+              -d '{"state":"failure","context":"code_freeze","description":"A code freeze is in place","target_url":"$targetUrl"}'
+        done
+      name: 'Update all PRs with Code Freeze status'
+
+        
+        


### PR DESCRIPTION
## Summary of changes

Adds workflows so we can implement a simple "code freeze" as required

## Reason for change

We want to have a period of stability when creating a release so we can get more reliable numbers from the reliability environment. Sometimes people aren't aware we're in code freeze and merge accidentally. This should reduce the chances of that happening

## Implementation details

The presence of a Code Freeze is indicated by a milestone called `Code Freeze` being open. To manage that, I introduced 3 new workflows:
- `start_code_freeze` is manually-triggered, and creates/opens the `Code Freeze` milestone. This also iterates over all open PRs and fails the `code_freeze` check so they can't be merged
- `auto_code_freeze_block_pr.yml`, runs on every PR open/change etc. Checks if the `Code Freeze` milestone exists. If it does, fails the `code_freeze` check.
- `end_code_freeze` is manually triggered. It goes through all open PRs, passes the `code_freeze` Check, and closes the `Code Freeze` milestone

## Test coverage
None... I can't test this until it's merged 🙄 

## Other details
Once we confirm it's working, we'll make the `code_freeze` check required.
