### PR TITLE
Exclude guid-like assembly names from telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -42,7 +42,12 @@ namespace Datadog.Trace.Telemetry
                || assemblyName.StartsWith("App_GlobalResources.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
-               || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal))))
+               || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)))
+             || (assemblyName.Length == 36
+              && assemblyName[8] == '-'
+              && assemblyName[13] == '-'
+              && assemblyName[18] == '-'
+              && assemblyName[23] == '-'))
             {
                 return;
             }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -61,6 +61,10 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData("App_Code.hhzpytyv")]
         [InlineData("App_Theme_Standard.6wkna0wf")]
         [InlineData("App_WebReferences.dvkaf7ph")]
+        [InlineData("0018eae6-bd49-41a4-9bd2-6be3a6544a15")]
+        [InlineData("005ec706-91d7-4237-9466-bac51a64d90f")]
+        [InlineData("00821386-7d9a-499b-8e7f-53dbbefcaf3d")]
+        [InlineData("OK_IM_NO-GUID-BUUT-NOT_-THAT_FAR_OFF")]
         public void DoesNotHaveChangesWhenAssemblyNameIsIgnoredAssembly(string assemblyName)
         {
             var ignoredName = CreateAssemblyName(new Version(1, 0), name: assemblyName);


### PR DESCRIPTION
## Summary of changes

- Exclude GUID-like assembly names from telemetry

## Reason for change

We're seeing a lot of dependencies listed that are just GUIDs. These aren't useful and blow up cardinality, so exclude them from the dependency list. We already exclude dynamic assemblies, so these are presumably something else.

## Implementation details

Went for a _super_ basic approach that just checks it's a string of the right length, with four hyphens in the right place. We could be more rigorous if people prefer, but these seems good enough to me

## Test coverage

Added a couple of basic unit tests. Demonstrated that we'll exclude "valid" names too, but I don't think it's a big deal

## Other details