### PR TITLE
Replace use of semantic info with syntax-only check instead

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
@@ -63,16 +63,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
         {
             foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes)
             {
-                IMethodSymbol? attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol as IMethodSymbol;
-                if (attributeSymbol is null)
-                {
-                    continue;
-                }
-
-                INamedTypeSymbol attributeContainingTypeSymbol = attributeSymbol.ContainingType;
-                string fullName = attributeContainingTypeSymbol.ToDisplayString();
-
-                if (fullName == Constants.InstrumentAttribute || fullName == Constants.AdoNetTargetSignatureAttribute)
+                if (attributeSyntax.Name.ToString() is "InstrumentMethod" or "InstrumentMethodAttribute" or "AdoNetTargetSignatureAttribute" or "AdoNetTargetSignature")
                 {
                     return classDeclarationSyntax;
                 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
@@ -49,16 +49,7 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
             {
                 foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes)
                 {
-                    IMethodSymbol? attributeSymbol = context.SemanticModel.GetSymbolInfo(attributeSyntax).Symbol as IMethodSymbol;
-                    if (attributeSymbol is null)
-                    {
-                        continue;
-                    }
-
-                    INamedTypeSymbol attributeContainingTypeSymbol = attributeSymbol.ContainingType;
-                    string fullName = attributeContainingTypeSymbol.ToDisplayString();
-
-                    if (fullName == Constants.TagAttribute || fullName == Constants.MetricAttribute)
+                    if (attributeSyntax.Name.ToString() is "Tag" or "TagAttribute" or "Metric" or "MetricAttribute")
                     {
                         return propertyDeclarationSyntax.Parent as ClassDeclarationSyntax;
                     }

--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/TagListGenerator.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -35,7 +34,11 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
             IncrementalValueProvider<(Compilation, ImmutableArray<ClassDeclarationSyntax>)> compilationAndClasses =
                 context.CompilationProvider.Combine(classDeclarations.Collect());
 
-            context.RegisterSourceOutput(compilationAndClasses, static (spc, source) => Execute(source.Item1, source.Item2, spc));
+            IncrementalValueProvider<(IReadOnlyList<TagList>, IReadOnlyList<Diagnostic>)> tagListsAndDiagnostics =
+                compilationAndClasses
+                   .Select(static (t, ct) => GetTagLists(t.Item1, t.Item2, ct));
+
+            context.RegisterSourceOutput(tagListsAndDiagnostics, static (spc, source) => Execute(source.Item1, source.Item2, spc));
         }
 
         private static bool IsAttributedProperty(SyntaxNode node, CancellationToken cancellationToken)
@@ -59,17 +62,13 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
             return null;
         }
 
-        private static void Execute(Compilation compilation, ImmutableArray<ClassDeclarationSyntax> classes, SourceProductionContext context)
+        private static void Execute(IReadOnlyList<TagList> tagLists, IReadOnlyList<Diagnostic> diagnostics, SourceProductionContext context)
         {
-            if (classes.IsDefaultOrEmpty)
+            foreach (var diagnostic in diagnostics)
             {
-                // nothing to do yet
-                return;
+                context.ReportDiagnostic(diagnostic);
             }
 
-            IEnumerable<ClassDeclarationSyntax> distinctClasses = classes.Distinct();
-
-            var tagLists = GetTagLists(compilation, distinctClasses, context.ReportDiagnostic, context.CancellationToken);
             if (tagLists.Count > 0)
             {
                 var sb = new StringBuilder();
@@ -82,18 +81,23 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
             }
         }
 
-        private static IReadOnlyList<TagList> GetTagLists(
+        private static (IReadOnlyList<TagList> TagLists, IReadOnlyList<Diagnostic> Diagnostics) GetTagLists(
             Compilation compilation,
-            IEnumerable<ClassDeclarationSyntax> classes,
-            Action<Diagnostic> reportDiagnostic,
+            ImmutableArray<ClassDeclarationSyntax> classes,
             CancellationToken cancellationToken)
         {
+            if (classes.IsDefaultOrEmpty)
+            {
+                // nothing to do yet
+                return (Array.Empty<TagList>(), Array.Empty<Diagnostic>());
+            }
+
             INamedTypeSymbol? tagAttribute = compilation.GetTypeByMetadataName(Constants.TagAttribute);
             INamedTypeSymbol? metricAttribute = compilation.GetTypeByMetadataName(Constants.MetricAttribute);
             if (tagAttribute is null || metricAttribute is null)
             {
                 // nothing to do if these types aren't available
-                return Array.Empty<TagList>();
+                return (Array.Empty<TagList>(), Array.Empty<Diagnostic>());
             }
 
             // get the double? return type
@@ -101,10 +105,11 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
             INamedTypeSymbol tagReturnType = compilation.GetSpecialType(SpecialType.System_String);
             INamedTypeSymbol metricReturnType = nullableT.Construct(compilation.GetSpecialType(SpecialType.System_Double));
 
+            List<Diagnostic>? diagnostics = null;
             var results = new List<TagList>();
 
             // we enumerate by syntax tree, to minimize the need to instantiate semantic models (since they're expensive)
-            foreach (var group in classes.GroupBy(x => x.SyntaxTree))
+            foreach (var group in classes.Distinct().GroupBy(x => x.SyntaxTree))
             {
                 SemanticModel? sm = null;
                 foreach (ClassDeclarationSyntax classDec in group)
@@ -166,16 +171,18 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
                             {
                                 // can't have both!
                                 hasMisconfiguredInput = true;
-                                reportDiagnostic(DuplicateAttributeDiagnostic.Create(
-                                                     metricAttributeData.ApplicationSyntaxReference?.GetSyntax(),
-                                                     tagAttributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(DuplicateAttributeDiagnostic.Create(
+                                                metricAttributeData.ApplicationSyntaxReference?.GetSyntax(),
+                                                tagAttributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 break;
                             }
 
                             if (isTag && propertyReturnType is not null
                                       && !tagReturnType.Equals(propertyReturnType, SymbolEqualityComparer.Default))
                             {
-                                reportDiagnostic(InvalidTagPropertyReturnTypeDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(InvalidTagPropertyReturnTypeDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 hasMisconfiguredInput = true;
                                 break;
                             }
@@ -183,7 +190,8 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
                             if (isMetric && propertyReturnType is not null
                                          && !metricReturnType.Equals(propertyReturnType, SymbolEqualityComparer.Default))
                             {
-                                reportDiagnostic(InvalidMetricPropertyReturnTypeDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(InvalidMetricPropertyReturnTypeDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 hasMisconfiguredInput = true;
                                 break;
                             }
@@ -212,21 +220,24 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
                             key = (string?)attributeData.ConstructorArguments[0].Value;
                             if (string.IsNullOrEmpty(key))
                             {
-                                reportDiagnostic(InvalidKeyDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(InvalidKeyDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 hasMisconfiguredInput = true;
                                 break;
                             }
 
                             if (key == "_dd.origin")
                             {
-                                reportDiagnostic(InvalidUseOfOriginDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(InvalidUseOfOriginDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 hasMisconfiguredInput = true;
                                 break;
                             }
 
                             if (key == "language")
                             {
-                                reportDiagnostic(InvalidUseOfLanguageDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
+                                diagnostics ??= new List<Diagnostic>();
+                                diagnostics.Add(InvalidUseOfLanguageDiagnostic.Create(attributeData.ApplicationSyntaxReference?.GetSyntax()));
                                 hasMisconfiguredInput = true;
                                 break;
                             }
@@ -268,7 +279,7 @@ namespace Datadog.Trace.SourceGenerators.TagsListGenerator
                 }
             }
 
-            return results;
+            return (results, (IReadOnlyList<Diagnostic>?)diagnostics ?? Array.Empty<Diagnostic>());
         }
 
         private static string GetClassNamespace(ClassDeclarationSyntax classDec)


### PR DESCRIPTION
## Summary of changes

Small tweak for incremental source generator

## Reason for change

The [incremental generator documentation](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md) now makes it clearer how the caching with `IncrementalValuesProvider<>` and `CreateSyntaxProvider(predicate, map)` works. Namely: 

- The `predicate` will run for _every_ change to a node. This is the same as the previously understood behaviour.
- The `map` will run for _every_ node that passed the `predicate`, whenever _any_ node changes. **This** is the surprising (to me) behaviour. From the documentation:

>  The driver will still re-run the second transform lambda even for nodes in unchanged files, as a change in one file can impact the semantic meaning of a node in another file.

So if a node passes the predicate, the `map` function will be _every_ time any node changes. So it has to be v. lightweight.

## Implementation details

Reduce the work done in the hot path of the generator by avoiding calls to `SemanticModel`, and using a cruder check based on syntax alone. There's a risk of collisions with namespaces, but those are going to be filtered out in the `Execute` function. We could (should?) consider pulling out the `GetTagLists()` func into another layer for caching but this is better than what we have right now. Hopefully. 🤞 

## Test coverage
The existing tests still pass without any modification.
