### PR TITLE
[Linux packaging] Make sure the createLogPath script is executable

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -621,6 +621,7 @@ partial class Build
 
                 var fpm = Fpm.Value;
                 var gzip = GZip.Value;
+                var chmod = Chmod.Value;
                 var packageName = "datadog-dotnet-apm";
 
                 var workingDirectory = ArtifactsDirectory / $"linux-{LinuxArchitectureIdentifier}";
@@ -637,6 +638,10 @@ partial class Build
                     var newName = MonitoringHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so";
                     RenameFile(sourceFile, newName);
                 }
+
+                // somehow the permissions are lost along the way, ensure they are correctly set here
+                var createLogPathScript = (IsArm64 ? TracerHomeDirectory : MonitoringHomeDirectory) / "createLogPath.sh";
+                chmod.Invoke("+x " + createLogPathScript);
 
                 ExtractDebugInfoAndStripSymbols();
 


### PR DESCRIPTION
## Summary of changes
Changed permissions on the `createLogPath.sh` file before packaging it

## Reason for change
Since our last release the script isn't executable by default, which makes our documented script not working out of the box

## Test coverage
Checked manually the debian package out of the CI.
There's still a difference between 2.8.0 and now. Back then the `netstandard2.0/System.*` dlls were executable. I don't think it should have been the case, just flagging here in case I would be wrong.

See below the diff between 2.8.0 (left) and the current version:
![image](https://user-images.githubusercontent.com/22597395/174812215-37610ec9-d5b4-4144-a5d7-ddac2d513b80.png)

## Other details
Fixes #2908 
