### PR TITLE
[Profiler] Run profiler tests on .NET 6

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -325,7 +325,7 @@ jobs:
     steps:
     
       - uses: actions/setup-dotnet@v2
-        if: matrix.platform == x64
+        if: matrix.platform == 'x64'
         with:
           dotnet-version: | 
             3.1.x

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -325,7 +325,7 @@ jobs:
     steps:
     
       - uses: actions/setup-dotnet@v2
-        if: platform == x64
+        if: matrix.platform == x64
         with:
           dotnet-version: | 
             3.1.x

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -259,7 +259,9 @@ jobs:
     
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            3.1.x
+            6.0.100
         
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -294,10 +296,6 @@ jobs:
         shell: bash
         run: ./.github/scripts/run-native-unit-tests.sh profiler/test ${{matrix.configuration}} x86
 
-      - uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6.0.100'
-
       - name: Build Monitoring home
         run: .\tracer\build.cmd BuildTracerHome BuildNativeLoader --build-configuration ${{matrix.configuration}}
 
@@ -328,7 +326,9 @@ jobs:
     
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x' 
+          dotnet-version: | 
+            3.1.x
+            6.0.100 
     
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -399,7 +399,9 @@ jobs:
     
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            3.1.x
+            6.0.100
     
       - name: Install Datadog agent
         continue-on-error: false
@@ -505,7 +507,9 @@ jobs:
     
       - uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: '6.0.x'    
+          dotnet-version: |
+            3.1.x          
+            6.0.100    
     
       - name: Install Datadog agent
         continue-on-error: false

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -324,9 +324,9 @@ jobs:
 
     steps:
     
-      - uses: actions/setup-dotnet@v2
-        if: matrix.platform == 'x64'
+      - uses: Datadog/setup-dotnet@v2
         with:
+          architecture: matrix.platform
           dotnet-version: | 
             3.1.x
             6.0.100

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -328,7 +328,7 @@ jobs:
         with:
           dotnet-version: | 
             3.1.x
-            6.0.100 
+            6.0.100
     
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -508,8 +508,8 @@ jobs:
       - uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            3.1.x          
-            6.0.100    
+            3.1.x
+            6.0.100
     
       - name: Install Datadog agent
         continue-on-error: false

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -325,6 +325,7 @@ jobs:
     steps:
     
       - uses: actions/setup-dotnet@v2
+        if: platform == x64
         with:
           dotnet-version: | 
             3.1.x

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -256,6 +256,11 @@ jobs:
           - Debug
 
     steps:
+    
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+        
       - name: Support longpaths
         run: git config --system core.longpaths true
 
@@ -320,6 +325,11 @@ jobs:
           - Debug
 
     steps:
+    
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x' 
+    
       - name: Support longpaths
         run: git config --system core.longpaths true
 
@@ -386,6 +396,11 @@ jobs:
           - net50
 
     steps:
+    
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'
+    
       - name: Install Datadog agent
         continue-on-error: false
         shell: pwsh
@@ -487,6 +502,11 @@ jobs:
           - Release
 
     steps:
+    
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: '6.0.x'    
+    
       - name: Install Datadog agent
         continue-on-error: false
         shell: pwsh

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         framework:
           - netcoreapp31
-          - net50
+          - net60
     services:
       dd-agent:
         image: 'datadog/agent:latest'
@@ -174,7 +174,7 @@ jobs:
         timeout-minutes: 4
         run: |
           source profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh `pwd`/profiler/_build/DDProf-Deploy &&
-          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net5.0 &&
+          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net6.0 &&
           # LD_PRELOAD was previously set in the DDProf-SetEnv.sh script, but ASAN does not work with other
           # library in LD_PRELOAD (segfault)
           ASAN_OPTIONS="detect_leaks=0" LD_PRELOAD="libasan.so.6" dotnet Samples.Computer01.dll --scenario 1 --timeout 120
@@ -232,7 +232,7 @@ jobs:
         if: '${{ always() }}'
         run: |
           source profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh `pwd`/profiler/_build/DDProf-Deploy &&
