### PR TITLE
[Tracer] Clean the way we build the tracer native code on Linux

### DIFF
--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -49,7 +49,7 @@ partial class Build
             var buildDirectory = NativeLoaderProject.Directory;
 
             CMake.Value(
-                arguments: $"-S .",
+                arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -S .",
                 workingDirectory: buildDirectory);
             CMake.Value(
                 arguments: $"--build . --parallel",

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -194,7 +194,7 @@ partial class Build
             EnsureExistingDirectory(buildDirectory);
 
             CMake.Value(
-                arguments: $"-B {buildDirectory} -S {NativeProfilerProject.Directory} -DCMAKE_BUILD_TYPE=Release");
+                arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B {buildDirectory} -S {NativeProfilerProject.Directory} -DCMAKE_BUILD_TYPE=Release");
             CMake.Value(
                 arguments: $"--build {buildDirectory} --parallel");
         });
@@ -707,7 +707,7 @@ partial class Build
                 .SetProperty("BuildProjectReferences", true)
                 .SetTargets("BuildInstrumentationVerificationLibrary"));
         });
-                                                        
+
     Target CompileManagedTestHelpers => _ => _
         .Unlisted()
         .DependsOn(CompileInstrumentationVerificationLibrary)

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeLists.txt
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/CMakeLists.txt
@@ -50,25 +50,22 @@ endif()
 # Detect prerequisites
 # ******************************************************
 
-if (NOT EXISTS /usr/bin/git)
+find_program(FOUND_GIT "git")
+if (NOT FOUND_GIT)
     message(FATAL_ERROR "GIT is required to build the project")
 else()
     message(STATUS "GIT was found")
 endif()
 
-if (NOT EXISTS /usr/bin/gcc)
-    message(FATAL_ERROR "GCC is required to build the project's dependencies")
-else()
-    message(STATUS "GCC was found")
-endif()
-
-if (NOT EXISTS /usr/bin/clang)
+find_program(FOUND_CLANG clang)
+if (NOT FOUND_CLANG)
     message(FATAL_ERROR "CLANG is required to build the project")
 else()
     message(STATUS "CLANG was found")
 endif()
 
-if (NOT EXISTS /usr/bin/clang++)
+find_program(FOUND_CLANGPP clang++)
+if (NOT FOUND_CLANGPP)
     message(FATAL_ERROR "CLANG++ is required to build the project")
 else()
     message(STATUS "CLANG++ was found")
@@ -113,12 +110,6 @@ set(fmt_INCLUDE_DIR ${source_dir}/include)
 # ******************************************************
 # Compiler options
 # ******************************************************
-
-# Sets the compiler
-if(ISLINUX)
-    SET (CMAKE_C_COMPILER   /usr/bin/clang)
-    SET (CMAKE_CXX_COMPILER /usr/bin/clang++)
-endif()
 
 # Sets compiler options
 add_compile_options(-std=c++17 -fPIC -fms-extensions)

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -48,25 +48,29 @@ endif()
 # Detect prerequisites
 # ******************************************************
 
-if (NOT EXISTS /usr/bin/git)
+find_program(FOUND_GIT "git")
+if (NOT FOUND_GIT)
     message(FATAL_ERROR "GIT is required to build the project")
 else()
     message(STATUS "GIT was found")
 endif()
 
-if (NOT EXISTS /usr/bin/gcc)
+find_program(FOUND_GCC gcc)
+if (NOT FOUND_GCC)
     message(FATAL_ERROR "GCC is required to build the project's dependencies")
 else()
     message(STATUS "GCC was found")
 endif()
 
-if (NOT EXISTS /usr/bin/clang)
+find_program(FOUND_CLANG clang)
+if (NOT FOUND_CLANG)
     message(FATAL_ERROR "CLANG is required to build the project")
 else()
     message(STATUS "CLANG was found")
 endif()
 
-if (NOT EXISTS /usr/bin/clang++)
+find_program(FOUND_CLANGPP clang++)
+if (NOT FOUND_CLANGPP)
     message(FATAL_ERROR "CLANG++ is required to build the project")
 else()
     message(STATUS "CLANG++ was found")
@@ -165,12 +169,6 @@ SET_SOURCE_FILES_PROPERTIES(
 # ******************************************************
 
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
-
-# Sets the compiler
-if(ISLINUX)
-    SET (CMAKE_C_COMPILER   /usr/bin/clang)
-    SET (CMAKE_CXX_COMPILER /usr/bin/clang++)
-endif()
 
 # Sets compiler options
 add_compile_options(-std=c++17 -fPIC -fms-extensions)


### PR DESCRIPTION
## Summary of changes

## Reason for change

This PR aims at unifying the way we build the native code (the profiler, the tracer and native loader) on Linux

## Implementation details

- Do not assume that clang is in `/usr/bin/clang`. Instead relies on CMake `find_program` to check if it's installed
- Set cmake variable on the command line instead in the file `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER`

## Test coverage

## Other details
<!-- Fixes #{issue} -->
