### PR TITLE
[Profiler] Refactor raw sample processing

### DIFF
--- a/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
+++ b/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
@@ -44,25 +44,16 @@ namespace Samples.ExceptionGenerator
                         case Scenario.ExceptionsProfilerTest:
                             new ExceptionsProfilerTestScenario().Run();
 
-                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
-                            Console.WriteLine(" ########### Sleeping for 10 seconds");
-                            Thread.Sleep(10_000);
                             break;
 
                         case Scenario.ParallelExceptions:
                             new ParallelExceptionsScenario().Run();
 
-                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
-                            Console.WriteLine(" ########### Sleeping for 20 seconds");
-                            Thread.Sleep(20_000);
                             break;
 
                         case Scenario.Sampling:
                             new SamplingScenario().Run();
 
-                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
-                            Console.WriteLine(" ########### Sleeping for 20 seconds");
-                            Thread.Sleep(20_000);
                             break;
 
                         default:

--- a/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
+++ b/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
@@ -44,16 +44,25 @@ namespace Samples.ExceptionGenerator
                         case Scenario.ExceptionsProfilerTest:
                             new ExceptionsProfilerTestScenario().Run();
 
+                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
+                            Console.WriteLine(" ########### Sleeping for 10 seconds");
+                            Thread.Sleep(10_000);
                             break;
 
                         case Scenario.ParallelExceptions:
                             new ParallelExceptionsScenario().Run();
 
+                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
+                            Console.WriteLine(" ########### Sleeping for 20 seconds");
+                            Thread.Sleep(20_000);
                             break;
 
                         case Scenario.Sampling:
                             new SamplingScenario().Run();
 
+                            // TODO: Remove the sleep when flush on shutdown is implemented in the profiler
+                            Console.WriteLine(" ########### Sleeping for 20 seconds");
+                            Thread.Sleep(20_000);
                             break;
 
                         default:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -86,13 +86,11 @@ public:
         _collectedSamples.push_back(std::forward<TRawSample>(sample));
     }
 
-    inline void ProcessRawSamples() override
+    inline std::list<Sample> GetSamples() override
     {
         std::list<TRawSample> input = FetchRawSamples();
-        if (input.size() != 0)
-        {
-            TransformRawSamples(input);
-        }
+                
+        return TransformRawSamples(input);
     }
 
 private:
@@ -105,15 +103,19 @@ private:
         return input;
     }
 
-    void TransformRawSamples(const std::list<TRawSample>& input)
+    std::list<Sample> TransformRawSamples(const std::list<TRawSample>& input)
     {
+        std::list<Sample> samples;
+
         for (auto const& rawSample : input)
         {
-            TransformRawSample(rawSample);
+            samples.push_back(TransformRawSample(rawSample));
         }
+
+        return samples;
     }
 
-    void TransformRawSample(const TRawSample& rawSample)
+    Sample TransformRawSample(const TRawSample& rawSample)
     {
         Sample sample(rawSample.Timestamp, _pRuntimeIdStore->GetId(rawSample.AppDomainId));
         if (rawSample.LocalRootSpanId != 0 && rawSample.SpanId != 0)
@@ -132,8 +134,7 @@ private:
         // allow inherited classes to add values and specific labels
         rawSample.OnTransform(sample);
 
-        // save it in the output list
-        Store(std::move(sample));
+        return sample;
     }
 
     void SetAppDomainDetails(const TRawSample& rawSample, Sample& sample)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -96,10 +96,6 @@ public:
         _collectedSamples.push_back(std::forward<TRawSample>(sample));
     }
 
-protected:
-    // set values and additional labels
-    virtual void OnTransformRawSample(const TRawSample& rawSample, Sample& sample) = 0;
-
 private:
     inline static const std::chrono::nanoseconds CollectingPeriod = 60ms;
 
@@ -168,7 +164,7 @@ private:
         SetStack(rawSample, sample);
 
         // allow inherited classes to add values and specific labels
-        OnTransformRawSample(rawSample, sample);
+        rawSample.OnTransform(sample);
 
         // save it in the output list
         Store(std::move(sample));

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -656,9 +656,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown(void)
     Log::Info("CorProfilerCallback::Shutdown()");
 
     // A final .pprof should be generated before exiting
-    // All providers should be stopped and flushed before the aggregator
-    // sends the last samples to the exporter
+    // The aggregator must be stopped before the provider, since it will call them to get the last samples
     _pStackSamplerLoopManager->Stop();
+
+    _pSamplesAggregator->Stop();
 
     // Calling Stop on providers transforms the last raw samples
     if (_pWallTimeProvider != nullptr)
@@ -673,10 +674,6 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown(void)
     {
         _pExceptionsProvider->Stop();
     }
-
-    // It is now time to aggregate the remaining samples and export the last .pprof
-    _pSamplesAggregator->Stop();
-
 
     // dump all threads time
     _pThreadsCpuManager->LogCpuTimes();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -21,6 +21,7 @@
 #include "Configuration.h"
 #include "CpuTimeProvider.h"
 #include "EnvironmentVariables.h"
+#include "ExceptionsProvider.h"
 #include "FrameStore.h"
 #include "IMetricsSender.h"
 #include "IMetricsSenderFactory.h"
@@ -35,7 +36,6 @@
 #include "StackSamplerLoopManager.h"
 #include "ThreadsCpuManager.h"
 #include "WallTimeProvider.h"
-#include "ExceptionsProvider.h"
 
 #include "shared/src/native-src/environment_variables.h"
 #include "shared/src/native-src/loader.h"
