### PR TITLE
Add smoke tests for the MSI installer

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -4,43 +4,18 @@ parameters:
 
   - name: 'snapshotPrefix'
     type: 'string'
+    
+  - name: isLinux
+    type: boolean
+    default: true
 
 steps:
-- script: |
-    docker-compose -p ddtrace_$(Build.BuildNumber) run --rm start-test-agent
-  env:
-    dockerTag: $(dockerTag)
-  displayName: docker-compose run start-test-agent
-  retryCountOnTaskFailure: 3
-
 - bash: |
-    token=$(cat /proc/sys/kernel/random/uuid)
-    echo "##vso[task.setvariable variable=snapshot_token]$token"
-    endpoint="/test/session/start?test_session_token=$token"
-    echo "Starting snapshot session with $endpoint"
-    docker-compose -p ddtrace_$(Build.BuildNumber) exec -T test-agent /usr/bin/curl --fail "http://localhost:8126$endpoint"
-  displayName: start snapshot session
-
-- script: |
-    docker-compose -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) ${{ parameters.target }}
-  env:
-    dockerTag: $(dockerTag)
-  displayName: docker-compose run ${{ parameters.target }}
-
-
-- bash: |
-    token=$(token)
-    endpoint="/test/session/traces?test_session_token=$token"
-    echo "Dumping traces with $endpoint"
-    docker-compose -p ddtrace_$(Build.BuildNumber) exec -T test-agent /usr/bin/curl -o /debug_snapshots/${{ parameters.snapshotPrefix }}_traces.json "http://localhost:8126$endpoint"
-    
-    endpoint="/test/session/stats?test_session_token=$token"
-    echo "Dumping stats with $endpoint"
-    docker-compose -p ddtrace_$(Build.BuildNumber) exec -T test-agent /usr/bin/curl -o /debug_snapshots/${{ parameters.snapshotPrefix }}_stats.json "http://localhost:8126$endpoint"
-    
-    endpoint="/test/session/requests?test_session_token=$token"
-    echo "Dumping all requests with $endpoint"
-    docker-compose -p ddtrace_$(Build.BuildNumber) exec -T test-agent /usr/bin/curl -o /debug_snapshots/${{ parameters.snapshotPrefix }}_requests.json "http://localhost:8126$endpoint"
+    echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"
+    echo "##vso[task.setvariable variable=START_ENDPOINT]/test/session/start?test_session_token=$(System.JobId)"
+    echo "##vso[task.setvariable variable=TRACE_DUMP_ENDPOINT]/test/session/traces?test_session_token=$(System.JobId)"
+    echo "##vso[task.setvariable variable=STATS_DUMP_ENDPOINT]/test/session/stats?test_session_token=$(System.JobId)"
+    echo "##vso[task.setvariable variable=REQUESTS_DUMP_ENDPOINT]/test/session/requests?test_session_token=$(System.JobId)"
     
     if [ "$(publishFramework)" = "netcoreapp2.1" ]; then
       snapshotfile="${{ parameters.snapshotPrefix }}_snapshots_2_1"
@@ -48,18 +23,64 @@ steps:
       snapshotfile="${{ parameters.snapshotPrefix }}_snapshots"
     fi
     
