### PR TITLE
Add smoke tests for dotnet-tool instrumentation on Linux

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2793,6 +2793,68 @@ stages:
         baseImage: debian
         command: "CheckBuildLogsForErrors"
 
+- stage: dotnet_tool_smoke_tests_arm64
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [dotnet_tool, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux]
+
+  - job: linux
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_smoke_tests_arm64_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      name: aws-arm64-auto-scaling
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download dotnet tool
+      inputs:
+        artifact: runner-standalone-$(platformSuffix)
+        patterns: "*.tar.gz"
+        path: $(Agent.TempDirectory)
+
+    - script: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+        mkdir -p $(smokeTestAppDir)/artifacts
+        tar -xf $(Agent.TempDirectory)/dd-trace-$(platformSuffix).tar.gz -C $(smokeTestAppDir)/artifacts
+        chmod +x $(smokeTestAppDir)/artifacts/dd-trace
+      displayName: create test data directories and extract tool
+
+    - script: |
+        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          dotnet-tool-smoke-tests
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dotnet-tool-smoke-tests'
+        snapshotPrefix: "smoke_test"
+
+    - publish: tracer/build_data
+      artifact: dotnet-tool-smoke-test-logs_arm64_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: debian
+        command: "CheckBuildLogsForErrors"
+
 - stage: nuget_installer_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1726,6 +1726,14 @@ stages:
         tarCompression: 'gz'
         archiveFile: $(System.DefaultWorkingDirectory)/tracer/src/Datadog.Trace.Tools.Runner/bin/$(buildConfiguration)/Console/publish/linux-musl-x64/dd-trace-linux-musl-x64.tar.gz
 
+    - task: ArchiveFiles@2
+      inputs:
+        rootFolderOrFile: $(System.DefaultWorkingDirectory)/tracer/src/Datadog.Trace.Tools.Runner/bin/$(buildConfiguration)/Console/publish/linux-arm64/dd-trace
+        includeRootFolder: false
+        archiveType: 'tar'
+        tarCompression: 'gz'
+        archiveFile: $(System.DefaultWorkingDirectory)/tracer/src/Datadog.Trace.Tools.Runner/bin/$(buildConfiguration)/Console/publish/linux-arm64/dd-trace-linux-arm64.tar.gz
+
     - publish: $(System.DefaultWorkingDirectory)/tracer/src/Datadog.Monitoring.Distribution/bin/$(buildConfiguration)/packages
       displayName: Publish Distribution package
       artifact: distribution-nuget-package
@@ -2104,6 +2112,13 @@ stages:
           displayName: Download standalone dotnet tool linux-musl-x64
           inputs:
             artifact: runner-standalone-linux-musl-x64
+            patterns: "*.tar.gz"
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download standalone dotnet tool linux-arm64
+          inputs:
+            artifact: runner-standalone-linux-arm64
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3159,6 +3159,7 @@ stages:
     - nuget_installer_smoke_tests_arm64
     - nuget_installer_smoke_tests_windows
     - dotnet_tool_smoke_tests_linux
+    - dotnet_tool_smoke_tests_arm64
     - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2599,6 +2599,72 @@ stages:
         baseImage: alpine
         command: "CheckBuildLogsForErrors"
 
+- stage: dotnet_tool_smoke_tests_linux
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [dotnet_tool, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux]
+
+  - job: linux
+    timeoutInMinutes: 60 #default value
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_linux_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: ubuntu-18.04
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tool runner-standalone-$(platformSuffix)
+      inputs:
+        artifact: runner-standalone-$(platformSuffix)
+        patterns: "*.tar.gz"
+        path: $(Agent.TempDirectory)
+
+    - script: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+        mkdir -p $(smokeTestAppDir)/artifacts
+        tar -xf $(Agent.TempDirectory)/dd-trace-$(platformSuffix).tar.gz -C $(smokeTestAppDir)/artifacts
+        chmod +x $(smokeTestAppDir)/artifacts/dd-trace
+      displayName: create test data directories and extract tool
+
+    - script: |
+        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          dotnet-tool-smoke-tests
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dotnet-tool-smoke-tests'
+        snapshotPrefix: "smoke_test"
+
+    - publish: tracer/build_data
+      artifact: dotnet-tool-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: alpine
+        command: "CheckBuildLogsForErrors"
+        
 - stage: installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [build_arm64, generate_variables, master_commit_id]
@@ -3015,6 +3081,7 @@ stages:
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
     - nuget_installer_smoke_tests_windows
+    - dotnet_tool_smoke_tests_linux
     - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -728,3 +728,22 @@ services:
     - DD_TRACE_AGENT_URL=http://test-agent:8126
     depends_on:
     - test-agent
+
+  dotnet-tool-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.dotnet-tool.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-tester
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+    - test-agent

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -577,19 +577,20 @@ partial class Build : NukeBuild
                         dockerName: "andrewlock/dotnet-fedora"
                     );
 