@@ -136,8 +136,7 @@ bool CorProfilerCallback::InitializeServices()
             _pConfiguration.get(),
             _pThreadsCpuManager,
             _pAppDomainStore.get(),
-            pRuntimeIdStore
-            );
+            pRuntimeIdStore);
     }
 
     _pStackSamplerLoopManager = RegisterService<StackSamplerLoopManager>(
@@ -155,22 +154,25 @@ bool CorProfilerCallback::InitializeServices()
     // The different elements of the libddprof pipeline are created and linked together
     // i.e. the exporter is passed to the aggregator and each provider is added to the aggregator.
     _pExporter = std::make_unique<LibddprofExporter>(_pConfiguration.get(), _pApplicationStore);
-    _pSamplesAggregator = RegisterService<SamplesAggregator>(_pConfiguration.get(), _pThreadsCpuManager, _pExporter.get(), _metricsSender.get());
+
+    _pSamplesCollector = RegisterService<SamplesCollector>(_pThreadsCpuManager);
 
     if (_pConfiguration->IsWallTimeProfilingEnabled())
     {
-        _pSamplesAggregator->Register(_pWallTimeProvider);
+        _pSamplesCollector->Register(_pWallTimeProvider);
     }
 
     if (_pConfiguration->IsCpuProfilingEnabled())
     {
-        _pSamplesAggregator->Register(_pCpuTimeProvider);
+        _pSamplesCollector->Register(_pCpuTimeProvider);
     }
 
     if (_pConfiguration->IsExceptionProfilingEnabled())
     {
-        _pSamplesAggregator->Register(_pExceptionsProvider);
+        _pSamplesCollector->Register(_pExceptionsProvider);
     }
+
+    _pSamplesAggregator = RegisterService<SamplesAggregator>(_pConfiguration.get(), _pThreadsCpuManager, _pExporter.get(), _metricsSender.get(), _pSamplesCollector);
 
     auto started = StartServices();
     if (!started)
@@ -659,6 +661,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown(void)
     // The aggregator must be stopped before the provider, since it will call them to get the last samples
     _pStackSamplerLoopManager->Stop();
 
+    _pSamplesCollector->Stop();
     _pSamplesAggregator->Stop();
 
     // Calling Stop on providers transforms the last raw samples
@@ -898,8 +901,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadNameChanged(ThreadID thread
     }
 
     auto threadName = (cchName == 0)
-                           ? shared::WSTRING()
-                           : shared::WSTRING(name, cchName);
+                          ? shared::WSTRING()
+                          : shared::WSTRING(name, cchName);
 
     Log::Debug("CorProfilerCallback::ThreadNameChanged(threadId=0x", std::hex, threadId, std::dec, ", name=\"", threadName, "\")");
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -18,6 +18,7 @@
 #include "IMetricsSender.h"
 #include "WallTimeProvider.h"
 #include "CpuTimeProvider.h"
+#include "SamplesCollector.h"
 #include "shared/src/native-src/string.h"
 
 #include <atomic>
@@ -197,6 +198,7 @@ private :
     WallTimeProvider* _pWallTimeProvider = nullptr;
     CpuTimeProvider* _pCpuTimeProvider = nullptr;
     SamplesAggregator* _pSamplesAggregator = nullptr;
+    SamplesCollector* _pSamplesCollector = nullptr;
 
     std::vector<std::unique_ptr<IService>> _services;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
@@ -4,7 +4,6 @@
 #include "CpuTimeProvider.h"
 
 #include "IAppDomainStore.h"
-#include "IConfiguration.h"
 #include "IFrameStore.h"
 #include "IRuntimeIdStore.h"
 #include "RawCpuSample.h"
@@ -18,11 +17,4 @@ CpuTimeProvider::CpuTimeProvider(
     :
     CollectorBase<RawCpuSample>("CpuTimeProvider", pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
 {
-}
-
-
-void CpuTimeProvider::OnTransformRawSample(const RawCpuSample& rawSample, Sample& sample)
-{
-    // from milliseconds to nanoseconds
-    sample.AddValue(rawSample.Duration * 1000000, SampleValue::CpuTimeDuration);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
@@ -2,10 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include <list>
-#include <mutex>
-#include <string>
-#include <thread>
 
 #include "CollectorBase.h"
 #include "RawCpuSample.h"
@@ -28,7 +24,4 @@ public:
         IAppDomainStore* pAssemblyStore,
         IRuntimeIdStore* pRuntimeIdStore
         );
-
-protected:
-    virtual void OnTransformRawSample(const RawCpuSample& rawSample, Sample& sample) override;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -260,6 +260,7 @@
     <ClInclude Include="IMetricsSender.h" />
     <ClInclude Include="IMetricsSenderFactory.h" />
     <ClInclude Include="IRuntimeIdStore.h" />
+    <ClInclude Include="ISamplesCollector.h" />
     <ClInclude Include="IService.h" />
     <ClInclude Include="IStackSamplerLoopManager.h" />
     <ClInclude Include="IThreadsCpuManager.h" />
@@ -279,6 +280,7 @@
     <ClInclude Include="RefCountingObject.h" />
     <ClInclude Include="RuntimeIdStore.h" />
     <ClInclude Include="Sample.h" />
+    <ClInclude Include="SamplesCollector.h" />
     <ClInclude Include="SamplesAggregator.h" />
     <ClInclude Include="ProviderBase.h" />
     <ClInclude Include="ScopeFinalizer.h" />
@@ -324,6 +326,7 @@
     <ClCompile Include="RefCountingObject.cpp" />
     <ClCompile Include="RuntimeIdStore.cpp" />
     <ClCompile Include="Sample.cpp" />
+    <ClCompile Include="SamplesCollector.cpp" />
     <ClCompile Include="SamplesAggregator.cpp" />
     <ClCompile Include="ProviderBase.cpp" />
     <ClCompile Include="StackFramesCollectorBase.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -206,6 +206,10 @@
     <ClInclude Include="AdaptiveSampler.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="ISamplesCollector.h">
+      <Filter>Profiler-Driver</Filter>
+    </ClInclude>
+    <ClInclude Include="SamplesCollector.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">
@@ -318,6 +322,9 @@
     </ClCompile>
     <ClCompile Include="Timer.Windows.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="SamplesCollector.cpp">
+      <Filter>Profiler-Driver</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -204,13 +204,6 @@ bool ExceptionsProvider::GetExceptionType(ClassID classId, std::string& exceptio
     return true;
 }
 
-void ExceptionsProvider::OnTransformRawSample(const RawExceptionSample& rawSample, Sample& sample)
-{
-    sample.AddValue(1, SampleValue::ExceptionCount);
-    sample.AddLabel(Label(Sample::ExceptionMessageLabel, rawSample.ExceptionMessage));
-    sample.AddLabel(Label(Sample::ExceptionTypeLabel, rawSample.ExceptionType));
-}
-
 bool ExceptionsProvider::LoadExceptionMetadata()
 {
     // This is the first observed exception, lazy-load the exception metadata

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -26,9 +26,6 @@ public:
     bool OnModuleLoaded(ModuleID moduleId);
     bool OnExceptionThrown(ObjectID exception);
 
-protected:
-    void OnTransformRawSample(const RawExceptionSample& rawSample, Sample& sample) override;
-
 private:
     bool LoadExceptionMetadata();
     bool GetExceptionType(ClassID classId, std::string& exceptionType);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesCollector.h
@@ -2,20 +2,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include <mutex>
-#include <list>
-
 #include "ISamplesProvider.h"
 #include "Sample.h"
 
+#include <list>
 
-class ProviderBase : public ISamplesProvider
+class ISamplesCollector
 {
 public:
-    ProviderBase(const char* name);
-    std::list<Sample> GetSamples() override = 0;
+    virtual ~ISamplesCollector() = default;
 
-protected:
-    std::mutex _samplesLock;
-    std::string _name;
+    virtual std::list<Sample> GetSamples() = 0;
+    virtual void Register(ISamplesProvider* sampleProvider) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
@@ -12,5 +12,4 @@ class ISamplesProvider
 public:
     virtual ~ISamplesProvider() = default;
     virtual std::list<Sample> GetSamples() = 0;
-    virtual void ProcessRawSamples() = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
@@ -12,4 +12,5 @@ class ISamplesProvider
 public:
     virtual ~ISamplesProvider() = default;
     virtual std::list<Sample> GetSamples() = 0;
+    virtual void ProcessRawSamples() = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProviderBase.cpp
@@ -10,24 +10,3 @@ ProviderBase::ProviderBase(const char* name)
     _name {name}
 {
 }
-
-void ProviderBase::Store(Sample&& sample)
-{
-    std::lock_guard<std::mutex> lock(_samplesLock);
-
-    _samples.push_back(std::move(sample));
-}
-
-
-std::list<Sample> ProviderBase::GetSamples()
-{
-    std::lock_guard<std::mutex> lock(_samplesLock);
-
-    auto samplesToReturn = std::move(_samples);  // _samples is empty now
-
-#if _DEBUG
-    Log::Info("Provider '", _name, "' --> ", samplesToReturn.size(), " samples.");
-#endif
-
-    return samplesToReturn;
-}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
@@ -4,9 +4,15 @@
 #pragma once
 
 #include "RawSample.h"
+#include "Sample.h"
 
 class RawCpuSample : public RawSample
 {
 public:
+    inline void OnTransform(Sample& sample) const override
+    {
+        sample.AddValue(Duration * 1000000, SampleValue::CpuTimeDuration);
+    }
+
     std::uint64_t Duration;  // in milliseconds
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
@@ -1,8 +1,17 @@
 #pragma once
 #include "RawSample.h"
+#include "Sample.h"
+
 class RawExceptionSample : public RawSample
 {
 public:
+    inline void OnTransform(Sample& sample) const override
+    {
+        sample.AddValue(1, SampleValue::ExceptionCount);
+        sample.AddLabel(Label(Sample::ExceptionMessageLabel, ExceptionMessage));
+        sample.AddLabel(Label(Sample::ExceptionTypeLabel, ExceptionType));
+    }
+
     std::string ExceptionMessage;
     std::string ExceptionType;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
@@ -10,11 +10,16 @@
 #include "ManagedThreadInfo.h"
 
 
+class Sample;
+
 class RawSample
 {
 public:
     RawSample();
     virtual ~RawSample() = default;
+
+    // set values and additional labels on target sample
+    virtual void OnTransform(Sample& sample) const = 0;
 
 public:
     std::uint64_t Timestamp;        // _unixTimeUtc;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
@@ -3,15 +3,17 @@
 
 #pragma once
 #include <cstdint>
-#include <vector>
 #include "cor.h"
-#include "corprof.h"
-#include "ManagedThreadInfo.h"
 #include "RawSample.h"
 
 
 class RawWallTimeSample : public RawSample
 {
 public:
+    inline void OnTransform(Sample& sample) const override
+    {
+        sample.AddValue(Duration, SampleValue::WallTimeDuration);
+    }
+
     std::uint64_t  Duration;  // in nanoseconds
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
@@ -35,7 +35,8 @@ public:
     void Register(ISamplesProvider* sampleProvider);
 
 private:
-    void Work();
+    void MainWorker();
+    void RawSamplesWorker();
     void ProcessRawSamples();
     void ProcessSamples();
     std::list<Sample> CollectSamples();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
@@ -8,8 +8,11 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <chrono>
 
 #include "IService.h"
+
+using namespace std::chrono_literals;
 
 class Sample;
 class IConfiguration;
@@ -18,7 +21,6 @@ class IMetricsSender;
 class IProfileFactory;
 class ISamplesProvider;
 class IThreadsCpuManager;
-
 
 class SamplesAggregator : public IService
 {
@@ -34,12 +36,15 @@ public:
 
 private:
     void Work();
+    void ProcessRawSamples();
     void ProcessSamples();
     std::list<Sample> CollectSamples();
     void Export();
     void SendHeartBeatMetric(bool success);
 
 private:
+    inline static constexpr std::chrono::nanoseconds CollectingPeriod = 60ms;
+
     const char* _serviceName = "SamplesAggregator";
     static const std::chrono::seconds ProcessingInterval;
     static const std::string SuccessfulExportsMetricName;
@@ -50,6 +55,7 @@ private:
     IExporter* _exporter;
     IThreadsCpuManager* _pThreadsCpuManager;
     std::thread _worker;
+    std::thread _transformerThread;
     bool _mustStop;
     IMetricsSender* _metricsSender;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesAggregator.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include <future>
 
 #include "IService.h"
 
@@ -58,5 +59,6 @@ private:
     std::thread _worker;
     std::thread _transformerThread;
     bool _mustStop;
+    std::promise<void> _exitWorkerPromise;
     IMetricsSender* _metricsSender;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "SamplesCollector.h"
+
+#include "Log.h"
+#include "OpSysTools.h"
+
+
+SamplesCollector::SamplesCollector(IThreadsCpuManager* pThreadsCpuManager) :
+    _pThreadsCpuManager(pThreadsCpuManager)
+{
+}
+
+void SamplesCollector::Register(ISamplesProvider* samplesProvider)
+{
+    _samplesProviders.push_front(samplesProvider);
+}
+
+std::list<Sample> SamplesCollector::GetSamples()
+{
+    std::lock_guard<std::mutex> lock(_samplesLock);
+
+    return std::move(_samples);
+}
+
+bool SamplesCollector::Start()
+{
+    Log::Info("Starting the samples collector");
+    _mustStop = false;
+    _worker = std::thread(&SamplesCollector::Work, this);
+    OpSysTools::SetNativeThreadName(&_worker, WorkerThreadName);
+    return true;
+}
+
+bool SamplesCollector::Stop()
+{
+    if (_mustStop)
+    {
+        return true;
+    }
+
+    _mustStop = true;
+    _worker.join();
+
+    return true;
+}
+
+const char* SamplesCollector::GetName()
+{
+    return _serviceName;
+}
+
+void SamplesCollector::Work()
+{
+    _pThreadsCpuManager->Map(OpSysTools::GetThreadId(), WorkerThreadName);
+
+    while (!_mustStop)
+    {
+        CollectSamples();
+        std::this_thread::sleep_for(CollectingPeriod);
+    }
+}
+
+void SamplesCollector::CollectSamples()
+{
+    for (auto const& samplesProvider : _samplesProviders)
+    {
+        auto result = samplesProvider->GetSamples();
+
+        std::lock_guard<std::mutex> lock(_samplesLock);
+
+        _samples.splice(_samples.cend(), result);
+    }
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+#include "ISamplesCollector.h"
+#include "IService.h"
+#include "IThreadsCpuManager.h"
+
+#include <forward_list>
+#include <mutex>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+class SamplesCollector
+    : public ISamplesCollector, public IService
+{
+public:
+    SamplesCollector(IThreadsCpuManager* pThreadsCpuManager);
+
+    // Inherited via IService
+    const char* GetName() override;
+    bool Start() override;
+    bool Stop() override;
+
+    void Register(ISamplesProvider* samplesProvider) override;
+    std::list<Sample> GetSamples() override;
+
+private:
+    void Work();
+    void CollectSamples();
+
+    const char* _serviceName = "SamplesCollector";
+    const WCHAR* WorkerThreadName = WStr("DD.Profiler.SamplesCollector.WorkerThread");
+
+    inline static constexpr std::chrono::nanoseconds CollectingPeriod = 60ms;
+
+    bool _mustStop;
+    IThreadsCpuManager* _pThreadsCpuManager;
+    std::forward_list<ISamplesProvider*> _samplesProviders;
+    std::thread _worker;
+    std::list<Sample> _samples;
+    std::mutex _samplesLock;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
@@ -4,7 +4,6 @@
 #include "WallTimeProvider.h"
 
 #include "IAppDomainStore.h"
-#include "IConfiguration.h"
 #include "IFrameStore.h"
 #include "IRuntimeIdStore.h"
 #include "IThreadsCpuManager.h"
@@ -21,9 +20,3 @@ WallTimeProvider::WallTimeProvider(
     CollectorBase<RawWallTimeSample>("WallTimeProvider", pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
 {
 }
-
-void WallTimeProvider::OnTransformRawSample(const RawWallTimeSample& rawSample, Sample& sample)
-{
-    sample.AddValue(rawSample.Duration, SampleValue::WallTimeDuration);
-}
-

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
@@ -2,10 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include <list>
-#include <mutex>
-#include <string>
-#include <thread>
 
 #include "CollectorBase.h"
 #include "RawWallTimeSample.h"
@@ -28,7 +24,4 @@ public:
         IAppDomainStore* pAssemblyStore,
         IRuntimeIdStore* pRuntimeIdStore
         );
-
-private:
-    virtual void OnTransformRawSample(const RawWallTimeSample& rawSample, Sample& sample) override;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="ProfilerMockedInterface.cpp" />
     <ClCompile Include="RuntimeIdStoreHelper.cpp" />
     <ClCompile Include="RuntimeIdTest.cpp" />
+    <ClCompile Include="SamplesCollectorTest.cpp" />
     <ClCompile Include="SamplesProviderTest.cpp" />
     <ClCompile Include="SamplesAggregatorTest.cpp" />
     <ClCompile Include="StackSnapshotResultReusableBufferTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -98,6 +98,9 @@
     <ClCompile Include="OpSysToolsTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="SamplesCollectorTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
@@ -23,6 +23,14 @@ std::tuple<std::unique_ptr<IExporter>, MockExporter&> CreateExporter()
     return {std::move(exporter), *exporterPtr};
 }
 
+std::tuple<std::unique_ptr<ISamplesCollector>, MockSamplesCollector&> CreateSamplesCollector()
+{
+    std::unique_ptr<ISamplesCollector> collector = std::make_unique<MockSamplesCollector>();
+    auto collectorPtr = static_cast<MockSamplesCollector*>(collector.get());
+
+    return {std::move(collector), *collectorPtr};
+}
+
 std::vector<std::pair<std::string, std::string>> CreateCallstack(int depth)
 {
     std::vector<std::pair<std::string, std::string>> result;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -53,6 +53,7 @@ class MockSampleProvider : public ISamplesProvider
 {
 public:
     MOCK_METHOD(std::list<Sample>, GetSamples, (), (override));
+    MOCK_METHOD(void, ProcessRawSamples, (), (override));
 };
 
 class MockMetricsSender : public IMetricsSender

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -13,6 +13,7 @@
 #include "TagsHelper.h"
 #include "IApplicationStore.h"
 #include "IRuntimeIdStore.h"
+#include "ISamplesCollector.h"
 
 class MockConfiguration : public IConfiguration
 {
@@ -49,11 +50,17 @@ public:
     MOCK_METHOD(bool, Export, (), (override));
 };
 
+class MockSamplesCollector : public ISamplesCollector
+{
+public:
+    MOCK_METHOD(void, Register, (ISamplesProvider * sampleProvider), (override));
+    MOCK_METHOD(std::list<Sample>, GetSamples, (), (override));
+};
+
 class MockSampleProvider : public ISamplesProvider
 {
 public:
     MOCK_METHOD(std::list<Sample>, GetSamples, (), (override));
-    MOCK_METHOD(void, ProcessRawSamples, (), (override));
 };
 
 class MockMetricsSender : public IMetricsSender
@@ -116,6 +123,7 @@ std::tuple<std::unique_ptr<IConfiguration>, MockConfiguration&> CreateConfigurat
 std::tuple<std::shared_ptr<ISamplesProvider>, MockSampleProvider&> CreateSamplesProvider();
 
 std::tuple<std::unique_ptr<IExporter>, MockExporter&> CreateExporter();
+std::tuple<std::unique_ptr<ISamplesCollector>, MockSamplesCollector&> CreateSamplesCollector();
 
 template <typename T>
 Sample CreateSample(std::string_view runtimeId, const T& callstack, std::initializer_list<std::pair<std::string, std::string>> labels, std::int64_t value)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -99,7 +99,7 @@ TEST(WallTimeProviderTest, CheckNoMissingSample)
     provider.Add(RawWallTimeSample());
 
     // wait for the provider to collect raw samples
-    std::this_thread::sleep_for(200ms);
+    provider.ProcessRawSamples();
 
     auto samples = provider.GetSamples();
     ASSERT_EQ(3, samples.size());

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -98,9 +98,6 @@ TEST(WallTimeProviderTest, CheckNoMissingSample)
     provider.Add(RawWallTimeSample());
     provider.Add(RawWallTimeSample());
 
-    // wait for the provider to collect raw samples
-    provider.ProcessRawSamples();
-
     auto samples = provider.GetSamples();
     ASSERT_EQ(3, samples.size());
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
@@ -12,12 +12,13 @@
 #include "SamplesAggregator.h"
 #include "ThreadsCpuManagerHelper.h"
 
-#include <list>
 #include <chrono>
+#include <list>
 #include <tuple>
 
 using ::testing::_;
 using ::testing::ByMove;
+using ::testing::InvokeWithoutArgs;
 using ::testing::Return;
 using ::testing::Throw;
 
@@ -42,109 +43,42 @@ std::list<Sample> CreateSamples(std::string_view runtimeId, int nbSamples)
     return samples;
 }
 
-class FakeSamplesProvider : public ISamplesProvider
-{
-public:
-    FakeSamplesProvider(std::string_view runtimeId, int nbSamples)
-        :
-        _calls{0},
-        _runtimeId{runtimeId},
-        _nbSamples{nbSamples}
-    {
-    }
-
-    std::list<Sample> GetSamples() override
-    {
-        _calls++;
-        return std::move(CreateSamples(_runtimeId, _nbSamples));
-    }
-
-    int GetNbCalls()
-    {
-        return _calls;
-    }
-
-    void ProcessRawSamples() override
-    {        
-    }
-
-private:
-    std::string_view _runtimeId;
-    int _nbSamples;
-    int _calls;
-};
-
-
-TEST(SamplesAggregatorTest, MustCollectOneSampleFromOneProvider)
+TEST(SamplesAggregatorTest, MustCollectSamples)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
-    std::string runtimeId = "MyRid";
-    FakeSamplesProvider samplesProvider(runtimeId, 1);
-
     auto [exporter, mockExporter] = CreateExporter();
-    EXPECT_CALL(mockExporter, Add(_)).Times(1*2); // 1 sample returned twice
+    EXPECT_CALL(mockExporter, Add(_)).Times(3 * 2); // 3 samples returned twice
     EXPECT_CALL(mockExporter, Export()).Times(2).WillRepeatedly(Return(true));
 
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
-    aggregator.Register(&samplesProvider);
-
-    aggregator.Start();
-
-    // wait for more than upload interval so that ProcessSamples()
-    // runs once before Stop()
-    std::this_thread::sleep_for(1500ms);
-    auto exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 1);
-
-    aggregator.Stop();
-    exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 2);  // the last .pprof triggers one more call
-
-    ASSERT_TRUE(metricsSender.WasCounterCalled());
-}
-
-TEST(SamplesAggregatorTest, MustCollectSamplesFromTwoProviders)
-{
-    auto [configuration, mockConfiguration] = CreateConfiguration();
-    EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
+    auto [collector, mockCollector] = CreateSamplesCollector();
 
     std::string runtimeId = "MyRid";
-    FakeSamplesProvider samplesProvider(runtimeId, 1);
 
-    std::string runtimeId2 = "MyRid2";
-    FakeSamplesProvider samplesProvider2(runtimeId2, 2);
+    uint32_t getSamplesCallCounter;
 
-    auto [exporter, mockExporter] = CreateExporter();
-    EXPECT_CALL(mockExporter, Add(_)).Times(3*2);  // 3 samples returned twice
-    EXPECT_CALL(mockExporter, Export()).Times(2).WillRepeatedly(Return(true));
+    EXPECT_CALL(mockCollector, GetSamples())
+        .WillRepeatedly(InvokeWithoutArgs([&getSamplesCallCounter, runtimeId] {
+            getSamplesCallCounter++;
+            return CreateSamples(runtimeId, 3);
+        }));
 
-    auto metricsSender = MockMetricsSender();
-    auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
-
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
-    aggregator.Register(&samplesProvider);
-    aggregator.Register(&samplesProvider2);
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
     // wait for more than upload interval so that ProcessSamples()
     // runs once before Stop()
     std::this_thread::sleep_for(1500ms);
-    auto exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 1);
-    auto exportsCount2 = samplesProvider2.GetNbCalls();
-    ASSERT_EQ(exportsCount2, 1);
+
+    ASSERT_EQ(getSamplesCallCounter, 1);
 
     aggregator.Stop();
-    // the last .pprof triggers one more call on each provider
-    exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 2);
-    exportsCount2 = samplesProvider2.GetNbCalls();
-    ASSERT_EQ(exportsCount, 2);
+    // the last .pprof triggers one more call
+    ASSERT_EQ(getSamplesCallCounter, 2);
 
     ASSERT_TRUE(metricsSender.WasCounterCalled());
 }
@@ -153,9 +87,6 @@ TEST(SamplesAggregatorTest, MustExportAfterStop)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(2s));
-
-    std::string runtimeId = "MyRid";
-    FakeSamplesProvider samplesProvider(runtimeId, 1);
 
     auto [exporter, mockExporter] = CreateExporter();
 
@@ -166,22 +97,31 @@ TEST(SamplesAggregatorTest, MustExportAfterStop)
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
-    aggregator.Register(&samplesProvider);
+    auto [collector, mockCollector] = CreateSamplesCollector();
+
+    std::string runtimeId = "MyRid";
+
+    uint32_t getSamplesCallCounter;
+
+    EXPECT_CALL(mockCollector, GetSamples())
+        .WillRepeatedly(InvokeWithoutArgs([&getSamplesCallCounter, runtimeId] {
+            getSamplesCallCounter++;
+            return CreateSamples(runtimeId, 1);
+        }));
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
 
     // wait less than upload interval to ensure that ProcessSamples()
     // won't be called
     std::this_thread::sleep_for(200ms);
-    auto exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 0);
+    ASSERT_EQ(getSamplesCallCounter, 0);
 
     aggregator.Stop();
     // Stop() is supposed to flush the remaining samples
     // from the provider and export them to a final and unique .pprof
-    exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 1);
+    ASSERT_EQ(getSamplesCallCounter, 1);
 
     ASSERT_TRUE(metricsSender.WasCounterCalled());
 }
@@ -191,25 +131,19 @@ TEST(SamplesAggregatorTest, MustNotFailWhenSendingProfileThrows)
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
-    std::string runtimeId = "MyRid";
-    auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId, 1))));
-
-    std::string runtimeId2 = "MyRid2";
-    auto [samplesProvider2, mockSamplesProvider2] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider2, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId2, 2))));
-
     auto [exporter, mockExporter] = CreateExporter();
