### PR TITLE
Fix Aerospike tests and convert to snapshots

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -689,8 +689,7 @@ partial class Build
 
     Target CompileInstrumentationVerificationLibrary => _ => _
         .Unlisted()
-        .DependsOn(Restore)
-        .After(CompileManagedSrc)
+        .After(Restore, CompileManagedSrc)
         .Executes(() =>
         {
             DotNetMSBuild(x => x

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -3,8 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Generic;
-using System.Linq;
+using System;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -43,6 +42,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 spans.Count.Should().Be(expectedSpanCount);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
+
+                // older versions of Aerospike use QueryRecord instead of QueryPartition
+                // Normalize to QueryPartition for simplicity
+                if (string.IsNullOrEmpty(packageVersion) || new Version(packageVersion) < new Version(5, 0, 0))
+                {
+                    settings.AddSimpleScrubber("QueryRecord", "QueryPartition");
+                }
+
                 await VerifyHelper.VerifySpans(spans, settings)
                                   .DisableRequireUniquePrefix()
                                   .UseFileName(nameof(AerospikeTests));

--- a/tracer/test/snapshots/AerospikeTests.verified.txt
+++ b/tracer/test/snapshots/AerospikeTests.verified.txt
@@ -1,0 +1,464 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aerospike.command,
+    Resource: BatchExistsArray,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1;test:myset2:mykey2;test:myset3:mykey3,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: aerospike.command,
+    Resource: BatchExistsArray,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1;test:myset2:mykey2;test:myset3:mykey3,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: aerospike.command,
+    Resource: BatchGetArray,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1;test:myset2:mykey2;test:myset3:mykey3,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: aerospike.command,
+    Resource: BatchGetArray,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1;test:myset2:mykey2;test:myset3:mykey3,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_10,
+    Name: aerospike.command,
+    Resource: Delete,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: aerospike.command,
+    Resource: Delete,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_13,
+    SpanId: Id_14,
+    Name: aerospike.command,
+    Resource: Exists,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_15,
+    SpanId: Id_16,
+    Name: aerospike.command,
+    Resource: Exists,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_17,
+    SpanId: Id_18,
+    Name: aerospike.command,
+    Resource: QueryRecord,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_20,
+    Name: aerospike.command,
+    Resource: Read,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_21,
+    SpanId: Id_22,
+    Name: aerospike.command,
+    Resource: Read,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_24,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_25,
+    SpanId: Id_26,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_27,
+    SpanId: Id_28,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_29,
+    SpanId: Id_30,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_34,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_36,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: aerospike.command,
+    Resource: Write,
+    Service: Samples.Aerospike-aerospike,
+    Type: aerospike,
+    Tags: {
+      aerospike.key: test:myset1:mykey1,
+      aerospike.namespace: test,
+      aerospike.setname: myset1,
+      aerospike.userkey: mykey1,
+      component: aerospike,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AerospikeTests.verified.txt
+++ b/tracer/test/snapshots/AerospikeTests.verified.txt
@@ -191,7 +191,7 @@
     TraceId: Id_17,
     SpanId: Id_18,
     Name: aerospike.command,
-    Resource: QueryRecord,
+    Resource: QueryPartition,
     Service: Samples.Aerospike-aerospike,
     Type: aerospike,
     Tags: {


### PR DESCRIPTION
## Summary of changes

- Fixes the aerospike tests which broke with a change in the Aerospike image used for testing
- Convert to snapshot tests

## Reason for change

I updated the VM images to include support for the new #2950 base image, but also pulled new versions of the docker images used for testing without thinking about it. It appears that the Aerospike client changes its behaviour based on the server it's connected. Converting to Snapshot tests made it easier to tell what that change was.

## Implementation details

Replaced Aerospike tests with snapshot tests.

## Test coverage

Well.... yes...

## Other details
This may help identify the failure in #2972 too