-          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net5.0 &&
+          cd profiler/_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net6.0 &&
           UBSAN_OPTIONS=print_stacktrace=1 LD_PRELOAD="libubsan.so.1:$LD_PRELOAD" dotnet Samples.Computer01.dll --scenario 1 --timeout 120
 
       - name: 'Publish Test results, Logs and PProf files'
@@ -393,7 +393,7 @@ jobs:
         framework:
           - net45
           - netcoreapp31
-          - net50
+          - net60
 
     steps:
     

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -326,7 +326,7 @@ jobs:
     
       - uses: Datadog/setup-dotnet@v2
         with:
-          architecture: matrix.platform
+          architecture: ${{ matrix.platform }}
           dotnet-version: | 
             3.1.x
             6.0.100

--- a/profiler/build/PiComputation.linux.net60.json
+++ b/profiler/build/PiComputation.linux.net60.json
@@ -15,7 +15,7 @@
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
-        "DD_TRACE_ENABLED": "0"
+        "DD_TRACE_ENABLED" : "0"
       }
     },
     {
@@ -35,26 +35,24 @@
       }
     }
   ],
-  "processName": ".\\Samples.Computer01.exe",
-  "processArguments": "--scenario 5 --iterations 1",
+  "processName": "dotnet",
+  "processArguments": "Samples.Computer01.dll --scenario 5 --iterations 1",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\_build\\bin\\Release-x64\\profiler\\src\\Demos\\Samples.Computer01\\net5.0",
+  "workingDirectory": "$(CWD)/../_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net6.0",
   "environmentVariables": {
-    "COR_ENABLE_PROFILING": "1",
-    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\continuousprofiler",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)/../../shared/bin/monitoring-home/Datadog.Trace.ClrProfiler.Native.so",
+    "DD_DOTNET_PROFILER_HOME": "$(CWD)/../../shared/bin/monitoring-home",
+    "LD_PRELOAD": "$(CWD)/../../shared/bin/monitoring-home/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },
   "tags": {
     "runtime.architecture": "x64",
     "runtime.name": ".NET Core",
-    "runtime.version": "5.0",
-    "benchmark.job.runtime.name": ".NET 5.0",
-    "benchmark.job.runtime.moniker": "net5.0"
+    "runtime.version": "6.0",
+    "benchmark.job.runtime.name": ".NET 6.0",
+    "benchmark.job.runtime.moniker": "net6.0"
   },
   "metricsFilePath": "*metrics.json"
 }

--- a/profiler/build/PiComputation.windows.net60.json
+++ b/profiler/build/PiComputation.windows.net60.json
@@ -15,7 +15,7 @@
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
-        "DD_TRACE_ENABLED" : "0"
+        "DD_TRACE_ENABLED": "0"
       }
     },
     {
@@ -35,24 +35,26 @@
       }
     }
   ],
-  "processName": "dotnet",
-  "processArguments": "Samples.Computer01.dll --scenario 5 --iterations 1",
+  "processName": ".\\Samples.Computer01.exe",
+  "processArguments": "--scenario 5 --iterations 1",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)/../_build/bin/Release-x64/profiler/src/Demos/Samples.Computer01/net5.0",
+  "workingDirectory": "$(CWD)\\..\\_build\\bin\\Release-x64\\profiler\\src\\Demos\\Samples.Computer01\\net6.0",
   "environmentVariables": {
+    "COR_ENABLE_PROFILING": "1",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-    "CORECLR_PROFILER_PATH_64": "$(CWD)/../../shared/bin/monitoring-home/Datadog.Trace.ClrProfiler.Native.so",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)/../../shared/bin/monitoring-home",
-    "LD_PRELOAD": "$(CWD)/../../shared/bin/monitoring-home/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\Datadog.AutoInstrumentation.NativeLoader.x64.dll",
+    "DD_DOTNET_PROFILER_HOME": "$(CWD)\\..\\..\\shared\\bin\\monitoring-home\\continuousprofiler",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },
   "tags": {
     "runtime.architecture": "x64",
     "runtime.name": ".NET Core",
-    "runtime.version": "5.0",
-    "benchmark.job.runtime.name": ".NET 5.0",
-    "benchmark.job.runtime.moniker": "net5.0"
+    "runtime.version": "6.0",
+    "benchmark.job.runtime.name": ".NET 6.0",
+    "benchmark.job.runtime.moniker": "net6.0"
   },
   "metricsFilePath": "*metrics.json"
 }

