### PR TITLE
Fix changed error message in Kafka 1.9.0

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 errorConsumerSpans
                    .Should()
                    .OnlyContain(x => x.Tags.ContainsKey(Tags.ErrorType))
-                   .And.OnlyContain(x => x.Tags[Tags.ErrorMsg] == "Broker: Unknown topic or partition")
+                   .And.OnlyContain(x => x.Tags[Tags.ErrorMsg].Contains("Broker: Unknown topic or partition"))
                    .And.OnlyContain(x => x.Tags[Tags.ErrorType] == "Confluent.Kafka.ConsumeException");
             }
 


### PR DESCRIPTION
## Summary of changes

- Changes how we check the error message in the Kafka tests

## Reason for change

The error message in 1.9.0 changes slightly, so this test is failing erroneously in #2901

## Other details
Prerequisite for #2901 
