### PR TITLE
Fix NuGet installer smoke tests not running

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2529,7 +2529,7 @@ stages:
         command: "CheckBuildLogsForErrors"
 
 - stage: nuget_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2657,7 +2657,7 @@ stages:
             command: "CheckBuildLogsForErrors"
 
 - stage: nuget_installer_smoke_tests_arm64
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]


### PR DESCRIPTION
## Summary of changes

- Rename `isScheduledBuild` to `isBenchmarksOnlyBuild` so the NuGet installer smoke tests run

## Reason for change

I renamed `isScheduledBuild` -> `isBenchmarksOnlyBuild` in #2893, but #2878 was already in progress, so it used the wrong value.
