### PR TITLE
[Profiler] POC to receive CLR events synchronously via ICorProfilerCallback

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -1,0 +1,342 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "ClrEventsParser.h"
+
+#include <iostream>
+#include <sstream>
+
+#include "Log.h"
+
+
+ClrEventsParser::ClrEventsParser(ICorProfilerInfo12* pCorProfilerInfo)
+    :
+    _pCorProfilerInfo{pCorProfilerInfo}
+{
+}
+
+const char* GetEventName(DWORD eventId)
+{
+    switch (eventId)
+    {
+        // GC events
+        case 1: return "GcStart";
+        case 2: return "GCEnd";
+        case 3: return "GCRestartEEEnd";
+        case 4: return "GCHeapStats";
+        case 7: return "GCRestartEEBegin";
+        case 8: return "GCSuspendEEEnd";
+        case 9: return "GCSuspendEEBegin";
+        case 13: return "GCFinalizersEnd";
+        case 14: return "GCFinalizersBegin";
+        case 35: return "GCTriggered";
+        case 202: return "GCMarkWithType";
+        case 204: return "GCPerHeapHistory";
+        case 205: return "GCGlobalHeap";
+        // verbose
+        case 10: return "___GCAllocationTick___";
+        case 29: return "___FinalizeObject";
+        case 200: return "___IncreaseMemoryPressure";
+        case 203: return "___GCJoin";
+
+        // Contention events
+        case 81: return "ContentionStart";
+        case 91: return "ContentionStop";
+
+        // other verbose
+        //
+        default:
+        {
+            return nullptr;
+        }
+    }
+}
+
+void DumpEvent(
+    std::string& providerName,
+    EventPipeMetadataInstance& metadata,
+    DWORD eventId,
+    DWORD eventVersion,
+    ULONG numStackFrames
+    )
+{
+    std::stringstream buffer;
+    buffer << providerName << " | "
+           << "k=0x" << std::hex << metadata.keywords << std::dec << " = ";
+
+    if (WStrLen(metadata.name) > 0)
+    {
+        buffer << "'" << shared::ToString(shared::WSTRING(metadata.name)) << "' : ";
+    }
+    else
+    {
+        // most event name are empty strings
+        const char* wellKnownEventName = GetEventName(metadata.id);
+        if (wellKnownEventName != nullptr)
+        {
+            buffer << "'" << wellKnownEventName << "' : ";
+        }
+        else
+        {
+            buffer << "'' : ";
+        }
+    }
+    buffer << metadata.id << "(" << eventId << ") v"
+           << metadata.version << "(" << eventVersion << ")";
+
+    if (numStackFrames > 0)
+    {
+        buffer << " [" << numStackFrames << " frames]";
+    }
+    buffer << std::endl;
+    std::cout << buffer.str();
+}
+
+void ClrEventsParser::ParseEvent(
+    EVENTPIPE_PROVIDER provider,
+    DWORD eventId,
+    DWORD eventVersion,
+    ULONG cbMetadataBlob,
+    LPCBYTE metadataBlob,
+    ULONG cbEventData,
+    LPCBYTE eventData,
+    LPCGUID pActivityId,
+    LPCGUID pRelatedActivityId,
+    ThreadID eventThread,
+    ULONG numStackFrames,
+    UINT_PTR stackFrames[])
+{
+    // Currently, only "Microsoft-Windows-DotNETRuntime" provider is used so no need to check.
+    // However, during the test, a last (k=0 id=1 V1) event is sent from "Microsoft-DotNETCore-EventPipe".
+    auto providerName = GetProviderName(provider);
+
+    // This implementation tries to cache the metadata in a thread-safe container.
+    // Maybe directly reading the keyword from the metadata blob without lock might be more effective.
+    auto metadata = GetMetadata(metadataBlob, cbMetadataBlob);
+
+    // Dump to see all received events
+    //DumpEvent(providerName, metadata, eventId, eventVersion, numStackFrames);
+
+    if (KEYWORD_GC == (metadata.keywords & KEYWORD_GC))
+    {
+        ParseGcEvent(metadata.id, metadata.version, cbEventData, eventData);
+    }
+    else
+    if (KEYWORD_CONTENTION == (metadata.keywords & KEYWORD_CONTENTION))
+    {
+        ParseContentionEvent(metadata.id, metadata.version, cbEventData, eventData);
+    }
+}
+
+
+// dump the buffer every 16 bytes + corresponding ASCII characters
+// ex:  44 4F 54 4E 45 54 5F 49  50 43 5F 56 31 00 77 00    DOTNET_IPC_V1.w.
+const DWORD LineWidth = 16;
+
+char GetCharFromBinary(uint8_t byte)
+{
+    if ((byte >= 0x21) && (byte <= 0x7E))
+        return static_cast<char>(byte);
+
+    return '.';
+}
+
+void DumpBuffer(const uint8_t* pBuffer, DWORD byteCount)
+{
+    //// TODO: uncomment to skip displaying memory buffer on console
+    // return;
+
+    DWORD pos = 0;
+    char stringBuffer[LineWidth + 1];
+    ::ZeroMemory(stringBuffer, LineWidth + 1);
+
+    std::cout << std::hex;
+    for (DWORD i = 0; i < byteCount; i++)
+    {
+        std::cout << std::uppercase << std::setfill('0') << std::setw(2) << (int)pBuffer[i] << " ";
+        stringBuffer[pos] = GetCharFromBinary(pBuffer[i]);
+        pos++;
+
+        if (pos % LineWidth == 0)
+        {
+            std::cout << "    ";
+            std::cout << stringBuffer;
+            std::cout << "\n";
+
+            ::ZeroMemory(stringBuffer, LineWidth + 1);
+            pos = 0;
+        }
+        else if (pos % (LineWidth / 2) == 0)
+        {
+            std::cout << " ";
+        }
+    }
+
+    // show the remaining characters if any
+    if (pos > 0)
+    {
+        for (size_t i = 0; i < LineWidth - pos; i++)
+        {
+            std::cout << "   ";
+        }
+
+        if (pos > LineWidth / 2)
+            std::cout << "    ";
+        else
+            std::cout << "     ";
+        std::cout << stringBuffer;
+        std::cout << "\n";
+    }
+
+    // reset to default
+    std::cout << std::setfill(' ') << std::setw(1) << std::dec;
+}
+
+void ClrEventsParser::ParseGcEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData)
+{
+// look for AllocationTick_V4
+    if ((id == EVENT_ALLOCATION_TICK) && (version == 4))
+    {
+        //template tid = "GCAllocationTick_V4" >
+        //    <data name = "AllocationAmount" inType = "win:UInt32" />
+        //    <data name = "AllocationKind" inType = "win:UInt32" />
+        //    <data name = "ClrInstanceID" inType = "win:UInt16" />
+        //    <data name = "AllocationAmount64" inType = "win:UInt64"/>
+        //    <data name = "TypeID" inType = "win:Pointer" />
+        //    <data name = "TypeName" inType = "win:UnicodeString" />
+        //    <data name = "HeapIndex" inType = "win:UInt32" />
+        //    <data name = "Address" inType = "win:Pointer" />
+        //    <data name = "ObjectSize" inType = "win:UInt64" />
+        //DumpBuffer(pEventData, cbEventData);
+
+        AllocationTickV4Payload payload{0};
+        ULONG offset = 0;
+        if (!Read(payload.AllocationAmount, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.AllocationKind, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.ClrInstanceId, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.AllocationAmount64, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.TypeId, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        payload.TypeName = ReadWideString(pEventData, cbEventData, &offset);
+        if (payload.TypeName == nullptr)
+        {
+            return;
+        }
+        if (!Read(payload.HeapIndex, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.Address, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+        if (!Read(payload.ObjectSize, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+
+        std::wstringstream buffer;
+        buffer << WStr("AllocationTick - ") << payload.TypeName;
+        buffer << WStr(" (") << payload.ObjectSize << WStr(" bytes)");
+        buffer << std::endl;
+        std::wcout << buffer.str();
+    }
+}
+
+void ClrEventsParser::ParseContentionEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData)
+{
+// look for ContentionStop_V1
+    if ((id == EVENT_CONTENTION_STOP) && (version == 1))
+    {
+        //<template tid="ContentionStop_V1">
+        //    <data name="ContentionFlags" inType="win:UInt8" />
+        //    <data name="ClrInstanceID" inType="win:UInt16" />
+        //    <data name="DurationNs" inType="win:Double" />
+        //DumpBuffer(pEventData, cbEventData);
+
+        ContentionStopV1Payload payload{0};
+        ULONG offset = 0;
+        if (!Read<ContentionStopV1Payload>(payload, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+
+        std::stringstream buffer;
+        buffer << "ContentionStop";
+        buffer << ((payload.ContentionFlags == 0) ? " - managed " : " - native ");
+        buffer << "(" << payload.DurationNs << " ns)";
+        buffer << std::endl;
+        std::cout << buffer.str();
+    }
+}
+
+
+const std::string UnknownProvider("UnknownProvider");
+
+std::string ClrEventsParser::GetProviderName(EVENTPIPE_PROVIDER provider)
+{
+    auto it = _providerNameCache.find(provider);
+    if (it == _providerNameCache.end())
+    {
+        WCHAR nameBuffer[LONG_LENGTH];
+        ULONG nameCount;
+        HRESULT hr = _pCorProfilerInfo->EventPipeGetProviderInfo(provider, LONG_LENGTH, &nameCount, nameBuffer);
+        if (FAILED(hr))
+        {
+            //Log::Error("EventPipeGetProviderInfo failed with hr=0x%x", hr);
+            return UnknownProvider;
+        }
+
+        _providerNameCache.insertNew(provider, shared::ToString(shared::WSTRING(nameBuffer)));
+
+        it = _providerNameCache.find(provider);
+        assert(it != _providerNameCache.end());
+    }
+
+    return it->second;
+}
+
+EventPipeMetadataInstance ClrEventsParser::GetMetadata(LPCBYTE pMetadata, ULONG cbMetadata)
+{
+    EventPipeMetadataInstance metadata {0};
+    if (pMetadata == NULL || cbMetadata == 0)
+    {
+        return metadata;
+    }
+
+    // TODO: find a way to limit the number of find() calls (ask Gregory who had to do this)
+    auto it = _metadataCache.find(pMetadata);
+    if (it == _metadataCache.end())
+    {
+        ULONG offset = 0;
+        //metadata.id = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
+        //metadata.name = ReadWideString(pMetadata, cbMetadata, &offset);
+        //metadata.keywords = ReadFromBuffer<INT64>(pMetadata, cbMetadata, &offset);
+        //metadata.version = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
+        //metadata.level = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
+        Read(metadata.id, pMetadata, cbMetadata, offset);
+        metadata.name = ReadWideString(pMetadata, cbMetadata, &offset);
+        Read(metadata.keywords, pMetadata, cbMetadata, offset);
+        Read(metadata.version, pMetadata, cbMetadata, offset);
+        Read(metadata.level, pMetadata, cbMetadata, offset);
+
+        _metadataCache.insertNew(pMetadata, metadata);
+        it = _metadataCache.find(pMetadata);
+    }
+
+    return it->second;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -323,11 +323,6 @@ EventPipeMetadataInstance ClrEventsParser::GetMetadata(LPCBYTE pMetadata, ULONG 
     if (it == _metadataCache.end())
     {
         ULONG offset = 0;
-        //metadata.id = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
-        //metadata.name = ReadWideString(pMetadata, cbMetadata, &offset);
-        //metadata.keywords = ReadFromBuffer<INT64>(pMetadata, cbMetadata, &offset);
-        //metadata.version = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
-        //metadata.level = ReadFromBuffer<UINT32>(pMetadata, cbMetadata, &offset);
         Read(metadata.id, pMetadata, cbMetadata, offset);
         metadata.name = ReadWideString(pMetadata, cbMetadata, &offset);
         Read(metadata.keywords, pMetadata, cbMetadata, offset);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -1,0 +1,168 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+// from dotnet coreclr includes
+#include "cor.h"
+#include "corprof.h"
+// end
+
+#include <string>
+#include <map>
+#include <shared_mutex>
+
+#include "shared/src/native-src/string.h"
+#include "assert.h"
+
+
+#define LONG_LENGTH 1024
+
+// from https://github.com/dotnet/samples/blob/main/core/profiling/eventpipe/src/CorProfiler.h
+template <class Key, class Value>
+class ThreadSafeMap
+{
+private:
+    std::map<Key, Value> _map;
+    mutable std::shared_mutex _mutex;
+
+public:
+    typename std::map<Key, Value>::const_iterator find(Key key) const
+    {
+        std::shared_lock lock(_mutex);
+        return _map.find(key);
+    }
+
+    typename std::map<Key, Value>::const_iterator end() const
+    {
+        return _map.end();
+    }
+
+    // Returns true if new value was inserted
+    bool insertNew(Key key, Value value)
+    {
+        std::unique_lock lock(_mutex);
+
+        if (_map.find(key) != _map.end())
+        {
+            return false;
+        }
+
+        _map[key] = value;
+        return true;
+    }
+};
+
+struct EventPipeMetadataInstance
+{
+    UINT32 id;
+    LPWSTR name;
+    INT64 keywords;
+    UINT32 level;
+    UINT32 version;
+    // BYTE opcode;
+    // Don't try to get the format of the payload because we already now which events we are interested in.
+    // See the xxxPayload types below.
+};
+
+struct AllocationTickV4Payload
+{
+    std::uint32_t AllocationAmount;     // The allocation size, in bytes.
+                                        // This value is accurate for allocations that are less than the length of a ULONG(4,294,967,295 bytes).
+                                        // If the allocation is greater, this field contains a truncated value.
+                                        // Use AllocationAmount64 for very large allocations.
+    std::uint32_t AllocationKind;       // 0x0 - Small object allocation(allocation is in small object heap).
+                                        // 0x1 - Large object allocation(allocation is in large object heap).
+    std::uint16_t ClrInstanceId;        // Unique ID for the instance of CLR or CoreCLR.
+    std::uint64_t AllocationAmount64;   // The allocation size, in bytes.This value is accurate for very large allocations.
+    std::uintptr_t TypeId;              // The address of the MethodTable. When there are several types of objects that were allocated during this event,
+                                        // this is the address of the MethodTable that corresponds to the last object allocated (the object that caused the 100 KB threshold to be exceeded).
+    const WCHAR* TypeName;              // The name of the type that was allocated. When there are several types of objects that were allocated during this event,
+                                        // this is the type of the last object allocated (the object that caused the 100 KB threshold to be exceeded).
+    std::uint32_t HeapIndex;            // The heap where the object was allocated. This value is 0 (zero) when running with workstation garbage collection.
+    std::uintptr_t Address;             // The address of the last allocated object.
+    std::uint64_t ObjectSize;           // The size of the last allocated object.
+};
+
+struct ContentionStopV1Payload
+{
+    std::uint8_t ContentionFlags;   // 0 for managed; 1 for native.
+    std::uint16_t ClrInstanceId;    // Unique ID for the instance of CLR.
+    std::double_t DurationNs;       // Duration of the contention (without spinning)
+};
+
+
+
+class ClrEventsParser
+{
+public:
+    ClrEventsParser(ICorProfilerInfo12* pCorProfilerInfo);
+    void ParseEvent(EVENTPIPE_PROVIDER provider,
+                    DWORD eventId,
+                    DWORD eventVersion,
+                    ULONG cbMetadataBlob,
+                    LPCBYTE metadataBlob,
+                    ULONG cbEventData,
+                    LPCBYTE eventData,
+                    LPCGUID pActivityId,
+                    LPCGUID pRelatedActivityId,
+                    ThreadID eventThread,
+                    ULONG numStackFrames,
+                    UINT_PTR stackFrames[]
+                    );
+
+private:
+    std::string GetProviderName(EVENTPIPE_PROVIDER provider);
+    EventPipeMetadataInstance GetMetadata(LPCBYTE pMetadata, ULONG cbMetadata);
+    void ParseGcEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData);
+    void ParseContentionEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData);
+
+private:
+    // Points to the UTF16, null terminated string from the given event data buffer
+    // and update the offset accordingly
+    WCHAR* ReadWideString(LPCBYTE eventData, ULONG cbEventData, ULONG* offset)
+    {
+        WCHAR* start = (WCHAR*)(eventData + *offset);
+        size_t length = WStrLen(start);
+
+        // Account for the null character
+        *offset += (ULONG)((length + 1) * sizeof(WCHAR));
+
+        assert(*offset <= cbEventData);
+        return start;
+    }
+
+    template <typename T>
+    bool Read(T& value, LPCBYTE eventData, ULONG cbEventData, ULONG& offset)
+    {
+        if ((offset + sizeof(T)) > cbEventData)
+        {
+            return false;
+        }
+
+        memcpy(&value, (T*)(eventData + offset), sizeof(T));
+        offset += sizeof(T);
+        return true;
+    }
+
+    template <typename T>
+    T ReadFromBuffer(LPCBYTE eventData, ULONG cbEventData, ULONG* offset)
+    {
+        T data = *((T*)(eventData + *offset));
+        *offset += sizeof(T);
+        assert(*offset <= cbEventData);
+        return data;
+    }
+
+private:
+    ICorProfilerInfo12* _pCorProfilerInfo = nullptr;
+    ThreadSafeMap<EVENTPIPE_PROVIDER, std::string> _providerNameCache;
+    ThreadSafeMap<LPCBYTE, EventPipeMetadataInstance> _metadataCache;
+
+private:
+    const int KEYWORD_GC = 0x1;
+    const int KEYWORD_CONTENTION = 0x4000;
+
+    const int EVENT_ALLOCATION_TICK = 10;   // version 4 contains the size + reference
+    const int EVENT_CONTENTION_STOP = 91;   // version 1 contains the duration in nanoseconds
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -145,15 +145,6 @@ private:
         return true;
     }
 
-    template <typename T>
-    T ReadFromBuffer(LPCBYTE eventData, ULONG cbEventData, ULONG* offset)
-    {
-        T data = *((T*)(eventData + *offset));
-        *offset += sizeof(T);
-        assert(*offset <= cbEventData);
-        return data;
-    }
-
 private:
     ICorProfilerInfo12* _pCorProfilerInfo = nullptr;
     ThreadSafeMap<EVENTPIPE_PROVIDER, std::string> _providerNameCache;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -36,6 +36,7 @@
 #include "ThreadsCpuManager.h"
 #include "WallTimeProvider.h"
 #include "ExceptionsProvider.h"
+#include "ClrEventsParser.h"
 
 #include "shared/src/native-src/environment_variables.h"
 #include "shared/src/native-src/loader.h"
@@ -267,7 +268,21 @@ void CorProfilerCallback::DisposeInternal(void)
 
         DisposeServices();
 
-        ICorProfilerInfo4* pCorProfilerInfo = _pCorProfilerInfo;
+        // don't forget to stop the CLR events session
+        auto* pInfo = _pCorProfilerInfoEvents;
+        if (pInfo != nullptr)
+        {
+            if (_session != 0)
+            {
+                pInfo->EventPipeStopSession(_session);
+                _session = 0;
+            }
+
+            pInfo->Release();
+            _pCorProfilerInfoEvents = nullptr;
+        }
+
+        ICorProfilerInfo5* pCorProfilerInfo = _pCorProfilerInfo;
         if (pCorProfilerInfo != nullptr)
         {
             pCorProfilerInfo->Release();
@@ -467,20 +482,18 @@ void CorProfilerCallback::InspectProcessorInfo(void)
 #endif
 }
 
-void CorProfilerCallback::InspectRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo)
+void CorProfilerCallback::InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerInfo, USHORT& major, USHORT& minor)
 {
     USHORT clrInstanceId;
     COR_PRF_RUNTIME_TYPE runtimeType;
-    USHORT majorVersion;
-    USHORT minorVersion;
     USHORT buildNumber;
     USHORT qfeVersion;
 
     HRESULT hr = pCorProfilerInfo->GetRuntimeInformation(
         &clrInstanceId,
         &runtimeType,
-        &majorVersion,
-        &minorVersion,
+        &major,
+        &minor,
         &buildNumber,
         &qfeVersion,
         0,
@@ -499,8 +512,8 @@ void CorProfilerCallback::InspectRuntimeVersion(ICorProfilerInfo4* pCorProfilerI
                    : (runtimeType == COR_PRF_CORE_CLR)
                        ? "CORE_CLR"
                        : (std::string("unknown(") + std::to_string(runtimeType) + std::string(")"))),
-                  ", majorVersion: ", majorVersion,
-                  ", minorVersion: ", minorVersion,
+                  ", majorVersion: ", major,
+                  ", minorVersion: ", minor,
                   ", buildNumber: ", buildNumber,
                   ", qfeVersion: ", qfeVersion,
                   " }.");
@@ -566,10 +579,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
         return E_FAIL;
     }
 
-    HRESULT hr = corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo4), (void**)&_pCorProfilerInfo);
+    HRESULT hr = corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo5), (void**)&_pCorProfilerInfo);
     if (hr == E_NOINTERFACE)
     {
-        Log::Error("This runtime does not support any ICorProfilerInfo4+ interface. .NET Framework 4.5 or later is required.");
+        Log::Error("This runtime does not support any ICorProfilerInfo5+ interface. .NET Framework 4.5 or later is required.");
         return E_FAIL;
     }
     else if (FAILED(hr))
@@ -579,7 +592,25 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
     }
 
     // Log some more important environment info:
-    CorProfilerCallback::InspectRuntimeVersion(_pCorProfilerInfo);
+    USHORT major = 0;
+    USHORT minor = 0;
+    CorProfilerCallback::InspectRuntimeVersion(_pCorProfilerInfo, major, minor);
+
+    if (major >= 5)
+    {
+        HRESULT hr = corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo12), (void**)&_pCorProfilerInfoEvents);
+        if (FAILED(hr))
+        {
+            Log::Error("Failed to get ICorProfilerInfo12: 0x", std::hex, hr, std::dec, ".");
+            _pCorProfilerInfoEvents = nullptr;
+
+            // we continue: the CLR events won't be received so no contention/memory profilers...
+        }
+        else
+        {
+            _pClrEventsParser = new ClrEventsParser(_pCorProfilerInfoEvents);
+        }
+    }
 
     // Init global state:
     OpSysTools::InitHighPrecisionTimer();
