### PR TITLE
[Profiler] Fix parsing thread information

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -8,6 +8,7 @@
 
 #include <sys/syscall.h>
 #include "OsSpecificApi.h"
+#include "OpSysTools.h"
 
 #include "Log.h"
 #include "LinuxStackFramesCollector.h"
@@ -67,14 +68,10 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
         return false;
     }
 
-    // based on https://linux.die.net/man/5/proc
-    char state = ' ';   // 3rd position  and 'R' for Running
-    int userTime = 0;   // 14th position in clock ticks
-    int kernelTime = 0; // 15th position in clock ticks
-
-    auto pos = sline.find_last_of(")");
-    const char* pEnd = sline.c_str() + pos + 1;
-    bool success = sscanf(pEnd, " %c %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &state, &userTime, &kernelTime) == 3;
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+    bool success = OpSysTools::ParseThreadInfo(sline, state, userTime, kernelTime);
     if (!success)
     {
         // log the first error to be able to analyze unexpected string format

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -314,7 +314,7 @@ std::string OpSysTools::GetHostname()
 
 std::string OpSysTools::GetProcessName()
 {
-#ifdef _WIN32
+#ifdef _WINDOWS
     const DWORD length = 260;
     char pathName[length]{};
 
@@ -332,4 +332,3 @@ std::string OpSysTools::GetProcessName()
     return name;
 #endif
 }
-

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -48,6 +48,27 @@ public:
     static std::string GetHostname();
     static std::string GetProcessName();
 
+    static bool ParseThreadInfo(std::string line, char& state, int& userTime, int& kernelTime)
+    {
+        // based on https://linux.die.net/man/5/proc
+        // state  = 3rd position  and 'R' for Running
+        // user   = 14th position in clock ticks
+        // kernel = 15th position in clock ticks
+
+        // The thread name is in second position and wrapped by ()
+        // Since the name can contain SPACE and () characters, skip it before scanning the values
+        auto pos = line.find_last_of(")");
+        const char* pEnd = line.c_str() + pos + 1;
+
+#ifdef _WINDOWS
+        bool result = sscanf_s(pEnd, " %c %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &state, 1, &userTime, &kernelTime) == 3;
+#else
+        bool result = sscanf(pEnd, " %c %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &state, &userTime, &kernelTime) == 3;
+#endif
+
+        return result;
+    }
+
 private:
     static constexpr std::int64_t NanosecondsPerSecond = 1000000000;
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -51,6 +51,7 @@
     <ClCompile Include="LibddprofExporterTest.cpp" />
     <ClCompile Include="LogTest.cpp" />
     <ClCompile Include="ManagedThreadListTest.cpp" />
+    <ClCompile Include="OpSysToolsTest.cpp" />
     <ClCompile Include="ProfilerMockedInterface.cpp" />
     <ClCompile Include="RuntimeIdStoreHelper.cpp" />
     <ClCompile Include="RuntimeIdTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClCompile Include="AdaptiveSamplerTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="OpSysToolsTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+
+#include "OpSysTools.h"
+
+// based on https://linux.die.net/man/5/proc
+// -------------------------------------------
+// state  = 3rd position  and 'R' for Running
+// user   = 14th position in clock ticks
+// kernel = 15th position in clock ticks
+//
+
+TEST(GetThreadInfoTest, Check_EmptyThreadName)
+{
+    std::string line = "377 () R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ('R', state);
+    ASSERT_EQ(1862, userTime);
+    ASSERT_EQ(609, kernelTime);
+}
+
+TEST(GetThreadInfoTest, Check_NoSpaceThreadName)
+{
+    std::string line = "377 (ThreadNameWithoutSpace) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ('R', state);
+    ASSERT_EQ(1862, userTime);
+    ASSERT_EQ(609, kernelTime);
+}
+
+TEST(GetThreadInfoTest, Check_SpaceInThreadName)
+{
+    std::string line = "377 (Thread Name With Space) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ('R', state);
+    ASSERT_EQ(1862, userTime);
+    ASSERT_EQ(609, kernelTime);
+}
+
+TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName)
+{
+    std::string line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_TRUE(result);
+    ASSERT_EQ('R', state);
+    ASSERT_EQ(1862, userTime);
+    ASSERT_EQ(609, kernelTime);
+}
+
+TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName_And_FinalParenthesis)
+{
+    std::string line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20)";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+    ASSERT_EQ(' ', state);
+    ASSERT_EQ(0, userTime);
+    ASSERT_EQ(0, kernelTime);
+}


### PR DESCRIPTION
## Summary of changes
Fix parsing of /proc/self/task/%d/stat to get thread running state and cpu consumption

## Reason for change
Test were failing in .NET 6

## Implementation details
Take into account thread names with SPACE and ()

## Test coverage

## Other details
<!-- Fixes #{issue} -->
