### PR TITLE
Allow queuing multiple connection for acceptance in UDS test agent

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -903,7 +903,7 @@ namespace Datadog.Trace.TestHelpers
                 TracesUdsPath = config.Traces;
                 _udsTracesSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
                 _udsTracesSocket.Bind(_tracesEndpoint);
-                _udsTracesSocket.Listen(1);
+                _udsTracesSocket.Listen();
                 _tracesListenerTask = Task.Run(HandleUdsTraces);
             }
 


### PR DESCRIPTION
## Summary of changes

- Allow queueing multiple connections in `MockTracerAgent`

## Reason for change

We are seeing occasional flakiness in the logs with "Resource Temporarily Unavailable" in the  Samples.Telemetry tests. My assumption is that because we perform the agent check and the initial telemetry ping in parallel, we may be trying to connect simultaneously, and the mock agent is rejecting the second connection attempt.

## Implementation details

Remove the limit on `Listen()` (I don't think it's necessary, but I guess we'll find out)

## Test coverage
N/A
