### PR TITLE
Add smoke tests for windows-tracer-home.zip

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2790,6 +2790,70 @@ stages:
     - script: tracer\build.cmd CheckBuildLogsForErrors
       displayName: CheckBuildLogsForErrors
 
+- stage: tracer_home_smoke_tests
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [package_windows, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [windows]
+
+  - job: windows
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.tracer_home_installer_windows_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - powershell: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+        mkdir -p $(smokeTestAppDir)/artifacts
+      displayName: Create test data directories
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tracer home zip
+      inputs:
+        artifact: windows-tracer-home.zip
+        path: $(smokeTestAppDir)/artifacts
+
+    - bash: |
+        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
+          --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
+          tracer-home-smoke-tests.windows
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'tracer-home-smoke-tests.windows'
+        snapshotPrefix: "smoke_test"
+        isLinux: false
+
+    - publish: tracer/build_data
+      artifact: tracer-home-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/install-latest-dotnet-sdk.yml
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: CheckBuildLogsForErrors
+
 - stage: trace_pipeline
   condition: eq(variables['isBenchmarksOnlyBuild'], 'False')
   dependsOn:
@@ -2815,6 +2879,7 @@ stages:
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
     - msi_installer_smoke_tests
+    - tracer_home_smoke_tests
     - coverage
     - exploration_tests_windows
     - exploration_tests_linux

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -28,7 +28,6 @@ services:
   smoke-tests.windows:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
-      target: publish-msi
       dockerfile: build/_build/docker/smoke.windows.dockerfile
         # args:
         # Note that the following build arguments must be provided
@@ -37,6 +36,27 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - CHANNEL_32_BIT=
     image: dd-trace-dotnet/${dockerTag:-not-set}-windows-tester
+    volumes:
+    - ./:c:/project
+    - ./tracer/build_data/logs:c:/logs
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
+    depends_on:
+    - test-agent.windows
+
+  tracer-home-smoke-tests.windows:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.windows.tracer-home.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - CHANNEL_32_BIT=
+        # - RELATIVE_PROFILER_PATH=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-windows-tracer-home-tester
     volumes:
     - ./:c:/project
     - ./tracer/build_data/logs:c:/logs

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -1,0 +1,53 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /app
+
+ARG CHANNEL_32_BIT
+RUN if($env:CHANNEL_32_BIT){ \
+    echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
+    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
+    [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
+    rm ./dotnet-install.ps1; }
+
+# Copy the tracer home file from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /install
+
+RUN mkdir /logs; \
+    mkdir /monitoring-home; \
+    cd /install; \
+    Expand-Archive 'c:\install\windows-tracer-home.zip' -DestinationPath 'c:\monitoring-home\';  \
+    cd /app; \
+    rm /install -r -fo
+
+
+ARG RELATIVE_PROFILER_PATH
+
+RUN [Environment]::SetEnvironmentVariable('CORECLR_PROFILER_PATH', 'c:\monitoring-home\' + $env:RELATIVE_PROFILER_PATH, [EnvironmentVariableTarget]::Machine);
+
+# Set the additional env vars
+ENV DD_PROFILING_ENABLED=1 \
+    CORECLR_ENABLE_PROFILING=1 \
+    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8} \
+    DD_DOTNET_TRACER_HOME="c:\monitoring-home" \
+    DD_TRACE_LOG_DIRECTORY="C:\logs" \
+    ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Adds smoke tests for the `windows-tracer-home.zip`

## Reason for change

We currently don't test the layout of this file to ensure we don't break it (other than indirectly via AAS). This will provide faster feedback

## Implementation details

Reuses much of the same work as #2937, so that should be merged first

## Test coverage

Just testing .NET 5 and .NET 6 on windows server code ATM. We could add more permutations (e.g. nano server etc) but that adds a bit more complexity without a lot of benefit IMO

## Other details
AIT-2818. Requires #2937 to be merged first
