### PR TITLE
Add CI Visibility through the junit importer

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -11,6 +11,14 @@ parameters:
     type: boolean
     default: false
     
+  - name: alwaysRun
+    type: boolean
+    default: false
+
+  - name: apiKey
+    type: string
+    default: ''
+    
   - name: command
     type: string
 
@@ -37,6 +45,10 @@ steps:
         --env TestAllPackageVersions=$(TestAllPackageVersions) \
         --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
         --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
+        --env DD_API_KEY=${{ parameters.apiKey }} \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker
+  ${{ if eq(parameters.alwaysRun, true) }}:
+    condition: succeededOrFailed()
+    continueOnError: true

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -527,6 +527,13 @@ stages:
         condition: succeededOrFailed()
         continueOnError: true
 
+      - script: tracer\build.cmd UploadJunitArtifacts
+        displayName: Upload junit results
+        condition: succeededOrFailed()
+        continueOnError: true
+        env:
+          DD_API_KEY: $(ddApiKey)
+
       - task: PublishTestResults@2
         displayName: publish test results
         inputs:
@@ -582,6 +589,13 @@ stages:
         condition: succeededOrFailed()
         continueOnError: true
 
+      - script: ./tracer/build.sh UploadJunitArtifacts
+        displayName: Upload junit artifacts
+        condition: succeededOrFailed()
+        continueOnError: true
+        env:
+          DD_API_KEY: $(ddApiKey)
+
       - task: PublishTestResults@2
         displayName: publish test results
         inputs:
@@ -629,6 +643,13 @@ stages:
       artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        alwaysRun: true
+        apiKey: $(ddApiKey)
+        baseImage: $(baseImage)
+        command: "UploadJunitArtifacts"
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -717,6 +738,13 @@ stages:
             testResultsFiles: tracer/build_data/results/**/*.trx
           condition: succeededOrFailed()
 
+        - template: steps/run-in-docker.yml
+          parameters:
+            alwaysRun: true
+            apiKey: $(ddApiKey)
+            baseImage: debian
+            command: "UploadJunitArtifacts"
+
 - stage: integration_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows_tracer, generate_variables, master_commit_id]
@@ -770,6 +798,13 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - script: tracer\build.cmd UploadJunitArtifacts
+      displayName: Upload junit results
+      condition: succeededOrFailed()
+      continueOnError: true
+      env:
+        DD_API_KEY: $(ddApiKey)
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows tracer logs
@@ -826,6 +861,13 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
+    - script: tracer\build.cmd UploadJunitArtifacts
+      displayName: Upload junit results
+      condition: succeededOrFailed()
+      continueOnError: true
+      env:
+        DD_API_KEY: $(ddApiKey)
+
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
       artifact: integration_tests_windows_iis_tracer_logs_$(targetPlatform)_$(framework)
@@ -869,6 +911,13 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - script: tracer\build.cmd UploadJunitArtifacts
+      displayName: Upload junit results
+      condition: succeededOrFailed()
+      continueOnError: true
+      env:
+        DD_API_KEY: $(ddApiKey)
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
@@ -940,6 +989,13 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - script: tracer\build.cmd UploadJunitArtifacts
+      displayName: Upload junit results
+      condition: succeededOrFailed()
+      continueOnError: true
+      env:
+        DD_API_KEY: $(ddApiKey)
 
     - task: DockerCompose@0
       displayName: docker-compose stop services
@@ -1030,6 +1086,13 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
+    - template: steps/run-in-docker.yml
+      parameters:
+        alwaysRun: true
+        apiKey: $(ddApiKey)
+        baseImage: $(baseImage)
+        command: "UploadJunitArtifacts"
+
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
       artifact: integration_tests_linux_snapshots_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
@@ -1119,6 +1182,13 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        alwaysRun: true
+        apiKey: $(ddApiKey)
+        baseImage: $(baseImage)
+        command: "UploadJunitArtifacts"
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
@@ -1264,6 +1334,13 @@ stages:
             testResultsFiles: tracer/build_data/results/**/*.trx
           condition: succeededOrFailed()
 
+        - template: steps/run-in-docker.yml
+          parameters:
+            alwaysRun: true
+            apiKey: $(ddApiKey)
+            baseImage: $(baseImage)
+            command: "UploadJunitArtifacts"
+
         - publish: tracer/test/snapshots
           displayName: Uploading snapshots
           artifact: integration_tests_linux_snapshots_arm64_$(publishTargetFramework)_$(System.JobAttempt)
