### PR TITLE
Add support for alpine to the dd-trace tool

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -577,20 +577,19 @@ partial class Build : NukeBuild
                         dockerName: "andrewlock/dotnet-fedora"
                     );
 
-                    // The dotnet tool doesn't currently support alpine
-                    // AddToDotNetToolSmokeTestsMatrix(
-                    //     matrix,
-                    //     "alpine",
-                    //     new (string publishFramework, string runtimeTag)[]
-                    //     {
-                    //         (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                    //         (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                    //         (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                    //         (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
-                    //     },
-                    //     platformSuffix: "linux-musl-x64",
-                    //     dockerName: "mcr.microsoft.com/dotnet/aspnet"
-                    // );
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "alpine",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                        },
+                        platformSuffix: "linux-musl-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
 
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Tools.Runner
             {
                 if (RuntimeInformation.OSArchitecture == Architecture.X64)
                 {
-                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-x64", "Datadog.Trace.ClrProfiler.Native.so"));
+                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, IsAlpine() ? "linux-musl-x64" : "linux-x64", "Datadog.Trace.ClrProfiler.Native.so"));
                 }
                 else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
                 {
@@ -180,7 +180,7 @@ namespace Datadog.Trace.Tools.Runner
             {
                 if (RuntimeInformation.OSArchitecture == Architecture.X64)
                 {
-                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-x64", "Datadog.Trace.ClrProfiler.Native.so"));
+                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, IsAlpine() ? "linux-musl-x64" : "linux-x64", "Datadog.Trace.ClrProfiler.Native.so"));
                 }
                 else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
                 {
@@ -446,6 +446,30 @@ namespace Datadog.Trace.Tools.Runner
         internal static void WriteSuccess(string message)
         {
             AnsiConsole.MarkupLine($"[green]{message.EscapeMarkup()}[/]");
+        }
+
+        private static bool IsAlpine()
+        {
+            try
+            {
+                if (File.Exists("/etc/os-release"))
+                {
+                    var strArray = File.ReadAllLines("/etc/os-release");
+                    foreach (var str in strArray)
+                    {
+                        if (str.StartsWith("ID=", StringComparison.Ordinal))
+                        {
+                            return str.Substring(3).Trim('"', '\'') == "alpine";
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // ignore error checking if the file doesn't exist or we can't read it
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Adds support for Alpine into dd-trace
- Add smoke testing for Alpine with dd-trace

## Reason for change

Previously we didn't support instrumenting an app with dd-trace when running on Alpine. We should.

## Implementation details

Borrowed the work by @shurivich in https://github.com/confluentinc/confluent-kafka-dotnet/pull/1715 (simplified for our use case) to try to detect when we're running on Alpine.

## Test coverage

Tested via the smoke tests

## Other details

Requires #2949 to be merged first
