### PR TITLE
[Profiler] Build and package the Profiler for Arm64 architecture

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1281,7 +1281,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_arm64, master_commit_id]
+  dependsOn: [package_arm64, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     TestAllPackageVersions: true
@@ -1320,6 +1320,12 @@ stages:
             build: true
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker false"
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download arm64 monitoring home
+          inputs:
+            artifact: linux-monitoring-home-arm64
+            path: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
 
         - task: DockerCompose@0
           displayName: docker-compose run --no-deps IntegrationTests
@@ -1381,6 +1387,12 @@ stages:
             build: true
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework) --IncludeTestsRequiringDocker true"
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download arm64 monitoring home
+          inputs:
+            artifact: linux-monitoring-home-arm64
+            path: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
 
         - script: |
             docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -485,10 +485,10 @@ stages:
       parameters:
         build: true
         target: builder
-        baseImage: $(baseImage)
+        baseImage: debian
         command: "BuildNativeLoader ZipMonitoringHome"
 
-    - publish: $(artifacts)/linux-x64
+    - publish: $(artifacts)/linux-arm64
       displayName: Upload arm64 packages
       artifact: linux-packages-arm64
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -378,7 +378,7 @@ stages:
       displayName: Upload linux-x64 monitoring home
       artifact: linux-monitoring-home-$(baseImage)
 
