### PR TITLE
[Profiler] Minor cleanup

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -31,7 +31,7 @@ using namespace std::chrono_literals;
 std::mutex LinuxStackFramesCollector::s_signalHandlerInitLock;
 std::mutex LinuxStackFramesCollector::s_stackWalkInProgressMutex;
 bool LinuxStackFramesCollector::s_isSignalHandlerSetup = false;
-int LinuxStackFramesCollector::s_signalToSend = -1;
+int32_t LinuxStackFramesCollector::s_signalToSend = -1;
 LinuxStackFramesCollector* LinuxStackFramesCollector::s_pInstanceCurrentlyStackWalking = nullptr;
 
 LinuxStackFramesCollector::LinuxStackFramesCollector(ICorProfilerInfo4* const _pCorProfilerInfo) :
@@ -192,7 +192,7 @@ void LinuxStackFramesCollector::InitializeSignalHandler()
     s_isSignalHandlerSetup = SetupSignalHandler();
 }
 
-bool LinuxStackFramesCollector::TrySetHandlerForSignal(int signal, struct sigaction& action)
+bool LinuxStackFramesCollector::TrySetHandlerForSignal(int32_t signal, struct sigaction& action)
 {
     struct sigaction oldAction;
     if (sigaction(signal, nullptr, &oldAction) < 0)
@@ -209,7 +209,7 @@ bool LinuxStackFramesCollector::TrySetHandlerForSignal(int signal, struct sigact
     if (oldAction.sa_handler == SIG_DFL || oldAction.sa_handler == SIG_IGN)
     {
         sigaddset(&action.sa_mask, signal);
-        int result = sigaction(signal, &action, &oldAction);
+        int32_t result = sigaction(signal, &action, &oldAction);
         if (result == 0)
         {
             return true;
@@ -258,7 +258,7 @@ bool LinuxStackFramesCollector::SetupSignalHandler()
     return false;
 }
 
-char const* LinuxStackFramesCollector::ErrorCodeToString(int errorCode)
+char const* LinuxStackFramesCollector::ErrorCodeToString(int32_t errorCode)
 {
     switch (errorCode)
     {
@@ -349,7 +349,7 @@ std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread()
     }
 }
 
-void LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal)
+void LinuxStackFramesCollector::CollectStackSampleSignalHandler(int32_t signal)
 {
     std::unique_lock<std::mutex> stackWalkInProgressLock(s_stackWalkInProgressMutex);
     LinuxStackFramesCollector* pCollectorInstanceCurrentlyStackWalking = s_pInstanceCurrentlyStackWalking;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -68,14 +68,14 @@ private:
     ICorProfilerInfo4* const _pCorProfilerInfo;
 
 private:
-    static bool TrySetHandlerForSignal(int signal, struct sigaction& action);
-    static void CollectStackSampleSignalHandler(int signal);
+    static bool TrySetHandlerForSignal(int32_t signal, struct sigaction& action);
+    static void CollectStackSampleSignalHandler(int32_t signal);
 
-    static char const* ErrorCodeToString(int errorCode);
+    static char const* ErrorCodeToString(int32_t errorCode);
     static std::mutex s_stackWalkInProgressMutex;
     static std::mutex s_signalHandlerInitLock;
     static bool s_isSignalHandlerSetup;
-    static int s_signalToSend;
+    static int32_t s_signalToSend;
 
     static LinuxStackFramesCollector* s_pInstanceCurrentlyStackWalking;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -65,8 +65,8 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
     }
 
     char state = ' ';
-    int userTime = 0;
-    int kernelTime = 0;
+    int32_t userTime = 0;
+    int32_t kernelTime = 0;
     bool success = OpSysTools::ParseThreadInfo(sline, state, userTime, kernelTime);
     if (!success)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -138,7 +138,7 @@ bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
     SYSTEM_THREAD_INFORMATION sti = {0};
     auto size = sizeof(SYSTEM_THREAD_INFORMATION);
     ULONG buflen = 0;
-    NTSTATUS lResult = NtQueryInformationThread(pThreadInfo->GetOsThreadHandle(), SYSTEMTHREADINFORMATION, &sti, size, &buflen);
+    NTSTATUS lResult = NtQueryInformationThread(pThreadInfo->GetOsThreadHandle(), SYSTEMTHREADINFORMATION, &sti, static_cast<ULONG>(size), &buflen);
     if (lResult != 0)
     {
         // This always happens in 32 bit so uses another API to at least get the CPU consumption

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.cpp
@@ -162,11 +162,11 @@ void AdaptiveSampler::RollWindow()
 
     if (_totalCountRunningAverage == 0 || _emaAlpha <= 0.0)
     {
-        _totalCountRunningAverage = totalCount;
+        _totalCountRunningAverage = static_cast<double>(totalCount);
     }
     else
     {
-        _totalCountRunningAverage = _totalCountRunningAverage + _emaAlpha * (totalCount - _totalCountRunningAverage);
+        _totalCountRunningAverage = _totalCountRunningAverage + _emaAlpha * (static_cast<double>(totalCount) - _totalCountRunningAverage);
     }
 
     if (_totalCountRunningAverage <= 0)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -22,7 +22,7 @@ std::string const Configuration::DefaultProdSite = "datadoghq.com";
 std::string const Configuration::DefaultVersion = "Unspecified-Version";
 std::string const Configuration::DefaultEnvironment = "Unspecified-Environment";
 std::string const Configuration::DefaultAgentHost = "localhost";
-int const Configuration::DefaultAgentPort = 8126;
+int32_t const Configuration::DefaultAgentPort = 8126;
 std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
@@ -105,7 +105,7 @@ bool Configuration::IsExceptionProfilingEnabled() const
     return _isExceptionProfilingEnabled;
 }
 
-int Configuration::ExceptionSampleLimit() const
+int32_t Configuration::ExceptionSampleLimit() const
 {
     return _exceptionSampleLimit;
 }
@@ -150,7 +150,7 @@ std::string const& Configuration::GetAgentHost() const
     return _agentHost;
 }
 
-int Configuration::GetAgentPort() const
+int32_t Configuration::GetAgentPort() const
 {
     return _agentPort;
 }
@@ -241,7 +241,7 @@ std::chrono::seconds Configuration::GetDefaultUploadInterval()
 // - replace shared::TryParse by this implementation
 // - add tests
 
-bool TryParse(shared::WSTRING const& s, int& result)
+bool TryParse(shared::WSTRING const& s, int32_t& result)
 {
     auto str = shared::ToString(s);
     if (str == "")
@@ -266,7 +266,7 @@ bool TryParse(shared::WSTRING const& s, int& result)
 std::chrono::seconds Configuration::ExtractUploadInterval()
 {
     auto r = shared::GetEnvironmentValue(EnvironmentVariables::UploadInterval);
-    int interval;
+    int32_t interval;
     if (TryParse(r, interval))
     {
         return std::chrono::seconds(interval);
@@ -305,7 +305,7 @@ bool convert_to(shared::WSTRING const& s, shared::WSTRING& result)
     return true;
 }
 
-bool convert_to(shared::WSTRING const& s, int& result)
+bool convert_to(shared::WSTRING const& s, int32_t& result)
 {
     return TryParse(s, result);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -32,7 +32,7 @@ public:
     std::string const& GetHostname() const override;
     std::string const& GetAgentUrl() const override;
     std::string const& GetAgentHost() const override;
-    int GetAgentPort() const override;
+    int32_t GetAgentPort() const override;
     bool IsAgentless() const override;
     std::string const& GetSite() const override;
     std::string const& GetApiKey() const override;
@@ -40,7 +40,7 @@ public:
     bool IsCpuProfilingEnabled() const override;
     bool IsWallTimeProfilingEnabled() const override;
     bool IsExceptionProfilingEnabled() const override;
-    int ExceptionSampleLimit() const override;
+    int32_t ExceptionSampleLimit() const override;
 
 private:
     static tags ExtractUserTags();
@@ -63,7 +63,7 @@ private:
     static std::string const DefaultEnvironment;
     static std::string const DefaultAgentHost;
     static std::string const DefaultEmptyString;
-    static int const DefaultAgentPort;
+    static int32_t const DefaultAgentPort;
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
 
@@ -88,5 +88,5 @@ private:
     tags _userTags;
     bool _isNativeFrameEnabled;
     bool _isAgentLess;
-    int _exceptionSampleLimit;
+    int32_t _exceptionSampleLimit;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.cpp
@@ -17,7 +17,7 @@
 /// - Add a conversion to DogFood::MetricType in the Convert function :
 ///     Add a new `if constexpr(...)` statement in Convert() for the new metric type
 
-DogstatsdService::DogstatsdService(const std::string& host, int port, const Tags& tags) :
+DogstatsdService::DogstatsdService(const std::string& host, int32_t port, const Tags& tags) :
     _commonTags{tags},
     _host{host},
     _port{port}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.h
@@ -11,7 +11,7 @@
 class DogstatsdService : public IMetricsSender
 {
 public:
-    DogstatsdService(const std::string& host, int port, const Tags& tags);
+    DogstatsdService(const std::string& host, int32_t port, const Tags& tags);
     ~DogstatsdService() override = default;
 
     bool Gauge(const std::string& name, double value) override;
@@ -29,5 +29,5 @@ private:
 private:
     const Tags _commonTags;
     const std::string _host;
-    int _port;
+    int32_t _port;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionSampler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionSampler.cpp
@@ -35,14 +35,14 @@ void ExceptionSampler::RollWindow()
     _knownExceptions.clear();
 }
 
-int ExceptionSampler::SamplingWindowsPerRecording(const IConfiguration* configuration)
+int32_t ExceptionSampler::SamplingWindowsPerRecording(const IConfiguration* configuration)
 {
     const auto uploadIntervalMs = std::chrono::duration_cast<std::chrono::milliseconds>(configuration->GetUploadInterval());
     const auto samplingWindowMs = std::chrono::duration_cast<std::chrono::milliseconds>(SamplingWindow);
-    return static_cast<int32_t>(std::min<long long>(uploadIntervalMs / samplingWindowMs, INT32_MAX));
+    return static_cast<int32_t>(std::min<int64_t>(uploadIntervalMs / samplingWindowMs, INT32_MAX));
 }
 
-int ExceptionSampler::SamplesPerWindow(const IConfiguration* configuration)
+int32_t ExceptionSampler::SamplesPerWindow(const IConfiguration* configuration)
 {
     return configuration->ExceptionSampleLimit() / SamplingWindowsPerRecording(configuration);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionSampler.h
@@ -20,6 +20,6 @@ private:
     std::mutex _knownExceptionsMutex;
 
     void RollWindow();
-    int SamplingWindowsPerRecording(const IConfiguration* configuration);
-    int SamplesPerWindow(const IConfiguration* configuration);
+    int32_t SamplingWindowsPerRecording(const IConfiguration* configuration);
+    int32_t SamplesPerWindow(const IConfiguration* configuration);
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -28,7 +28,7 @@ public:
     virtual std::string const& GetHostname() const = 0;
     virtual std::string const& GetAgentUrl() const = 0;
     virtual std::string const& GetAgentHost() const = 0;
-    virtual int GetAgentPort() const = 0;
+    virtual int32_t GetAgentPort() const = 0;
     virtual bool IsAgentless() const = 0;
     virtual std::string const& GetSite() const = 0;
     virtual std::string const& GetApiKey() const = 0;
@@ -37,5 +37,5 @@ public:
     virtual bool IsCpuProfilingEnabled() const = 0;
     virtual bool IsWallTimeProfilingEnabled() const = 0;
     virtual bool IsExceptionProfilingEnabled() const = 0;
-    virtual int ExceptionSampleLimit() const = 0;
+    virtual int32_t ExceptionSampleLimit() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -36,7 +36,7 @@ tags LibddprofExporter::CommonTags = {
 // need to be static so it leave longer for the shared library
 std::string const LibddprofExporter::ProcessId = std::to_string(OpSysTools::GetProcId());
 
-int const LibddprofExporter::RequestTimeOutMs = 10000;
+int32_t const LibddprofExporter::RequestTimeOutMs = 10000;
 
 std::string const LibddprofExporter::LanguageFamily = "dotnet";
 
@@ -229,7 +229,7 @@ bool LibddprofExporter::Export()
 {
     bool exported = false;
 
-    int idx = 0;
+    int32_t idx = 0;
     for (auto& [runtimeId, profileInfo] : _perAppInfo)
     {
         auto samplesCount = profileInfo.samplesCount;
@@ -292,7 +292,7 @@ bool LibddprofExporter::Export()
     return exported;
 }
 
-std::string LibddprofExporter::GeneratePprofFilePath(const std::string& applicationName, int idx) const
+std::string LibddprofExporter::GeneratePprofFilePath(const std::string& applicationName, int32_t idx) const
 {
     auto time = std::time(nullptr);
     struct tm buf = {};
@@ -313,7 +313,7 @@ std::string LibddprofExporter::GeneratePprofFilePath(const std::string& applicat
     return pprofFilePath.string();
 }
 
-void LibddprofExporter::ExportToDisk(const std::string& applicationName, SerializedProfile const& encodedProfile, int idx)
+void LibddprofExporter::ExportToDisk(const std::string& applicationName, SerializedProfile const& encodedProfile, int32_t idx)
 {
     auto pprofFilePath = GeneratePprofFilePath(applicationName, idx);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -13,8 +13,8 @@
 #include "shared/src/native-src/string.h"
 
 
-static constexpr int MinFieldAlignRequirement = 8;
-static constexpr int FieldAlignRequirement = (MinFieldAlignRequirement >= alignof(std::uint64_t)) ? MinFieldAlignRequirement : alignof(std::uint64_t);
+static constexpr int32_t MinFieldAlignRequirement = 8;
+static constexpr int32_t FieldAlignRequirement = (MinFieldAlignRequirement >= alignof(std::uint64_t)) ? MinFieldAlignRequirement : alignof(std::uint64_t);
 
 struct alignas(FieldAlignRequirement) TraceContextTrackingInfo
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -42,7 +42,7 @@ OpSysTools::SetThreadDescriptionDelegate_t OpSysTools::s_setThreadDescriptionDel
 OpSysTools::GetThreadDescriptionDelegate_t OpSysTools::s_getThreadDescriptionDelegate = nullptr;
 #endif
 
-int OpSysTools::GetProcId()
+int32_t OpSysTools::GetProcId()
 {
 #ifdef _WINDOWS
     return ::GetCurrentProcessId();
@@ -51,7 +51,7 @@ int OpSysTools::GetProcId()
 #endif
 }
 
-int OpSysTools::GetThreadId()
+int32_t OpSysTools::GetThreadId()
 {
 #ifdef _WINDOWS
     return ::GetCurrentThreadId();
@@ -97,7 +97,7 @@ std::int64_t OpSysTools::GetHighPrecisionNanosecondsFallback(void)
 {
     std::chrono::high_resolution_clock::time_point now = std::chrono::high_resolution_clock::now();
 
-    long long totalNanosecs = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+    int64_t totalNanosecs = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
     return static_cast<std::int64_t>(totalNanosecs);
 }
 
@@ -320,7 +320,7 @@ std::string OpSysTools::GetProcessName()
     const DWORD len = GetModuleFileNameA(nullptr, pathName, length);
     return fs::path(pathName).filename().string();
 #elif MACOS
-    const int length = 260;
+    const int32_t length = 260;
     char* buffer = new char[length];
     proc_name(getpid(), buffer, length);
     return std::string(buffer);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -16,8 +16,8 @@
 class OpSysTools final
 {
 public:
-    static int GetProcId();
-    static int GetThreadId();
+    static int32_t GetProcId();
+    static int32_t GetThreadId();
     // static std::string UnicodeToAnsi(const WCHAR* str);
 
     /// <summary>
@@ -48,7 +48,7 @@ public:
     static std::string GetHostname();
     static std::string GetProcessName();
 
-    static bool ParseThreadInfo(std::string line, char& state, int& userTime, int& kernelTime)
+    static bool ParseThreadInfo(std::string line, char& state, int32_t& userTime, int32_t& kernelTime)
     {
         // based on https://linux.die.net/man/5/proc
         // state  = 3rd position  and 'R' for Running

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfilerEngineStatus.h
@@ -9,13 +9,13 @@ class ProfilerEngineStatus
 {
 private:
     // The memory for the IsProfilerEngineActive is allocated on the heap and must be properly aligned to ensure fast atomic operations.
-    static constexpr int MinimalAlignmentOf_IsProfilerEngineActive = 8;
-    static constexpr int ActualAlignmentOf_IsProfilerEngineActive = (MinimalAlignmentOf_IsProfilerEngineActive >= alignof(bool))
+    static constexpr int32_t MinimalAlignmentOf_IsProfilerEngineActive = 8;
+    static constexpr int32_t ActualAlignmentOf_IsProfilerEngineActive = (MinimalAlignmentOf_IsProfilerEngineActive >= alignof(bool))
                                                                         ? MinimalAlignmentOf_IsProfilerEngineActive
                                                                         : alignof(bool);
 
     // We will allocate a memory chunk that is at least as big as the alignment, even if we do not need all of that.
-    static constexpr int SizeOf_IsProfilerEngineActive = (ActualAlignmentOf_IsProfilerEngineActive >= sizeof(bool))
+    static constexpr int32_t SizeOf_IsProfilerEngineActive = (ActualAlignmentOf_IsProfilerEngineActive >= sizeof(bool))
                                                              ? ActualAlignmentOf_IsProfilerEngineActive
                                                              : sizeof(bool);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -176,10 +176,10 @@ void StackSamplerLoop::MainLoopIteration(void)
 
 void StackSamplerLoop::WalltimeProfilingIteration(void)
 {
-    int managedThreadsCount = _pManagedThreadList->Count();
-    int sampledThreadsCount = (std::min)(managedThreadsCount, MaxThreadsPerIterationForWallTime);
+    int32_t managedThreadsCount = _pManagedThreadList->Count();
+    int32_t sampledThreadsCount = (std::min)(managedThreadsCount, MaxThreadsPerIterationForWallTime);
 
-    for (int i = 0; i < sampledThreadsCount && !_shutdownRequested; i++)
+    for (int32_t i = 0; i < sampledThreadsCount && !_shutdownRequested; i++)
     {
         _targetThread = _pManagedThreadList->LoopNext(_iteratorWallTime);
         if (_targetThread != nullptr)
@@ -207,11 +207,11 @@ void StackSamplerLoop::WalltimeProfilingIteration(void)
 
 void StackSamplerLoop::CpuProfilingIteration(void)
 {
-    int managedThreadsCount = _pManagedThreadList->Count();
+    int32_t managedThreadsCount = _pManagedThreadList->Count();
     // TODO: as an optimization, don't scan more threads than nb logical cores
-    int sampledThreadsCount = (std::min)(managedThreadsCount, MaxThreadsPerIterationForCpuTime);
+    int32_t sampledThreadsCount = (std::min)(managedThreadsCount, MaxThreadsPerIterationForCpuTime);
 
-    for (int i = 0; i < sampledThreadsCount && !_shutdownRequested; i++)
+    for (int32_t i = 0; i < sampledThreadsCount && !_shutdownRequested; i++)
     {
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Timer.Windows.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Timer.Windows.cpp
@@ -38,7 +38,7 @@ void Timer::Start()
     dueTime.dwHighDateTime = rawDueTime.HighPart;
     dueTime.dwLowDateTime = rawDueTime.LowPart;
 
-    SetThreadpoolTimer(_internalTimer, &dueTime, _period.count(), 100);
+    SetThreadpoolTimer(_internalTimer, &dueTime, static_cast<DWORD>(_period.count()), 100);
 }
 
 void NTAPI Timer::OnTick(

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/BuggyBitsTest.cs
@@ -29,7 +29,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
             _output = output;
         }
 
-        [TestAppFact("Samples.BuggyBits", DisplayName = "BuggyBits")]
+        [TestAppFact("Samples.BuggyBits")]
         public void CheckSpanContextAreAttached(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true);
@@ -73,7 +73,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
             // profiler was a subset. But this makes the test flacky: not flushed when the application is closing.
         }
 
-        [TestAppFact("Samples.BuggyBits", DisplayName = "BuggyBits")]
+        [TestAppFact("Samples.BuggyBits")]
         public void NoTraceContextAttachedIfFeatureDeactivated(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuProfiler/CpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuProfiler/CpuProfilerTest.cs
@@ -23,14 +23,14 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
             _output = output;
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Computer01")]
+        [TestAppFact("Samples.Computer01")]
         public void NoCpuSampleIfCpuProfilerIsNotActivatedByDefault(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
             CheckCpuProfiles(runner, false);
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Computer01")]
+        [TestAppFact("Samples.Computer01")]
         public void NoCpuSampleIfCpuProfilerIsDeactivated(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
@@ -38,7 +38,7 @@ namespace Datadog.Profiler.IntegrationTests.CpuProfiler
             CheckCpuProfiles(runner, false);
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Computer01")]
+        [TestAppFact("Samples.Computer01")]
         public void GetCpuSamplesIfCpuProfilerIsActivated(string appName, string framework, string appAssembly)
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -16,7 +16,7 @@ namespace Datadog.Profiler.SmokeTests
             _output = output;
         }
 
-        [TestAppFact("Samples.BuggyBits", DisplayName = "BuggyBits")]
+        [TestAppFact("Samples.BuggyBits")]
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -26,28 +26,28 @@ namespace Datadog.Profiler.SmokeTests
         //  4: start a thread to compute pi at a certain precision(high CPU usage)
         //  5: start a to compute fibonacci (high CPU usage + deep stacks)
         // -----------------------------------------------------------------------------------------
-        [TestAppFact("Samples.Computer01", DisplayName = "AppDomain")]
+        [TestAppFact("Samples.Computer01")]
         public void CheckAppDomain(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
             runner.RunAndCheck();
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Generics")]
+        [TestAppFact("Samples.Computer01")]
         public void CheckGenerics(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", _output);
             runner.RunAndCheck();
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Pi")]
+        [TestAppFact("Samples.Computer01")]
         public void CheckPi(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", _output);
             runner.RunAndCheck();
         }
 
-        [TestAppFact("Samples.Computer01", DisplayName = "Fibonacci")]
+        [TestAppFact("Samples.Computer01")]
         public void CheckFibonacci(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", _output);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
@@ -16,7 +16,7 @@ namespace Datadog.Profiler.SmokeTests
             _output = output;
         }
 
-        [TestAppFact("Samples.ExceptionGenerator", DisplayName = "ExceptionGenerator")]
+        [TestAppFact("Samples.ExceptionGenerator")]
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
@@ -16,7 +16,7 @@ namespace Datadog.Profiler.SmokeTests
             _output = output;
         }
 
-        [TestAppFact("Samples.Website-AspNetCore01", DisplayName = "Website-AspNetCore01")]
+        [TestAppFact("Samples.Website-AspNetCore01")]
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);

--- a/profiler/test/Datadog.Profiler.Native.Tests/HResultConverterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/HResultConverterTest.cpp
@@ -22,7 +22,7 @@ TEST_P(HResultConverterParametersTests, CheckMessageForHresult)
     EXPECT_STREQ(expectedMessage, HResultConverter::ToChars(code));
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     HResultConverterTests,
     HResultConverterParametersTests,
     ::testing::Values(

--- a/profiler/test/Datadog.Profiler.Native.Tests/IMetricsSenderFactoryTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/IMetricsSenderFactoryTest.cpp
@@ -8,12 +8,12 @@
 #include "IMetricsSender.h"
 #include "IMetricsSenderFactory.h"
 
-#include "string.h"
+#include "shared/src/native-src/util.h"
 
 TEST(IMetricsSenderFactoryTest, MustReturnNullIfEnvVarNotSet)
-{
-    auto envVarValue = std::getenv(shared::ToString(EnvironmentVariables::OperationalMetricsEnabled).c_str());
-    EXPECT_TRUE(envVarValue == nullptr);
+{    
+    auto envVarValue = shared::GetEnvironmentValue(EnvironmentVariables::OperationalMetricsEnabled);
+    EXPECT_TRUE(envVarValue.length() == 0);
 
     auto metricsSender = IMetricsSenderFactory::Create();
     EXPECT_TRUE(metricsSender == nullptr);


### PR DESCRIPTION
## Summary of changes

- Remove `DisplayName` attribute from tests to use the test name instead
- Replace usage of `int`, `long`, and `long long` by their explicit equivalent
- Fix warnings

## Reason for change

Clean is good.

