### PR TITLE
Fix code-freeze bot (part deux)

### DIFF
--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -25,7 +25,7 @@ jobs:
         targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_code_freeze_block_pr.yml"
         state="success"
         description="No code freeze is in place"
-        json=$(cat << ENDOFMESSAGE
+        json=$(cat << 'ENDOFMESSAGE'
           ${{ steps.milestones.outputs.data }}
         ENDOFMESSAGE
         )

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -1,4 +1,4 @@
-name: Block PR on Code Freeze
+name: Auto Block PR on Code Freeze
 
 on:
   pull_request:
@@ -25,8 +25,12 @@ jobs:
         targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_code_freeze_block_pr.yml"
         state="success"
         description="No code freeze is in place"
+        json=$(cat << ENDOFMESSAGE
+          ${{ steps.milestones.outputs.data }}
+        ENDOFMESSAGE
+        )
         
-        if addr=$(echo "${{ steps.milestones.outputs.data }}" | jq -er '.[] | select(.title == "Code Freeze")'); then
+        if addr=$(echo $json | jq -er '.[] | select(.title == "Code Freeze")'); then
           state="failure"
           description="A code freeze is in place"
         fi

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -50,7 +50,7 @@ jobs:
         echo "Updating code freeze status for $arrayLength PRs" 
 
         arrayLength=$((arrayLength-1))
-        for i in $(seq 1 $arrayLength); do
+        for i in $(seq 0 $arrayLength); do
           title=$(echo $json | jq -r ".[$i].title")
           echo "Removing code freeze for '$title'" 
           sha=$(echo $json | jq -r ".[$i].head.sha")

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -42,7 +42,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=$(cat << ENDOFMESSAGE
+        json=$(cat << 'ENDOFMESSAGE'
           ${{ steps.prs.outputs.data }}
         ENDOFMESSAGE
         )

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -50,7 +50,7 @@ jobs:
         echo "Updating code freeze  status for $arrayLength PRs" 
 
         arrayLength=$((arrayLength-1))
-        for i in $(seq 1 $arrayLength); do
+        for i in $(seq 0 $arrayLength); do
           title=$(echo $json | jq -r ".[$i].title")
           echo "Setting code freeze for '$title'" 
           sha=$(echo $json | jq -r ".[$i].head.sha")

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -42,7 +42,7 @@ jobs:
 
     - run: |
         set -o pipefail
-        json=$(cat << ENDOFMESSAGE
+        json=$(cat << 'ENDOFMESSAGE'
           ${{ steps.prs.outputs.data }}
         ENDOFMESSAGE
         )


### PR DESCRIPTION
## Summary of changes

Fix the "Block PRs that are raised after a code freeze is started"

## Reason for change

It didn't work

## Implementation details

The API returns multi-line strings and just substitutes them directly in the script, so need to use a Heredoc to work around it. I fixed this in the other workflows but missed this one

## Test coverage

This PR should be blocked if it works correctly!
