### PR TITLE
[Profiler] Do not dereference nullptr to avoid crashing

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -661,7 +661,10 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Shutdown(void)
     _pStackSamplerLoopManager->Stop();
 
     // Calling Stop on providers transforms the last raw samples
-    _pWallTimeProvider->Stop();
+    if (_pWallTimeProvider != nullptr)
+    {
+        _pWallTimeProvider->Stop();
+    }
     if (_pCpuTimeProvider != nullptr)
     {
         _pCpuTimeProvider->Stop();


### PR DESCRIPTION

## Summary of changes

## Reason for change
When deactivating the walltime profiler, the walltime instance variable is null. If we do not protect it access, we will dereference a nullptr and will crash the application.

## Implementation details

Check if the walltime provider is activated or not.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
