### PR TITLE
Add smoke tests for dotnet-tool instrumentation on Windows

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2752,8 +2752,8 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download dotnet tool
       inputs:
-        artifact: runner-standalone-win-$(targetPlatform)
-        patterns: "dd-trace-win-$(targetPlatform).zip"
+        artifact: runner-standalone-win-x64
+        patterns: "dd-trace-win-x64.zip"
         path: $(Agent.TempDirectory)
 
     - powershell: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2725,6 +2725,71 @@ stages:
         baseImage: debian
         command: "CheckBuildLogsForErrors"
 
+- stage: dotnet_tool_smoke_tests_windows
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [windows]
+
+  - job: windows
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_windows_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download dotnet tool
+      inputs:
+        artifact: runner-standalone-win-$(targetPlatform)
+        patterns: "dd-trace-win-$(targetPlatform).zip"
+        path: $(Agent.TempDirectory)
+
+    - powershell: |
+        mkdir -f -p tracer/build_data/snapshots
+        mkdir -f -p tracer/build_data/logs
+        mkdir -f -p $(smokeTestAppDir)/artifacts
+        mv $(Agent.TempDirectory)/*.zip $(smokeTestAppDir)/artifacts/dd-trace-win.zip
+      displayName: Create test data directories
+      
+    - bash: |
+        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
+          dotnet-tool-smoke-tests.windows
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dotnet-tool-smoke-tests.windows'
+        snapshotPrefix: "smoke_test"
+        isLinux: false
+
+    - publish: tracer/build_data
+      artifact: dotnet-tool-smoke-test-windows-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/install-latest-dotnet-sdk.yml
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: CheckBuildLogsForErrors
+
 - stage: msi_installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [package_windows, generate_variables, master_commit_id]
@@ -2878,6 +2943,7 @@ stages:
     - installer_smoke_tests_arm64
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
+    - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests
     - coverage

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -65,3 +65,23 @@ services:
     - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
     depends_on:
     - test-agent.windows
+
+  dotnet-tool-smoke-tests.windows:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - CHANNEL_32_BIT=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-windows-dotnet-tool-tester
+    volumes:
+    - ./:c:/project
+    - ./tracer/build_data/logs:c:/logs
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
+    depends_on:
+    - test-agent.windows

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -234,6 +234,9 @@ partial class Build : NukeBuild
                 GenerateLinuxNuGetSmokeTestsMatrix();
                 GenerateLinuxNuGetSmokeTestsArm64Matrix();
                 
+                // dotnet tool smoke tests
+                GenerateWindowsDotnetToolSmokeTestsMatrix();
+
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
                 
@@ -602,6 +605,38 @@ partial class Build : NukeBuild
                     Logger.Info($"Installer smoke tests tracer-home matrix Windows");
                     Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetVariable("tracer_home_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateWindowsDotnetToolSmokeTestsMatrix()
+                {
+                    var dockerName = "mcr.microsoft.com/dotnet/aspnet";
+
+                    var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
+                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    {
+                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2019"),
+                        (publishFramework: TargetFramework.NET5_0, "5.0-windowsservercore-ltsc2019"),
+                    };
+
+                    var matrix = (
+                                     from platform in platforms
+                                     from image in runtimeImages
+                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let channel32Bit = platform == MSBuildTargetPlatform.x86
+                                                                       ? (image.publishFramework == TargetFramework.NET6_0 ? "6.0" : "5.0")
+                                                                       : string.Empty
+                                     select new
+                                     {
+                                         dockerTag = dockerTag,
+                                         publishFramework = image.publishFramework,
+                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         targetPlatform = platform,
+                                         channel32Bit = channel32Bit,
+                                     }).ToDictionary(x=>x.dockerTag, x => x);
+
+                    Logger.Info($"Installer smoke tests dotnet-tool matrix Windows");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("dotnet_tool_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
             }
         };

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -1,0 +1,45 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /app
+
+ARG CHANNEL_32_BIT
+RUN if($env:CHANNEL_32_BIT){ \
+    echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
+    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
+    [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
+    rm ./dotnet-install.ps1; }
+
+# Copy the tracer home file from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /install
+
+RUN mkdir /logs; \
+    mkdir /tool; \
+    cd /install; \
+    Expand-Archive 'c:\install\dd-trace-win.zip' -DestinationPath 'c:\tool\';  \
+    cd /app; \
+    rm /install -r -fo
+
+# Set the additional env vars
+ENV DD_PROFILING_ENABLED=1 \
+    DD_TRACE_LOG_DIRECTORY="C:\logs" \
+    ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT c:\tool\dd-trace.exe dotnet AspNetCoreSmokeTest.dll

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -32,6 +32,7 @@ RUN mkdir /logs; \
     cd /install; \
     Expand-Archive 'c:\install\dd-trace-win.zip' -DestinationPath 'c:\tool\';  \
     cd /app; \
+    echo (gcm dotnet).Path; \
     rm /install -r -fo
 
 # Set the additional env vars

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.Net.Http;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,12 @@ namespace AspNetCoreSmokeTest
                 Console.WriteLine("Error: Profiler is required and is not loaded.");
                 return 1;
             }
+            
+            Console.WriteLine("Process details: ");
+            Console.WriteLine($"Framework: {RuntimeInformation.FrameworkDescription}");
+            Console.WriteLine($"Process arch: {RuntimeInformation.ProcessArchitecture}");
+            Console.WriteLine($"OS arch: {RuntimeInformation.OSArchitecture}");
+            Console.WriteLine($"OS description: {RuntimeInformation.OSDescription}");
 
             await CreateHostBuilder(args).Build().RunAsync();
 


### PR DESCRIPTION
## Summary of changes

Adds instrumentation smoke tests for the `dd-trace` tool on windows

## Reason for change

This is another option for instrumentation of processes. We already have some testing of the tool, but this ensures we match the traces etc.

## Implementation details

Reuses much of the same work as #2937, so that should be merged first.

## Test coverage

Just testing .NET 5 and .NET 6 on windows server code ATM. We could add more permutations (e.g. nano server etc) but that adds a bit more complexity without a lot of benefit IMO

## Other details
AIT-2818. Requires #2937 and #2941 to be merged first
