### PR TITLE
Add Smoke testing of the NuGet package on Windows

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2725,6 +2725,75 @@ stages:
         baseImage: debian
         command: "CheckBuildLogsForErrors"
 
+- stage: nuget_installer_smoke_tests_windows
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [windows]
+
+  - job: windows
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.nuget_installer_windows_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download distribution nuget
+      inputs:
+        artifact: distribution-nuget-package
+        path: $(smokeTestAppDir)/artifacts
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Datadog.Trace package
+      inputs:
+        artifact: nuget-packages
+        path: $(smokeTestAppDir)/artifacts
+
+    - powershell: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+      displayName: create test data directories
+    
+    - bash: |
+        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
+          --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
+          nuget-smoke-tests.windows
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'nuget-smoke-tests.windows'
+        snapshotPrefix: "smoke_test"
+        isLinux: false
+
+    - publish: tracer/build_data
+      artifact: nuget_installer_windows-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/install-latest-dotnet-sdk.yml
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: CheckBuildLogsForErrors
+
 - stage: dotnet_tool_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
@@ -2943,6 +3012,7 @@ stages:
     - installer_smoke_tests_arm64
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
+    - nuget_installer_smoke_tests_windows
     - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -85,3 +85,23 @@ services:
     - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
     depends_on:
     - test-agent.windows
+
+  nuget-smoke-tests.windows:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.windows.nuget.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+      # - RELATIVE_PROFILER_PATH=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-windows-nuget-tester
+    volumes:
+    - ./:c:/project
+    - ./tracer/build_data/logs:c:/logs
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent.windows:8126
+    depends_on:
+    - test-agent.windows

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -233,6 +233,7 @@ partial class Build : NukeBuild
                 // nuget smoke tests
                 GenerateLinuxNuGetSmokeTestsMatrix();
                 GenerateLinuxNuGetSmokeTestsArm64Matrix();
+                GenerateWindowsNuGetSmokeTestsMatrix();
                 
                 // dotnet tool smoke tests
                 GenerateWindowsDotnetToolSmokeTestsMatrix();
@@ -605,6 +606,39 @@ partial class Build : NukeBuild
                     Logger.Info($"Installer smoke tests tracer-home matrix Windows");
                     Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetVariable("tracer_home_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+                
+                void GenerateWindowsNuGetSmokeTestsMatrix()
+                {
+                    var dockerName = "mcr.microsoft.com/dotnet/aspnet";
+
+                    var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
+                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    {
+                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2019"),
+                        (publishFramework: TargetFramework.NET5_0, "5.0-windowsservercore-ltsc2019"),
+                    };
+
+                    var matrix = (
+                                     from platform in platforms
+                                     from image in runtimeImages
+                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let channel32Bit = platform == MSBuildTargetPlatform.x86
+                                                                       ? (image.publishFramework == TargetFramework.NET6_0 ? "6.0" : "5.0")
+                                                                       : string.Empty
+                                     select new
+                                     {
+                                         relativeProfilerPath = $"datadog/win-{platform}/Datadog.Trace.ClrProfiler.Native.dll",
+                                         dockerTag = dockerTag,
+                                         publishFramework = image.publishFramework,
+                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         targetPlatform = platform,
+                                         channel32Bit = channel32Bit,
+                                     }).ToDictionary(x=>x.dockerTag, x => x);
+
+                    Logger.Info($"Installer smoke tests NuGet matrix Windows");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("nuget_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void GenerateWindowsDotnetToolSmokeTestsMatrix()

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -4,6 +4,9 @@ ARG RUNTIME_IMAGE
 # Build the ASP.NET Core app using the latest SDK
 FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 
+# Without this, the container doesn't have permission to add the new package 
+USER ContainerAdministrator
+
 # Build the smoke test app
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -1,0 +1,46 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source "c:\src\artifacts" \
+    && dotnet add package "Datadog.Monitoring.Distribution" --prerelease \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
+
+FROM $RUNTIME_IMAGE AS publish-msi
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+WORKDIR /app
+
+ARG CHANNEL_32_BIT
+RUN if($env:CHANNEL_32_BIT){ \
+    echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
+    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
+    [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
+    rm ./dotnet-install.ps1; }
+
+RUN mkdir /logs
+
+ARG RELATIVE_PROFILER_PATH
+
+RUN [Environment]::SetEnvironmentVariable('CORECLR_PROFILER_PATH',  $env:RELATIVE_PROFILER_PATH, [EnvironmentVariableTarget]::Machine);
+# Set the required env vars
+ENV CORECLR_ENABLE_PROFILING=1 \
+    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8} \
+    DD_DOTNET_TRACER_HOME="c:\app\datadog" \
+    DD_TRACE_LOG_DIRECTORY="C:\logs" \
+    DD_PROFILING_ENABLED=1 \
+    ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Adds installer smoke tests for the NuGet auto-instrumentation package

## Reason for change

We now have tests for the NuGet on Linux, but we want to test on Windows too

## Implementation details

Similar to #2878, but for Windows. Ran into one weird case where adding the NuGet package inside the Dockerfile was failing with `Access denied` (only in CI, not locally). Resolved by adding `USER ContainerAdministrator` in the Dockerfile. I don't really understand it, but it works, so 🤷‍♂️ 

## Test coverage

As with other windows tests, only testing Windows Server Core currently which I think is sufficient for now. We can always add nano server later if required.

## Other details
AIT-2818. Requires #2937, #2938, #2941, #2944 to be merged first
