### PR TITLE
[Tracer] Ignore more assemblies and don't resend them all at each run

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -80,13 +80,9 @@ namespace Datadog.Trace.Telemetry
             {
                 if (assembly.Value == false)
                 {
+                    _assemblies[assembly.Key] = true;
                     assembliesToRecord.Add(assembly.Key);
                 }
-            }
-
-            foreach (var key in assembliesToRecord)
-            {
-                _assemblies[key] = true;
             }
 
             return assembliesToRecord;
@@ -126,7 +122,7 @@ namespace Datadog.Trace.Telemetry
                 // Simple implementation to remove guids
                 case 36 when assemblyName[8] == '-' && assemblyName[13] == '-' && assemblyName[18] == '-' && assemblyName[23] == '-':
                 // and other weird use cases like ℛ*710fa04a-6428-4dd1-85a0-0419c142709b#5-0 where the suffix can be up to 7 chars long
-                case >= 42 and <= 45 when assemblyName[10] == '-' && assemblyName[15] == '-' && assemblyName[20] == '-' && assemblyName[25] == '-':
+                case >= 42 when assemblyName[10] == '-' && assemblyName[15] == '-' && assemblyName[20] == '-' && assemblyName[25] == '-':
                     return true;
                 default:
                     return false;

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -43,11 +43,7 @@ namespace Datadog.Trace.Telemetry
                || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)))
-             || (assemblyName.Length == 36
-              && assemblyName[8] == '-'
-              && assemblyName[13] == '-'
-              && assemblyName[18] == '-'
-              && assemblyName[23] == '-'))
+             || IsGuid(assemblyName))
             {
                 return;
             }
@@ -103,6 +99,20 @@ namespace Datadog.Trace.Telemetry
                     >= '0' and <= '5' => true,
                     _ => false
                 };
+            }
+        }
+
+        private static bool IsGuid(string assemblyName)
+        {
+            switch (assemblyName.Length)
+            {
+                // Simple implementation to remove guids
+                case 36 when assemblyName[8] == '-' && assemblyName[13] == '-' && assemblyName[18] == '-' && assemblyName[23] == '-':
+                // and other weird use cases like ℛ*710fa04a-6428-4dd1-85a0-0419c142709b#5-0
+                case 42 or 43 when assemblyName[10] == '-' && assemblyName[15] == '-' && assemblyName[20] == '-' && assemblyName[25] == '-':
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Telemetry
         /// Get the latest data to send to the intake.
         /// </summary>
         /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
-        public ICollection<DependencyTelemetryData> GetData()
+        public List<DependencyTelemetryData> GetData()
         {
             var hasChanges = Interlocked.CompareExchange(ref _hasChangesFlag, 0, 1) == 1;
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -41,17 +41,18 @@ namespace Datadog.Trace.Tests.Telemetry
         }
 
         [Fact]
-        public void DoesNotHaveChangesWhenSameAssemblyAddedTwice()
+        public void DoesHaveChangesWhenSameAssemblyAddedTwice()
         {
             var assembly = typeof(DependencyTelemetryCollectorTests).Assembly;
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assembly);
+            collector.HasChanges().Should().BeTrue();
 
             collector.GetData();
             collector.HasChanges().Should().BeFalse();
 
             collector.AssemblyLoaded(assembly);
-            collector.HasChanges().Should().BeFalse();
+            collector.HasChanges().Should().BeTrue();
         }
 
         [Theory]
@@ -119,10 +120,6 @@ namespace Datadog.Trace.Tests.Telemetry
             var assemblyV2 = CreateAssemblyName(new Version(2, 0));
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assemblyV1);
-
-            collector.GetData();
-            collector.HasChanges().Should().BeFalse();
-
             collector.AssemblyLoaded(assemblyV2);
             collector.HasChanges().Should().BeTrue();
             var data = collector.GetData();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests.Telemetry
         }
 
         [Fact]
-        public void DoesHaveChangesWhenSameAssemblyAddedTwice()
+        public void DoesNotHaveChangesWhenSameAssemblyAddedTwice()
         {
             var assembly = typeof(DependencyTelemetryCollectorTests).Assembly;
             var collector = new DependencyTelemetryCollector();
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Tests.Telemetry
             collector.HasChanges().Should().BeFalse();
 
             collector.AssemblyLoaded(assembly);
-            collector.HasChanges().Should().BeTrue();
+            collector.HasChanges().Should().BeFalse();
         }
 
         [Theory]
@@ -67,6 +67,8 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData("00821386-7d9a-499b-8e7f-53dbbefcaf3d")]
         [InlineData("ℛ*00093a17-a657-432d-ad25-13cf53f44319#2-0")]
         [InlineData("ℛ*71ccc5b6-6f30-4c09-9e23-4e7ac5a9ad31#13-0")]
+        [InlineData("ℛ*1887feb5-1546-46da-a64e-07cba2cb32fa#112-0")]
+        [InlineData("ℛ*bcd9d48c-2728-46f5-bd56-bfb58cb0bb22#1156-0")]
         [InlineData("OK_IM_NO-GUID-BUUT-NOT_-THAT_FAR_OFF")]
         public void DoesNotHaveChangesWhenAssemblyNameIsIgnoredAssembly(string assemblyName)
         {
@@ -120,13 +122,17 @@ namespace Datadog.Trace.Tests.Telemetry
             var assemblyV2 = CreateAssemblyName(new Version(2, 0));
             var collector = new DependencyTelemetryCollector();
             collector.AssemblyLoaded(assemblyV1);
+
+            collector.GetData();
+            collector.HasChanges().Should().BeFalse();
+
             collector.AssemblyLoaded(assemblyV2);
             collector.HasChanges().Should().BeTrue();
             var data = collector.GetData();
             data.Should().NotBeNull();
             data.Should()
                 .NotBeNullOrEmpty()
-                .And.HaveCount(2)
+                .And.HaveCount(1) // as we send to the backend only new versions
                 .And.OnlyHaveUniqueItems();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -64,6 +64,8 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData("0018eae6-bd49-41a4-9bd2-6be3a6544a15")]
         [InlineData("005ec706-91d7-4237-9466-bac51a64d90f")]
         [InlineData("00821386-7d9a-499b-8e7f-53dbbefcaf3d")]
+        [InlineData("ℛ*00093a17-a657-432d-ad25-13cf53f44319#2-0")]
+        [InlineData("ℛ*71ccc5b6-6f30-4c09-9e23-4e7ac5a9ad31#13-0")]
         [InlineData("OK_IM_NO-GUID-BUUT-NOT_-THAT_FAR_OFF")]
         public void DoesNotHaveChangesWhenAssemblyNameIsIgnoredAssembly(string assemblyName)
         {


### PR DESCRIPTION
## Summary of changes
Ignore assembly names like `ℛ*fe48e1c0-b9fb-433d-a781-5f0f0b6555e4#2-0` as there were 6000 of them. Also do not resend all assemblies at each run.

## Reason for change
There was a misunderstanding with R&P, we need to send them once, not resend the whole package every time. We'll need to do the same for config and integrations.

## Implementation details
For the update, rebuild a ConcurrentDictionnary at each upload.

## Test coverage
Added 2 test cases

## Other details
<!-- Fixes #{issue} -->