--- a/profiler/src/Demos/Samples.BuggyBits/Samples.BuggyBits.csproj
+++ b/profiler/src/Demos/Samples.BuggyBits/Samples.BuggyBits.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
 
     <!--This is required for smoke test assembly discovery-->

--- a/profiler/src/Demos/Samples.Computer01/Samples.Computer01.csproj
+++ b/profiler/src/Demos/Samples.Computer01/Samples.Computer01.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net6.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
 
     <!--This is required for smoke test assembly discovery-->
@@ -65,7 +65,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1') Or ('$(TargetFramework)' == 'net5.0')">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="System.ServiceProcess.ServiceController">
       <Version>5.0.0</Version>
     </PackageReference>

--- a/profiler/src/Demos/Samples.ExceptionGenerator/Samples.ExceptionGenerator.csproj
+++ b/profiler/src/Demos/Samples.ExceptionGenerator/Samples.ExceptionGenerator.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net6.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
 
     <!--This is required for smoke test assembly discovery-->
@@ -63,7 +63,7 @@
     <Reference Include="System.ServiceProcess" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(TargetFramework)' == 'netcoreapp3.1') Or ('$(TargetFramework)' == 'net5.0')">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="System.ServiceProcess.ServiceController">
       <Version>5.0.0</Version>
     </PackageReference>

--- a/profiler/src/Demos/Samples.Website-AspNetCore01/Samples.Website-AspNetCore01.csproj
+++ b/profiler/src/Demos/Samples.Website-AspNetCore01/Samples.Website-AspNetCore01.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace>Samples.Website_AspNetCore01</RootNamespace>
     <Platforms>AnyCPU;x64;x86</Platforms>
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -40,6 +40,12 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
                     new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |fn:ThrowExceptions"),
                     new StackFrame("|lm:mscorlib |ns:System.Threading |ct:ThreadHelper |fn:ThreadStart"));
             }
+            else if (framework == "net60")
+            {
+                expectedStack = new StackTrace(
+                    new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |fn:ThrowExceptions"),
+                    new StackFrame("|lm:System.Private.CoreLib |ns:System.Threading |ct:Thread |fn:StartCallback"));
+            }
             else
             {
                 expectedStack = new StackTrace(

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -40,7 +40,7 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
                     new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |fn:ThrowExceptions"),
                     new StackFrame("|lm:mscorlib |ns:System.Threading |ct:ThreadHelper |fn:ThreadStart"));
             }
-            else if (framework == "net60")
+            else if (framework == "net6.0")
             {
                 expectedStack = new StackTrace(
                     new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |fn:ThrowExceptions"),

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -324,7 +324,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         private bool IsCoreClr()
         {
             return _framework.StartsWith("netcore", StringComparison.Ordinal) ||
-                   _framework.StartsWith("net5", StringComparison.Ordinal);
+                   !_framework.StartsWith("net4", StringComparison.Ordinal);
         }
     }
 }

--- a/profiler/test/Directory.Build.props
+++ b/profiler/test/Directory.Build.props
@@ -12,8 +12,8 @@
 
     <PropertyGroup>
       <!-- only run .NET Framework tests on Windows -->
-      <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net5.0</TargetFrameworks>
-      <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+      <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.1;net6.0</TargetFrameworks>
+      <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1;net6.0</TargetFrameworks>
       <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
       <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>


### PR DESCRIPTION
## Summary of changes

Use .NET 6 in profiler tests instead of .NET 5.

## Reason for change

.NET 5 is EOL and is being removed from the github hosted agents. The profiler doesn't rely on any feature that is specific to .NET 5, so we can just test with .NET 6 instead.
