### PR TITLE
Upgrade WAF

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -59,7 +59,7 @@ partial class Build
     AbsolutePath ProfilerBuildDataDirectory => ProfilerDirectory / "build_data";
     AbsolutePath ProfilerTestLogsDirectory => ProfilerBuildDataDirectory / "logs";
 
-    const string LibDdwafVersion = "1.3.0";
+    const string LibDdwafVersion = "1.4.0";
     AbsolutePath LibDdwafDirectory => (NugetPackageDirectory ?? RootDirectory / "packages") / $"libddwaf.{LibDdwafVersion}";
 
     AbsolutePath SourceDirectory => TracerDirectory / "src";

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/packages.config
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libddwaf" version="1.3.0" targetFramework="native" />
+  <package id="libddwaf" version="1.4.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Version WAF 1.4.0 was released, release notes are here: https://github.com/DataDog/libddwaf/releases/tag/1.4.0