-    EXPECT_CALL(mockExporter, Add(_)).Times(3);
+    EXPECT_CALL(mockExporter, Add(_)).Times(2);
     EXPECT_CALL(mockExporter, Export()).Times(1).WillRepeatedly(Throw(std::exception()));
 
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
+    auto [collector, mockCollector] = CreateSamplesCollector();
 
-    aggregator.Register(&mockSamplesProvider);
-    aggregator.Register(&mockSamplesProvider2);
+    std::string runtimeId = "MyRid";
+    EXPECT_CALL(mockCollector, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId, 2))));
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
     std::this_thread::sleep_for(100ms);
@@ -223,14 +157,6 @@ TEST(SamplesAggregatorTest, MustNotFailWhenAddingSampleThrows)
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
-    std::string runtimeId = "MyRid";
-    auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId, 1))));
-
-    std::string runtimeId2 = "MyRid2";
-    auto [samplesProvider2, mockSamplesProvider2] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider2, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId2, 2))));
-
     auto [exporter, mockExporter] = CreateExporter();
     EXPECT_CALL(mockExporter, Add(_)).Times(2).WillOnce(Return()).WillRepeatedly(Throw(std::exception()));
     EXPECT_CALL(mockExporter, Export()).Times(0);
@@ -238,10 +164,12 @@ TEST(SamplesAggregatorTest, MustNotFailWhenAddingSampleThrows)
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
+    auto [collector, mockCollector] = CreateSamplesCollector();
 
