### PR TITLE
[Profiler] Don't sample if no CPU time was consumed nor in Ready state

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -128,9 +128,9 @@ bool IsRunning(ULONG threadState)
 {
     return
         (THREAD_STATE::Running == threadState) ||
-        (THREAD_STATE::Standby == threadState) ||
-        (THREAD_STATE::Ready == threadState) ||
-        (THREAD_STATE::DeferredReady == threadState);
+        (THREAD_STATE::DeferredReady == threadState) ||
+        (THREAD_STATE::Standby == threadState)
+        ;
 
     // Note that THREAD_STATE::Standby, THREAD_STATE::Ready and THREAD_STATE::DeferredReady
     // indicate that threads are simply waiting for an available core to run.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -233,10 +233,12 @@ void StackSamplerLoop::CpuProfilingIteration(void)
                 _targetThread->SetCpuConsumptionMilliseconds(currentConsumption);
                 uint64_t cpuForSample = currentConsumption - lastConsumption;
 
-                int64_t thisSampleTimestampNanosecs = OpSysTools::GetHighPrecisionNanoseconds();
-                CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, cpuForSample, PROFILING_TYPE::CpuTime);
-
-                //std::this_thread::yield();
+                // we don't collect a sample for this thread is no CPU was consumed since the last check
+                if (cpuForSample > 0)
+                {
+                    int64_t thisSampleTimestampNanosecs = OpSysTools::GetHighPrecisionNanoseconds();
+                    CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, cpuForSample, PROFILING_TYPE::CpuTime);
+                }
             }
             // don't yield until a thread to sample is found
 


### PR DESCRIPTION
## Summary of changes
Filter out more samples based on CPU-related criteria

## Reason for change
Try to avoid waiting frames on call stacks for CPU profiling

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