-                    AddToDotNetToolSmokeTestsMatrix(
-                        matrix,
-                        "alpine",
-                        new (string publishFramework, string runtimeTag)[]
-                        {
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
-                        },
-                        platformSuffix: "linux-musl-x64",
-                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
-                    );
+                    // The dotnet tool doesn't currently support alpine
+                    // AddToDotNetToolSmokeTestsMatrix(
+                    //     matrix,
+                    //     "alpine",
+                    //     new (string publishFramework, string runtimeTag)[]
+                    //     {
+                    //         (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                    //         (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                    //         (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                    //         (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                    //     },
+                    //     platformSuffix: "linux-musl-x64",
+                    //     dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    // );
 
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -238,6 +238,7 @@ partial class Build : NukeBuild
                 // dotnet tool smoke tests
                 GenerateWindowsDotnetToolSmokeTestsMatrix();
                 GenerateLinuxDotnetToolSmokeTestsMatrix();
+                GenerateLinuxDotnetToolSmokeTestsArm64Matrix();
 
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
@@ -621,6 +622,29 @@ partial class Build : NukeBuild
                     Logger.Info($"Installer smoke tests dotnet-tool matrix Linux");
                     Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetVariable("dotnet_tool_installer_linux_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateLinuxDotnetToolSmokeTestsArm64Matrix()
+                {
+                    var matrix = new Dictionary<string, object>();
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                        },
+                        platformSuffix: "linux-arm64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    Logger.Info($"Installer smoke tests dotnet-tool matrix Arm64");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("dotnet_tool_installer_smoke_tests_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void AddToDotNetToolSmokeTestsMatrix(

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -237,6 +237,7 @@ partial class Build : NukeBuild
                 
                 // dotnet tool smoke tests
                 GenerateWindowsDotnetToolSmokeTestsMatrix();
+                GenerateLinuxDotnetToolSmokeTestsMatrix();
 
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
@@ -538,6 +539,108 @@ partial class Build : NukeBuild
                                 dockerTag = dockerTag,
                                 publishFramework = image.publishFramework,
                                 relativeProfilerPath = relativeProfilerPath,
+                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                            });
+                    }
+                }
+                
+                void GenerateLinuxDotnetToolSmokeTestsMatrix()
+                {
+                    var matrix = new Dictionary<string, object>();
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                        },
+                        platformSuffix: "linux-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "fedora",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                        },
+                        platformSuffix: "linux-x64",
+                        dockerName: "andrewlock/dotnet-fedora"
+                    );
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "alpine",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                        },
+                        platformSuffix: "linux-musl-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "centos",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                        },
+                        platformSuffix: "linux-x64",
+                        dockerName: "andrewlock/dotnet-centos"
+                    );
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "opensuse",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                        },
+                        platformSuffix: "linux-x64",
+                        dockerName: "andrewlock/dotnet-opensuse"
+                    );
+
+                    Logger.Info($"Installer smoke tests dotnet-tool matrix Linux");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("dotnet_tool_installer_linux_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void AddToDotNetToolSmokeTestsMatrix(
+                    Dictionary<string, object> matrix,
+                    string shortName,
+                    (string publishFramework, string runtimeTag)[] images,
+                    string platformSuffix,
+                    string dockerName
+                )
+                {
+                    foreach (var image in images)
+                    {
+                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        matrix.Add(
+                            dockerTag,
+                            new
+                            {
+                                dockerTag = dockerTag,
+                                publishFramework = image.publishFramework,
+                                platformSuffix = platformSuffix,
                                 runtimeImage = $"{dockerName}:{image.runtimeTag}"
                             });
                     }

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -1,0 +1,35 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /app/install
+
+ARG INSTALL_CMD
+RUN mkdir -p /opt/datadog \
+    && mkdir -p /var/log/datadog \
+    && mkdir -p /tool \
+    && cp /app/install/* /tool \
+    && rm -rf /app/install
+
+# Set the optional env vars
+ENV DD_PROFILING_ENABLED=1
+ENV ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["/tool/dd-trace", "dotnet", "/app/AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

- Add smoke tests for standalone `dd-trace` instrumentation on `linux-x64`
- Add smoke tests for standalone `dd-trace` instrumentation on `linux-arm64`
- Publish the arm64 standalone tool as a release artifact

## Reason for change

We want to test that we don't break instrumentation via the dd-trace tool.

## Implementation details

Pretty standard. Note that testing of alpine was temporarily removed, as we don't support this scenario. We will update the tests once we add support.

## Test coverage

Testing the reduced-set of distro/fx combinations (only covers 16 combos + 4 arm64, but hopefully sufficient).

## Other details
AIT-2818. Requires #2937, #2938, #2941, #2944 to be merged first