@@ -629,12 +660,58 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
         eventMask |= COR_PRF_MONITOR_EXCEPTIONS;
     }
 
-    hr = _pCorProfilerInfo->SetEventMask(eventMask);
-    if (FAILED(hr))
+    if ((major >= 5) && (_pCorProfilerInfoEvents != nullptr))
     {
-        Log::Error("SetEventMask(0x", std::hex, eventMask, ") returned an unexpected result: 0x", std::hex, hr, std::dec, ".");
-        return E_FAIL;
+        // listen to CLR events via ICorProfilerCallback
+        DWORD highMask = COR_PRF_HIGH_MONITOR_EVENT_PIPE;
+        hr = _pCorProfilerInfo->SetEventMask2(eventMask, highMask);
+        if (FAILED(hr))
+        {
+            Log::Error("SetEventMask2(0x", std::hex, eventMask, ", ", std::hex, highMask,") returned an unexpected result: 0x", std::hex, hr, std::dec, ".");
+            return E_FAIL;
+        }
+
+        // Microsoft-Windows-DotNETRuntime is the provider for the runtime events.
+        // Listen to interesting events:
+        //  - AllocationTick_V4
+        //  - ContentionStop_V1
+        COR_PRF_EVENTPIPE_PROVIDER_CONFIG providers[] =
+        {
+            {
+                WStr("Microsoft-Windows-DotNETRuntime"),
+                0x01 | 0x4000,  // GC and Contention keywords
+                //4, // Informational verbosity level
+                5, // the documentation states that AllocationTick is Informational but... need Verbose  :^(
+                NULL
+            }
+        };
+
+        hr = _pCorProfilerInfoEvents->EventPipeStartSession(
+            sizeof(providers) / sizeof(providers[0]),
+            providers,
+            false,
+            &_session
+            );
+
+        if (FAILED(hr))
+        {
+            _session = 0;
+            printf("Failed to start event pipe session with hr=0x%x\n", hr);
+            return hr;
+        }
+
+        // TODO: add the corresponding CLR events listener service when available
     }
