### PR TITLE
[CI Visibility] Send Code Coverage Payload to the agentless endpoint

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterFileSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterFileSender.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.Agent.Payloads;
 using Datadog.Trace.Logging;
@@ -23,7 +24,7 @@ namespace Datadog.Trace.Ci.Agent
             Log.Information("CIWriterFileSender Initialized.");
         }
 
-        public Task SendPayloadAsync(EventsPayload payload)
+        public Task SendPayloadAsync(CIVisibilityProtocolPayload payload)
         {
             var str = $"c:\\temp\\file-{Guid.NewGuid().ToString("n")}";
 
@@ -32,6 +33,36 @@ namespace Datadog.Trace.Ci.Agent
 
             var json = Vendors.MessagePack.MessagePackSerializer.ToJson(msgPackBytes);
             File.WriteAllText(str + ".json", json);
+
+            return Task.CompletedTask;
+        }
+
+        public Task SendPayloadAsync(MultipartPayload payload)
+        {
+            var str = $"c:\\temp\\multipart-{Guid.NewGuid().ToString("n")}";
+            foreach (var item in payload.ToArray())
+            {
+                byte[] bytes = null;
+
+                if (item.ContentInStream is { } stream)
+                {
+                    using var ms = new MemoryStream();
+                    stream.CopyTo(ms);
+                    bytes = ms.ToArray();
+                }
+                else if (item.ContentInBytes is { } arraySegment)
+                {
+                    bytes = arraySegment.ToArray();
+                }
+
+                if (bytes is not null)
+                {
+                    File.WriteAllBytes(str + $"{item.Name}.mpack", bytes);
+
+                    var json = Vendors.MessagePack.MessagePackSerializer.ToJson(bytes);
+                    File.WriteAllText(str + $"{item.Name}.json", json);
+                }
+            }
 
             return Task.CompletedTask;
         }

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci.Agent.Payloads;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Ci.Agent
 {
@@ -29,20 +30,75 @@ namespace Datadog.Trace.Ci.Agent
             Log.Information("CIWriterHttpSender Initialized.");
         }
 
-        public async Task SendPayloadAsync(EventsPayload payload)
+        public async Task SendPayloadAsync(CIVisibilityProtocolPayload payload)
         {
-            var numberOfTraces = payload.Count;
-            var tracesEndpoint = payload.Url;
+            var payloadArray = payload.ToArray();
+            Log.Information<int, string>("Sending ({numberOfTraces} events) {bytesValue} bytes...", payload.Count, payloadArray.Length.ToString("N0"));
+            await SendPayloadAsync(
+                payload.Url,
+                static (request, payloadBytes) => request.PostAsync(new ArraySegment<byte>(payloadBytes), MimeTypes.MsgPack),
+                payloadArray).ConfigureAwait(false);
+        }
 
