### PR TITLE
Fix code freeze workflow

### DIFF
--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -42,7 +42,10 @@ jobs:
 
     - run: |
         set -o pipefail
-        json="${{ steps.prs.outputs.data }}"
+        json=$(CAT << ENDOFMESSAGE
+          ${{ steps.prs.outputs.data }}
+        ENDOFMESSAGE
+        )
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze status for $arrayLength PRs" 
 

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -43,7 +43,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=${{ steps.prs.outputs.data }}
+        json="${{ steps.prs.outputs.data }}"
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze status for $arrayLength PRs" 
 

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -42,7 +42,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=$(CAT << ENDOFMESSAGE
+        json=$(cat << ENDOFMESSAGE
           ${{ steps.prs.outputs.data }}
         ENDOFMESSAGE
         )

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -20,11 +20,10 @@ jobs:
       id: milestones
       if: github.event_name == 'workflow_dispatch'
       with:
-        route: POST /repos/{owner}/{repo}/milestones
+        route: PATCH /repos/{owner}/{repo}/milestones/115
         owner: DataDog
         repo: dd-trace-dotnet
-        state: open
-        title: 'Code Freeze'
+        state: closed
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -42,7 +42,10 @@ jobs:
 
     - run: |
         set -o pipefail
-        json="${{ steps.prs.outputs.data }}"
+        json=$(CAT << ENDOFMESSAGE
+          ${{ steps.prs.outputs.data }}
+        ENDOFMESSAGE
+        )
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze  status for $arrayLength PRs" 
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -16,16 +16,14 @@ jobs:
 
     steps:
     - uses: octokit/request-action@v2.x
-      name: 'Create Code Freeze Milestone'
+      name: 'Open Code Freeze Milestone'
       id: milestones
       if: github.event_name == 'workflow_dispatch'
       with:
-        route: POST /repos/{owner}/{repo}/milestones
+        route: PATCH /repos/{owner}/{repo}/milestones/115
         owner: DataDog
         repo: dd-trace-dotnet
         state: open
-        title: 'Code Freeze'
-        description: 'When opened, indicates a code freeze is in place'
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -42,7 +42,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=$(CAT << ENDOFMESSAGE
+        json=$(cat << ENDOFMESSAGE
           ${{ steps.prs.outputs.data }}
         ENDOFMESSAGE
         )

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -44,7 +44,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=${{ steps.prs.outputs.data }}
+        json="${{ steps.prs.outputs.data }}"
         arrayLength=$(echo $json | jq -r 'length')
         echo "Updating code freeze  status for $arrayLength PRs" 
 


### PR DESCRIPTION
## Summary of changes

Fixes the code freeze workflow so it actually works.

## Reason for change

Couldn't test it until it was available on the main branch.

## Implementation details

Fixed some bugs

## Test coverage

I tested that running start_code_freeze fails the check on all PRs, and end_code_freeze passes it. Next step (once this is merged) is to make that check required.

## Other details
Still can't test the "run on new PR" workflow until _this_ one is merged. 
