### PR TITLE
[Tracer] Convert ServiceStackRedis integration tests to snapshots

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -6,15 +6,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
+    [UsesVerify]
     public class ServiceStackRedisTests : TestHelper
     {
         public ServiceStackRedisTests(ITestOutputHelper output)
@@ -26,68 +30,52 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.ServiceStackRedis), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion)
+        public async Task SubmitsTraces(string packageVersion)
         {
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
+#if NETCOREAPP3_1_OR_GREATER
+                var numberOfRuns = 3;
+#else
+                var numberOfRuns = 2;
+#endif
+
+                var expectedSpansPerRun = 9;
+
                 // note: ignore the INFO command because it's timing is unpredictable (on Linux?)
-                var spans = agent.WaitForSpans(11)
+                var spans = agent.WaitForSpans(numberOfRuns * expectedSpansPerRun)
                                  .Where(s => s.Type == "redis" && s.Resource != "INFO" && s.Resource != "ROLE" && s.Resource != "QUIT")
                                  .OrderBy(s => s.Start)
                                  .ToList();
+                spans.Count.Should().Be(numberOfRuns * expectedSpansPerRun);
 
                 var host = Environment.GetEnvironmentVariable("SERVICESTACK_REDIS_HOST") ?? "localhost:6379";
                 var port = host.Substring(host.IndexOf(':') + 1);
                 host = host.Substring(0, host.IndexOf(':'));
 
-                foreach (var span in spans)
+                var settings = VerifyHelper.GetSpanVerifierSettings();
+                settings.UseFileName($"{nameof(ServiceStackRedisTests)}.RunServiceStack");
+                settings.DisableRequireUniquePrefix();
+                settings.AddSimpleScrubber($" {TestPrefix}ServiceStack.Redis.", " ServiceStack.Redis.");
+                settings.AddSimpleScrubber($"out.host: {host}", "out.host: servicestackredis");
+                settings.AddSimpleScrubber($"out.port: {port}", "out.port: 6379");
+
+                // The test application runs the same RunServiceStack method X number of times
+                // Use the snapshot to verify each run of RunServiceStack, instead of testing all of the application spans
+                for (int i = 0; i < numberOfRuns; i++)
                 {
-                    Assert.Equal("redis.command", span.Name);
-                    Assert.Equal("Samples.ServiceStack.Redis-redis", span.Service);
-                    Assert.Equal(SpanTypes.Redis, span.Type);
-                    Assert.Equal(host, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.host"));
-                    Assert.Equal(port, DictionaryExtensions.GetValueOrDefault(span.Tags, "out.port"));
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
-
-                var expectedFromOneRun = new TupleList<string, string>
-                {
-                    { "SET", $"SET {TestPrefix}ServiceStack.Redis.INCR 0" },
-                    { "PING", "PING" },
-                    { "DDCUSTOM", "DDCUSTOM COMMAND" },
-                    { "ECHO", "ECHO Hello World" },
-                    { "SLOWLOG", "SLOWLOG GET 5" },
-                    { "INCR", $"INCR {TestPrefix}ServiceStack.Redis.INCR" },
-                    { "INCRBYFLOAT", $"INCRBYFLOAT {TestPrefix}ServiceStack.Redis.INCR 1.25" },
-                    { "TIME", "TIME" },
-                    { "SELECT", "SELECT 0" },
-                };
-
-                var expected = new TupleList<string, string>();
-                expected.AddRange(expectedFromOneRun);
-                expected.AddRange(expectedFromOneRun);
-#if NETCOREAPP3_1_OR_GREATER
-                expected.AddRange(expectedFromOneRun); // On .NET Core 3.1 and .NET 5 we run the routine a third time
-#endif
-
-                Assert.Equal(expected.Count, spans.Count);
-
-                for (int i = 0; i < expected.Count; i++)
-                {
-                    var e1 = expected[i].Item1;
-                    var e2 = expected[i].Item2;
-
-                    var a1 = i < spans.Count
-                                 ? spans[i].Resource
-                                 : string.Empty;
-                    var a2 = i < spans.Count
-                                 ? DictionaryExtensions.GetValueOrDefault(spans[i].Tags, "redis.raw_command")
-                                 : string.Empty;
-
-                    Assert.True(e1 == a1, $@"invalid resource name for span #{i}, expected ""{e1}"", actual ""{a1}""");
-                    Assert.True(e2 == a2, $@"invalid raw command for span #{i}, expected ""{e2}"" != ""{a2}""");
+                    var routineSpans = spans.GetRange(i * expectedSpansPerRun, expectedSpansPerRun).AsReadOnly();
+                    await VerifyHelper.VerifySpans(
+                        routineSpans,
+                        settings,
+                        o => o
+                            .OrderBy(x => VerifyHelper.GetRootSpanName(x, o))
+                            .ThenBy(x => VerifyHelper.GetSpanDepth(x, o))
+                            .ThenBy(x => x.Tags.TryGetValue("redis.raw_command", out var value) ? value.Replace(TestPrefix, string.Empty) : null)
+                            .ThenBy(x => x.Start)
+                            .ThenBy(x => x.Duration));
                 }
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.ServiceStackRedis);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -43,9 +43,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #endif
 
                 var expectedSpansPerRun = 9;
+                var ignoredSpansPerRun = 3; // INFO + ROLE on connection open, QUIT on connection disposing
 
                 // note: ignore the INFO command because it's timing is unpredictable (on Linux?)
-                var spans = agent.WaitForSpans(numberOfRuns * expectedSpansPerRun)
+                var spans = agent.WaitForSpans(numberOfRuns * (expectedSpansPerRun + ignoredSpansPerRun))
                                  .Where(s => s.Type == "redis" && s.Resource != "INFO" && s.Resource != "ROLE" && s.Resource != "QUIT")
                                  .OrderBy(s => s.Start)
                                  .ToList();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -42,12 +42,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var numberOfRuns = 2;
 #endif
 
-                var expectedSpansPerRun = 9;
-                var ignoredSpansPerRun = 3; // INFO + ROLE on connection open, QUIT on connection disposing
-
-                // note: ignore the INFO command because it's timing is unpredictable (on Linux?)
-                var spans = agent.WaitForSpans(numberOfRuns * (expectedSpansPerRun + ignoredSpansPerRun))
-                                 .Where(s => s.Type == "redis" && s.Resource != "INFO" && s.Resource != "ROLE" && s.Resource != "QUIT")
+                var expectedSpansPerRun = 12;
+                var spans = agent.WaitForSpans(numberOfRuns * expectedSpansPerRun)
                                  .OrderBy(s => s.Start)
                                  .ToList();
                 spans.Count.Should().Be(numberOfRuns * expectedSpansPerRun);

--- a/tracer/test/snapshots/ServiceStackRedisTests.RunServiceStack.verified.txt
+++ b/tracer/test/snapshots/ServiceStackRedisTests.RunServiceStack.verified.txt
@@ -105,6 +105,30 @@ at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
     TraceId: Id_9,
     SpanId: Id_10,
     Name: redis.command,
+    Resource: INFO,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: INFO,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: redis.command,
     Resource: PING,
     Service: Samples.ServiceStack.Redis-redis,
     Type: redis,
@@ -126,8 +150,56 @@ at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
     }
   },
   {
-    TraceId: Id_11,
-    SpanId: Id_12,
+    TraceId: Id_13,
+    SpanId: Id_14,
+    Name: redis.command,
+    Resource: QUIT,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: QUIT,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_15,
+    SpanId: Id_16,
+    Name: redis.command,
+    Resource: ROLE,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: ROLE,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
     Name: redis.command,
     Resource: SELECT,
     Service: Samples.ServiceStack.Redis-redis,
@@ -150,8 +222,8 @@ at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
     }
   },
   {
-    TraceId: Id_13,
-    SpanId: Id_14,
+    TraceId: Id_19,
+    SpanId: Id_20,
     Name: redis.command,
     Resource: SET,
     Service: Samples.ServiceStack.Redis-redis,
@@ -174,8 +246,8 @@ at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
     }
   },
   {
-    TraceId: Id_15,
-    SpanId: Id_16,
+    TraceId: Id_21,
+    SpanId: Id_22,
     Name: redis.command,
     Resource: SLOWLOG,
     Service: Samples.ServiceStack.Redis-redis,
@@ -198,8 +270,8 @@ at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
     }
   },
   {
-    TraceId: Id_17,
-    SpanId: Id_18,
+    TraceId: Id_23,
+    SpanId: Id_24,
     Name: redis.command,
     Resource: TIME,
     Service: Samples.ServiceStack.Redis-redis,

--- a/tracer/test/snapshots/ServiceStackRedisTests.RunServiceStack.verified.txt
+++ b/tracer/test/snapshots/ServiceStackRedisTests.RunServiceStack.verified.txt
@@ -1,0 +1,224 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: redis.command,
+    Resource: DDCUSTOM,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Error: 1,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      error.msg: unknown command `DDCUSTOM`, with args beginning with: `COMMAND`, ,
+      error.stack:
+ServiceStack.Redis.RedisResponseException: unknown command `DDCUSTOM`, with args beginning with: `COMMAND`, 
+at ServiceStack.Redis.RedisNativeClient.ReadComplexResponse(),
+      error.type: ServiceStack.Redis.RedisResponseException,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: DDCUSTOM COMMAND,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: redis.command,
+    Resource: ECHO,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: ECHO Hello World,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: redis.command,
+    Resource: INCR,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: INCR ServiceStack.Redis.INCR,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: redis.command,
+    Resource: INCRBYFLOAT,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: INCRBYFLOAT ServiceStack.Redis.INCR 1.25,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_10,
+    Name: redis.command,
+    Resource: PING,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: PING,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: redis.command,
+    Resource: SELECT,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: SELECT 0,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_13,
+    SpanId: Id_14,
+    Name: redis.command,
+    Resource: SET,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: SET ServiceStack.Redis.INCR 0,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_15,
+    SpanId: Id_16,
+    Name: redis.command,
+    Resource: SLOWLOG,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: SLOWLOG GET 5,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: redis.command,
+    Resource: TIME,
+    Service: Samples.ServiceStack.Redis-redis,
+    Type: redis,
+    Tags: {
+      component: StackExchangeRedis,
+      env: integration_tests,
+      out.host: servicestackredis,
+      out.port: 6379,
+      redis.raw_command: TIME,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes
Convert ServiceStackRedis integration tests to snapshots

## Reason for change
Provides stronger regression testing

## Implementation details
The one quirk of the ServiceStackRedis integration test application is that it runs the same `RunServiceStack` method a variable number of times depending on the runtime -- this is used to test various assembly loading scenarios. On runtimes before .NET Core 3.1 it runs 2 times, and on .NET Core 3.1 and newer it runs 3 times. As a result, I authored the snapshot and the snapshot verification to validate the spans generated by each invocation of the `RunServiceStack` method instead of the spans generated during the entire application runtime. If the assembly loading mechanism affects the spans generated by the integration, this should identify that.

## Test coverage

## Other details
Implements suggestions from #2918
