### PR TITLE
Installer test tweaks

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2637,7 +2637,7 @@ stages:
         command: "CheckBuildLogsForErrors"
 
 - stage: nuget_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2706,7 +2706,7 @@ stages:
         command: "CheckBuildLogsForErrors"
 
 - stage: dotnet_tool_smoke_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2831,7 +2831,7 @@ stages:
             command: "CheckBuildLogsForErrors"
 
 - stage: nuget_installer_smoke_tests_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2900,7 +2900,7 @@ stages:
         command: "CheckBuildLogsForErrors"
 
 - stage: dotnet_tool_smoke_tests_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2962,7 +2962,7 @@ stages:
         command: "CheckBuildLogsForErrors"
 
 - stage: nuget_installer_smoke_tests_windows
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -3031,7 +3031,7 @@ stages:
       displayName: CheckBuildLogsForErrors
 
 - stage: dotnet_tool_smoke_tests_windows
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -3096,7 +3096,7 @@ stages:
       displayName: CheckBuildLogsForErrors
 
 - stage: msi_installer_smoke_tests
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [package_windows, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2585,7 +2585,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 10 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_smoke_tests_matrix'] ]
     variables:
@@ -2647,7 +2647,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 10 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.nuget_installer_linux_smoke_tests_matrix'] ]
     variables:
@@ -2716,7 +2716,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 10 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_linux_smoke_tests_matrix'] ]
     variables:
@@ -2782,7 +2782,7 @@ stages:
         jobs: [linux]
 
     - job: linux
-      timeoutInMinutes: 60 #default value
+      timeoutInMinutes: 30 # should take ~15 mins
       strategy:
         matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_smoke_tests_arm64_matrix'] ]
       variables:
@@ -2841,7 +2841,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.nuget_installer_linux_smoke_tests_arm64_matrix'] ]
     variables:
@@ -2910,7 +2910,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_smoke_tests_arm64_matrix'] ]
     variables:
@@ -2972,7 +2972,7 @@ stages:
       jobs: [windows]
 
   - job: windows
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins as large Windows docker files
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.nuget_installer_windows_smoke_tests_matrix'] ]
     variables:
@@ -3041,7 +3041,7 @@ stages:
       jobs: [windows]
 
   - job: windows
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins as large Windows docker files
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_windows_smoke_tests_matrix'] ]
     variables:
@@ -3106,7 +3106,7 @@ stages:
       jobs: [windows]
 
   - job: windows
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins as large Windows docker files
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.msi_installer_windows_smoke_tests_matrix'] ]
     variables:
@@ -3171,7 +3171,7 @@ stages:
       jobs: [windows]
 
   - job: windows
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 30 # should take ~15 mins as large Windows docker files
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.tracer_home_installer_windows_smoke_tests_matrix'] ]
     variables:


### PR DESCRIPTION
## Summary of changes

- Reduce the timeouts on the installer tests
- Don't run all the installer smoke tests on all the PRs

## Reason for change

- Azure Devops seems especially prone to losing contact with agents when running these tests. In that situation, the job will continue until the timeout expires. That can mean a long time before you get feedback. Reducing the timeout should reduce the feedback loop.
- With all the extra jobs there's more chance of random flakiness due to connectivity issues etc. In addition we are generally unlikely to make changes that _only_ affect the installers, and don't break other things.

## Implementation details

To reduce the impact of flake, we skip most of the installer tests for PRs, and instead run them on master only. You can also trigger a "full run" by setting the variable `isRunAllInstallerTestsBuild` in AzDo.

I opted to _keep_ running the "raw" installer tests on arm64 + linux, and the "tracer home" tests on Windows, so that we are at least doing some installer testing on every PR

The rough expected times + timeout set are:
- Linux max ~5 mins (10 min timeout)
- Arm64 max ~15 mins (30 min timeout)
- Windows max ~15 mins (30 min timeout)

## Test coverage

I'll check it behaves as expected in this PR, and will confirm they run correctly after merging

## Other details

