### PR TITLE
[Tracer] Convert SQS integration tests to snapshots

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -5,112 +5,21 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [Trait("RequiresDockerDependency", "true")]
+    [UsesVerify]
     public class AwsSqsTests : TestHelper
     {
-        private static List<MockSpan> _expectedSpans = new()
-        {
-#if NETFRAMEWORK
-            // Method: CreateSqsQueue
-            AwsSqsSpan.GetDefault("CreateQueue", queueName: "MySyncSQSQueue"),
-            AwsSqsSpan.GetDefault("CreateQueue", queueName: "MySyncSQSQueue2"),
-
-            // Method: SendMessagesWithInjectedHeaders
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: SendMessagesWithoutInjectedHeaders
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: SendMessage
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("SendMessage"),
-
-            // Method: ReceiveMessageAndDeleteMessage
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-
-            // Method: SendMessageBatch
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-
-            // Method: ReceiveMessagesAndDeleteMessageBatch
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: DeleteQueue
-            AwsSqsSpan.GetDefault("DeleteQueue"),
-            AwsSqsSpan.GetDefault("DeleteQueue"),
-
-#endif
-            // Note: Resource names will match the SQS API, which does not have Async suffixes
-            // Method: CreateSqsQueueAsync
-            AwsSqsSpan.GetDefault("CreateQueue", queueName: "MyAsyncSQSQueue"),
-            AwsSqsSpan.GetDefault("CreateQueue", queueName: "MyAsyncSQSQueue2"),
-
-            // Method: SendMessagesWithInjectedHeadersAsync
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: SendMessagesWithoutInjectedHeadersAsync
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: SendMessageAsync
-            AwsSqsSpan.GetDefault("SendMessage"),
-            AwsSqsSpan.GetDefault("SendMessage"),
-
-            // Method: ReceiveMessageAndDeleteMessageAsync
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessage"),
-
-            // Method: SendMessageBatchAsync
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-            AwsSqsSpan.GetDefault("SendMessageBatch"),
-
-            // Method: ReceiveMessagesAndDeleteMessageBatchAsync
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-            AwsSqsSpan.GetDefault("ReceiveMessage"),
-            AwsSqsSpan.GetDefault("DeleteMessageBatch"),
-
-            // Method: DeleteQueueAsync
-            AwsSqsSpan.GetDefault("DeleteQueue"),
-            AwsSqsSpan.GetDefault("DeleteQueue"),
-        };
-
         public AwsSqsTests(ITestOutputHelper output)
             : base("AWS.SQS", output)
         {
@@ -119,54 +28,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.AwsSqs), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion)
+        public async Task SubmitsTraces(string packageVersion)
         {
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(_expectedSpans.Count, operationName: "sqs.request");
-                spans.Should().HaveCountGreaterOrEqualTo(_expectedSpans.Count);
+#if NETFRAMEWORK
+                var expectedCount = 56;
+                var frameworkName = "NetFramework";
+#else
+                var expectedCount = 28;
+                var frameworkName = "NetCore";
+#endif
+                var spans = agent.WaitForSpans(expectedCount, operationName: "sqs.request");
 
-                spans.OrderBy(s => s.Start).Should().BeEquivalentTo(_expectedSpans, options => options
-                    .WithStrictOrdering()
-                    .ExcludingMissingMembers()
-                    .ExcludingDefaultSpanProperties()
-                    .AssertMetricsMatchExcludingKeys("_dd.tracer_kr", "_sampling_priority_v1")
-                    .AssertTagsMatchAndSpecifiedTagsPresent("env", "aws.requestId", "aws.queue.url", "runtime-id"));
+                var settings = VerifyHelper.GetSpanVerifierSettings();
+                settings.UseFileName($"{nameof(AwsSqsTests)}.{frameworkName}");
+                settings.DisableRequireUniquePrefix();
+
+                await VerifyHelper.VerifySpans(spans, settings);
+
                 telemetry.AssertIntegrationEnabled(IntegrationId.AwsSqs);
-            }
-        }
-
-        private class AwsSqsSpan : MockSpan
-        {
-            public static AwsSqsSpan GetDefault(string operationName, string queueName = null)
-            {
-                var span = new AwsSqsSpan
-                           {
-                               Name = "sqs.request",
-                               Resource = $"SQS.{operationName}",
-                               Service = "Samples.AWS.SQS-aws-sqs",
-                               Tags = new()
-                                      {
-                                          { "component", "aws-sdk" },
-                                          { "span.kind", "client" },
-                                          { "aws.agent", "dotnet-aws-sdk" },
-                                          { "aws.operation", operationName },
-                                          { "aws.service", "SQS" },
-                                          { "http.method", "POST" },
-                                          { "http.status_code", "200" },
-                                      },
-                               Metrics = new() { { "_dd.top_level", 1 } },
-                               Type = SpanTypes.Http,
-                           };
-
-                if (queueName is not null)
-                {
-                    span.Tags["aws.queue.name"] = queueName;
-                }
-
-                return span;
             }
         }
     }

--- a/tracer/test/snapshots/AwsSqsTests.NetCore.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetCore.verified.txt
@@ -1,0 +1,704 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MyAsyncSQSQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MyAsyncSQSQueue2,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_23,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_24,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_25,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_26,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_27,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_30,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AwsSqsTests.NetFramework.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetFramework.verified.txt
@@ -1,0 +1,1406 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MySyncSQSQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MySyncSQSQueue2,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MyAsyncSQSQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_8,
+    Name: sqs.request,
+    Resource: SQS.CreateQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: CreateQueue,
+      aws.queue.name: MyAsyncSQSQueue2,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_13,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_14,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_15,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_16,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_21,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_22,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_24,
+    Name: sqs.request,
+    Resource: SQS.DeleteMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_25,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_26,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_27,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_28,
+    Name: sqs.request,
+    Resource: SQS.DeleteQueue,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: DeleteQueue,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_30,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_31,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_32,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_33,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_34,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_35,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_36,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_37,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_38,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_39,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_40,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_41,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_42,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_43,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_44,
+    Name: sqs.request,
+    Resource: SQS.ReceiveMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: ReceiveMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_49,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_50,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_51,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_52,
+    Name: sqs.request,
+    Resource: SQS.SendMessage,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessage,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_54,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_55,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_56,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_57,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_58,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_59,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_60,
+    Name: sqs.request,
+    Resource: SQS.SendMessageBatch,
+    Service: Samples.AWS.SQS-aws-sqs,
+    Type: http,
+    ParentId: Id_7,
+    Tags: {
+      aws.agent: dotnet-aws-sdk,
+      aws.operation: SendMessageBatch,
+      aws.queue.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      aws.requestId: Guid_Empty,
+      aws.service: SQS,
+      component: aws-sdk,
+      env: integration_tests,
+      http.method: POST,
+      http.status_code: 200,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes
Converts the SQS integration tests to snapshots

## Reason for change
Provides stronger regression testing

## Implementation details
The snapshots are separated into a .NET Framework snapshot and a .NET Core snapshot because the .NET Framework SQS library expose synchronous methods for interacting with SQS.

## Test coverage
Updated integration tests

## Other details
Implements suggestion from #2918
