### PR TITLE
[Tracer] Make timeout for trace submission configurable with `DD_TRACE_AGENT_TIMEOUT` and reduce default timeout from 100s to 10s

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
@@ -63,7 +63,7 @@ internal static class AgentTransportStrategy
                     getBaseEndpoint(Localhost));
 #elif NETCOREAPP3_1_OR_GREATER
                 // intentionally using string interpolation, as this is only called once, and avoids array allocation
-                Log.Information($"Using {nameof(UnixDomainSocketStreamFactory)} for {productName} transport, with Unix Domain Sockets path {settings.TracesUnixDomainSocketPath} and timeout {settings.TracesPipeTimeoutMs}ms.");
+                Log.Information($"Using {nameof(UnixDomainSocketStreamFactory)} for {productName} transport, with Unix Domain Sockets path {settings.TracesUnixDomainSocketPath}.");
                 return new HttpStreamRequestFactory(
                     new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
                     new DatadogHttpClient(getHttpHeaderHelper()),

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -11,11 +11,13 @@ namespace Datadog.Trace.Agent
 {
     internal static class TracesTransportStrategy
     {
+        private static readonly TimeSpan TcpTimeout = TimeSpan.FromSeconds(15);
+
         public static IApiRequestFactory Get(ImmutableExporterSettings settings)
             => AgentTransportStrategy.Get(
                 settings,
                 productName: "trace",
-                tcpTimeout: null,
+                tcpTimeout: TcpTimeout,
                 AgentHttpHeaderNames.DefaultHeaders,
                 () => new TraceAgentHttpHeaderHelper(),
                 uri => uri);

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -11,13 +11,11 @@ namespace Datadog.Trace.Agent
 {
     internal static class TracesTransportStrategy
     {
-        private static readonly TimeSpan TcpTimeout = TimeSpan.FromSeconds(15);
-
         public static IApiRequestFactory Get(ImmutableExporterSettings settings)
             => AgentTransportStrategy.Get(
                 settings,
                 productName: "trace",
-                tcpTimeout: TcpTimeout,
+                tcpTimeout: TimeSpan.FromMilliseconds(settings.TracesTimeoutMs),
                 AgentHttpHeaderNames.DefaultHeaders,
                 () => new TraceAgentHttpHeaderHelper(),
                 uri => uri);

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Agent
             => AgentTransportStrategy.Get(
                 settings,
                 productName: "trace",
-                tcpTimeout: TimeSpan.FromMilliseconds(settings.TracesTimeoutMs),
+                tcpTimeout: TimeSpan.FromSeconds(settings.TracesTimeout),
                 AgentHttpHeaderNames.DefaultHeaders,
                 () => new TraceAgentHttpHeaderHelper(),
                 uri => uri);

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -26,6 +26,13 @@ namespace Datadog.Trace.Configuration
         public const string AgentPort = "DD_TRACE_AGENT_PORT";
 
         /// <summary>
+        /// Configuration key for setting the timeout in milliseconds for sending traces to the Agent.
+        /// Default value is <c>15,000</c>.
+        /// </summary>
+        /// <seealso cref="ExporterSettings.TracesTimeoutMs"/>
+        public const string TracesTimeoutMs = "DD_TRACE_TIMEOUT_MS";
+
+        /// <summary>
         /// Configuration key for the named pipe where the Tracer can send traces.
         /// Default value is <c>null</c>.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -26,11 +26,11 @@ namespace Datadog.Trace.Configuration
         public const string AgentPort = "DD_TRACE_AGENT_PORT";
 
         /// <summary>
-        /// Configuration key for setting the timeout in milliseconds for sending traces to the Agent.
-        /// Default value is <c>15,000</c>.
+        /// Configuration key for setting the timeout in seconds for sending traces to the Agent.
+        /// Default value is <c>10</c>.
         /// </summary>
-        /// <seealso cref="ExporterSettings.TracesTimeoutMs"/>
-        public const string TracesTimeoutMs = "DD_TRACE_TIMEOUT_MS";
+        /// <seealso cref="ExporterSettings.TracesTimeout"/>
+        public const string TracesTimeout = "DD_TRACE_AGENT_TIMEOUT";
 
         /// <summary>
         /// Configuration key for the named pipe where the Tracer can send traces.

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Configuration
         // while adding the a general traces timeout configuration,
         // use backing fields of type Nullable<int> to determine if the user explicitly configured
         // the either timeout.
-        private int? _tracesTimeoutMs;
+        private int? _tracesTimeout;
         private int? _tracesPipeTimeoutMs;
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Configuration
 
             // Get values from the config
             var traceAgentUrl = source?.GetString(ConfigurationKeys.AgentUri);
-            var tracesTimeoutMs = source?.GetInt32(ConfigurationKeys.TracesTimeoutMs);
+            var tracesTimeout = source?.GetInt32(ConfigurationKeys.TracesTimeout);
             var tracesPipeName = source?.GetString(ConfigurationKeys.TracesPipeName);
             var tracesUnixDomainSocketPath = source?.GetString(ConfigurationKeys.TracesUnixDomainSocketPath);
 
@@ -113,9 +113,9 @@ namespace Datadog.Trace.Configuration
             ConfigureTraceTransport(traceAgentUrl, tracesPipeName, agentHost, agentPort, tracesUnixDomainSocketPath);
             ConfigureMetricsTransport(traceAgentUrl, agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
 
-            if (tracesTimeoutMs.HasValue)
+            if (tracesTimeout.HasValue)
             {
-                TracesTimeoutMs = tracesTimeoutMs.Value;
+                TracesTimeout = tracesTimeout.Value;
             }
 
             if (tracesPipeTimeoutMs.HasValue)
@@ -162,7 +162,7 @@ namespace Datadog.Trace.Configuration
         /// <seealso cref="ConfigurationKeys.TracesPipeTimeoutMs"/>
         public int TracesPipeTimeoutMs
         {
-            get => _tracesPipeTimeoutMs ?? _tracesTimeoutMs ?? 500;
+            get => _tracesPipeTimeoutMs ?? (_tracesTimeout * 1000) ?? 500;
             set
             {
                 if (value > 0)
@@ -226,18 +226,18 @@ namespace Datadog.Trace.Configuration
         internal TracesTransportType TracesTransport { get; set; }
 
         /// <summary>
-        /// Gets or sets the timeout in milliseconds for sending traces to the Agent.
-        /// Default is <c>15,000</c>.
+        /// Gets or sets the timeout in seconds for sending traces to the Agent.
+        /// Default is <c>10</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.TracesTimeoutMs"/>
-        internal int TracesTimeoutMs
+        /// <seealso cref="ConfigurationKeys.TracesTimeout"/>
+        internal int TracesTimeout
         {
-            get => _tracesTimeoutMs ?? 15_000;
+            get => _tracesTimeout ?? 10;
             set
             {
                 if (value > 0)
                 {
-                    _tracesTimeoutMs = value;
+                    _tracesTimeout = value;
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Configuration
         {
             AgentUri = settings.AgentUri;
 
-            TracesTimeoutMs = settings.TracesTimeoutMs;
+            TracesTimeout = settings.TracesTimeout;
             TracesTransport = settings.TracesTransport;
             TracesPipeName = settings.TracesPipeName;
             TracesPipeTimeoutMs = settings.TracesPipeTimeoutMs;
@@ -111,11 +111,11 @@ namespace Datadog.Trace.Configuration
         public string MetricsUnixDomainSocketPath { get; }
 
         /// <summary>
-        /// Gets the timeout in milliseconds for sending traces to the Agent.
-        /// Default is <c>15,000</c>.
+        /// Gets the timeout in seconds for sending traces to the Agent.
+        /// Default is <c>10</c>.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.TracesTimeoutMs"/>
-        internal int TracesTimeoutMs { get; }
+        /// <seealso cref="ConfigurationKeys.TracesTimeout"/>
+        internal int TracesTimeout { get; }
 
         /// <summary>
         /// Gets the transport used to send traces to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.Configuration
         {
             AgentUri = settings.AgentUri;
 
+            TracesTimeoutMs = settings.TracesTimeoutMs;
             TracesTransport = settings.TracesTransport;
             TracesPipeName = settings.TracesPipeName;
             TracesPipeTimeoutMs = settings.TracesPipeTimeoutMs;
@@ -68,7 +69,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets the timeout in milliseconds for the windows named pipe requests.
-        /// Default is <c>100</c>.
+        /// Default is <c>500</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TracesPipeTimeoutMs"/>
         public int TracesPipeTimeoutMs { get; }
@@ -108,6 +109,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.MetricsUnixDomainSocketPath"/>
         public string MetricsUnixDomainSocketPath { get; }
+
+        /// <summary>
+        /// Gets the timeout in milliseconds for sending traces to the Agent.
+        /// Default is <c>15,000</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TracesTimeoutMs"/>
+        internal int TracesTimeoutMs { get; }
 
         /// <summary>
         /// Gets the transport used to send traces to the Agent.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -403,6 +403,12 @@ namespace Datadog.Trace.Tests.Configuration
                 settings.MetricsTransport.Should().Be(MetricsTransportType.UDP);
             }
 
+            // TracesTimeoutMs
+            if (!paramToIgnore.Contains("TracesTimeoutMs"))
+            {
+                settings.TracesTimeoutMs.Should().Be(15_000);
+            }
+
             if (!paramToIgnore.Contains("TracesPipeName"))
             {
                 settings.TracesPipeName.Should().BeNull();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -403,10 +403,9 @@ namespace Datadog.Trace.Tests.Configuration
                 settings.MetricsTransport.Should().Be(MetricsTransportType.UDP);
             }
 
-            // TracesTimeoutMs
-            if (!paramToIgnore.Contains("TracesTimeoutMs"))
+            if (!paramToIgnore.Contains("TracesTimeout"))
             {
-                settings.TracesTimeoutMs.Should().Be(15_000);
+                settings.TracesTimeout.Should().Be(10);
             }
 
             if (!paramToIgnore.Contains("TracesPipeName"))

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -70,6 +70,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.DogStatsdPort == i.DogStatsdPort,
                 (e, i) => e.MetricsTransport == i.MetricsTransport,
                 (e, i) => e.TracesTransport == i.TracesTransport,
+                (e, i) => e.TracesTimeoutMs == i.TracesTimeoutMs,
                 (e, i) => e.TracesPipeTimeoutMs == i.TracesPipeTimeoutMs,
                 (e, i) => e.AgentUri == i.AgentUri,
                 (e, i) => e.PartialFlushEnabled == i.PartialFlushEnabled,
@@ -95,6 +96,7 @@ namespace Datadog.Trace.Tests.Configuration
             exporterSettings.DogStatsdPort = 1234;
             exporterSettings.MetricsTransport = Vendors.StatsdClient.Transport.TransportType.NamedPipe;
             exporterSettings.TracesTransport = TracesTransportType.WindowsNamedPipe;
+            exporterSettings.TracesTimeoutMs = 7778;
             exporterSettings.TracesPipeTimeoutMs = 5556;
 
             var immutableSettings = new ImmutableExporterSettings(exporterSettings);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.DogStatsdPort == i.DogStatsdPort,
                 (e, i) => e.MetricsTransport == i.MetricsTransport,
                 (e, i) => e.TracesTransport == i.TracesTransport,
-                (e, i) => e.TracesTimeoutMs == i.TracesTimeoutMs,
+                (e, i) => e.TracesTimeout == i.TracesTimeout,
                 (e, i) => e.TracesPipeTimeoutMs == i.TracesPipeTimeoutMs,
                 (e, i) => e.AgentUri == i.AgentUri,
                 (e, i) => e.PartialFlushEnabled == i.PartialFlushEnabled,
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tests.Configuration
             exporterSettings.DogStatsdPort = 1234;
             exporterSettings.MetricsTransport = Vendors.StatsdClient.Transport.TransportType.NamedPipe;
             exporterSettings.TracesTransport = TracesTransportType.WindowsNamedPipe;
-            exporterSettings.TracesTimeoutMs = 7778;
+            exporterSettings.TracesTimeout = 7778;
             exporterSettings.TracesPipeTimeoutMs = 5556;
 
             var immutableSettings = new ImmutableExporterSettings(exporterSettings);


### PR DESCRIPTION
## Summary of changes
- Make the timeout for trace agent requests configurable via `DD_TRACE_AGENT_TIMEOUT`
- Reduce timeout for trace agent requests from 100s (HttpClient default) to 10s
- The timeout for named pipes is configured with the following order of precedence: `DD_TRACE_PIPE_TIMEOUT_MS` => `DD_TRACE_AGENT_TIMEOUT` => 500ms (same default as before)

**Note:** The default named pipe timeout is unchanged and remains at the previous value of 500ms

## Reason for change
The previous behavior of a 100s timeout is quite large

## Implementation details

## Test coverage
Existing tests should all pass, and I've added several more to test the 

## Other details
<!-- Fixes #{issue} -->
