### PR TITLE
Add NCrunch to gitignore and get it to work with the test runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,14 @@ _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user
 
+# NCrunch is a .NET Unit test runner
+# NCrunch
+*.ncrunch*.user
+_NCrunch_*
+*.crunch.xml
+nCrunchTemp_*
+
+
 # JustCode is a .NET coding add-in
 .JustCode
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -20,7 +20,9 @@ namespace Datadog.Trace.TestHelpers
                                                                     "xunit.console.x64",
                                                                     "ReSharperTestRunner",
                                                                     "ReSharperTestRunner64",
-                                                                    "ReSharperTestRunner64c"
+                                                                    "ReSharperTestRunner64c",
+                                                                    "nCrunch.TaskRunner.DotNetCore.20.x64",
+                                                                    "nCrunch.TestHost461.x86"
                                                                 };
     }
 }


### PR DESCRIPTION
Files that get created if you have nCrunch installed in Visual Studio

## Summary of changes

Added gitignore entries and tetrunner names

## Reason for change

I don't want to accidently commit my NCrunch config, and I want the unit tests that care about the testrunner name to pass.

## Implementation details

copied from http://gitignore.io, and fixed unit tests

## Test coverage

Technically not covered by CI/CD, but if you guys bought a license there is a CLI version of ncrunch that you might be able to get working in CI/CD

## Other details
