### PR TITLE
Disable cpu profiler during exception tests

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -35,6 +35,7 @@ Configuration::Configuration()
     _isOperationalMetricsEnabled = GetEnvironmentValue(EnvironmentVariables::OperationalMetricsEnabled, false);
     _isNativeFrameEnabled = GetEnvironmentValue(EnvironmentVariables::NativeFramesEnabled, false);
     _isCpuProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::CpuProfilingEnabled, false);
+    _isWallTimeProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WallTimeProfilingEnabled, true);
     _isExceptionProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::ExceptionProfilingEnabled, false);
     _uploadPeriod = ExtractUploadInterval();
     _userTags = ExtractUserTags();
@@ -92,6 +93,11 @@ bool Configuration::IsNativeFramesEnabled() const
 bool Configuration::IsCpuProfilingEnabled() const
 {
     return _isCpuProfilingEnabled;
+}
+
+bool Configuration::IsWallTimeProfilingEnabled() const
+{
+    return _isWallTimeProfilingEnabled;
 }
 
 bool Configuration::IsExceptionProfilingEnabled() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -38,6 +38,7 @@ public:
     std::string const& GetApiKey() const override;
     std::string const& GetServiceName() const override;
     bool IsCpuProfilingEnabled() const override;
+    bool IsWallTimeProfilingEnabled() const override;
     bool IsExceptionProfilingEnabled() const override;
     int ExceptionSampleLimit() const override;
 
@@ -68,6 +69,7 @@ private:
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;
+    bool _isWallTimeProfilingEnabled;
     bool _isExceptionProfilingEnabled;
     bool _debugLogEnabled;
     fs::path _logDirectory;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -116,7 +116,11 @@ bool CorProfilerCallback::InitializeServices()
     _pManagedThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
 
     auto* pRuntimeIdStore = RegisterService<RuntimeIdStore>();
-    _pWallTimeProvider = RegisterService<WallTimeProvider>(_pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore);
+
+    if (_pConfiguration->IsWallTimeProfilingEnabled())
+    {
+        _pWallTimeProvider = RegisterService<WallTimeProvider>(_pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore);
+    }
 
     if (_pConfiguration->IsCpuProfilingEnabled())
     {
@@ -152,7 +156,11 @@ bool CorProfilerCallback::InitializeServices()
     // i.e. the exporter is passed to the aggregator and each provider is added to the aggregator.
     _pExporter = std::make_unique<LibddprofExporter>(_pConfiguration.get(), _pApplicationStore);
     _pSamplesAggregator = RegisterService<SamplesAggregator>(_pConfiguration.get(), _pThreadsCpuManager, _pExporter.get(), _metricsSender.get());
-    _pSamplesAggregator->Register(_pWallTimeProvider);
+
+    if (_pConfiguration->IsWallTimeProfilingEnabled())
+    {
+        _pSamplesAggregator->Register(_pWallTimeProvider);
+    }
 
     if (_pConfiguration->IsCpuProfilingEnabled())
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -26,6 +26,7 @@ public:
     inline static const shared::WSTRING Tags                        = WStr("DD_TAGS");
     inline static const shared::WSTRING NativeFramesEnabled         = WStr("DD_PROFILING_FRAMES_NATIVE_ENABLED");
     inline static const shared::WSTRING CpuProfilingEnabled         = WStr("DD_PROFILING_CPU_ENABLED");
+    inline static const shared::WSTRING WallTimeProfilingEnabled    = WStr("DD_PROFILING_WALLTIME_ENABLED");
     inline static const shared::WSTRING ExceptionProfilingEnabled   = WStr("DD_PROFILING_EXCEPTION_ENABLED");
     inline static const shared::WSTRING ExceptionSampleLimit        = WStr("DD_PROFILING_EXCEPTION_SAMPLE_LIMIT");
     inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_INTERNAL_PROFILING_OUTPUT_DIR");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -35,6 +35,7 @@ public:
     virtual std::string const& GetServiceName() const = 0;
     virtual tags const& GetUserTags() const = 0;
     virtual bool IsCpuProfilingEnabled() const = 0;
+    virtual bool IsWallTimeProfilingEnabled() const = 0;
     virtual bool IsExceptionProfilingEnabled() const = 0;
     virtual int ExceptionSampleLimit() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -161,7 +161,10 @@ void StackSamplerLoop::MainLoopIteration(void)
 {
     // In each iteration, a few threads (up to MaxThreadsPerIterationForWallTime) are sampled
     // to compute wall time.
-    WalltimeProfilingIteration();
+    if (_pConfiguration->IsWallTimeProfilingEnabled())
+    {
+        WalltimeProfilingIteration();
+    }
 
     // When CPU profiling is enabled, most of the threads (up to MaxThreadsPerIterationForCpuTime)
     // are scanned and if they are currently running, they are sampled.

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -127,6 +127,8 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: Scenario1);
             runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "1");
+            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "0");
 
             CheckExceptionProfiles(runner);
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -12,6 +12,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string CodeHotSpotsEnable = "DD_PROFILING_CODEHOTSPOTS_ENABLED";
         public const string UseNativeLoader = "USE_NATIVE_LOADER";
         public const string CpuProfilerEnabled = "DD_PROFILING_CPU_ENABLED";
+        public const string WallTimeProfilerEnabled = "DD_PROFILING_WALLTIME_ENABLED";
         public const string ExceptionProfilerEnabled = "DD_PROFILING_EXCEPTION_ENABLED";
         public const string ExceptionSampleLimit = "DD_PROFILING_EXCEPTION_SAMPLE_LIMIT";
     }


### PR DESCRIPTION
## Summary of changes

There is a known race-condition where the callstacks of the exception is not collected if the cpu/walltime profiler is sampling the same thread at the same time. This makes the GetExceptionSamples test flaky.

This PR adds a setting to disable the CPU profiler to make the test more reliable.
