### PR TITLE
[Tracer] Add throughput tests for stats computation

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2169,6 +2169,8 @@ stages:
   dependsOn: [package_linux, build_arm64, build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+    # By default all throughput tests happen on release or master branches only. Overridable by setting 'run_extended_throughput_tests' to true
+    runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_extended_throughput_tests, 'true'))]
   pool: Throughput
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -2195,7 +2197,7 @@ stages:
         test ! -s "tracer/tracer-home-linux/libddwaf.so" && echo "tracer/tracer-home-linux/libddwaf.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
-        ./run.sh "linux"
+        ./run.sh "linux" "$(runExtendedThroughputTests)"
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
@@ -2221,7 +2223,7 @@ stages:
         test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
-        ./run.sh "windows"
+        ./run.sh "windows" "$(runExtendedThroughputTests)"
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
@@ -2246,7 +2248,7 @@ stages:
         test ! -s "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
-        ./run.sh "linux_arm64"
+        ./run.sh "linux_arm64" "$(runExtendedThroughputTests)"
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -49,7 +49,7 @@ scenarios:
         serverPort: 5000
         path: /hello
 
-  calltarget_ngen_stats:
+  trace_stats:
     application:
       job: server
       environmentVariables:

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -48,3 +48,21 @@ scenarios:
         duration: 240
         serverPort: 5000
         path: /hello
+
+  calltarget_ngen_stats:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_CLR_ENABLE_INLINING: 1
+        DD_CLR_ENABLE_NGEN: 1
+        DD_TRACE_STATS_COMPUTATION_ENABLED: 1
+
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -36,6 +36,10 @@ if [ "$1" = "windows" ]; then
     dd-trace --crank-import="calltarget_ngen_windows.json"
     rm calltarget_ngen_windows.json
 
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen_stats --profile windows --json calltarget_ngen_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_ngen_stats_windows.json"
+    rm calltarget_ngen_stats_windows.json
+
 elif [ "$1" = "linux" ]; then
     echo "Running Linux  x64 throughput tests"
 
@@ -46,6 +50,10 @@ elif [ "$1" = "linux" ]; then
     crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="calltarget_ngen_linux.json"
     rm calltarget_ngen_linux.json
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen_stats --profile linux --json calltarget_ngen_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_ngen_stats_linux.json"
+    rm calltarget_ngen_stats_linux.json
 
 elif [ "$1" = "linux_arm64" ]; then
     echo "Running Linux arm64 throughput tests"

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -8,6 +8,7 @@ echo "BUILD_SOURCEVERSION=$BUILD_SOURCEVERSION"
 echo "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"
 echo "BUILD_REPOSITORY_URI=$BUILD_REPOSITORY_URI"
 echo "DD_CIVISIBILITY_AGENTLESS_ENABLED=$DD_CIVISIBILITY_AGENTLESS_ENABLED"
+echo "Will run extended throughput tests: $2"
 
 repo="$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"
 commit_sha="$SYSTEM_PULLREQUEST_SOURCECOMMITID"
@@ -36,9 +37,12 @@ if [ "$1" = "windows" ]; then
     dd-trace --crank-import="calltarget_ngen_windows.json"
     rm calltarget_ngen_windows.json
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen_stats --profile windows --json calltarget_ngen_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="calltarget_ngen_stats_windows.json"
-    rm calltarget_ngen_stats_windows.json
+    if [ "$2" = "True" ]; then
+      echo "Running throughput tests with stats enabled"
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile windows --json trace_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="trace_stats_windows.json"
+      rm trace_stats_windows.json
+    fi
 
 elif [ "$1" = "linux" ]; then
     echo "Running Linux  x64 throughput tests"
@@ -51,9 +55,12 @@ elif [ "$1" = "linux" ]; then
     dd-trace --crank-import="calltarget_ngen_linux.json"
     rm calltarget_ngen_linux.json
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen_stats --profile linux --json calltarget_ngen_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="calltarget_ngen_stats_linux.json"
-    rm calltarget_ngen_stats_linux.json
+    if [ "$2" = "True" ]; then
+      echo "Running throughput tests with stats enabled"
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux --json trace_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="trace_stats_linux.json"
+      rm trace_stats_linux.json
+    fi
 
 elif [ "$1" = "linux_arm64" ]; then
     echo "Running Linux arm64 throughput tests"
@@ -65,6 +72,13 @@ elif [ "$1" = "linux_arm64" ]; then
     crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux_arm64 --json calltarget_ngen_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="calltarget_ngen_linux_arm64.json"
     rm calltarget_ngen_linux_arm64.json
+
+    if [ "$2" = "True" ]; then
+      echo "Running throughput tests with stats enabled"
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="trace_stats_linux_arm64.json"
+      rm trace_stats_linux_arm64.json
+    fi
 
 else
     echo "Unknown argument $1"


### PR DESCRIPTION
## Summary of changes
Add throughput tests for stats computation

## Reason for change
Test and monitor of performances when computing stats in the tracer

## Implementation details
After discussion, we run those tests only on master or when `run_extended_throughput_tests` is set to `true`.

## Results
I've ran the pipeline. By default, the tests don't run. When `run_extended_throughput_tests` is set, the tests are run.

Cf the [dash](https://ddstaging.datadoghq.com/dashboard/c5g-i7d-kcy/ciapp-apm-net-throughput-tests?tpl_var_app_name=%2A&tpl_var_branch%5B0%5D=pierre%2Fcrank-stats&from_ts=1656335559098&to_ts=1656940359098&live=true)
![image](https://user-images.githubusercontent.com/22597395/177162397-a1ff1a4d-d608-46bb-8a4f-7f9a260890a5.png)

## Other details
AIT-2712