+        public async Task SendPayloadAsync(MultipartPayload payload)
+        {
+            Log.Information<int>("Sending {count} multipart items...", payload.Count);
+            await SendPayloadAsync(
+                payload.Url,
+                static (request, payloadArray) =>
+                {
+                    if (request is IMultipartApiRequest multipartRequest)
+                    {
+                        return multipartRequest.PostAsync(payloadArray);
+                    }
+
+                    ThrowHelper.ThrowInvalidOperationException("Sender doesn't support IMultipartApiRequest.");
+                    return Task.FromResult<IApiResponse>(null);
+                },
+                payload.ToArray()).ConfigureAwait(false);
+        }
+
+        private static async Task<bool> SendPayloadAsync<T>(Func<IApiRequest, T, Task<IApiResponse>> senderFunc, IApiRequest request, T state, bool finalTry)
+        {
+            IApiResponse response = null;
+
+            try
+            {
+                response = await senderFunc(request, state).ConfigureAwait(false);
+
+                // Attempt a retry if the status code is not SUCCESS
+                if (response.StatusCode is < 200 or >= 300)
+                {
+                    if (finalTry)
+                    {
+                        try
+                        {
+                            var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                            Log.Error<int, string>("Failed to submit events with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error<int>(ex, "Unable to read response for failed request with status code {StatusCode}", response.StatusCode);
+                        }
+                    }
+
+                    return false;
+                }
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+
+            return true;
+        }
+
+        private async Task SendPayloadAsync<T>(Uri url, Func<IApiRequest, T, Task<IApiResponse>> senderFunc, T state)
+        {
             // retry up to 5 times with exponential back-off
             const int retryLimit = 5;
             var retryCount = 1;
             var sleepDuration = 100; // in milliseconds
-
-            var payloadMimeType = MimeTypes.MsgPack;
-            var payloadBytes = payload.ToArray();
-
-            Log.Information($"Sending ({numberOfTraces} events) {payloadBytes.Length.ToString("N0")} bytes...");
 
             while (true)
             {
@@ -50,22 +106,22 @@ namespace Datadog.Trace.Ci.Agent
 
                 try
                 {
-                    request = _apiRequestFactory.Create(tracesEndpoint);
+                    request = _apiRequestFactory.Create(url);
                     request.AddHeader(ApiKeyHeader, CIVisibility.Settings.ApiKey);
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "An error occurred while generating http request to send events to {AgentEndpoint}", _apiRequestFactory.Info(tracesEndpoint));
+                    Log.Error(ex, "An error occurred while generating http request to send events to {AgentEndpoint}", _apiRequestFactory.Info(url));
                     return;
                 }
 
-                bool success = false;
+                var success = false;
+                var isFinalTry = retryCount >= retryLimit;
                 Exception exception = null;
-                bool isFinalTry = retryCount >= retryLimit;
 
                 try
                 {
-                    success = await SendPayloadAsync(new ArraySegment<byte>(payloadBytes), payloadMimeType, request, isFinalTry).ConfigureAwait(false);
+                    success = await SendPayloadAsync(senderFunc, request, state, isFinalTry).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -75,7 +131,7 @@ namespace Datadog.Trace.Ci.Agent
                     {
                         if (ex.InnerException is InvalidOperationException ioe)
                         {
-                            Log.Error<int, string>(ex, "An error occurred while sending {Count} events to {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(tracesEndpoint));
+                            Log.Error<string>(ex, "An error occurred while sending events to {AgentEndpoint}", _apiRequestFactory.Info(url));
                             return;
                         }
                     }
@@ -87,7 +143,7 @@ namespace Datadog.Trace.Ci.Agent
                     if (isFinalTry)
                     {
                         // stop retrying
-                        Log.Error<int, int, string>(exception, "An error occurred while sending {Count} events after {Retries} retries to {AgentEndpoint}", numberOfTraces, retryCount, _apiRequestFactory.Info(tracesEndpoint));
+                        Log.Error<int, string>(exception, "An error occurred while sending events after {Retries} retries to {AgentEndpoint}", retryCount, _apiRequestFactory.Info(url));
                         return;
                     }
 
@@ -108,7 +164,7 @@ namespace Datadog.Trace.Ci.Agent
 
                     if (isSocketException)
                     {
-                        Log.Debug(exception, "Unable to communicate with {AgentEndpoint}", _apiRequestFactory.Info(tracesEndpoint));
+                        Log.Debug(exception, "Unable to communicate with {AgentEndpoint}", _apiRequestFactory.Info(url));
                     }
 
                     // Execute retry delay
@@ -119,53 +175,9 @@ namespace Datadog.Trace.Ci.Agent
                     continue;
                 }
 
-                Log.Debug<int, string>("Successfully sent {Count} events to {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(tracesEndpoint));
+                Log.Debug<string>("Successfully sent events to {AgentEndpoint}", _apiRequestFactory.Info(url));
                 return;
             }
-        }
-
-        private async Task<bool> SendPayloadAsync(ArraySegment<byte> payload, string mimeType, IApiRequest request, bool finalTry)
-        {
-            IApiResponse response = null;
-
-            try
-            {
-                try
-                {
-                    response = await request.PostAsync(payload, mimeType).ConfigureAwait(false);
-                }
-                catch
-                {
-                    // count only network/infrastructure errors, not valid responses with error status codes
-                    // (which are handled below)
-                    throw;
-                }
-
-                // Attempt a retry if the status code is not SUCCESS
-                if (response.StatusCode < 200 || response.StatusCode >= 300)
-                {
-                    if (finalTry)
-                    {
-                        try
-                        {
-                            string responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                            Log.Error<int, string>("Failed to submit events with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
-                        }
-                        catch (Exception ex)
-                        {
-                            Log.Error<int>(ex, "Unable to read response for failed request with status code {StatusCode}", response.StatusCode);
-                        }
-                    }
-
-                    return false;
-                }
-            }
-            finally
-            {
-                response?.Dispose();
-            }
-
-            return true;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/ICIAgentlessWriterSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/ICIAgentlessWriterSender.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.Ci.Agent
 {
     internal interface ICIAgentlessWriterSender
     {
-        Task SendPayloadAsync(EventsPayload payload);
+        Task SendPayloadAsync(CIVisibilityProtocolPayload payload);
+
+        Task SendPayloadAsync(MultipartPayload payload);
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -13,7 +13,7 @@ using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Ci.Agent.MessagePack
 {
-    internal class CIEventMessagePackFormatter : EventMessagePackFormatter<EventsPayload>
+    internal class CIEventMessagePackFormatter : EventMessagePackFormatter<CIVisibilityProtocolPayload>
     {
         private readonly byte[] _metadataBytes = StringEncoding.UTF8.GetBytes("metadata");
         private readonly byte[] _asteriskBytes = StringEncoding.UTF8.GetBytes("*");
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             _envelopBytes = GetEnvelopeArraySegment();
         }
 
-        public override int Serialize(ref byte[] bytes, int offset, EventsPayload? value, IFormatterResolver formatterResolver)
+        public override int Serialize(ref byte[] bytes, int offset, CIVisibilityProtocolPayload? value, IFormatterResolver formatterResolver)
         {
             if (value is null)
             {

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIFormatterResolver.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIFormatterResolver.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
         public static readonly IFormatterResolver Instance = new CIFormatterResolver();
 
         private readonly IMessagePackFormatter<Span> _spanFormatter;
-        private readonly IMessagePackFormatter<EventsPayload> _eventsPayloadFormatter;
+        private readonly IMessagePackFormatter<CIVisibilityProtocolPayload> _eventsPayloadFormatter;
         private readonly IMessagePackFormatter<IEvent> _eventFormatter;
         private readonly IMessagePackFormatter<TestEvent> _testEventFormatter;
         private readonly IMessagePackFormatter<SpanEvent> _spanEventFormatter;
@@ -40,7 +40,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
                 return (IMessagePackFormatter<T>)_spanFormatter;
             }
 
-            if (typeof(T) == typeof(EventsPayload))
+            if (typeof(T) == typeof(CIVisibilityProtocolPayload))
             {
                 return (IMessagePackFormatter<T>)_eventsPayloadFormatter;
             }

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
@@ -1,0 +1,63 @@
+// <copyright file="CICodeCoveragePayload.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Text;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Ci.Coverage.Models;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.Ci.Agent.Payloads
+{
+    internal class CICodeCoveragePayload : MultipartPayload
+    {
+        public CICodeCoveragePayload(int maxItemsPerPayload = DefaultMaxItemsPerPayload, int maxBytesPerPayload = DefaultMaxBytesPerPayload, IFormatterResolver formatterResolver = null)
+            : base(maxItemsPerPayload, maxBytesPerPayload, formatterResolver)
+        {
+            var agentlessUrl = CIVisibility.Settings.AgentlessUrl;
+            if (!string.IsNullOrWhiteSpace(agentlessUrl))
+            {
+                var builder = new UriBuilder(agentlessUrl);
+                builder.Path = "api/v2/citestcov";
+                Url = builder.Uri;
+            }
+            else
+            {
+                var builder = new UriBuilder("https://datadog.host.com/api/v2/citestcov");
+                builder.Host = "event-platform-intake." + CIVisibility.Settings.Site;
+                Url = builder.Uri;
+            }
+        }
+
+        public override Uri Url { get; }
+
+        public override bool CanProcessEvent(IEvent @event)
+        {
+            return @event is CoveragePayload;
+        }
+
+        protected override MultipartFormItem CreateMultipartFormItem(ArraySegment<byte> eventInBytes)
+        {
+            var index = Count + 1;
+            return new MultipartFormItem($"coverage{index}", MimeTypes.MsgPack, $"filecoverage{index}.msgpack", eventInBytes);
+        }
+
+        public override MultipartFormItem[] ToArray()
+        {
+            // This is a current limitation in the backend side
+            // an "event" item must be included in each payload.
+            // So here we are adding a dummy one.
+            AddMultipartFormItem(
+                new MultipartFormItem(
+                    "event",
+                    MimeTypes.Json,
+                    "fileevent.json",
+                    new ArraySegment<byte>(Encoding.UTF8.GetBytes("{\"dummy\": true}"))));
+
+            return base.ToArray();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CITestCyclePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CITestCyclePayload.cs
@@ -5,16 +5,19 @@
 
 using System;
 using Datadog.Trace.Ci.EventModel;
+using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Ci.Agent.Payloads
 {
-    internal class CITestCyclePayload : EventsPayload
+    internal class CITestCyclePayload : CIVisibilityProtocolPayload
     {
-        public CITestCyclePayload()
+        public CITestCyclePayload(IFormatterResolver formatterResolver = null)
+            : base(formatterResolver)
         {
-            if (!string.IsNullOrWhiteSpace(CIVisibility.Settings.AgentlessUrl))
+            var agentlessUrl = CIVisibility.Settings.AgentlessUrl;
+            if (!string.IsNullOrWhiteSpace(agentlessUrl))
             {
-                var builder = new UriBuilder(CIVisibility.Settings.AgentlessUrl);
+                var builder = new UriBuilder(agentlessUrl);
                 builder.Path = "api/v2/citestcycle";
                 Url = builder.Uri;
             }

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CIVisibilityProtocolPayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CIVisibilityProtocolPayload.cs
@@ -1,4 +1,4 @@
-// <copyright file="EventsPayload.cs" company="Datadog">
+// <copyright file="CIVisibilityProtocolPayload.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -10,14 +10,12 @@ using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Ci.Agent.Payloads
 {
-    internal abstract class EventsPayload
+    internal abstract class CIVisibilityProtocolPayload
     {
-        protected static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<EventsPayload>();
-
         private readonly EventsBuffer<IEvent> _events;
         private readonly IFormatterResolver _formatterResolver;
 
-        public EventsPayload(IFormatterResolver formatterResolver = null)
+        public CIVisibilityProtocolPayload(IFormatterResolver formatterResolver = null)
         {
             _formatterResolver = formatterResolver ?? CIFormatterResolver.Instance;
 
@@ -35,19 +33,10 @@ namespace Datadog.Trace.Ci.Agent.Payloads
 
         public abstract bool CanProcessEvent(IEvent @event);
 
-        public bool TryProcessEvent(IEvent @event)
-        {
-            return _events.TryWrite(@event);
-        }
+        public bool TryProcessEvent(IEvent @event) => _events.TryWrite(@event);
 
-        public void Clear()
-        {
-            _events.Clear();
-        }
+        public void Clear() => _events.Clear();
 
-        public byte[] ToArray()
-        {
-            return MessagePackSerializer.Serialize(this, _formatterResolver);
-        }
+        public byte[] ToArray() => MessagePackSerializer.Serialize(this, _formatterResolver);
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/MultipartPayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/MultipartPayload.cs
@@ -1,0 +1,97 @@
+// <copyright file="MultipartPayload.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Ci.Agent.MessagePack;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.Ci.Agent.Payloads
+{
+    internal abstract class MultipartPayload
+    {
+        internal const int DefaultMaxItemsPerPayload = 100;
+        internal const int DefaultMaxBytesPerPayload = 48_000_000;
+
+        private readonly List<MultipartFormItem> _items;
+        private readonly IFormatterResolver _formatterResolver;
+        private readonly int _maxItemsPerPayload;
+        private readonly int _maxBytesPerPayload;
+        private long _bytesCount;
+
+        public MultipartPayload(int maxItemsPerPayload = DefaultMaxItemsPerPayload, int maxBytesPerPayload = DefaultMaxBytesPerPayload, IFormatterResolver formatterResolver = null)
+        {
+            _maxItemsPerPayload = maxItemsPerPayload;
+            _maxBytesPerPayload = maxBytesPerPayload;
+            _bytesCount = 0;
+            _formatterResolver = formatterResolver ?? CIFormatterResolver.Instance;
+            _items = new List<MultipartFormItem>(Math.Min(maxItemsPerPayload, DefaultMaxItemsPerPayload));
+        }
+
+        public abstract Uri Url { get; }
+
+        public bool HasEvents => _items.Count > 0;
+
+        public int Count => _items.Count;
+
+        public long BytesCount => _bytesCount;
+
+        public abstract bool CanProcessEvent(IEvent @event);
+
+        protected abstract MultipartFormItem CreateMultipartFormItem(ArraySegment<byte> eventInBytes);
+
+        protected void AddMultipartFormItem(MultipartFormItem item)
+        {
+            lock (_items)
+            {
+                _items.Add(item);
+            }
+        }
+
+        public bool TryProcessEvent(IEvent @event)
+        {
+            lock (_items)
+            {
+                if (_items.Count >= _maxItemsPerPayload)
+                {
+                    return false;
+                }
+
+                if (_bytesCount >= _maxBytesPerPayload)
+                {
+                    return false;
+                }
+
+                var eventInBytes = MessagePackSerializer.Serialize(@event, _formatterResolver);
+                if (_bytesCount + eventInBytes.Length > _maxBytesPerPayload)
+                {
+                    return false;
+                }
+
+                _items.Add(CreateMultipartFormItem(new ArraySegment<byte>(eventInBytes)));
+                _bytesCount += eventInBytes.Length;
+                return true;
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_items)
+            {
+                _items.Clear();
+                _bytesCount = 0;
+            }
+        }
+
+        public virtual MultipartFormItem[] ToArray()
+        {
+            lock (_items)
+            {
+                return _items.ToArray();
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -90,7 +90,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                     coveragePayload.SpanId = span.SpanId;
                 }
 
-                span.SetTag("test.coverage", Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(coveragePayload));
                 Ci.CIVisibility.Manager?.WriteEvent(coveragePayload);
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
@@ -7,7 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Ci.Agent;
+using Datadog.Trace.Ci.Coverage.Models;
 using Datadog.Trace.Ci.EventModel;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Vendors.MessagePack;
@@ -33,8 +35,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             var expectedBytes = expectedPayload.ToArray();
 
             byte[] finalPayload = null;
-            sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.EventsPayload>()))
-                .Returns<Ci.Agent.Payloads.EventsPayload>(payload =>
+            sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.CIVisibilityProtocolPayload>()))
+                .Returns<Ci.Agent.Payloads.CIVisibilityProtocolPayload>(payload =>
                 {
                     finalPayload = payload.ToArray();
                     return Task.CompletedTask;
@@ -48,16 +50,67 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
         }
 
         [Fact]
+        public async Task AgentlessCodeCoverageEvent()
+        {
+            var sender = new Mock<ICIAgentlessWriterSender>();
+            var agentlessWriter = new CIAgentlessWriter(sender.Object);
+            var coveragePayload = new CoveragePayload
+            {
+                TraceId = 42,
+                SpanId = 84,
+                Files =
+                {
+                    new FileCoverage
+                    {
+                        FileName = "MyFile",
+                        Segments =
+                        {
+                            new uint[] { 1, 2, 3, 4 }
+                        }
+                    }
+                }
+            };
+
+            var expectedPayload = new Ci.Agent.Payloads.CICodeCoveragePayload();
+            expectedPayload.TryProcessEvent(coveragePayload);
+            var expectedFormItems = expectedPayload.ToArray();
+
+            MultipartFormItem[] finalFormItems = null;
+            sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.CICodeCoveragePayload>()))
+                  .Returns<Ci.Agent.Payloads.CICodeCoveragePayload>(payload =>
+                   {
+                       finalFormItems = payload.ToArray();
+                       return Task.CompletedTask;
+                   });
+
+            agentlessWriter.WriteEvent(coveragePayload);
+            await agentlessWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            Assert.NotNull(finalFormItems);
+            Assert.Equal(expectedFormItems.Length, finalFormItems.Length);
+            for (var i = 0; i < expectedFormItems.Length; i++)
+            {
+                var finalItem = finalFormItems[i];
+                var expectedItem = expectedFormItems[i];
+
+                Assert.Equal(expectedItem.Name, finalItem.Name);
+                Assert.Equal(expectedItem.ContentType, finalItem.ContentType);
+                Assert.Equal(expectedItem.FileName, finalItem.FileName);
+                Assert.True(finalItem.ContentInBytes.Value.ToArray().SequenceEqual(expectedItem.ContentInBytes.Value.ToArray()));
+            }
+        }
+
+        [Fact]
         public async Task SlowSenderTest()
         {
             var flushTcs = new TaskCompletionSource<bool>();
 
             var sender = new Mock<ICIAgentlessWriterSender>();
-            var agentlessWriter = new CIAgentlessWriter(sender.Object);
+            var agentlessWriter = new CIAgentlessWriter(sender.Object, concurrency: 1);
             var lstPayloads = new List<byte[]>();
 
-            sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.EventsPayload>()))
-                .Returns<Ci.Agent.Payloads.EventsPayload>(payload =>
+            sender.Setup(x => x.SendPayloadAsync(It.IsAny<Ci.Agent.Payloads.CIVisibilityProtocolPayload>()))
+                .Returns<Ci.Agent.Payloads.CIVisibilityProtocolPayload>(payload =>
                 {
                     lstPayloads.Add(payload.ToArray());
                     return flushTcs.Task;
@@ -124,6 +177,47 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
                 // without decimals (items that doesn't fit doesn't get added)
                 var numItemsTrunc = (bufferSize - headerSize) / individualType.Length;
                 Assert.Equal(numItemsTrunc, eventBuffer.Count);
+
+                bufferSize *= 2;
+            }
+        }
+
+        [Fact]
+        public void CoverageBufferTest()
+        {
+            int bufferSize = 256;
+            int maxBufferSize = (int)(4.5 * 1024 * 1024);
+            var coveragePayload = new CoveragePayload
+            {
+                TraceId = 42,
+                SpanId = 84,
+                Files =
+                {
+                    new FileCoverage
+                    {
+                        FileName = "MyFile",
+                        Segments =
+                        {
+                            new uint[] { 1, 2, 3, 4 }
+                        }
+                    }
+                }
+            };
+
+            var coveragePayloadInBytes = MessagePackSerializer.Serialize<Ci.IEvent>(coveragePayload, Ci.Agent.MessagePack.CIFormatterResolver.Instance);
+
+            while (bufferSize < maxBufferSize)
+            {
+                var payloadBuffer = new Ci.Agent.Payloads.CICodeCoveragePayload(maxItemsPerPayload: int.MaxValue, maxBytesPerPayload: bufferSize);
+                while (payloadBuffer.TryProcessEvent(coveragePayload))
+                {
+                    // .
+                }
+
+                // The number of items in the events should be the same as the num calculated
+                // without decimals (items that doesn't fit doesn't get added)
+                var numItemsTrunc = bufferSize / coveragePayloadInBytes.Length;
+                Assert.Equal(numItemsTrunc, payloadBuffer.Count);
 
                 bufferSize *= 2;
             }


### PR DESCRIPTION
## Summary of changes

This PR includes:

- [x] A refactor of the `CIAgentlessWriter` and `ICIAgentlessWriterSender` to support the CodeCoverage track/endpoint and support for multiple levels of concurrency.
- [x] A new abstract base class for sending MultipartPayloads.
- [x] A new class to send CodeCoveragePayloads

## Reason for change

The Code Coverage data collected by the data collector must be sent to a specific backend endpoint, this PR includes all the modifications to make that possible.

## Implementation details

Is implemented as an extension and refactor of the current CIAgentlessWriter to support multiple payload buffers depending of different endpoints.