@@ -1341,6 +1418,13 @@ stages:
             testResultsFormat: VSTest
             testResultsFiles: tracer/build_data/results/**/*.trx
           condition: succeededOrFailed()
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            alwaysRun: true
+            apiKey: $(ddApiKey)
+            baseImage: $(baseImage)
+            command: "UploadJunitArtifacts"
 
         - publish: tracer/test/snapshots
           displayName: Uploading snapshots
@@ -1819,6 +1903,13 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
+    - script: tracer\build.cmd UploadJunitArtifacts
+      displayName: Upload junit results
+      condition: succeededOrFailed()
+      continueOnError: true
+      env:
+        DD_API_KEY: $(ddApiKey)
+
 - stage: tool_artifacts_tests_linux
   dependsOn: [dotnet_tool, master_commit_id]
   variables:
@@ -1895,6 +1986,13 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        alwaysRun: true
+        apiKey: $(ddApiKey)
+        baseImage: $(baseImage)
+        command: "UploadJunitArtifacts"
 
 - stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
@@ -2289,6 +2387,9 @@ stages:
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet-appsec
+        DD_ENV: CI
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+        DD_API_KEY: $(ddApiKey)
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
@@ -2401,6 +2502,7 @@ stages:
       displayName: Execute Samples.$(sampleName) benchmark
       env:
         DD_SERVICE: dd-trace-dotnet
+        DD_ENV: CI
 
     - task: PowerShell@2
       displayName: Wait 20 seconds to agent flush before finishing pipeline

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -156,36 +156,6 @@ stages:
       displayName: Fetch master id
       name: set_sha
 
-- stage: build_datadog_ci_on_arm64
-  dependsOn: []
-  jobs:
-  - job: fetch
-    timeoutInMinutes: 60 #default value
-    pool:
-      name: aws-arm64-auto-scaling
-    workspace:
-      clean: all
-    steps:
-    - checkout: none
-    - script: git clone --branch andrew/add-arm64-build --depth 1 https://github.com/DataDog/datadog-ci.git .
-      displayName: Get datadog-ci repo
-    - task: NodeTool@0 
-      inputs:
-        versionSpec: '14.x'
-    - script: |
-        npm install --global yarn
-        yarn install --immutable
-        yarn build
-        yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
-        rm -rf dist
-        rm -rf src
-        yarn dist-standalone:test
-      displayName: Build tool
-
-    - publish: ./datadog-ci_linux-arm64
-      artifact: datadog-ci_linux-arm64
-      condition: succeededOrFailed()
-
 - stage: generate_variables
   dependsOn: [master_commit_id]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2418,7 +2418,7 @@ stages:
         inputs:
           reports: '$(Build.SourcesDirectory)\cover\**\coverage.cobertura.xml'
           targetdir: '$(Build.SourcesDirectory)\coveragereport'
-          sourcedirs: '$(Build.SourcesDirectory);..'
+          sourcedirs: '$(Build.SourcesDirectory);'
           reporttypes: 'Cobertura'
 
       - task: PublishCodeCoverageResults@1

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -156,6 +156,36 @@ stages:
       displayName: Fetch master id
       name: set_sha
 
+- stage: build_datadog_ci_on_arm64
+  dependsOn: []
+  jobs:
+  - job: fetch
+    timeoutInMinutes: 60 #default value
+    pool:
+      name: aws-arm64-auto-scaling
+    workspace:
+      clean: all
+    steps:
+    - checkout: none
+    - script: git clone --branch andrew/add-arm64-build --depth 1 https://github.com/DataDog/datadog-ci.git .
+      displayName: Get datadog-ci repo
+    - task: NodeTool@0 
+      inputs:
+        versionSpec: '14.x'
+    - script: |
+        npm install --global yarn
+        yarn install --immutable
+        yarn build
+        yarn dist-standalone -t node14-linux-arm64 -o datadog-ci_linux-arm64
+        rm -rf dist
+        rm -rf src
+        yarn dist-standalone:test
+      displayName: Build tool
+
+    - publish: ./datadog-ci_linux-arm64
+      artifact: datadog-ci_linux-arm64
+      condition: succeededOrFailed()
+
 - stage: generate_variables
   dependsOn: [master_commit_id]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2408,7 +2408,6 @@ stages:
         parameters:
           masterCommitId: $(masterCommitId)
       - template: steps/install-latest-dotnet-sdk.yml