-    # Fail if the snapshots don't match
-    endpoint="/test/session/snapshot?test_session_token=$token&file=/snapshots/$snapshotfile"
-    echo "Verifying snapshot session with $endpoint"
-    docker-compose -p ddtrace_$(Build.BuildNumber) exec -T test-agent /usr/bin/curl --fail "http://localhost:8126$endpoint"
+    echo "##vso[task.setvariable variable=VERIFY_ENDPOINT]/test/session/snapshot?test_session_token=$(System.JobId)&file=/snapshots/$snapshotfile"
+  displayName: Set endpoints
+
+- ${{ if eq(parameters.isLinux, true) }}:
+  - bash: |
+      echo "##vso[task.setvariable variable=CURL_COMMAND]/usr/bin/curl"
+      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]test-agent"
+      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-test-agent"
+      echo "##vso[task.setvariable variable=COMPOSE_PATH]docker-compose.yml"
+    displayName: Set env-specific variables
+- ${{ else }}:
+  - bash: |
+      echo "##vso[task.setvariable variable=CURL_COMMAND]curl"
+      echo "##vso[task.setvariable variable=TEST_AGENT_TARGET]test-agent.windows"
+      echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-test-agent.windows"
+      echo "##vso[task.setvariable variable=COMPOSE_PATH]docker-compose.windows.yml"
+    displayName: Set env-specific  variables
+
+- bash: |
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run --rm $(START_TEST_AGENT_TARGET)
+  env:
+    dockerTag: $(dockerTag)
+  displayName: docker-compose run start-test-agent
+  retryCountOnTaskFailure: 3
+
+- script: |
+    echo "Starting snapshot session"
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail "http://localhost:8126$(START_ENDPOINT)"
+  displayName: start snapshot session
+
+- bash: |
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) ${{ parameters.target }}
+  env:
+    dockerTag: $(dockerTag)
+  displayName: docker-compose run ${{ parameters.target }}
+
+
+- script: |
+    echo "Dumping traces"
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) -o /debug_snapshots/${{ parameters.snapshotPrefix }}_traces.json "http://localhost:8126$(TRACE_DUMP_ENDPOINT)"
+    
+    echo "Dumping stats"
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) -o /debug_snapshots/${{ parameters.snapshotPrefix }}_stats.json "http://localhost:8126$(STATS_DUMP_ENDPOINT)"
+    
+    echo "Dumping all requests"
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) -o /debug_snapshots/${{ parameters.snapshotPrefix }}_requests.json "http://localhost:8126$(REQUESTS_DUMP_ENDPOINT)"
+    
+    echo "Verifying snapshot session (fail on mis-match)"
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
   displayName: check snapshots
 
 - task: DockerCompose@0
-  displayName: dump docker-compose logs for test-agent
+  displayName: dump docker-compose logs for $(TEST_AGENT_TARGET)
   inputs:
     containerregistrytype: Container Registry
-    dockerComposeCommand: logs test-agent
+    dockerComposeCommand: logs $(TEST_AGENT_TARGET)
     projectName: ddtrace_$(Build.BuildNumber)
+    dockerComposeFile: $(COMPOSE_PATH)
   condition: succeededOrFailed()
   continueOnError: true
 
@@ -69,5 +90,6 @@ steps:
     containerregistrytype: Container Registry
     dockerComposeCommand: down
     projectName: ddtrace_$(Build.BuildNumber)
+    dockerComposeFile: $(COMPOSE_PATH)
   condition: succeededOrFailed()
   continueOnError: true

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2725,6 +2725,71 @@ stages:
         baseImage: debian
         command: "CheckBuildLogsForErrors"
 
