### PR TITLE
Save loader and profiler native symbols from GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,11 +12,6 @@ variables:
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
     
 build:
-  only:
-    - master
-    - main
-    - /^hotfix.*$/
-    - /^release.*$/
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,11 @@ variables:
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
     
 build:
+  only:
+    - master
+    - main
+    - /^hotfix.*$/
+    - /^release.*$/
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:

--- a/shared/src/msi-installer/shared/Files.wxs
+++ b/shared/src/msi-installer/shared/Files.wxs
@@ -20,12 +20,6 @@
         </File>
 
       </Component>
-      <Component Win64="yes">
-        <File Id="Datadog.AutoInstrumentation.NativeLoader.x64.pdb"
-              Source="$(var.MonitoringHomeDirectory)\Datadog.AutoInstrumentation.NativeLoader.x64.pdb"
-              Checksum="yes">
-        </File>
-      </Component>
     </ComponentGroup>
 
     <!-- For the 64-bit installer, also install the 32-bit binaries -->
@@ -35,12 +29,6 @@
               Source="$(var.MonitoringHomeDirectory)\Datadog.AutoInstrumentation.NativeLoader.x86.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
-        </File>
-      </Component>
-      <Component Win64="no">
-        <File Id="Datadog.AutoInstrumentation.NativeLoader.x86.pdb"
-              Source="$(var.MonitoringHomeDirectory)\Datadog.AutoInstrumentation.NativeLoader.x86.pdb"
-              Checksum="yes">
         </File>
       </Component>
     </ComponentGroup>
@@ -54,12 +42,6 @@
               Source="$(var.MonitoringHomeDirectory)\Datadog.AutoInstrumentation.NativeLoader.x86.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
-        </File>
-      </Component>
-      <Component Win64="no">
-        <File Id="Datadog.AutoInstrumentation.NativeLoader.x86.pdb"
-              Source="$(var.MonitoringHomeDirectory)\Datadog.AutoInstrumentation.NativeLoader.x86.pdb"
-              Checksum="yes">
         </File>
       </Component>
     </ComponentGroup>

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -1,8 +1,10 @@
+using System;
 using Nuke.Common;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.IO;
 using System.Linq;
 using System.Collections.Generic;
+using System.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.MSBuild;
 using static Nuke.Common.EnvironmentInfo;
@@ -184,8 +186,11 @@ partial class Build
             {
                 var source = ProfilerOutputDirectory / "DDProf-Deploy" / $"Datadog.AutoInstrumentation.Profiler.Native.{architecture}.dll";
                 var dest = ProfilerHomeDirectory;
-                Logger.Info($"Copying file '{source}' to 'file {dest}'");
                 CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+
+                source = ProfilerOutputDirectory / "DDProf-Deploy" / $"Datadog.AutoInstrumentation.Profiler.Native.{architecture}.pdb";
+                dest = SymbolsDirectory / $"win-{architecture}" / Path.GetFileName(source);
+                CopyFile(source, dest, FileExistsPolicy.Overwrite);
             }
         });
 

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -85,27 +85,23 @@ partial class Build
                 var source = NativeProfilerProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
                              $"{NativeProfilerProject.Name}.dll";
                 var dest = TracerHomeDirectory / $"win-{architecture}";
-                Logger.Info($"Copying '{source}' to '{dest}'");
                 CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
 
                 // Copy native loader assets
                 source = NativeLoaderProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
                              "loader.conf";
                 dest = MonitoringHomeDirectory;
-                Logger.Info($"Copying '{source}' to '{dest}'");
                 CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
 
                 source = NativeLoaderProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
                              $"{NativeLoaderProject.Name}.dll";
                 var destFile = MonitoringHomeDirectory / $"{NativeLoaderProject.Name}.{architecture.ToString()}.dll";
-                Logger.Info($"Copying file '{source}' to 'file {destFile}'");
                 CopyFile(source, destFile, FileExistsPolicy.Overwrite);
 
                 source = NativeLoaderProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
                              $"{NativeLoaderProject.Name}.pdb";
-                destFile = MonitoringHomeDirectory / $"{NativeLoaderProject.Name}.{architecture.ToString()}.pdb";
-                Logger.Info($"Copying '{source}' to '{destFile}'");
-                CopyFile(source, destFile, FileExistsPolicy.Overwrite);
+                destFile = SymbolsDirectory / $"win-{architecture}";
+                CopyFileToDirectory(source, destFile, FileExistsPolicy.Overwrite);
             }
         });
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -401,9 +401,8 @@ partial class Build
            {
                var source = NativeProfilerProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
                             $"{NativeProfilerProject.Name}.pdb";
-               var dest = SymbolsDirectory / $"win-{architecture}";
-               Logger.Info($"Copying '{source}' to '{dest}'");
-               CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+               var dest = SymbolsDirectory / $"win-{architecture}" / Path.GetFileName(source);
+               CopyFile(source, dest, FileExistsPolicy.Overwrite);
            }
        });
 


### PR DESCRIPTION
## Summary of changes

- Excludes the native loader pdbs from the MSI
- Adds the native loader and profiler sysmbols to the `windows-native-loader.zip` in GitLab

## Reason for change

Removing the native loader symbols from the MSI reduces the MSI size. But we need the symbols for debugging purposes, so save them to the GitLab release artifacts

## Implementation details

Copy the pdbs to the appropriate `SymbolsDirectory`

## Test coverage

Did a run in Gitlab [here](https://gitlab.ddbuild.io/DataDog/dd-trace-dotnet/-/jobs/143646726) and confirmed the symbols were added correctly