-    aggregator.Register(&mockSamplesProvider);
-    aggregator.Register(&mockSamplesProvider2);
+    std::string runtimeId = "MyRid";
+    EXPECT_CALL(mockCollector, GetSamples()).Times(1).WillOnce(Return(ByMove(CreateSamples(runtimeId, 2))));
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
     std::this_thread::sleep_for(100ms);
@@ -255,9 +183,6 @@ TEST(SamplesAggregatorTest, MustNotFailWhenCollectingSampleThrows)
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
-    auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Throw(std::exception()));
-
     auto [exporter, mockExporter] = CreateExporter();
     EXPECT_CALL(mockExporter, Add(_)).Times(0);
     EXPECT_CALL(mockExporter, Export()).Times(0);
@@ -265,8 +190,10 @@ TEST(SamplesAggregatorTest, MustNotFailWhenCollectingSampleThrows)
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
-    aggregator.Register(&mockSamplesProvider);
+    auto [collector, mockCollector] = CreateSamplesCollector();
+    EXPECT_CALL(mockCollector, GetSamples()).Times(1).WillOnce(Throw(std::exception()));
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
     std::this_thread::sleep_for(100ms);
@@ -286,17 +213,17 @@ TEST(SamplesAggregatorTest, MustdNotAddSampleInExporterIfEmptyCallstack)
     // add sample with empty callstack
     samples.push_back({runtimeId.c_str()});
 