+    else
+    {
+        hr = _pCorProfilerInfo->SetEventMask(eventMask);
+        if (FAILED(hr))
+        {
+            Log::Error("SetEventMask(0x", std::hex, eventMask, ") returned an unexpected result: 0x", std::hex, hr, std::dec, ".");
+            return E_FAIL;
+        }
+    }
+
 
     // Initialization complete:
     _isInitialized.store(true);
@@ -1223,6 +1300,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::DynamicMethodUnloaded(FunctionID 
 {
     return S_OK;
 }
+
 HRESULT STDMETHODCALLTYPE CorProfilerCallback::EventPipeEventDelivered(EVENTPIPE_PROVIDER provider,
                                                                        DWORD eventId,
                                                                        DWORD eventVersion,
@@ -1236,6 +1314,21 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::EventPipeEventDelivered(EVENTPIPE
                                                                        ULONG numStackFrames,
                                                                        UINT_PTR stackFrames[])
 {
+    _pClrEventsParser->ParseEvent(
+        provider,
+        eventId,
+        eventVersion,
+        cbMetadataBlob,
+        metadataBlob,
+        cbEventData,
+        eventData,
+        pActivityId,
+        pRelatedActivityId,
+        eventThread,
+        numStackFrames,
+        stackFrames
+        );
+
     return S_OK;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -31,6 +31,7 @@ class IStackSamplerLoopManager;
 class IConfiguration;
 class IExporter;
 class SamplesAggregator;
+class ClrEventsParser;
 
 namespace shared {
 class Loader;
@@ -182,7 +183,10 @@ private :
     std::unique_ptr<IClrLifetime> _pClrLifetime = nullptr;
 
     std::atomic<ULONG> _refCount{0};
-    ICorProfilerInfo4* _pCorProfilerInfo = nullptr;
+    ICorProfilerInfo5* _pCorProfilerInfo = nullptr;
+    ICorProfilerInfo12* _pCorProfilerInfoEvents = nullptr;
+    ClrEventsParser* _pClrEventsParser = nullptr;
+    EVENTPIPE_SESSION _session{0};
     inline static bool _isNet46OrGreater = false;
     std::shared_ptr<IMetricsSender> _metricsSender;
     std::atomic<bool> _isInitialized{false}; // pay attention to keeping ProfilerEngineStatus::IsProfilerEngiveActive in sync with this!
@@ -209,7 +213,7 @@ private:
     static void ConfigureDebugLog();
     static void InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk);
     static void InspectProcessorInfo();
-    static void InspectRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo);
+    static void InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerInfo, USHORT& major, USHORT& minor);
     static const char* SysInfoProcessorArchitectureToStr(WORD wProcArch);
 
     void DisposeInternal();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="AppDomainStore.h" />
     <ClInclude Include="ApplicationInfo.h" />
     <ClInclude Include="ApplicationStore.h" />
+    <ClInclude Include="ClrEventsParser.h" />
     <ClInclude Include="ClrLifetime.h" />
     <ClInclude Include="Configuration.h" />
     <ClInclude Include="CorProfilerCallback.h" />
@@ -301,6 +302,7 @@
     <ClCompile Include="AppDomainStore.cpp" />
     <ClCompile Include="ApplicationInfo.cpp" />
     <ClCompile Include="ApplicationStore.cpp" />
+    <ClCompile Include="ClrEventsParser.cpp" />
     <ClCompile Include="ClrLifetime.cpp" />
     <ClCompile Include="Configuration.cpp" />
     <ClCompile Include="CorProfilerCallback.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -206,6 +206,9 @@
     <ClInclude Include="AdaptiveSampler.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="ClrEventsParser.h">
+      <Filter>CorProfiler-Infrastructure</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">
@@ -318,6 +321,9 @@
     </ClCompile>
     <ClCompile Include="Timer.Windows.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="ClrEventsParser.cpp">
+      <Filter>CorProfiler-Infrastructure</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes
Create a session to receive CLR events via ICorProfilerCallback
Handle AllocationTickV4 (Allocation profiling) and ContentionStopV1 (Contention profiling)

## Reason for change
Validate the solution

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
