### PR TITLE
[Profiler] Run Profiler unit tests in container in Github Actions

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -47,13 +47,10 @@ jobs:
         with:
           command: "Clean BuildTracerHome BuildNativeLoader BuildProfilerHome ZipMonitoringHome --TracerHome /project/shared/bin/monitoring-home"
 
-      - name: Run Native Unit tests
-        shell: bash
-        run: |
-          sudo mkdir /var/log/datadog
-          sudo chmod 777 /var/log/datadog 
-          sudo chmod +x ./profiler/_build/bin/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests
-          ./profiler/_build/bin/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests --gtest_output=xml
+      - uses: ./.github/actions/run-in-docker
+        name: Run Native Unit tests
+        with:
+          command: "RunProfilerNativeUnitTestsLinux"
 
       - name: Publish artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Summary of changes

## Reason for change

Recently, Github Actions worker are changing and time to time unit tests are failing due to wrong glibc version.
We will run the unit tests in a container (we do the same in AzDo)

## Implementation details

Change the step to run the unit tests in docker container.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
