### PR TITLE
Ensure we release cached StringBuilder instances back to the StringBuilderCache

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             {
                 var msgOut = StringBuilderCache.Acquire(256);
                 var size = FormatMessage(FORMAT_MESSAGE.ALLOCATE_BUFFER | FORMAT_MESSAGE.FROM_SYSTEM | FORMAT_MESSAGE.IGNORE_INSERTS, IntPtr.Zero, hresult, 0, ref msgOut, (uint)msgOut.Capacity, IntPtr.Zero);
-                var message = msgOut.ToString().Trim();
+                var message = StringBuilderCache.GetStringAndRelease(msgOut).Trim();
                 Log.Warning("Error occurred when calling {Function} message was: 0x{HResult}: {Message}", source, hresult.ToString("X8"), message);
             }
             else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/GraphQLCommon.cs
@@ -217,6 +217,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
             catch (Exception ex)
             {
                 Log.Error(ex, "Error creating GraphQL error message.");
+                Util.StringBuilderCache.Release(builder);
                 return "errors: []";
             }
 

--- a/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
+++ b/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
@@ -45,10 +45,7 @@ namespace Datadog.Trace.Util
         public static string GetStringAndRelease(StringBuilder sb)
         {
             string result = sb.ToString();
-            if (sb.Capacity <= MaxBuilderSize)
-            {
-                _cachedInstance = sb;
-            }
+            Release(sb);
 
             return result;
         }

--- a/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
+++ b/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
@@ -52,5 +52,13 @@ namespace Datadog.Trace.Util
 
             return result;
         }
+
+        public static void Release(StringBuilder sb)
+        {
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                _cachedInstance = sb;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes
I manually inspected and ensured that all codepaths that invoke `StringBuilderCache.Acquire` either call `StringBuilderCache.GetStringAndRelease` or `StringBuilderCache.Release` (new).

## Reason for change
@pierotibou noticed a small issue in #2897 where a StringBuilder instance wasn't being released back to the cache, so I figured I'd do a quick scan of the repo to see if there existing instances of this.

## Implementation details
N/A

## Test coverage
N/A

## Other details
N/A
