### PR TITLE
[codeowners] Rename ci-app-tracers to ci-app-libraries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@
 /tracer/                                  @DataDog/apm-dotnet
 
 # CI
-/tracer/src/Datadog.Trace/Ci/             @DataDog/apm-dotnet @DataDog/ci-app-tracers
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-tracers
+/tracer/src/Datadog.Trace/Ci/             @DataDog/apm-dotnet @DataDog/ci-app-libraries
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries
 
 # ASM
 /tracer/src/Datadog.Trace/AppSec/         @DataDog/apm-dotnet @DataDog/asm-dotnet


### PR DESCRIPTION
## Summary of changes
Update CI Visibility team in CODEOWNERS.
 
## Reason for change
The team name changed.