+- stage: msi_installer_smoke_tests
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [package_windows, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [windows]
+
+  - job: windows
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.msi_installer_windows_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download MSI to temp directory
+      inputs:
+        artifact: windows-msi-$(targetPlatform)
+        patterns: '**/*-$(targetPlatform).msi'
+        path: $(Agent.TempDirectory)
+
+    - powershell: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+        mkdir -p $(smokeTestAppDir)/artifacts
+        mv $(Agent.TempDirectory)/*.msi $(smokeTestAppDir)/artifacts/datadog-apm.msi
+      displayName: Create test data directories
+
+    - bash: |
+        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg INSTALL_CMD="$(installCmd)" \
+          smoke-tests.windows
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'smoke-tests.windows'
+        snapshotPrefix: "smoke_test"
+        isLinux: false
+
+    - publish: tracer/build_data
+      artifact: msi-installer-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/install-latest-dotnet-sdk.yml
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: CheckBuildLogsForErrors
+
 - stage: trace_pipeline
   condition: eq(variables['isBenchmarksOnlyBuild'], 'False')
   dependsOn:
@@ -2749,6 +2814,7 @@ stages:
     - installer_smoke_tests_arm64
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
+    - msi_installer_smoke_tests
     - coverage
     - exploration_tests_windows
     - exploration_tests_linux

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2768,7 +2768,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
-          --build-arg INSTALL_CMD="$(installCmd)" \
+          --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           smoke-tests.windows
       env:
         dockerTag: $(dockerTag)

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -23,6 +23,7 @@ services:
     - "8126:8126"
     environment:
     - SNAPSHOT_CI=1
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id
 
   smoke-tests.windows:
     build:

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  start-test-agent.windows:
+    build:
+      context: ./tracer/build/_build/docker/
+      dockerfile: wait-for-dependencies-windows.dockerfile
+    image: andrewlock/wait-for-dependencies-windows
+    depends_on:
+    - test-agent.windows
+    environment:
+    - TIMEOUT_LENGTH=120
+    command: test-agent.windows:8126
+
+  test-agent.windows:
+    build:
+      context: ./tracer/build/_build/docker/
+      dockerfile: test-agent.windows.dockerfile
+    image: dd-trace-dotnet/ddapm-test-agent-windows
+    volumes:
+    - ./tracer/build/smoke_test_snapshots:c:/snapshots
+    - ./tracer/build_data/snapshots:c:/debug_snapshots
+    ports:
+    - "8126:8126"
+    environment:
+    - SNAPSHOT_CI=1
+
+  smoke-tests.windows:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      target: publish-msi
+      dockerfile: build/_build/docker/smoke.windows.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - CHANNEL_32_BIT=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-windows-tester
+    volumes:
+    - ./:c:/project
+    - ./tracer/build_data/logs:c:/logs
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
+    depends_on:
+    - test-agent.windows

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -546,17 +546,21 @@ partial class Build : NukeBuild
                         (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2019"),
                         (publishFramework: TargetFramework.NET5_0, "5.0-windowsservercore-ltsc2019"),
                     };
-                    
+
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
                                      let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let channel32Bit = platform == MSBuildTargetPlatform.x86
+                                                                       ? (image.publishFramework == TargetFramework.NET6_0 ? "6.0" : "5.0")
+                                                                       : string.Empty
                                      select new
                                      {
                                          dockerTag = dockerTag,
                                          publishFramework = image.publishFramework,
                                          runtimeImage = $"{dockerName}:{image.runtimeTag}",
                                          targetPlatform = platform,
+                                         channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
 
                     Logger.Info($"Installer smoke tests MSI matrix Windows");

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using Nuke.Common;
 using Nuke.Common.CI.AzurePipelines;
 using Nuke.Common.Tools.Git;
+using Nuke.Common.Tools.MSBuild;
 using NukeExtensions;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -232,6 +233,9 @@ partial class Build : NukeBuild
                 // nuget smoke tests
                 GenerateLinuxNuGetSmokeTestsMatrix();
                 GenerateLinuxNuGetSmokeTestsArm64Matrix();
+                
+                // msi smoke tests
+                GenerateWindowsMsiSmokeTestsMatrix();
 
                 void GenerateLinuxInstallerSmokeTestsMatrix()
                 {
@@ -530,6 +534,34 @@ partial class Build : NukeBuild
                                 runtimeImage = $"{dockerName}:{image.runtimeTag}"
                             });
                     }
+                }
+                
+                void GenerateWindowsMsiSmokeTestsMatrix()
+                {
+                    var dockerName = "mcr.microsoft.com/dotnet/aspnet";
+
+                    var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
+                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    {
+                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2019"),
+                        (publishFramework: TargetFramework.NET5_0, "5.0-windowsservercore-ltsc2019"),
+                    };
+                    
+                    var matrix = (
+                                     from platform in platforms
+                                     from image in runtimeImages
+                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     select new
+                                     {
+                                         dockerTag = dockerTag,
+                                         publishFramework = image.publishFramework,
+                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         targetPlatform = platform,
+                                     }).ToDictionary(x=>x.dockerTag, x => x);
+
+                    Logger.Info($"Installer smoke tests MSI matrix Windows");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("msi_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
             }
         };

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -1,0 +1,38 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish-msi
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /install
+
+RUN mkdir /logs; \
+    cd /install; \
+    Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-apm.msi'; \
+    cd /app; \
+    rm /install -r -fo
+
+# Set the additional env vars
+ENV DD_PROFILING_ENABLED=1 \
+    CORECLR_ENABLE_PROFILING=1 \
+    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8} \
+    DD_TRACE_LOG_DIRECTORY="C:\logs" \
+    ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -16,6 +16,14 @@ SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPref
 
 WORKDIR /app
 
+ARG CHANNEL_32_BIT
+RUN if($env:CHANNEL_32_BIT){ \
+    echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
+    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
+    [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
+    rm ./dotnet-install.ps1; }
+
 # Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
 COPY --from=builder /src/artifacts /install
 

--- a/tracer/build/_build/docker/test-agent.windows.dockerfile
+++ b/tracer/build/_build/docker/test-agent.windows.dockerfile
@@ -1,0 +1,7 @@
+﻿FROM python:3.10.5-windowsservercore-1809
+
+WORKDIR /
+
+RUN pip install --no-cache-dir ddapm-test-agent
+
+ENTRYPOINT [ "ddapm-test-agent", "--port=8126" ]

--- a/tracer/build/_build/docker/wait-for-dependencies-windows.dockerfile
+++ b/tracer/build/_build/docker/wait-for-dependencies-windows.dockerfile
@@ -1,0 +1,8 @@
+﻿FROM mcr.microsoft.com/windows/servercore:ltsc2019-amd64
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /app
+
+ADD wait-for-dependencies.ps1 .
+
+ENTRYPOINT ["powershell.exe", ".\\wait-for-dependencies.ps1"]

--- a/tracer/build/_build/docker/wait-for-dependencies.ps1
+++ b/tracer/build/_build/docker/wait-for-dependencies.ps1
@@ -1,0 +1,44 @@
+$sleep = $env:SLEEP_LENGTH
+$timeout = $env:TIMEOUT_LENGTH
+if (!$sleep)
+{
+    $sleep = 2
+}
+if (!$timeout)
+{
+    $timeout = 300
+}
+
+echo "Checking $( $args.count ) hosts with Sleep $sleep and timeout $timeout..."
+
+for ($i = 0; $i -lt $args.count; $i++) {
+    $splitArg = $args[$i].Split(":")
+    $address = $splitArg[0]
+    $port = $splitArg[1]
+    echo "Waiting for $address to listen on $port..."
+
+    $success = $false;
+    $timer = [Diagnostics.Stopwatch]::StartNew()
+    while ($timer.Elapsed.TotalSeconds -lt $Timeout) {
+        try {
+            $connection = New-Object System.Net.Sockets.TcpClient($address, $port)
+            if ($connection.Connected) {
+                echo "Connected!"
+                $success = $true;
+                break;
+            }
+        }
+        catch {}
+
+        if ($timer.Elapsed.TotalSeconds -lt $timeout) {
+            echo "sleeping"
+            sleep -Seconds $sleep
+        }
+    }
+
+    $timer.Stop()
+    if (!$success) {
+        echo "Service $( $address ):$( $port ) did not start within $timeout seconds. Aborting..."
+        exit 1
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds smoke tests for the x64 and x86 installers

## Reason for change

We currently don't validate that instrumentation works after the MSI is installed, and we should.

## Implementation details

- Generalized the `steps/run-snapshot-test.yml` template so that it works on both Windows and Linux
- Added a new stage, `msi_installer_smoke_tests`, which tests against .NET 5 and .NET 6
  - We could test additional framework versions if we manually install the dotnet sdk (which we already have to do for the x86 support), but I'm not too concerned about doing that.
- There are weird compatibility issues with volume mounts in docker-compose files, so I had to create a separate file. (The required format for Windows volume mounts causes the file to be considered invalid when you run on Linux. Yay).
- Had to create Windows Docker containers of the `wait-for-dependencies` image and the `ddapm-test-agent`. Down the line I might look at pushing those to docker hub/gcr.io but this will do for now I think.
- I tried to make the dockerfile more general, by allowing you to pass in the `INSTALL_CMD`, same as we do for the linux dockerfiles, but for some reason, that just doesn't work. 🤷‍♂️ I lost all patience with it, so here we are.
- The `metrics.process_id` value is not ignored by default currently, so ignoring it manually (fixed in https://github.com/DataDog/dd-apm-test-agent/pull/89)

## Test coverage

The snapshot smoke tests are running and they pass 🎉 

## Other details

AIT-2818

Smoke tests remaining (for subsequent PRs)
- NuGet installer smoke test (Windows)
- Tracer Home smoke test (Windows)
- dd-trace smoke tests (Windows + Linux + Arm64)