-    auto [samplesProvider, mockSamplesProvider] = CreateSamplesProvider();
-    EXPECT_CALL(mockSamplesProvider, GetSamples()).Times(1).WillOnce(Return(ByMove(std::move(samples))));
-
     auto [exporter, mockExporter] = CreateExporter();
     EXPECT_CALL(mockExporter, Add(_)).Times(0);
 
     auto metricsSender = MockMetricsSender();
     auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
 
-    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender);
-    aggregator.Register(&mockSamplesProvider);
+    auto [collector, mockCollector] = CreateSamplesCollector();
+
+    EXPECT_CALL(mockCollector, GetSamples()).Times(1).WillOnce(Return(ByMove(std::move(samples))));
+
+    auto aggregator = SamplesAggregator(&mockConfiguration, &threadsCpuManagerHelper, &mockExporter, &metricsSender, collector.get());
 
     aggregator.Start();
     std::this_thread::sleep_for(100ms);

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
@@ -64,6 +64,10 @@ public:
         return _calls;
     }
 
+    void ProcessRawSamples() override
+    {        
+    }
+
 private:
     std::string_view _runtimeId;
     int _nbSamples;

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesAggregatorTest.cpp
@@ -59,7 +59,7 @@ TEST(SamplesAggregatorTest, MustCollectSamples)
 
     std::string runtimeId = "MyRid";
 