-      - template: steps/restore-working-directory.yml
 
       - task: DownloadPipelineArtifact@2
         inputs:

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -749,6 +749,7 @@ partial class Build
                     .When(!string.IsNullOrEmpty(Filter), c => c.SetFilter(Filter))
                     .CombineWith(testProjects, (x, project) => x
                         .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .WithJUnitLogger(GetResultsDirectory(project))
                         .SetProjectFile(project)));
             }
             finally
@@ -1011,6 +1012,7 @@ partial class Build
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ParallelIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .WithJUnitLogger(GetResultsDirectory(project))
                         .SetProjectFile(project)), degreeOfParallelism: 4);
 
 
@@ -1030,6 +1032,7 @@ partial class Build
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .WithJUnitLogger(GetResultsDirectory(project))
                         .SetProjectFile(project)));
             }
             finally
@@ -1067,6 +1070,7 @@ partial class Build
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .WithJUnitLogger(GetResultsDirectory(project))
                         .SetProjectFile(project)));
             }
             finally
@@ -1110,6 +1114,7 @@ partial class Build
                                 .SetFilter(Filter ?? "(RunOnWindows=True)&LoadFromGAC=True")
                                 .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                                 .SetLogsDirectory(TestLogsDirectory)
+                                .WithJUnitLogger(GetResultsDirectory(project))
                                 .When(CodeCoverage, ConfigureCodeCoverage)
                                 .EnableTrxLogOutput(GetResultsDirectory(project))
                                 .SetProjectFile(project));
@@ -1144,6 +1149,7 @@ partial class Build
                     .SetFilter(Filter ?? "(RunOnWindows=True)&MSI=True")
                     .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
+                    .WithJUnitLogger(resultsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .EnableTrxLogOutput(resultsDirectory)
                     .SetProjectFile(project));
@@ -1406,6 +1412,7 @@ partial class Build
                         .When(CodeCoverage, ConfigureCodeCoverage)
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
                             .EnableTrxLogOutput(GetResultsDirectory(project))
+                            .WithJUnitLogger(GetResultsDirectory(project))
                             .SetProjectFile(project)),
                     degreeOfParallelism: 2);
 
@@ -1416,7 +1423,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFramework(Framework)
-                    //.WithMemoryDumpAfter(timeoutInMinutes: 30)
+                    // .WithMemoryDumpAfter(timeoutInMinutes: 30)
                     .SetFilter(filter)
                     .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
@@ -1426,6 +1433,7 @@ partial class Build
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
+                        .WithJUnitLogger(GetResultsDirectory(project))
                         .SetProjectFile(project))
                 );
             }

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -184,4 +184,13 @@ internal static partial class DotNetSettingsExtensions
                     .Add($"--blame-hang-timeout {timeoutInMinutes}m")
         );
     }
+    
+    public static DotNetTestSettings WithJUnitLogger(this DotNetTestSettings settings, string resultsDirectory)
+    {
+        var filePath = Path.Combine(resultsDirectory, "{framework}\\junit-result.xml");
+        return settings.SetProcessArgumentConfigurator(
+            args =>
+                args.Add("--logger:{value}", "junit;LogFilePath=" + filePath)
+        );
+    }
 }

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -190,7 +190,7 @@ internal static partial class DotNetSettingsExtensions
         var filePath = Path.Combine(resultsDirectory, "{framework}\\junit-result.xml");
         return settings.SetProcessArgumentConfigurator(
             args =>
-                args.Add("--logger:{value}", "junit;LogFilePath=" + filePath)
+                args.Add("--logger:{value}", "junit;MethodFormat=Class;FailureBodyFormat=Verbose;LogFilePath=" + filePath)
         );
     }
 }

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -17,6 +17,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Adds CI Visibility through the junit importer

## Reason for change

A slightly alternative approach to #2872, which uses the native `datadog-ci` binaries and a Nuke target instead of node/powershell

## Other details
There's no official alpine or arm64 binaries, so compiled them from source and uploaded to Azure for our purposes. I'll look at opening a PR for the alpine one at least in the `datadog-ci` repo.

The changes to the `run_in_docker.sh` script are a bit annoying, but it's still the simplest approach I think
