### PR TITLE
Update usages of Newtonsoft.Json to 13.0.1 across test applications

### DIFF
--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Web.config
@@ -37,7 +37,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -13,5 +13,5 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
 </packages>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
@@ -86,6 +86,9 @@
       <HintPath>..\..\..\..\..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -108,9 +111,6 @@
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Web.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/packages.config
@@ -8,6 +8,6 @@
   <package id="Microsoft.AspNet.Web.Optimization.WebForms" version="1.1.3" targetFramework="net472" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net472" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
@@ -36,8 +36,8 @@
       <HintPath>..\..\..\..\..\packages\AttributeRouting.3.5.6\lib\net40\AttributeRouting.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/Web.config
@@ -38,7 +38,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc4/packages.config
@@ -20,7 +20,7 @@
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net462" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net462" />
   <package id="WebActivator" version="1.0.0.0" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -37,8 +37,8 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
@@ -123,6 +123,7 @@
     <Content Include="Areas\Datadog\Views\_ViewStart.cshtml" />
     <Content Include="Areas\Datadog\Views\Shared\_Layout.cshtml" />
     <Content Include="Areas\Datadog\Views\DogHouse\Index.cshtml" />
+    <Content Include="libman.json" />
     <None Include="packages.config" />
     <Content Include="Views\_Layout.cshtml" />
     <Content Include="Views\_ViewStart.cshtml" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -123,7 +123,6 @@
     <Content Include="Areas\Datadog\Views\_ViewStart.cshtml" />
     <Content Include="Areas\Datadog\Views\Shared\_Layout.cshtml" />
     <Content Include="Areas\Datadog\Views\DogHouse\Index.cshtml" />
-    <Content Include="libman.json" />
     <None Include="packages.config" />
     <Content Include="Views\_Layout.cshtml" />
     <Content Include="Views\_ViewStart.cshtml" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/Web.config
@@ -37,7 +37,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>

--- a/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNetMvc5/packages.config
@@ -12,5 +12,5 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net45" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
 </packages>

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -92,8 +92,8 @@
     <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\NEST.6.1.0\lib\net45\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/Web.config
@@ -59,7 +59,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51"/>

--- a/tracer/test/test-applications/aspnet/Samples.WebForms/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.WebForms/packages.config
@@ -20,7 +20,7 @@
   <package id="Microsoft.Owin.Security.OAuth" version="3.1.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
   <package id="NEST" version="6.1.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net45" />
   <package id="WebGrease" version="1.6.0" targetFramework="net45" />

--- a/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="$(ApiVersion)" />
     <PackageReference Include="NEST" Version="$(ApiVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Samples.Kafka.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Samples.Kafka.csproj
@@ -13,6 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="$(ApiVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -89,6 +89,9 @@
       <HintPath>..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -137,9 +140,6 @@
     <Reference Include="System.Web.WebPages.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Web.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301880
@@ -35,7 +35,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/packages.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/packages.config
@@ -12,6 +12,6 @@
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.11" targetFramework="net462" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net462" />
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
@@ -118,6 +118,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -136,9 +139,6 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\..\..\..\..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
     </Reference>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Web.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Web.config
@@ -30,7 +30,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/packages.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/packages.config
@@ -15,6 +15,6 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
@@ -117,6 +117,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -151,9 +154,6 @@
     </Reference>
     <Reference Include="System.Web.Optimization, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <HintPath>..\..\..\..\..\..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\..\..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Web.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Web.config
@@ -24,7 +24,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/packages.config
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/packages.config
@@ -14,6 +14,6 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Modernizr" version="2.8.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="WebGrease" version="1.6.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
## Summary of changes
These are all test applications, so they're not production code, but update to the latest Newtonsoft.Json to avoid security alerts.

## Reason for change

## Implementation details

## Test coverage

## Other details

