### PR TITLE
[Profiler] Clean the way we build the profiler on Linux

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -57,19 +57,24 @@ endif()
 # Detect prerequisites
 # ******************************************************
 
-if (NOT EXISTS /usr/bin/clang)
+find_program(FOUND_CLANG clang)
+
+if (NOT FOUND_CLANG)
     message(FATAL_ERROR "CLANG is required to build the project")
 else()
     message(STATUS "CLANG was found")
 endif()
 
-if (NOT EXISTS /usr/bin/clang++)
+find_program(FOUND_CLANGPP clang++)
+if (NOT FOUND_CLANGPP)
     message(FATAL_ERROR "CLANG++ is required to build the project")
 else()
     message(STATUS "CLANG++ was found")
 endif()
 
-if (NOT EXISTS /usr/bin/git)
+find_program(FOUND_GIT "git")
+
+if (NOT FOUND_GIT)
     message(FATAL_ERROR "GIT is required to build the project")
 else()
     message(STATUS "GIT was found")

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -14,11 +14,6 @@ message(STATUS "Run Clang Undefined-Behavior Sanitizer: " ${RUN_UBSAN})
 # Compiler options
 # ******************************************************
 
-if(ISLINUX)
-    SET (CMAKE_C_COMPILER   /usr/bin/clang)
-    SET (CMAKE_CXX_COMPILER /usr/bin/clang++)
-endif()
-
 # Sets compiler options
 add_compile_options(-std=c++17 -fPIC -fms-extensions)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -280,7 +280,7 @@ void* OpSysTools::AlignedMAlloc(size_t alignment, size_t size)
 #ifdef _WINDOWS
     return _aligned_malloc(size, alignment);
 #else
-    return std::aligned_alloc(alignment, size);
+    return aligned_alloc(alignment, size);
 #endif
 }
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -6,11 +6,6 @@ include(GoogleTest)
 # ******************************************************
 set(CMAKE_CXX_STANDARD 17)
 
-if(ISLINUX)
-    SET (CMAKE_C_COMPILER   /usr/bin/clang)
-    SET (CMAKE_CXX_COMPILER /usr/bin/clang++)
-endif()
-
 # Sets compiler options
 add_compile_options(-fPIC -fms-extensions)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -84,7 +84,7 @@ partial class Build
             EnsureExistingDirectory(ProfilerLinuxBuildDirectory);
 
             CMake.Value(
-                arguments: $"-B {ProfilerLinuxBuildDirectory} -S {ProfilerDirectory} -DCMAKE_BUILD_TYPE=Release");
+                arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B {ProfilerLinuxBuildDirectory} -S {ProfilerDirectory} -DCMAKE_BUILD_TYPE=Release");
 
             CMake.Value(
                 arguments: $"--build {ProfilerLinuxBuildDirectory} --parallel");


### PR DESCRIPTION
## Summary of changes

## Reason for change

This PR is the first step to build the profiler on CentOS7. We need to clean the way we build and ensure that we use clang to build the native code.

## Implementation details

- Do not assume that clang is in `/usr/bin/clang`. Instead relies on CMake `find_program` to check if it's installed
- Set cmake variable on the command line instead in the file `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER`
- use `aligned_alloc` instead of `std::aligned_alloc` 

## Test coverage

## Other details
<!-- Fixes #{issue} -->
