### PR TITLE
Fix tiny build dependency order issue

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -689,8 +689,7 @@ partial class Build
 
     Target CompileInstrumentationVerificationLibrary => _ => _
         .Unlisted()
-        .DependsOn(Restore)
-        .After(CompileManagedSrc)
+        .After(Restore, CompileManagedSrc)
         .Executes(() =>
         {
             DotNetMSBuild(x => x


### PR DESCRIPTION
## Summary of changes

Convert `DependsOn` to`After`

## Reason for change

`CompileInstrumentationVerificationLibrary` shouldn't depend directly on `Restore`, otherwise it will force unnecessary new restores.
