### PR TITLE
Allow running CosmosDb tests in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -824,14 +824,16 @@ stages:
         includeX86: true
     - template: steps/restore-working-directory.yml
 
-# Cosmos is _way_ to flaky at the moment. Try enabling again at a later time
-#    - powershell: |
-#        Write-Host "Starting CosmosDB Emulator"
-#        Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
-#        Start-CosmosDbEmulator -Timeout 300
-#      displayName: 'Start CosmosDB Emulator'
-#      workingDirectory: $(Pipeline.Workspace)
-#      retryCountOnTaskFailure: 5
+    # Cosmos is _way_ to flaky at the moment. Allow conditionally running the cosmos integration tests,
+    # so we can test new versions 
+    - powershell: |
+        Write-Host "Starting CosmosDB Emulator"
+        Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+        Start-CosmosDbEmulator -Timeout 300
+      displayName: 'Start CosmosDB Emulator'
+      condition: and(succeeded(), eq(variables.run_cosmos_integration_tests, 'true'))
+      workingDirectory: $(Pipeline.Workspace)
+      retryCountOnTaskFailure: 5
 
     - powershell: |
         Write-Host "Initializing LocalDB"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -829,11 +829,11 @@ stages:
     - powershell: |
         Write-Host "Starting CosmosDB Emulator"
         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
-        Start-CosmosDbEmulator -Timeout 300
+        Start-CosmosDbEmulator -Timeout 500
       displayName: 'Start CosmosDB Emulator'
       condition: and(succeeded(), eq(variables.run_cosmos_integration_tests, 'true'))
       workingDirectory: $(Pipeline.Workspace)
-      retryCountOnTaskFailure: 5
+      retryCountOnTaskFailure: 3
 
     - powershell: |
         Write-Host "Initializing LocalDB"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        [SkippableTheory(Skip = "Cosmos emulator is too flaky at the moment")]
+        [SkippableTheory]
         [MemberData(nameof(PackageVersions.CosmosDb), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
@@ -40,6 +40,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public void SubmitsTraces(string packageVersion)
         {
+            if (Environment.GetEnvironmentVariable("run_cosmos_integration_tests") != "true")
+            {
+                throw new SkipException("Skipping Cosmos tests. To run set environment variable 'run_cosmos_integration_tests=true'");
+            }
+
             var expectedSpanCount = 14;
 
             using var telemetry = this.ConfigureTelemetry();


### PR DESCRIPTION
## Summary of changes

- Allow running the CosmosDB tests in CI by setting the variable `run_cosmos_integration_tests`

## Reason for change

We disabled the CosmosDB tests in CI a while back because the emulator was incredibly flaky. However, as new versions are released, we do want to actually test the cosmosDB integration. 

## Implementation details

Only start the emulator if `run_cosmos_integration_tests` is set. Only skip the cosmosdb tests if `run_cosmos_integration_tests` is _not_ set

## Test coverage

- [ ] Trigger a manual CI run with the variable set to confirm this works as expected

> Ah, it doesn't work. Looks like our hosted VMs don't have the emulator installed. I'll update the VM images at some point, and come back to this

## Other details
We could try and update the dependency bot runner to automatically set this variable if it sees cosmosdb has been updated. For now, we can run that test ourselves manually when required