-    uint32_t getSamplesCallCounter;
+    uint32_t getSamplesCallCounter = 0;
 
     EXPECT_CALL(mockCollector, GetSamples())
         .WillRepeatedly(InvokeWithoutArgs([&getSamplesCallCounter, runtimeId] {
@@ -101,7 +101,7 @@ TEST(SamplesAggregatorTest, MustExportAfterStop)
 
     std::string runtimeId = "MyRid";
 
-    uint32_t getSamplesCallCounter;
+    uint32_t getSamplesCallCounter = 0;
 
     EXPECT_CALL(mockCollector, GetSamples())
         .WillRepeatedly(InvokeWithoutArgs([&getSamplesCallCounter, runtimeId] {

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "SamplesCollector.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "Configuration.h"
+#include "IExporter.h"
+#include "ISamplesProvider.h"
+#include "ProfilerMockedInterface.h"
+#include "Sample.h"
+#include "SamplesAggregator.h"
+#include "ThreadsCpuManagerHelper.h"
+
+#include <chrono>
+#include <list>
+#include <tuple>
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::Invoke;
+using ::testing::InvokeWithoutArgs;
+using ::testing::Return;
+using ::testing::Throw;
+
+using namespace std::chrono_literals;
+
+class FakeSamplesProvider : public ISamplesProvider
+{
+public:
+    FakeSamplesProvider(std::string_view runtimeId, int nbSamples) :
+        _calls{0},
+        _runtimeId{runtimeId},
+        _nbSamples{nbSamples}
+    {
+    }
+
+    std::list<Sample> GetSamples() override
+    {
+        _calls++;
+        return std::move(CreateSamples(_runtimeId, _nbSamples));
+    }
+
+    int GetNbCalls()
+    {
+        return _calls;
+    }
+
+    Sample CreateSample(std::string_view rid)
+    {
+        Sample s{rid};
+
+        s.AddFrame("My module", "My frame");
+
+        return s;
+    }
+
+    std::list<Sample> CreateSamples(std::string_view runtimeId, int nbSamples)
+    {
+        std::list<Sample> samples;
+        for (int i = 0; i < nbSamples; i++)
+        {
+            samples.push_back(CreateSample(runtimeId));
+        }
+        return samples;
+    }
+
+private:
+    std::string_view _runtimeId;
+    int _nbSamples;
+    int _calls;
+};
+
+TEST(SamplesCollectorTest, MustCollectSamplesFromTwoProviders)
+{
+    std::string runtimeId = "MyRid";
+    FakeSamplesProvider samplesProvider(runtimeId, 1);
+
+    std::string runtimeId2 = "MyRid2";
+    FakeSamplesProvider samplesProvider2(runtimeId2, 2);
+
+    auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
+
+    auto collector = SamplesCollector(&threadsCpuManagerHelper);
+    collector.Register(&samplesProvider);
+    collector.Register(&samplesProvider2);
+
+    collector.Start();
+    // wait for more than upload interval so that ProcessSamples() is called multiple times
+    std::this_thread::sleep_for(90ms);
+    
+    collector.Stop();
+
+    auto exportsCount = samplesProvider.GetNbCalls();
+    ASSERT_GE(exportsCount, 2);
+    auto exportsCount2 = samplesProvider2.GetNbCalls();
+    ASSERT_GE(exportsCount2, 2);
+
+    auto samples = collector.GetSamples();
+
+    uint32_t samplesCount1 = 0;
+    uint32_t samplesCount2 = 0;
+
+    for (auto& sample : samples)
+    {
+        if (sample.GetRuntimeId() == runtimeId)
+        {
+            samplesCount1++;
+        }
+        else if (sample.GetRuntimeId() == runtimeId2)
+        {
+            samplesCount2++;
+        }
+        else
+        {
+            // unexpected
+            ASSERT_TRUE(false);
+        }
+    }
+
+    ASSERT_EQ(samplesCount1, exportsCount);
+    ASSERT_EQ(samplesCount2, exportsCount2 * 2);
+
+    auto samples2 = collector.GetSamples();
+
+    ASSERT_EQ(samples2.size(), 0);
+}
+
+TEST(SamplesCollectorTest, MustStopCollectingSamples)
+{
+    std::string runtimeId = "MyRid";
+    FakeSamplesProvider samplesProvider(runtimeId, 1);
+
+    auto threadsCpuManagerHelper = ThreadsCpuManagerHelper();
+
+    auto collector = SamplesCollector(&threadsCpuManagerHelper);
+    collector.Register(&samplesProvider);
+
+    collector.Start();
+    // wait for more than upload interval so that ProcessSamples() is called multiple times
+    std::this_thread::sleep_for(90ms);
+    
+    collector.Stop();
+
+    auto exportsCount = samplesProvider.GetNbCalls();
+
+    ASSERT_GE(exportsCount, 2);
+
+    std::this_thread::sleep_for(200ms);
+
+    auto newExportsCount = samplesProvider.GetNbCalls();
+
+    ASSERT_EQ(newExportsCount, exportsCount);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesProviderTest.cpp
@@ -21,6 +21,10 @@ public:
     {
         Store(std::move(sample));
     }
+
+    void ProcessRawSamples() override
+    {        
+    }
 };
 
 Sample GetTestSample(std::string_view runtimeId, const std::string& framePrefix, const std::string& labelId, const std::string& labelValue)

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesProviderTest.cpp
@@ -9,24 +9,6 @@
 #include "ProviderBase.h"
 #include "Sample.h"
 
-class TestSamplesProvider : public ProviderBase
-{
-public:
-    TestSamplesProvider(const char* name)
-    :
-        ProviderBase(name)
-    {}
-
-    void Add(Sample&& sample)
-    {
-        Store(std::move(sample));
-    }
-
-    void ProcessRawSamples() override
-    {        
-    }
-};
-
 Sample GetTestSample(std::string_view runtimeId, const std::string& framePrefix, const std::string& labelId, const std::string& labelValue)
 {
     Sample sample{runtimeId};
@@ -108,29 +90,6 @@ void ValidateTestSample(const Sample& sample, const std::string& framePrefix, co
         std::stringstream buffer;
         buffer << framePrefix << " #" << current;
         ASSERT_EQ(buffer.str(), frame.second);
-
-        current++;
-    }
-}
-
-// Add samples and check their presence
-TEST(SamplesTimeProviderTest, CheckStore)
-{
-    TestSamplesProvider provider("TestSamplesProvider");
-
-    std::string runtimeId = "MyRid";
-    provider.Add(GetTestSample(runtimeId, "Frame", "thread name", "thread 1"));
-    provider.Add(GetTestSample(runtimeId, "Frame", "thread name", "thread 2"));
-
-    auto samples = provider.GetSamples();
-    ASSERT_EQ(2, samples.size());
-
-    size_t current = 1;
-    for (auto const& sample : samples)
-    {
-        std::stringstream builder;
-        builder << "thread " << current;
-        ValidateTestSample(sample, "Frame", "thread name", builder.str());
 
         current++;
     }


### PR DESCRIPTION
## Summary of changes

- Move the transform method to the implementation of RawSample
- Have a single thread in SampleAggregator process the raw samples, instead of one thread per provider

## Reason for change

Having one thread per provider wouldn't scale as we keep adding new providers.
