### PR TITLE
[Profiler] Do not print stack walker error messages everytime

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -76,7 +76,9 @@ void LinuxStackFramesCollector::PrintStatistics(std::unordered_map<std::int32_t,
 
     if (hasErrors)
     {
-        Log::Info("LinuxStackFramesCollector::CollectStackSampleImplementation: The sampler thread encoutered errors in the last ", TimeIntervalInSeconds, "s\n", ss.str());
+        Log::Info("LinuxStackFramesCollector::CollectStackSampleImplementation: The sampler thread encoutered errors in the last ", TimeIntervalInSeconds, "s\n",
+                  "Below, we print for each error code the message, the code in parentheses and the number of times we encountered it.\n",
+                  ss.str());
         errorStats.clear();
     }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <signal.h>
 #include <atomic>
+#include <unordered_map>
 
 class IManagedThreadList;
 
@@ -41,6 +42,8 @@ private:
     void InitializeSignalHandler();
     bool SetupSignalHandler();
     void NotifyStackWalkCompleted(std::int32_t resultErrorCode);
+    void UpdateStackwalkingStats(std::int32_t errorCode);
+    void PrintStatistics(std::unordered_map<std::int32_t, std::int32_t>& errorStats);
 
 
     std::int32_t _lastStackWalkErrorCode;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -10,11 +10,11 @@
 
 #include "StackFramesCollectorBase.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <signal.h>
-#include <atomic>
 #include <unordered_map>
 
 class IManagedThreadList;
@@ -39,12 +39,23 @@ protected:
                                                                 bool selfCollect) override;
 
 private:
+    class ErrorStatistics
+    {
+    public:
+        void Add(std::int32_t errorCode);
+        void Log();
+
+    private:
+        //                 v- error code v- # of errors
+        std::unordered_map<std::int32_t, std::int32_t> _stats;
+    };
+
+private:
     void InitializeSignalHandler();
     bool SetupSignalHandler();
     void NotifyStackWalkCompleted(std::int32_t resultErrorCode);
-    void UpdateStackwalkingStats(std::int32_t errorCode);
-    void PrintStatistics(std::unordered_map<std::int32_t, std::int32_t>& errorStats);
-
+    void UpdateErrorStats(std::int32_t errorCode);
+    bool ShouldLogStats();
 
     std::int32_t _lastStackWalkErrorCode;
     std::condition_variable _stackWalkInProgressWaiter;
@@ -69,4 +80,6 @@ private:
     static LinuxStackFramesCollector* s_pInstanceCurrentlyStackWalking;
 
     std::int32_t CollectCallStackCurrentThread();
+
+    ErrorStatistics _errorStatistics;
 };


### PR DESCRIPTION
## Summary of changes

## Reason for change

Time to time the stack sampler can encounter errors. We log those messages each time. The log file size will continue increasing and this is an issue on customer using alpine with little storage allocated to the application.

## Implementation details

Collect the different errors as statistics and log them every 10min.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