-- stage: build_arm64
+- stage: build_arm64_tracer
   dependsOn: [master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -403,23 +403,102 @@ stages:
         build: true
         target: builder
         baseImage: debian
-        command: "Clean BuildTracerHome ZipMonitoringHome"
+        command: "Clean BuildTracerHome"
 
     - publish: $(tracerHome)
       displayName: Uploading linux tracer home artifact
       artifact: linux-tracer-home-arm64
 
-    - publish: $(artifacts)/linux-arm64
-      displayName: Upload linux-arm64 packages
-      artifact: linux-packages-arm64
-
-    - publish: $(symbols)
-      displayName: Upload linux-arm64 symbols
-      artifact: linux-symbols-arm64
-
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
       artifact: build-linux-arm64-working-directory
+
+- stage: build_arm64_profiler
+  dependsOn: [master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [build]
+
+  - job: build
+    timeoutInMinutes: 60 #default value
+    dependsOn: []
+    pool:
+      name: aws-arm64-auto-scaling
+    workspace:
+      clean: all
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        target: builder
+        baseImage: debian
+        command: "Clean BuildProfilerHome"
+
+    - publish: $(System.DefaultWorkingDirectory)/profiler/_build
+      displayName: Uploading linux profiler output build folder
+      artifact: linux-profiler-binaries-arm64
+
+    - publish: $(profilerHome)
+      displayName: Uploading linux profiler home artifact
+      artifact: linux-profiler-home-arm64
+
+- stage: package_arm64
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [master_commit_id, build_arm64_tracer, build_arm64_profiler]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [package]
+
+  - job: package
+    dependsOn: []
+    timeoutInMinutes: 60 #default value
+    pool:
+      name: aws-arm64-auto-scaling
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tracer arm64 native binary
+      inputs:
+        artifact: linux-tracer-home-arm64
+        path: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home/
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download profiler arm64 native binary
+      inputs:
+        artifact: linux-profiler-home-arm64
+        path: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home/continuousprofiler
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        target: builder
+        baseImage: $(baseImage)
+        command: "BuildNativeLoader ZipMonitoringHome"
+
+    - publish: $(artifacts)/linux-x64
+      displayName: Upload arm64 packages
+      artifact: linux-packages-arm64
+
+    - publish: $(symbols)
+      displayName: Upload arm64 symbols
+      artifact: linux-symbols-arm64
+
+    - publish: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
+      displayName: Upload arm64 monitoring home
+      artifact: linux-monitoring-home-arm64
 
 - stage: build_macos
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -677,7 +756,7 @@ stages:
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64, master_commit_id]
+  dependsOn: [build_arm64_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1202,7 +1281,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64, master_commit_id]
+  dependsOn: [build_arm64_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     TestAllPackageVersions: true
@@ -1620,7 +1699,7 @@ stages:
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
-  dependsOn: [build_windows_tracer, build_linux_tracer, build_arm64, build_macos, master_commit_id]
+  dependsOn: [build_windows_tracer, build_linux_tracer, build_arm64_tracer, build_macos, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -1906,7 +1985,7 @@ stages:
 
 - stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, package_linux, build_arm64, master_commit_id]
+  dependsOn: [package_windows, package_linux, package_arm64, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -2006,7 +2085,7 @@ stages:
 
 - stage: upload_to_azure
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), eq(variables.isMainRepository, true))
-  dependsOn: [package_windows, package_linux, build_arm64, dotnet_tool, master_commit_id]
+  dependsOn: [package_windows, package_linux, package_arm64, dotnet_tool, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -2181,7 +2260,7 @@ stages:
 
 - stage: throughput
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
-  dependsOn: [package_linux, build_arm64, build_windows_tracer, master_commit_id]
+  dependsOn: [package_linux, package_arm64, build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     # By default all throughput tests happen on release or master branches only. Overridable by setting 'run_extended_throughput_tests' to true
@@ -2682,7 +2761,7 @@ stages:
         
 - stage: installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64, generate_variables, master_commit_id]
+  dependsOn: [package_arm64, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1328,7 +1328,7 @@ stages:
             dockerComposeFileArgs: |
               baseImage=$(baseImage)
               framework=$(publishTargetFramework)
-            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=false IntegrationTests.ARM64
+            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=false IntegrationTests.ARM64
             projectName: ddtrace_$(Build.BuildNumber)
 
         - publish: tracer/build_data
@@ -1398,7 +1398,7 @@ stages:
             dockerComposeFileArgs: |
               baseImage=$(baseImage)
               framework=$(publishTargetFramework)
-            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=true IntegrationTests.ARM64
+            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=true IntegrationTests.ARM64
             projectName: ddtrace_$(Build.BuildNumber)
 
         - task: DockerCompose@0

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1281,7 +1281,7 @@ stages:
 
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_arm64_tracer, master_commit_id]
+  dependsOn: [package_arm64, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     TestAllPackageVersions: true

--- a/profiler/build/cmake/FindLibddprof.cmake
+++ b/profiler/build/cmake/FindLibddprof.cmake
@@ -3,18 +3,30 @@ include(ExternalProject)
 set(LIBDDPROF_VERSION "v0.6.0" CACHE STRING "libddprof version")
 
 if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
-   set(SHA256_LIBDDPROF "ca5e49636465ee977943d64815442d4bff2de2b74678b1376e6368280534f909" CACHE STRING "libddprof sha256")
-   set(LIBDDPROF_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libddprof-${LIBDDPROF_VERSION}/src/libddprof-build/libddprof/libddprof-x86_64-alpine-linux-musl)
+   set(LIBDDPROF_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libddprof-${LIBDDPROF_VERSION}/src/libddprof-build/libddprof/libddprof-${CMAKE_SYSTEM_PROCESSOR}-alpine-linux-musl)
 else()
-   set(SHA256_LIBDDPROF "8eaec92d14bcfa8839843ba2ddfeae254804e087a4984985132a508d6f841645" CACHE STRING "libddprof sha256")
-   set(LIBDDPROF_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libddprof-${LIBDDPROF_VERSION}/src/libddprof-build/libddprof/libddprof-x86_64-unknown-linux-gnu)
+   set(LIBDDPROF_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libddprof-${LIBDDPROF_VERSION}/src/libddprof-build/libddprof/libddprof-${CMAKE_SYSTEM_PROCESSOR}-unknown-linux-gnu)
+endif()
+
+if (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
+  if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
+    set(SHA256_LIBDDPROF "7501d26ed9b2607c2bca79b3fd39971efa4dbb6949226d7d123f095e47ca541c" CACHE STRING "libddprof sha256")
+  else()
+    set(SHA256_LIBDDPROF "c18351882fdb4b64df76f4cd49dbf567d8871349fa444144aa9a8ddf0532bad2" CACHE STRING "libddprof sha256")
+  endif()
+else()
+  if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
+    set(SHA256_LIBDDPROF "ca5e49636465ee977943d64815442d4bff2de2b74678b1376e6368280534f909" CACHE STRING "libddprof sha256")
+  else()
+    set(SHA256_LIBDDPROF "8eaec92d14bcfa8839843ba2ddfeae254804e087a4984985132a508d6f841645" CACHE STRING "libddprof sha256")
+  endif()
 endif()
 
 ExternalProject_Add(libddprof
   PREFIX "libddprof-${LIBDDPROF_VERSION}"
   INSTALL_COMMAND ""
   CONFIGURE_COMMAND ""
-  DOWNLOAD_COMMAND ${CMAKE_SOURCE_DIR}/build/tools/fetch_libddprof.sh ${LIBDDPROF_VERSION} ${SHA256_LIBDDPROF} <BINARY_DIR>
+  DOWNLOAD_COMMAND ${CMAKE_SOURCE_DIR}/build/tools/fetch_libddprof.sh ${LIBDDPROF_VERSION} ${CMAKE_SYSTEM_PROCESSOR} ${SHA256_LIBDDPROF} <BINARY_DIR>
   BUILD_COMMAND ""
 )
 

--- a/profiler/build/cmake/FindLibunwind.cmake
+++ b/profiler/build/cmake/FindLibunwind.cmake
@@ -11,28 +11,17 @@ ExternalProject_Add(libunwind
     BUILD_ALWAYS false
 )
 
-SET(LIBUNWIND_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind)
 SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build)
 
-SET(LIBUNWIND_x86_64_PATH ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind-x86_64.a CACHE FILEPATH "location of libunwind-x64_64.a")
-SET(LIBUNWIND_PATH ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind.a CACHE FILEPATH "location of libunwind.a")
+add_library(libunwind-lib INTERFACE)
 
-SET(LIBUNWIND_LIBS
-    ${LIBUNWIND_x86_64_PATH}
-    ${LIBUNWIND_PATH})
-
-
-SET(LIBUNWIND_INCLUDES
+target_include_directories(libunwind-lib INTERFACE
+    ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build/include
     ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind/include
-    ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build/include)
+)
 
+target_link_libraries(libunwind-lib INTERFACE
+    ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
+    ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind.a)
 
-add_library(libunwind-lib STATIC IMPORTED)
-set_property(TARGET libunwind-lib PROPERTY
-             IMPORTED_LOCATION ${LIBUNWIND_PATH})
-add_dependencies(libunwind-lib libunwind-build)
-
-add_library(libunwind-x86_64-lib STATIC IMPORTED)
-set_property(TARGET libunwind-x86_64-lib PROPERTY
-             IMPORTED_LOCATION ${LIBUNWIND_x86_64_PATH})
-add_dependencies(libunwind-x86_64-lib libunwind-build)
+add_dependencies(libunwind-lib libunwind)

--- a/profiler/build/tools/fetch_libddprof.sh
+++ b/profiler/build/tools/fetch_libddprof.sh
@@ -10,13 +10,13 @@ IFS=$'\n\t'
 
 usage() {
     echo "Usage :"
-    echo "$0 <github_release_version> <SHA256> <path>"
+    echo "$0 <github_release_version> <ARCH> <SHA256> <path>"
     echo ""
     echo "Example"
-    echo "  $0 v0.2.0 cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27 ./vendor"
+    echo "  $0 v0.2.0 x86_64 cba0f24074d44781d7252b912faff50d330957e84a8f40a172a8138e81001f27 ./vendor"
 }
 
-if [ $# != 3 ] || [ $1 == "-h" ]; then
+if [ $# != 4 ] || [ $1 == "-h" ]; then
     usage
     exit 1
 fi
@@ -30,17 +30,18 @@ TOP_LVL_DIR=$PWD
 cd $CURRENTDIR
 
 VER_LIBDDPROF=$1
+ARCH_LIBDDPROF=$2
 if [ -z "${IsAlpine}" ]; then
-    TAR_LIBDDPROF=libddprof-x86_64-unknown-linux-gnu.tar.gz
+    TAR_LIBDDPROF=libddprof-${ARCH_LIBDDPROF}-unknown-linux-gnu.tar.gz
 else
-    TAR_LIBDDPROF=libddprof-x86_64-alpine-linux-musl.tar.gz
+    TAR_LIBDDPROF=libddprof-${ARCH_LIBDDPROF}-alpine-linux-musl.tar.gz
 fi
 
 URL_LIBDDPROF=https://github.com/DataDog/libddprof/releases/download/${VER_LIBDDPROF}/${TAR_LIBDDPROF}
 
-SHA256_LIBDDPROF=$2
-mkdir -p $3
-cd $3
+SHA256_LIBDDPROF=$3
+mkdir -p $4
+cd $4
 DOWNLOAD_PATH=$PWD
 TARGET_EXTRACT=${DOWNLOAD_PATH}/libddprof
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -98,7 +98,6 @@ target_include_directories(${PROFILER_STATIC_LIB_NAME}
         PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/coreclr/src/inc
         PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}/shared/src/native-lib/spdlog/include
         PUBLIC ${FMT_INCLUDE}
-        PUBLIC ${LIBUNWIND_INCLUDES}
         PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}
         PUBLIC ${LIBDDPROF_INCLUDE_DIR}
 )
@@ -119,7 +118,6 @@ endif()
 
 target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     fmt-lib
-    libunwind-x86_64-lib
     libunwind-lib
     libddprof-lib
     -static-libgcc
@@ -129,7 +127,7 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -ldl
 )
 
-add_dependencies(${PROFILER_STATIC_LIB_NAME} fmt libddprof libunwind)
+add_dependencies(${PROFILER_STATIC_LIB_NAME} fmt libddprof libunwind-lib)
 
 # ******************************************************
 # Define shared target

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -12,7 +12,13 @@
 #include <unordered_map>
 #include <iomanip>
 
+#ifdef ARM64
+#include <libunwind-aarch64.h>
+#elif AMD64
 #include <libunwind-x86_64.h>
+#else
+error("unsupported architecture")
+#endif
 
 #include "Log.h"
 #include "ManagedThreadInfo.h"

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -627,20 +627,17 @@ partial class Build
                 var workingDirectory = ArtifactsDirectory / $"linux-{LinuxArchitectureIdentifier}";
                 EnsureCleanDirectory(workingDirectory);
 
-                if (!IsArm64)
-                {
-                    var tracerNativeFile = MonitoringHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so";
-                    var newTracerNativeFile = MonitoringHomeDirectory / "tracer" / "Datadog.Tracer.Native.so";
-                    MoveFile(tracerNativeFile, newTracerNativeFile);
+                var tracerNativeFile = MonitoringHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so";
+                var newTracerNativeFile = MonitoringHomeDirectory / "tracer" / "Datadog.Tracer.Native.so";
+                MoveFile(tracerNativeFile, newTracerNativeFile);
 
-                    // For backward compatibility, we need to rename Datadog.AutoInstrumentation.NativeLoader.so into Datadog.Trace.ClrProfiler.Native.so
-                    var sourceFile = MonitoringHomeDirectory / "Datadog.AutoInstrumentation.NativeLoader.so";
-                    var newName = MonitoringHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so";
-                    RenameFile(sourceFile, newName);
-                }
+                // For backward compatibility, we need to rename Datadog.AutoInstrumentation.NativeLoader.so into Datadog.Trace.ClrProfiler.Native.so
+                var sourceFile = MonitoringHomeDirectory / "Datadog.AutoInstrumentation.NativeLoader.so";
+                var newName = MonitoringHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so";
+                RenameFile(sourceFile, newName);
 
                 // somehow the permissions are lost along the way, ensure they are correctly set here
-                var createLogPathScript = (IsArm64 ? TracerHomeDirectory : MonitoringHomeDirectory) / "createLogPath.sh";
+                var createLogPathScript = MonitoringHomeDirectory / "createLogPath.sh";
                 chmod.Invoke("+x " + createLogPathScript);
 
                 ExtractDebugInfoAndStripSymbols();
@@ -655,7 +652,7 @@ partial class Build
                         $"-n {packageName}",
                         $"-v {Version}",
                         packageType == "tar" ? "" : "--prefix /opt/datadog",
-                        $"--chdir {(IsArm64 ? TracerHomeDirectory : MonitoringHomeDirectory)}",
+                        $"--chdir {MonitoringHomeDirectory}",
                         "createLogPath.sh",
                         "netstandard2.0/",
                         "netcoreapp3.1/",
@@ -664,13 +661,9 @@ partial class Build
                     };
 
                     args.Add("libddwaf.so");
-
-                    if (!IsArm64)
-                    {
-                        args.Add("tracer/");
-                        args.Add("continuousprofiler/");
-                        args.Add("loader.conf");
-                    }
+                    args.Add("tracer/");
+                    args.Add("continuousprofiler/");
+                    args.Add("loader.conf");
 
                     var arguments = string.Join(" ", args);
                     fpm(arguments, workingDirectory: workingDirectory);

--- a/tracer/src/Datadog.AutoInstrumentation.NativeLoader/loader.conf
+++ b/tracer/src/Datadog.AutoInstrumentation.NativeLoader/loader.conf
@@ -2,10 +2,11 @@
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x64;.\continuousprofiler\Datadog.AutoInstrumentation.Profiler.Native.x64.dll
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x86;.\continuousprofiler\Datadog.AutoInstrumentation.Profiler.Native.x86.dll
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-x64;./continuousprofiler/Datadog.AutoInstrumentation.Profiler.Native.x64.so
+PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-arm64;./continuousprofiler/Datadog.AutoInstrumentation.Profiler.Native.x64.so
 
 #Tracer
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-x64;.\tracer\win-x64\Datadog.Trace.ClrProfiler.Native.dll
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-x86;.\tracer\win-x86\Datadog.Trace.ClrProfiler.Native.dll
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-x64;./tracer/Datadog.Tracer.Native.so
-TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-arm64;./tracer/Datadog.Trace.ClrProfiler.Native.so
+TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-arm64;./tracer/Datadog.Tracer.Native.so
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -135,8 +135,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 ("win", "X64")     => "Datadog.AutoInstrumentation.NativeLoader.x64.dll",
                 ("win", "X86")     => "Datadog.AutoInstrumentation.NativeLoader.x86.dll",
-                ("linux", "X64")   => "Datadog.Trace.ClrProfiler.Native.so",
-                ("linux", "Arm64") => "Datadog.Trace.ClrProfiler.Native.so",
+                ("linux", "X64" or "Arm64") => "Datadog.Trace.ClrProfiler.Native.so",
                 ("osx", _)         => "Datadog.AutoInstrumentation.NativeLoader.dylib",
                 _ => throw new PlatformNotSupportedException()
             };

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.TestHelpers
                 ("win", "X64")     => "Datadog.AutoInstrumentation.NativeLoader.x64.dll",
                 ("win", "X86")     => "Datadog.AutoInstrumentation.NativeLoader.x86.dll",
                 ("linux", "X64")   => "Datadog.Trace.ClrProfiler.Native.so",
-                ("linux", "Arm64") => "Datadog.AutoInstrumentation.NativeLoader.so",
+                ("linux", "Arm64") => "Datadog.Trace.ClrProfiler.Native.so",
                 ("osx", _)         => "Datadog.AutoInstrumentation.NativeLoader.dylib",
                 _ => throw new PlatformNotSupportedException()
             };


### PR DESCRIPTION
## Summary of changes

Compiles and package the profiler with the tracer on ARM64.

## Reason for change

Customer using the tracer on ARM64 architecture might want to use the profiler too.

## Implementation details

- Update the profiler cmake files
- Package the profiler and the tracer
- Run tracer integration tests with the native loader

## Test coverage

## Other details
<!-- Fixes #{issue} -->
