### PR TITLE
Trigger AAS extension update on nightly builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,9 @@ variables:
   DEPLOY_TO_REL_ENV:
     value: "false"
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
-    
+  DEPLOY_TO_AAS:
+    value: "false"
+        
 build:
   only:
     - master
@@ -77,3 +79,15 @@ deploy_to_reliability_env:
     UPSTREAM_PACKAGE_JOB: build
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     FORCE_TRIGGER: $DEPLOY_TO_REL_ENV
+
+deploy_to_aas:
+  stage: deploy_aas
+  rules:
+    - if: '$DEPLOY_TO_AAS == "true"'
+  script: 
+    - |
+      curl -X POST \
+      -H "Accept: application/vnd.github.v3+json" \
+      -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+      https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
+      -d '{"event_type": "dd-trace-dotnet-nightly", "client_payload": {"sha":"${CI_COMMIT_SHA}" } }'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - publish
   - deploy
   - deploy_aas
-  
+
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
   GIT_PROFILER_REF: master
@@ -13,7 +13,7 @@ variables:
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
   DEPLOY_TO_AAS:
     value: "false"
-        
+
 build:
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
@@ -39,7 +39,7 @@ publish:
     - /^release.*$/
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  dependencies: 
+  dependencies:
     - build
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
@@ -78,12 +78,14 @@ deploy_to_reliability_env:
 
 deploy_to_aas:
   stage: deploy_aas
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   rules:
     - if: '$DEPLOY_TO_AAS == "true"'
-  script: 
+  script:
     - |
+      export GH_TOKEN_PIERO=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-dotnet.gh_token_piero --with-decryption --query "Parameter.Value" --out text)
       curl -X POST \
       -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+      -H "Authorization: Bearer ${{ GH_TOKEN_PIERO }}" \
       https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
       -d '{"event_type": "dd-trace-dotnet-nightly", "client_payload": {"sha":"${CI_COMMIT_SHA}" } }'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,11 +15,6 @@ variables:
     value: "false"
         
 build:
-  only:
-    - master
-    - main
-    - /^hotfix.*$/
-    - /^release.*$/
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,7 @@ stages:
   - build
   - publish
   - deploy
+  - deploy_aas
   
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,5 @@
 
 stages:
-  - build
-  - publish
   - deploy
   - deploy_aas
 
@@ -13,56 +11,6 @@ variables:
     description: "Set to true to override rules in the reliability-env pipeline (e.g. override 'only deploy master')"
   DEPLOY_TO_AAS:
     value: "false"
-
-build:
-  stage: build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  script:
-    - if (Test-Path build-out) { remove-item -recurse -force build-out }
-    - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tracer\build\_build\gitlab.bat
-    - mkdir artifacts
-    - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
-    - remove-item -recurse -force build-out\${CI_JOB_ID}
-    - get-childitem build-out
-    - get-childitem artifacts
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-    - artifacts
-
-publish:
-  only:
-    - master
-    - main
-    - /^hotfix.*$/
-    - /^release.*$/
-  stage: publish
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  dependencies:
-    - build
-  script:
-    - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
-    - $resultjson = $result | convertfrom-json
-    - $credentials = $($resultjson.Credentials)
-    - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
-    - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
-    - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - |
-      $i = 0
-      do {
-          try {
-              # The grants option at the end is used to allow public access on the files we upload as the acls only aren't enough.
-              aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-              return
-          } catch {
-              $msg = $Error[0].Exception.Message
-              Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
-              Write-Output "Retrying..."
-              $i++
-              Start-Sleep -Milliseconds 100
-          }
-      } while ($i -lt 3)
 
 deploy_to_reliability_env:
   stage: deploy
@@ -82,10 +30,16 @@ deploy_to_aas:
   rules:
     - if: '$DEPLOY_TO_AAS == "true"'
   script:
+    - $result = aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-dd-trace-dotnet" --role-session-name AWSCLI-Session
+    - $resultjson = $result | convertfrom-json
+    - $credentials = $($resultjson.Credentials)
+    - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
+    - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
+    - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
+    - $GH_TOKEN_PIERO = aws ssm get-parameter --region us-east-1 --name ci.dd-trace-dotnet.gh_token_piero --with-decryption --query "Parameter.Value" --out text
     - |
-      export GH_TOKEN_PIERO=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-dotnet.gh_token_piero --with-decryption --query "Parameter.Value" --out text)
       curl -X POST \
       -H "Accept: application/vnd.github.v3+json" \
-      -H "Authorization: Bearer ${{ GH_TOKEN_PIERO }}" \
+      -H "Authorization: Bearer $GH_TOKEN_PIERO" \
       https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
       -d '{"event_type": "dd-trace-dotnet-nightly", "client_payload": {"sha":"${CI_COMMIT_SHA}" } }'


### PR DESCRIPTION
## Summary of changes
Extension update flow was added at `datadog-aas-extension`.
This PR adds trigger AAS extension update on nightly builds.

## Implementation details
See following PRs on `datadog-aas-extension` for flow details.

https://github.com/DataDog/datadog-aas-extension/pull/129
https://github.com/DataDog/datadog-aas-extension/pull/130