### PR TITLE
[Tracer] Add endpoint discovery and dropping of P0 traces to stats computation feature

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Agent
         private Task _frontBufferFlushTask;
         private Task _backBufferFlushTask;
 
+        private long _droppedP0Traces;
+        private long _droppedP0Spans;
+
         private long _droppedSpans;
 
         static AgentWriter()
@@ -107,7 +110,7 @@ namespace Datadog.Trace.Agent
 
         public Task<bool> Ping()
         {
-            return _api.SendTracesAsync(EmptyPayload, 0);
+            return _api.SendTracesAsync(EmptyPayload, 0, false, 0, 0);
         }
 
         public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
@@ -319,9 +322,19 @@ namespace Datadog.Trace.Agent
 
                     if (buffer.TraceCount > 0)
                     {
-                        Log.Debug<int, int>("Flushing {spans} spans across {traces} traces", buffer.SpanCount, buffer.TraceCount);
+                        var droppedP0Traces = Interlocked.Exchange(ref _droppedP0Traces, 0);
+                        var droppedP0Spans = Interlocked.Exchange(ref _droppedP0Spans, 0);
 
-                        var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount).ConfigureAwait(false);
+                        if (CanComputeStats)
+                        {
+                            Log.Debug<int, int, long, long>("Flushing {spans} spans across {traces} traces. CanComputeStats is enabled with {droppedP0Traces} droppedP0Traces and {droppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
+                        }
+                        else
+                        {
+                            Log.Debug<int, int>("Flushing {spans} spans across {traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
+                        }
+
+                        var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans).ConfigureAwait(false);
 
                         if (success)
                         {
@@ -377,6 +390,8 @@ namespace Datadog.Trace.Agent
             // skip all other processing
             if (!shouldSerializeSpans)
             {
+                Interlocked.Increment(ref _droppedP0Traces);
+                Interlocked.Add(ref _droppedP0Spans, trace.Count);
                 return;
             }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -101,6 +101,8 @@ namespace Datadog.Trace.Agent
 
         internal SpanBuffer BackBuffer => _backBuffer;
 
+        public bool CanComputeStats => _statsAggregator.CanComputeStats ?? false;
+
         public bool CanDropP0s => _statsAggregator.CanDropP0s ?? false;
 
         public Task<bool> Ping()

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Agent
 
         internal SpanBuffer BackBuffer => _backBuffer;
 
-        public bool CanDropP0s => _statsAggregator.AgentIsCompatible ?? false;
+        public bool CanDropP0s => _statsAggregator.CanDropP0s ?? false;
 
         public Task<bool> Ping()
         {

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -101,6 +101,8 @@ namespace Datadog.Trace.Agent
 
         internal SpanBuffer BackBuffer => _backBuffer;
 
+        public bool CanDropP0s => _statsAggregator.AgentIsCompatible ?? false;
+
         public Task<bool> Ping()
         {
             return _api.SendTracesAsync(EmptyPayload, 0);

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -42,6 +42,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         public string AgentVersion { get; private set; }
 
+        public bool ClientDropP0s { get; private set; }
+
         public static DiscoveryService Create(IApiRequestFactory apiRequestFactory)
         {
             return new DiscoveryService(apiRequestFactory);
@@ -96,6 +98,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                .FirstOrDefault(
                     supportedEndpoint => discoveredEndpoints.Any(
                         endpoint => endpoint.Trim('/').Equals(supportedEndpoint, StringComparison.OrdinalIgnoreCase)));
+
+            ClientDropP0s = jObject["client_drop_p0s"]?.Value<bool>() ?? false;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             _agentUri = apiRequestFactory.GetEndpoint(InfoPath);
         }
 
-        public static string[] AllSupportedEndpoints => SupportedDebuggerEndpoints.Concat(SupportedProbeConfigurationEndpoints).ToArray();
+        public static string[] AllSupportedEndpoints => SupportedDebuggerEndpoints.Concat(SupportedProbeConfigurationEndpoints).Concat(SupportedStatsEndpoints).ToArray();
 
         public string ProbeConfigurationEndpoint { get; private set; }
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private const string InfoPath = "/info";
         private static readonly string[] SupportedDebuggerEndpoints = new[] { "debugger/v1/input" };
         private static readonly string[] SupportedProbeConfigurationEndpoints = new[] { "v0.7/config" };
+        private static readonly string[] SupportedStatsEndpoints = new[] { "v0.6/stats" };
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DiscoveryService>();
 
@@ -36,6 +37,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
         public string ProbeConfigurationEndpoint { get; private set; }
 
         public string DebuggerEndpoint { get; private set; }
+
+        public string StatsEndpoint { get; private set; }
 
         public string AgentVersion { get; private set; }
 
@@ -85,6 +88,11 @@ namespace Datadog.Trace.Agent.DiscoveryService
                         endpoint => endpoint.Trim('/').Equals(supportedEndpoint, StringComparison.OrdinalIgnoreCase)));
 
             DebuggerEndpoint = SupportedDebuggerEndpoints
+               .FirstOrDefault(
+                    supportedEndpoint => discoveredEndpoints.Any(
+                        endpoint => endpoint.Trim('/').Equals(supportedEndpoint, StringComparison.OrdinalIgnoreCase)));
+
+            StatsEndpoint = SupportedStatsEndpoints
                .FirstOrDefault(
                     supportedEndpoint => discoveredEndpoints.Any(
                         endpoint => endpoint.Trim('/').Equals(supportedEndpoint, StringComparison.OrdinalIgnoreCase)));

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/IDiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/IDiscoveryService.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         string AgentVersion { get; }
 
+        bool ClientDropP0s { get; }
+
         Task<bool> DiscoverAsync();
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/IDiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/IDiscoveryService.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
         string DebuggerEndpoint { get; }
 
+        string StatsEndpoint { get; }
+
         string AgentVersion { get; }
 
         Task<bool> DiscoverAsync();

--- a/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
+        bool CanComputeStats { get; }
+
         bool CanDropP0s { get; }
 
         void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans);

--- a/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
+        bool CanDropP0s { get; }
+
         void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans);
 
         Task<bool> Ping();

--- a/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
-        void WriteTrace(ArraySegment<Span> trace);
+        void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans);
 
         Task<bool> Ping();
 

--- a/tracer/src/Datadog.Trace/Agent/IApi.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApi.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
-        Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces);
+        Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans);
 
         Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration);
     }

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -10,13 +10,13 @@ namespace Datadog.Trace.Agent
     internal interface IStatsAggregator
     {
         /// <summary>
-        /// Gets a value indicating whether the Datadog agent supports stats
-        /// computation in tracers.
+        /// Gets a value indicating whether the Datadog agent supports
+        /// tracers dropping P0 traces.
         ///
         /// This will return null if the endpoint discovery request has not
         /// completed.
         /// </summary>
-        bool? AgentIsCompatible { get; }
+        bool? CanDropP0s { get; }
 
         void Add(params Span[] spans);
 

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -9,6 +9,15 @@ namespace Datadog.Trace.Agent
 {
     internal interface IStatsAggregator
     {
+        /// <summary>
+        /// Gets a value indicating whether the Datadog agent supports stats
+        /// computation in tracers.
+        ///
+        /// This will return null if the endpoint discovery request has not
+        /// completed.
+        /// </summary>
+        bool? AgentIsCompatible { get; }
+
         void Add(params Span[] spans);
 
         void AddRange(Span[] spans, int offset, int count);

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -10,6 +10,15 @@ namespace Datadog.Trace.Agent
     internal interface IStatsAggregator
     {
         /// <summary>
+        /// Gets a value indicating whether the Datadog agent supports stats
+        /// computation in tracers.
+        ///
+        /// This will return null if the endpoint discovery request has not
+        /// completed.
+        /// </summary>
+        bool? CanComputeStats { get; }
+
+        /// <summary>
         /// Gets a value indicating whether the Datadog agent supports
         /// tracers dropping P0 traces.
         ///

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Agent
 {
     internal class NullStatsAggregator : IStatsAggregator
     {
-        public bool? AgentIsCompatible => false;
+        public bool? CanDropP0s => false;
 
         public void Add(params Span[] spans)
         {

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.Agent
 {
     internal class NullStatsAggregator : IStatsAggregator
     {
+        public bool? CanComputeStats => false;
+
         public bool? CanDropP0s => false;
 
         public void Add(params Span[] spans)

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.Agent
 {
     internal class NullStatsAggregator : IStatsAggregator
     {
+        public bool? AgentIsCompatible => false;
+
         public void Add(params Span[] spans)
         {
         }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -137,7 +137,9 @@ namespace Datadog.Trace.Agent
         }
 
         /// <summary>
-        /// Converts a nanosec timestamp into a float nanosecond timestamp truncated to a fixed precision
+        /// Converts a nanosec timestamp into a float nanosecond timestamp truncated to a fixed precision.
+        /// Span timestamps must have maximum precision, but we can reduce precision of timestamps for
+        /// aggregated stats points to achieve more efficient data representation.
         /// </summary>
         /// <param name="ns">Timestamp to convert</param>
         /// <returns>Timestamp with truncated precision</returns>

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -65,6 +65,8 @@ namespace Datadog.Trace.Agent
         /// </summary>
         internal StatsBuffer CurrentBuffer => _buffers[_currentBuffer];
 
+        public bool? CanComputeStats { get; private set; }
+
         public bool? CanDropP0s { get; private set; }
 
         public static IStatsAggregator Create(IApi api, ImmutableTracerSettings settings, IDiscoveryService discoveryService)
@@ -134,11 +136,13 @@ namespace Datadog.Trace.Agent
 
                     if (completedTask == initializationTask && initializationTask.Result == false)
                     {
+                        CanComputeStats = false;
                         CanDropP0s = false;
                         return;
                     }
                     else if (completedTask == initializationTask && initializationTask.Result == true)
                     {
+                        CanComputeStats = true;
                         CanDropP0s = true;
                         initiailizationCompleted = true;
                     }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Agent
         /// </summary>
         internal StatsBuffer CurrentBuffer => _buffers[_currentBuffer];
 
-        public bool? AgentIsCompatible { get; private set; }
+        public bool? CanDropP0s { get; private set; }
 
         public static IStatsAggregator Create(IApi api, ImmutableTracerSettings settings, IDiscoveryService discoveryService)
         {
@@ -134,12 +134,12 @@ namespace Datadog.Trace.Agent
 
                     if (completedTask == initializationTask && initializationTask.Result == false)
                     {
-                        AgentIsCompatible = false;
+                        CanDropP0s = false;
                         return;
                     }
                     else if (completedTask == initializationTask && initializationTask.Result == true)
                     {
-                        AgentIsCompatible = true;
+                        CanDropP0s = true;
                         initiailizationCompleted = true;
                     }
                     else

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -93,6 +93,24 @@ namespace Datadog.Trace.Agent
             }
         }
 
+        internal static StatsAggregationKey BuildKey(Span span)
+        {
+            var rawHttpStatusCode = span.GetTag(Tags.HttpStatusCode);
+
+            if (rawHttpStatusCode == null || !int.TryParse(rawHttpStatusCode, out var httpStatusCode))
+            {
+                httpStatusCode = 0;
+            }
+
+            return new StatsAggregationKey(
+                span.ResourceName,
+                span.ServiceName,
+                span.OperationName,
+                span.Type,
+                httpStatusCode,
+                span.Context.Origin == "synthetics");
+        }
+
         internal async Task Flush()
         {
             // Use a do/while loop to still flush once if _processExit is already completed (this makes testing easier)
@@ -137,24 +155,6 @@ namespace Datadog.Trace.Agent
             }
 
             return ns << shift;
-        }
-
-        private static StatsAggregationKey BuildKey(Span span)
-        {
-            var rawHttpStatusCode = span.GetTag(Tags.HttpStatusCode);
-
-            if (rawHttpStatusCode == null || !int.TryParse(rawHttpStatusCode, out var httpStatusCode))
-            {
-                httpStatusCode = 0;
-            }
-
-            return new StatsAggregationKey(
-                span.ResourceName,
-                span.ServiceName,
-                span.OperationName,
-                span.Type,
-                httpStatusCode,
-                span.Context.Origin == "synthetics");
         }
 
         private void AddToBuffer(Span span)

--- a/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -59,6 +59,16 @@ namespace Datadog.Trace
         public const string StatsComputation = "Datadog-Client-Computed-Stats";
 
         /// <summary>
+        /// Tells the agent how many P0 traces were dropped as a result of stats computation in the tracer
+        /// </summary>
+        public const string DroppedP0Traces = "Datadog-Client-Dropped-P0-Traces";
+
+        /// <summary>
+        /// Tells the agent how many P0 spans were dropped as a result of stats computation in the tracer
+        /// </summary>
+        public const string DroppedP0Spans = "Datadog-Client-Dropped-P0-Spans";
+
+        /// <summary>
         /// Gets the default constant header that should be added to any request to the agent
         /// </summary>
         internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -54,12 +54,12 @@ namespace Datadog.Trace.Ci.Agent
             if (@event is TestEvent testEvent)
             {
                 spanArray[0] = testEvent.Content;
-                WriteTrace(new ArraySegment<Span>(spanArray));
+                WriteTrace(new ArraySegment<Span>(spanArray), true);
             }
             else if (@event is SpanEvent spanEvent)
             {
                 spanArray[0] = spanEvent.Content;
-                WriteTrace(new ArraySegment<Span>(spanArray));
+                WriteTrace(new ArraySegment<Span>(spanArray), true);
             }
         }
 
@@ -78,9 +78,9 @@ namespace Datadog.Trace.Ci.Agent
             return _agentWriter.Ping();
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
-            _agentWriter.WriteTrace(trace);
+            _agentWriter.WriteTrace(trace, shouldSerializeSpans);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -42,6 +42,8 @@ namespace Datadog.Trace.Ci.Agent
             _agentWriter = new AgentWriter(api, null, null, maxBufferSize: maxBufferSize);
         }
 
+        public bool CanComputeStats => _agentWriter.CanComputeStats;
+
         public bool CanDropP0s => _agentWriter.CanDropP0s;
 
         public void WriteEvent(IEvent @event)

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci.EventModel;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
@@ -30,7 +31,8 @@ namespace Datadog.Trace.Ci.Agent
             var statsComputationEnabled = settings.StatsComputationEnabled;
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
             var api = new Api(apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), partialFlushEnabled, statsComputationEnabled);
-            var statsAggregator = StatsAggregator.Create(api, settings);
+            var discoveryService = DiscoveryService.Create(apiRequestFactory);
+            var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
             _agentWriter = new AgentWriter(api, statsAggregator, null, maxBufferSize: maxBufferSize);
         }
@@ -39,6 +41,8 @@ namespace Datadog.Trace.Ci.Agent
         {
             _agentWriter = new AgentWriter(api, null, null, maxBufferSize: maxBufferSize);
         }
+
+        public bool CanDropP0s => _agentWriter.CanDropP0s;
 
         public void WriteEvent(IEvent @event)
         {

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
@@ -88,6 +88,8 @@ namespace Datadog.Trace.Ci.Agent
             Log.Information<int>($"CIAgentlessWriter Initialized with concurrency level of: {concurrencyLevel}", concurrencyLevel);
         }
 
+        public bool CanComputeStats => false;
+
         public bool CanDropP0s => false;
 
         public void WriteEvent(IEvent @event)

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
@@ -88,6 +88,8 @@ namespace Datadog.Trace.Ci.Agent
             Log.Information<int>($"CIAgentlessWriter Initialized with concurrency level of: {concurrencyLevel}", concurrencyLevel);
         }
 
+        public bool CanDropP0s => false;
+
         public void WriteEvent(IEvent @event)
         {
             if (_eventQueue.IsAddingCompleted)

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Ci.Agent
             return Task.FromResult(true);
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             // Transform spans to events
             for (var i = trace.Offset; i < trace.Count; i++)

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Debugger
             }
 
             var apiFactory = DebuggerTransportStrategy.Get(settings.AgentUri);
-            IDiscoveryService discoveryService = DiscoveryService.Create(source, apiFactory);
+            IDiscoveryService discoveryService = DiscoveryService.Create(apiFactory);
 
             var probeConfigurationApi = ProbeConfigurationApiFactory.Create(settings, apiFactory, discoveryService);
             var updater = ConfigurationUpdater.Create(settings);

--- a/tracer/src/Datadog.Trace/IDatadogTracer.cs
+++ b/tracer/src/Datadog.Trace/IDatadogTracer.cs
@@ -15,12 +15,14 @@ namespace Datadog.Trace
     /// </summary>
     internal interface IDatadogTracer
     {
+        bool CanDropP0s { get; }
+
         string DefaultServiceName { get; }
 
         ISampler Sampler { get; }
 
         ImmutableTracerSettings Settings { get; }
 
-        void Write(ArraySegment<Span> span);
+        void Write(ArraySegment<Span> span, bool shouldSerializeSpans);
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Logging
         public void Debug<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
+        public void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+            => Write(LogEventLevel.Debug, exception: null, messageTemplate, property0, property1, property2, property3, sourceLine, sourceFile);
+
         public void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
@@ -168,6 +171,15 @@ namespace Datadog.Trace.Logging
             {
                 // Avoid boxing + array allocation if disabled
                 WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2 }, sourceLine, sourceFile);
+            }
+        }
+
+        private void Write<T0, T1, T2, T3>(LogEventLevel level, Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, int sourceLine, string sourceFile)
+        {
+            if (_logger.IsEnabled(level))
+            {
+                // Avoid boxing + array allocation if disabled
+                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2, property3 }, sourceLine, sourceFile);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
@@ -21,6 +21,8 @@ namespace Datadog.Trace.Logging
 
         void Debug<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
+        void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+
         void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void Debug(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -146,9 +146,6 @@ namespace Datadog.Trace
                     _spans = new ArrayBuilder<Span>(spansToWrite.Count);
                 }
 
-                // TODO: I guess we should also report the number of P0 traces and P0 spans were dropped?
-                // The Go tracer seems to add this in a trace requst header, that only increments
-                // Gotta feed that into the Tracer somehow
                 shouldKeepTraceFinal = _shouldKeepTrace;
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -107,8 +107,6 @@ namespace Datadog.Trace
             bool shouldPropagateMetadata = false;
             bool shouldKeepTraceFinal = default;
 
-            // For now, assume that we have enabled stats computation AND the agent has been confirmed to be compatible
-            // We'll need to redo this because we should asynchronously send the agent compatibility check and then set enabled/disabled accordingly
             if (Tracer.CanDropP0s)
             {
                 shouldKeepSpan = ShouldKeepSpan(span);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -214,6 +214,11 @@ namespace Datadog.Trace
         ImmutableTracerSettings ITracer.Settings => Settings;
 
         /// <summary>
+        /// Gets a value indicating whether the tracer can drop P0 spans and traces.
+        /// </summary>
+        bool IDatadogTracer.CanDropP0s => Settings.StatsComputationEnabled;
+
+        /// <summary>
         /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
         ISampler IDatadogTracer.Sampler => TracerManager.Sampler;
@@ -319,11 +324,12 @@ namespace Datadog.Trace
         /// Writes the specified <see cref="Span"/> collection to the agent writer.
         /// </summary>
         /// <param name="trace">The <see cref="Span"/> collection to write.</param>
-        void IDatadogTracer.Write(ArraySegment<Span> trace)
+        /// <param name="shouldSerializeSpans">Indicates whether the spans should be serialized into traces.</param>
+        void IDatadogTracer.Write(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             if (Settings.TraceEnabled || AzureAppServices.Metadata.CustomTracingEnabled)
             {
-                TracerManager.WriteTrace(trace);
+                TracerManager.WriteTrace(trace, shouldSerializeSpans);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -214,6 +214,12 @@ namespace Datadog.Trace
         ImmutableTracerSettings ITracer.Settings => Settings;
 
         /// <summary>
+        /// Gets a value indicating whether the tracer can compute stats and the
+        /// agent will accept them.
+        /// </summary>
+        internal bool CanComputeStats => TracerManager.AgentWriter.CanComputeStats;
+
+        /// <summary>
         /// Gets a value indicating whether the tracer can drop P0 spans and traces.
         /// </summary>
         bool IDatadogTracer.CanDropP0s => TracerManager.AgentWriter.CanDropP0s;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -216,7 +216,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets a value indicating whether the tracer can drop P0 spans and traces.
         /// </summary>
-        bool IDatadogTracer.CanDropP0s => Settings.StatsComputationEnabled;
+        bool IDatadogTracer.CanDropP0s => TracerManager.AgentWriter.CanDropP0s;
 
         /// <summary>
         /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -523,7 +523,7 @@ namespace Datadog.Trace
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             foreach (var processor in TraceProcessors)
             {
@@ -542,7 +542,7 @@ namespace Datadog.Trace
 
             if (trace.Count > 0)
             {
-                AgentWriter.WriteTrace(trace);
+                AgentWriter.WriteTrace(trace, shouldSerializeSpans);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
@@ -168,8 +169,9 @@ namespace Datadog.Trace
         {
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
             var api = new Api(apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled, settings.StatsComputationEnabled);
+            var discoveryService = DiscoveryService.Create(apiRequestFactory);
 
-            var statsAggregator = StatsAggregator.Create(api, settings);
+            var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
             return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize);
         }

--- a/tracer/src/Datadog.Trace/Vendors/Datadog.Sketches/Stores/DenseStore.cs
+++ b/tracer/src/Datadog.Trace/Vendors/Datadog.Sketches/Stores/DenseStore.cs
@@ -74,7 +74,9 @@ internal abstract class DenseStore : Store, ISerializable
 
         if (store.Counts.Length > 0 && !store.IsEmpty())
         {
-            Counts = new double[store.MaxIndex - store.MinIndex + 1];
+            // This change seems correct based on the code in the java repo: https://github.com/DataDog/sketches-java/blob/5031ddff8e6d6de5174d2c06e2ced618f3a48621/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java#L60-L64
+            // If we approve of this change, I'll push this as a PR to DataDog/sketches-dotnet, update the package, then update our vendor reference
+            Counts = new double[store.MaxIndex - store.Offset + 1];
             Array.Copy(store.Counts, store.MinIndex - store.Offset, Counts, 0, Counts.Length);
             Offset = store.MinIndex;
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             trace = new[] { new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow) };
             var expectedData2 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()), Times.Once);
 
             _api.Invocations.Clear();
 
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()), Times.Once);
 
             await _ciAgentWriter.FlushAndCloseAsync();
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
                 });
 
             var trace = new[] { span };
-            agentlessWriter.WriteTrace(new ArraySegment<Span>(trace));
+            agentlessWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await agentlessWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             Assert.True(finalPayload.SequenceEqual(expectedBytes));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TransportTests.cs" company="Datadog">
+// <copyright file="TransportTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -535,6 +535,8 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         private class AgentWriterStub : IAgentWriter
         {
+            public bool CanDropP0s => false;
+
             public List<ArraySegment<Span>> Traces { get; } = new();
 
             public Task FlushAndCloseAsync() => Task.CompletedTask;
@@ -543,7 +545,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             public Task<bool> Ping() => Task.FromResult(true);
 
-            public void WriteTrace(ArraySegment<Span> trace) => Traces.Add(trace);
+            public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans) => Traces.Add(trace);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -535,6 +535,8 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         private class AgentWriterStub : IAgentWriter
         {
+            public bool CanComputeStats => false;
+
             public bool CanDropP0s => false;
 
             public List<ArraySegment<Span>> Traces { get; } = new();

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -83,6 +83,13 @@ namespace Datadog.Trace.IntegrationTests
 
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
 
+            // Wait until the discovery service has been reached and we've confirmed that we can send stats
+            if (expectStats)
+            {
+                SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000);
+                tracer.CanComputeStats.Should().Be(true, "the stats agreggator should invoke the agent discovery");
+            }
+
             // Scenario 1: Send server span with 200 status code (success)
             Span span1;
             using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -21,25 +21,25 @@ namespace Datadog.Trace.IntegrationTests
         [Fact]
         public async Task SendStats()
         {
-            await SendStatsHelper(statsComputationEnabled: true);
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: true);
         }
 
         [Fact]
         public async Task SendsStatsAndDropsSpansWhenSampleRateIsZero_TS007()
         {
-            await SendStatsHelper(statsComputationEnabled: true, expectAllTraces: false, globalSamplingRate: 0.0);
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: true, expectAllTraces: false, globalSamplingRate: 0.0);
         }
 
         [Fact]
         public async Task SendsStatsOnlyAfterSpansAreFinished_TS008()
         {
-            await SendStatsHelper(statsComputationEnabled: true, finishSpansOnClose: false);
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: false, finishSpansOnClose: false);
         }
 
         [Fact]
         public async Task IsDisabledThroughConfiguration_TS010()
         {
-            await SendStatsHelper(statsComputationEnabled: false);
+            await SendStatsHelper(statsComputationEnabled: false, expectStats: false);
         }
 
         [Fact]
@@ -48,9 +48,8 @@ namespace Datadog.Trace.IntegrationTests
             await SendStatsHelper(statsComputationEnabled: true, expectStats: false, statsEndpointEnabled: false);
         }
 
-        private async Task SendStatsHelper(bool statsComputationEnabled, double? globalSamplingRate = null, bool statsEndpointEnabled = true, bool expectStats = true, bool expectAllTraces = true, bool finishSpansOnClose = true)
+        private async Task SendStatsHelper(bool statsComputationEnabled, bool expectStats, double? globalSamplingRate = null, bool statsEndpointEnabled = true, bool expectAllTraces = true, bool finishSpansOnClose = true)
         {
-            expectStats &= statsComputationEnabled && statsEndpointEnabled && finishSpansOnClose;
             var statsWaitEvent = new AutoResetEvent(false);
             var tracesWaitEvent = new AutoResetEvent(false);
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
@@ -53,7 +54,13 @@ namespace Datadog.Trace.IntegrationTests
             var statsWaitEvent = new AutoResetEvent(false);
             var tracesWaitEvent = new AutoResetEvent(false);
 
-            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), statsEndpointEnabled: statsEndpointEnabled);
+            var agentConfiguration = new MockTracerAgent.AgentConfiguration();
+            if (!statsEndpointEnabled)
+            {
+                agentConfiguration.Endpoints = agentConfiguration.Endpoints.Where(s => s != "/v0.6/stats").ToArray();
+            }
+
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), configuration: agentConfiguration);
 
             var statsReceived = false;
             agent.StatsDeserialized += (_, _) =>

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -221,5 +221,106 @@ namespace Datadog.Trace.IntegrationTests
 
             statsReceived.Should().BeFalse();
         }
+
+        [Fact(Skip = "P0 traces can be dropped when stats computation is enabled, but the feature has not been implemented yet")]
+        public async Task SendsStatsAndDropsSpansWhenSampleRateIsZero()
+        {
+            var waitEvent = new AutoResetEvent(false);
+
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
+
+            agent.StatsDeserialized += (_, _) => waitEvent.Set();
+
+            var settings = new TracerSettings
+            {
+                GlobalSamplingRate = 0.0,
+                StatsComputationEnabled = true,
+                ServiceVersion = "V",
+                Environment = "Test",
+                Exporter = new ExporterSettings
+                {
+                    AgentUri = new Uri($"http://localhost:{agent.Port}"),
+                }
+            };
+
+            var immutableSettings = settings.Build();
+
+            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+
+            Span span1;
+
+            using (var scope = tracer.StartActiveInternal("operationName"))
+            {
+                span1 = scope.Span;
+                span1.ResourceName = "resourceName";
+                span1.SetHttpStatusCode(200, isServer: false, immutableSettings);
+                span1.Type = "span1";
+            }
+
+            await tracer.FlushAsync();
+            waitEvent.WaitOne(TimeSpan.FromMinutes(1)).Should().Be(true, "timeout while waiting for stats");
+
+            Span span2;
+
+            using (var scope = tracer.StartActiveInternal("operationName"))
+            {
+                span2 = scope.Span;
+                span2.ResourceName = "resourceName";
+                span2.SetHttpStatusCode(500, isServer: true, immutableSettings);
+                span2.Type = "span2";
+            }
+
+            await tracer.FlushAsync();
+            waitEvent.WaitOne(TimeSpan.FromMinutes(1)).Should().Be(true, "timeout while waiting for stats");
+
+            var payload = agent.WaitForStats(2);
+
+            payload.Should().HaveCount(2);
+
+            // Wait for two spans expecting a timeout
+            var spans = agent.WaitForSpans(2);
+            spans.Should().HaveCount(0, "when stats computation is enabled, the sample rate of 0 should prevent traces from being sent to the agent");
+
+            void AssertStats(MockClientStatsPayload stats, Span span, bool isError)
+            {
+                stats.Env.Should().Be(settings.Environment);
+                stats.Hostname.Should().Be(HostMetadata.Instance.Hostname);
+                stats.Version.Should().Be(settings.ServiceVersion);
+                stats.TracerVersion.Should().Be(TracerConstants.AssemblyVersion);
+                stats.AgentAggregation.Should().Be(null);
+                stats.Lang.Should().Be(TracerConstants.Language);
+                stats.RuntimeId.Should().Be(Tracer.RuntimeId);
+                stats.Stats.Should().HaveCount(1);
+
+                var bucket = stats.Stats[0];
+                bucket.AgentTimeShift.Should().Be(0);
+                bucket.Duration.Should().Be(TimeSpan.FromSeconds(10).ToNanoseconds());
+                bucket.Start.Should().NotBe(0);
+
+                bucket.Stats.Should().HaveCount(1);
+
+                var group = bucket.Stats[0];
+
+                group.DbType.Should().BeNull();
+                group.Duration.Should().Be(span.Duration.ToNanoseconds());
+                group.Errors.Should().Be(isError ? 1 : 0);
+                group.ErrorSummary.Should().NotBeEmpty();
+                group.Hits.Should().Be(1);
+                group.HttpStatusCode.Should().Be(int.Parse(span.GetTag(Tags.HttpStatusCode)));
+                group.Name.Should().Be(span.OperationName);
+                group.OkSummary.Should().NotBeEmpty();
+                group.Synthetics.Should().Be(false);
+                group.TopLevelHits.Should().Be(1);
+                group.Type.Should().Be(span.Type);
+            }
+
+            var stats1 = payload[0];
+            stats1.Sequence.Should().Be(1);
+            AssertStats(stats1, span1, isError: false);
+
+            var stats2 = payload[1];
+            stats2.Sequence.Should().Be(2);
+            AssertStats(stats2, span2, isError: true);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -24,22 +24,22 @@ namespace Datadog.Trace.IntegrationTests
             await SendStatsHelper(statsComputationEnabled: true);
         }
 
-        [Fact(Skip = "DiscoveryService is not yet hooked up to Tracer initialization.")]
-        public async Task IsDisabledWhenIncompatibleAgentDetected()
+        [Fact(Skip = "P0 traces can be dropped when stats computation is enabled, but the feature has not been implemented yet")]
+        public async Task SendsStatsAndDropsSpansWhenSampleRateIsZero_TS007()
         {
-            await SendStatsHelper(statsComputationEnabled: true, statsEndpointEnabled: false);
+            await SendStatsHelper(statsComputationEnabled: true, globalSamplingRate: 0.0);
         }
 
         [Fact]
-        public async Task IsDisabledThroughConfiguration()
+        public async Task IsDisabledThroughConfiguration_TS010()
         {
             await SendStatsHelper(statsComputationEnabled: false);
         }
 
-        [Fact(Skip = "P0 traces can be dropped when stats computation is enabled, but the feature has not been implemented yet")]
-        public async Task SendsStatsAndDropsSpansWhenSampleRateIsZero()
+        [Fact(Skip = "DiscoveryService is not yet hooked up to Tracer initialization.")]
+        public async Task IsDisabledWhenIncompatibleAgentDetected_TS011()
         {
-            await SendStatsHelper(statsComputationEnabled: true, globalSamplingRate: 0.0);
+            await SendStatsHelper(statsComputationEnabled: true, statsEndpointEnabled: false);
         }
 
         private async Task SendStatsHelper(bool statsComputationEnabled, double? globalSamplingRate = null, bool statsEndpointEnabled = true)

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.IntegrationTests
             await SendStatsHelper(statsComputationEnabled: false);
         }
 
-        [Fact(Skip = "DiscoveryService is not yet hooked up to Tracer initialization.")]
+        [Fact]
         public async Task IsDisabledWhenIncompatibleAgentDetected_TS011()
         {
             await SendStatsHelper(statsComputationEnabled: true, expectStats: false, statsEndpointEnabled: false);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -39,12 +39,12 @@ namespace Datadog.Trace.IntegrationTests
         [Fact(Skip = "DiscoveryService is not yet hooked up to Tracer initialization.")]
         public async Task IsDisabledWhenIncompatibleAgentDetected_TS011()
         {
-            await SendStatsHelper(statsComputationEnabled: true, statsEndpointEnabled: false);
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: false, statsEndpointEnabled: false);
         }
 
-        private async Task SendStatsHelper(bool statsComputationEnabled, double? globalSamplingRate = null, bool statsEndpointEnabled = true)
+        private async Task SendStatsHelper(bool statsComputationEnabled, double? globalSamplingRate = null, bool statsEndpointEnabled = true, bool expectStats = true)
         {
-            bool expectStats = statsComputationEnabled && statsEndpointEnabled;
+            expectStats &= statsComputationEnabled && statsEndpointEnabled;
             var waitEvent = new AutoResetEvent(false);
 
             using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), statsEndpointEnabled: statsEndpointEnabled);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -49,12 +49,19 @@ namespace Datadog.Trace.IntegrationTests
             await SendStatsHelper(statsComputationEnabled: true, expectStats: false, statsEndpointEnabled: false);
         }
 
-        private async Task SendStatsHelper(bool statsComputationEnabled, bool expectStats, double? globalSamplingRate = null, bool statsEndpointEnabled = true, bool expectAllTraces = true, bool finishSpansOnClose = true)
+        [Fact]
+        public async Task SendsStatsAndKeepsP0sWhenAgentDropP0sIsFalse()
+        {
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: true, expectAllTraces: true, globalSamplingRate: 0.0, clientDropP0sEnabled: false);
+        }
+
+        private async Task SendStatsHelper(bool statsComputationEnabled, bool expectStats, double? globalSamplingRate = null, bool statsEndpointEnabled = true, bool clientDropP0sEnabled = true, bool expectAllTraces = true, bool finishSpansOnClose = true)
         {
             var statsWaitEvent = new AutoResetEvent(false);
             var tracesWaitEvent = new AutoResetEvent(false);
 
             var agentConfiguration = new MockTracerAgent.AgentConfiguration();
+            agentConfiguration.ClientDropP0s = clientDropP0sEnabled;
             if (!statsEndpointEnabled)
             {
                 agentConfiguration.Endpoints = agentConfiguration.Endpoints.Where(s => s != "/v0.6/stats").ToArray();

--- a/tracer/test/Datadog.Trace.IntegrationTests/TestApi.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TestApi.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.IntegrationTests
             return objects;
         }
 
-        public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces)
+        public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans)
         {
             var spans = MessagePackSerializer.Deserialize<List<List<MockSpan>>>(traces);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -552,7 +552,7 @@ namespace Datadog.Trace.TestHelpers
             public string[] Endpoints { get; set; } = DiscoveryService.AllSupportedEndpoints.Select(s => s.StartsWith("/") ? s : "/" + s).ToArray();
 
             [JsonProperty("client_drop_p0s")]
-            public bool ClientDropP0s { get; set; }
+            public bool ClientDropP0s { get; set; } = true;
         }
 
         public class TcpUdpAgent : MockTracerAgent

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -33,11 +33,11 @@ namespace Datadog.Trace.TestHelpers
     {
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-        protected MockTracerAgent(bool telemetryEnabled, TestTransports transport, bool statsEndpointEnabled)
+        protected MockTracerAgent(bool telemetryEnabled, TestTransports transport, AgentConfiguration configuration)
         {
             TelemetryEnabled = telemetryEnabled;
             TransportType = transport;
-            StatsEndpointEnabled = statsEndpointEnabled;
+            Configuration = configuration;
         }
 
         public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
@@ -56,7 +56,7 @@ namespace Datadog.Trace.TestHelpers
 
         public bool TelemetryEnabled { get; }
 
-        public bool StatsEndpointEnabled { get; }
+        public AgentConfiguration Configuration { get; }
 
         /// <summary>
         /// Gets the filters used to filter out spans we don't want to look at for a test.
@@ -91,8 +91,8 @@ namespace Datadog.Trace.TestHelpers
         /// </summary>
         public bool ShouldDeserializeTraces { get; set; } = true;
 
-        public static TcpUdpAgent Create(int port = 8126, int retries = 5, bool useStatsd = false, bool doNotBindPorts = false, int? requestedStatsDPort = null, bool useTelemetry = false, bool statsEndpointEnabled = true)
-            => new TcpUdpAgent(port, retries, useStatsd, doNotBindPorts, requestedStatsDPort, useTelemetry, statsEndpointEnabled);
+        public static TcpUdpAgent Create(int port = 8126, int retries = 5, bool useStatsd = false, bool doNotBindPorts = false, int? requestedStatsDPort = null, bool useTelemetry = false, AgentConfiguration configuration = null)
+            => new TcpUdpAgent(port, retries, useStatsd, doNotBindPorts, requestedStatsDPort, useTelemetry, configuration ?? new AgentConfiguration());
 
 #if NETCOREAPP3_1_OR_GREATER
         public static UdsAgent Create(UnixDomainSocketConfig config) => new UdsAgent(config);
@@ -546,6 +546,15 @@ namespace Datadog.Trace.TestHelpers
             Snapshots.AddRange(snapshots);
         }
 
+        public class AgentConfiguration
+        {
+            [JsonProperty("endpoints")]
+            public string[] Endpoints { get; set; } = DiscoveryService.AllSupportedEndpoints.Select(s => s.StartsWith("/") ? s : "/" + s).ToArray();
+
+            [JsonProperty("client_drop_p0s")]
+            public bool ClientDropP0s { get; set; }
+        }
+
         public class TcpUdpAgent : MockTracerAgent
         {
             private readonly HttpListener _listener;
@@ -553,8 +562,8 @@ namespace Datadog.Trace.TestHelpers
             private readonly Task _tracesListenerTask;
             private readonly Task _statsdTask;
 
-            public TcpUdpAgent(int port, int retries, bool useStatsd, bool doNotBindPorts, int? requestedStatsDPort, bool useTelemetry, bool statsEndpointEnabled)
-                : base(useTelemetry, TestTransports.Tcp, statsEndpointEnabled)
+            public TcpUdpAgent(int port, int retries, bool useStatsd, bool doNotBindPorts, int? requestedStatsDPort, bool useTelemetry, AgentConfiguration configuration)
+                : base(useTelemetry, TestTransports.Tcp, configuration)
             {
                 if (doNotBindPorts)
                 {
@@ -697,17 +706,7 @@ namespace Datadog.Trace.TestHelpers
 
                             if (ctx.Request.RawUrl.EndsWith("/info"))
                             {
-                                if (StatsEndpointEnabled)
-                                {
-                                    var endpointsArray = DiscoveryService.AllSupportedEndpoints.Concat("/v0.6/stats").ToArray();
-                                    var content = $"{{\"endpoints\":{JsonConvert.SerializeObject(endpointsArray)}, \"client_drop_p0s\":true}}";
-                                    buffer = Encoding.UTF8.GetBytes(content);
-                                }
-                                else
-                                {
-                                    var endpoints = $"{{\"endpoints\":{JsonConvert.SerializeObject(DiscoveryService.AllSupportedEndpoints)}}}";
-                                    buffer = Encoding.UTF8.GetBytes(endpoints);
-                                }
+                                buffer = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(Configuration));
                             }
                             else if (ctx.Request.RawUrl.Contains("/debugger/v1/input"))
                             {
@@ -808,7 +807,7 @@ namespace Datadog.Trace.TestHelpers
             private readonly Task _tracesListenerTask;
 
             public NamedPipeAgent(WindowsPipesConfig config)
-                : base(config.UseTelemetry, TestTransports.WindowsNamedPipe, config.StatsEndpointEnabled)
+                : base(config.UseTelemetry, TestTransports.WindowsNamedPipe, config.Configuration)
             {
                 ListenerInfo = $"Traces at {config.Traces}";
 
@@ -1013,7 +1012,7 @@ namespace Datadog.Trace.TestHelpers
             private readonly Task _statsdTask;
 
             public UdsAgent(UnixDomainSocketConfig config)
-                : base(config.UseTelemetry, TestTransports.Uds, config.StatsEndpointEnabled)
+                : base(config.UseTelemetry, TestTransports.Uds, config.Configuration)
             {
                 ListenerInfo = $"Traces at {config.Traces}";
 

--- a/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
@@ -20,5 +20,7 @@ namespace Datadog.Trace.TestHelpers
         public bool UseDogstatsD { get; set; } = false;
 
         public bool UseTelemetry { get; set; } = false;
+
+        public bool StatsEndpointEnabled { get; set; } = false;
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/UnixDomainSocketConfig.cs
@@ -7,10 +7,11 @@ namespace Datadog.Trace.TestHelpers
 {
     public class UnixDomainSocketConfig
     {
-        public UnixDomainSocketConfig(string traces, string metrics)
+        public UnixDomainSocketConfig(string traces, string metrics, MockTracerAgent.AgentConfiguration configuration = null)
         {
             Traces = traces;
             Metrics = metrics;
+            Configuration = configuration ?? new MockTracerAgent.AgentConfiguration();
         }
 
         public string Traces { get; }
@@ -21,6 +22,6 @@ namespace Datadog.Trace.TestHelpers
 
         public bool UseTelemetry { get; set; } = false;
 
-        public bool StatsEndpointEnabled { get; set; } = false;
+        public MockTracerAgent.AgentConfiguration Configuration { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/WindowsPipesConfig.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/WindowsPipesConfig.cs
@@ -7,10 +7,11 @@ namespace Datadog.Trace.TestHelpers
 {
     public class WindowsPipesConfig
     {
-        public WindowsPipesConfig(string traces, string metrics)
+        public WindowsPipesConfig(string traces, string metrics, MockTracerAgent.AgentConfiguration configuration = null)
         {
             Traces = traces;
             Metrics = metrics;
+            Configuration = configuration ?? new MockTracerAgent.AgentConfiguration();
         }
 
         public string Traces { get; }
@@ -21,6 +22,6 @@ namespace Datadog.Trace.TestHelpers
 
         public bool UseTelemetry { get; set; } = false;
 
-        public bool StatsEndpointEnabled { get; set; } = false;
+        public MockTracerAgent.AgentConfiguration Configuration { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/WindowsPipesConfig.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/WindowsPipesConfig.cs
@@ -20,5 +20,7 @@ namespace Datadog.Trace.TestHelpers
         public bool UseDogstatsD { get; set; } = false;
 
         public bool UseTelemetry { get; set; } = false;
+
+        public bool StatsEndpointEnabled { get; set; } = false;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -100,240 +100,7 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public async Task CollectsTopLevelSpans()
-        {
-            const int millisecondsToNanoseconds = 1_000_000;
-
-            // All spans should be recorded except snapshotSpan
-            const long expectedTotalDuration = (100 + 200) * millisecondsToNanoseconds;
-            const long expectedOkDuration = (100 + 200) * millisecondsToNanoseconds;
-
-            const long expectedHttpClientTotalDuration = 400 * millisecondsToNanoseconds;
-            const long expectedHttpClientOkDuration = 400 * millisecondsToNanoseconds;
-
-            var start = DateTimeOffset.UtcNow;
-
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
-
-            try
-            {
-                var simpleSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
-                simpleSpan.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                var parentSpan = new Span(new SpanContext(2, 2, serviceName: "service"), start);
-                parentSpan.SetDuration(TimeSpan.FromMilliseconds(200));
-
-                // snapshotSpan shouldn't be recorded, because it has the PartialSnapshot metric (even though it is top-level)
-                var snapshotSpan = new Span(new SpanContext(5, 5, serviceName: "service"), start);
-                snapshotSpan.SetMetric(Tags.PartialSnapshot, 1.0);
-                snapshotSpan.SetDuration(TimeSpan.FromMilliseconds(300));
-
-                // Create a new child span that is a service entry span, which means it will have stats computed for it
-                var httpClientServiceSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service-http-client"), start);
-                httpClientServiceSpan.SetDuration(TimeSpan.FromMilliseconds(400));
-
-                aggregator.Add(simpleSpan, parentSpan, snapshotSpan, httpClientServiceSpan);
-
-                var buffer = aggregator.CurrentBuffer;
-
-                buffer.Buckets.Should().HaveCount(2);
-
-                var serviceKey = StatsAggregator.BuildKey(simpleSpan);
-                buffer.Buckets.Should().ContainKey(serviceKey);
-                var serviceBucket = buffer.Buckets[serviceKey];
-
-                serviceBucket.Duration.Should().Be(expectedTotalDuration);
-                serviceBucket.Hits.Should().Be(2);
-                serviceBucket.Errors.Should().Be(0);
-                serviceBucket.TopLevelHits.Should().Be(2);
-                serviceBucket.ErrorSummary.GetCount().Should().Be(0);
-                serviceBucket.ErrorSummary.GetSum().Should().Be(0);
-                serviceBucket.OkSummary.GetCount().Should().Be(2.0);
-                serviceBucket.OkSummary.GetSum().Should().BeApproximately(
-                    expectedOkDuration, expectedOkDuration * serviceBucket.OkSummary.IndexMapping.RelativeAccuracy);
-
-                var httpClientServiceKey = StatsAggregator.BuildKey(httpClientServiceSpan);
-                buffer.Buckets.Should().ContainKey(httpClientServiceKey);
-                var httpClientServiceBucket = buffer.Buckets[httpClientServiceKey];
-
-                httpClientServiceBucket.Duration.Should().Be(expectedHttpClientTotalDuration);
-                httpClientServiceBucket.Hits.Should().Be(1);
-                httpClientServiceBucket.Errors.Should().Be(0);
-                httpClientServiceBucket.TopLevelHits.Should().Be(1);
-                httpClientServiceBucket.ErrorSummary.GetCount().Should().Be(0);
-                httpClientServiceBucket.ErrorSummary.GetSum().Should().Be(0);
-                httpClientServiceBucket.OkSummary.GetCount().Should().Be(1.0);
-                httpClientServiceBucket.OkSummary.GetSum().Should().BeApproximately(
-                    expectedHttpClientOkDuration, expectedHttpClientOkDuration * httpClientServiceBucket.OkSummary.IndexMapping.RelativeAccuracy);
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-        }
-
-        [Fact]
-        public async Task RecordsSuccessesAndErrorsSeparately()
-        {
-            const int millisecondsToNanoseconds = 1_000_000;
-
-            const long expectedTotalDuration = (100 + 200 + 400) * millisecondsToNanoseconds;
-            const long expectedOkDuration = (100 + 200) * millisecondsToNanoseconds;
-            const long expectedErrorDuration = 400 * millisecondsToNanoseconds;
-
-            var start = DateTimeOffset.UtcNow;
-
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
-
-            try
-            {
-                var success1Span = new Span(new SpanContext(1, 1, serviceName: "service"), start);
-                success1Span.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                var success2Span = new Span(new SpanContext(2, 2, serviceName: "service"), start);
-                success2Span.SetDuration(TimeSpan.FromMilliseconds(200));
-
-                var errorSpan = new Span(new SpanContext(3, 3, serviceName: "service"), start);
-                errorSpan.Error = true;
-                errorSpan.SetDuration(TimeSpan.FromMilliseconds(400));
-
-                aggregator.Add(success1Span, success2Span, errorSpan);
-
-                var buffer = aggregator.CurrentBuffer;
-
-                buffer.Buckets.Should().HaveCount(1);
-                var bucket = buffer.Buckets.Values.Single();
-
-                bucket.Duration.Should().Be(expectedTotalDuration);
-                bucket.Hits.Should().Be(3);
-                bucket.Errors.Should().Be(1);
-                bucket.TopLevelHits.Should().Be(3);
-                bucket.ErrorSummary.GetCount().Should().Be(1.0);
-                bucket.ErrorSummary.GetSum().Should().BeApproximately(
-                    expectedErrorDuration, expectedErrorDuration * bucket.ErrorSummary.IndexMapping.RelativeAccuracy);
-                bucket.OkSummary.GetCount().Should().Be(2.0);
-                bucket.OkSummary.GetSum().Should().BeApproximately(
-                    expectedOkDuration, expectedOkDuration * bucket.OkSummary.IndexMapping.RelativeAccuracy);
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-        }
-
-        [Fact]
-        public async Task CollectsMeasuredSpans()
-        {
-            const int millisecondsToNanoseconds = 1_000_000;
-
-            // All spans should be recorded except childSpan
-            const long expectedTotalDuration = 100 * millisecondsToNanoseconds;
-            const long expectedOkDuration = 100 * millisecondsToNanoseconds;
-
-            var start = DateTimeOffset.UtcNow;
-
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
-
-            try
-            {
-                var parentSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
-                parentSpan.OperationName = "web.request";
-                parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                // childSpan shouldn't be recorded, because it's not top-level and doesn't have the Measured tag
-                var childSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
-                childSpan.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                var measuredChildSpan1 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
-                measuredChildSpan1.OperationName = "child.op1";
-                measuredChildSpan1.SetTag(Tags.Measured, "1");
-                measuredChildSpan1.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                var measuredChildSpan2 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
-                measuredChildSpan2.OperationName = "child.op2";
-                measuredChildSpan2.SetTag(Tags.Measured, "1");
-                measuredChildSpan2.SetDuration(TimeSpan.FromMilliseconds(100));
-
-                aggregator.Add(parentSpan, childSpan, measuredChildSpan1, measuredChildSpan2);
-
-                var buffer = aggregator.CurrentBuffer;
-
-                buffer.Buckets.Should().HaveCount(3);
-
-                foreach (var bucket in buffer.Buckets.Values)
-                {
-                    var topLevelHits = bucket.Key.OperationName == "web.request" ? 1 : 0;
-
-                    bucket.Duration.Should().Be(expectedTotalDuration);
-                    bucket.Hits.Should().Be(1);
-                    bucket.Errors.Should().Be(0);
-                    bucket.TopLevelHits.Should().Be(topLevelHits);
-                    bucket.ErrorSummary.GetCount().Should().Be(0);
-                    bucket.ErrorSummary.GetSum().Should().Be(0);
-                    bucket.OkSummary.GetCount().Should().Be(1.0);
-                    bucket.OkSummary.GetSum().Should().BeApproximately(
-                        expectedOkDuration, expectedOkDuration * bucket.OkSummary.IndexMapping.RelativeAccuracy);
-                }
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-        }
-
-        [Fact]
-        public async Task RelativeErrorIsAccurate()
-        {
-            var start = DateTimeOffset.UtcNow;
-
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
-
-            try
-            {
-                int sampleCount = 100;
-                var durations = new double[sampleCount];
-                for (int i = 0; i < sampleCount; i++)
-                {
-                    var span = new Span(new SpanContext((ulong)i, (ulong)i, serviceName: "service"), start);
-                    var duration = TimeSpan.FromMilliseconds(i * 100);
-
-                    span.SetDuration(duration);
-                    durations[i] = ConvertTimestamp(duration.ToNanoseconds());
-                    aggregator.Add(span);
-                }
-
-                var buffer = aggregator.CurrentBuffer;
-                buffer.Buckets.Should().HaveCount(1);
-                var bucket = buffer.Buckets.Values.Single();
-
-                // Sort the durations so we can grab the actual sample that corresponds with a quantile
-                Array.Sort(durations);
-                double[] quantiles = new double[] { 0.5, 0.75, 0.95, 0.99, 1 };
-
-                foreach (var quantile in quantiles)
-                {
-                    var actualQuantileValue = durations[GetQuantileIndex(quantile, sampleCount)];
-                    var ddSketchQuantileValue = bucket.OkSummary.GetValueAtQuantile(quantile);
-                    ddSketchQuantileValue.Should().BeApproximately(actualQuantileValue, actualQuantileValue * bucket.OkSummary.IndexMapping.RelativeAccuracy, "We expect quantiles to be accurate at quantile {0}", quantile);
-                }
-            }
-            finally
-            {
-                await aggregator.DisposeAsync();
-            }
-
-            // Accepted values of quantile are 0 <= q <= 1
-            // If q = 0, returns 0
-            // If q = 1, returns arrayLength - 1
-            static int GetQuantileIndex(double quantile, int arrayLength)
-            {
-                var numberOfElementsLessThanOrEqualTo = (int)Math.Floor(1 + (quantile * (arrayLength - 1)));
-                return numberOfElementsLessThanOrEqualTo - 1;
-            }
-        }
-
-        [Fact]
-        public async Task CreatesDistinctBuckets()
+        public async Task CreatesDistinctBuckets_TS003()
         {
             const int millisecondsToNanoseconds = 1_000_000;
             const long durationMs = 100;
@@ -408,6 +175,239 @@ namespace Datadog.Trace.Tests.Agent
                 span.Context.Origin = origin;
 
                 return span;
+            }
+        }
+
+        [Fact]
+        public async Task CollectsMeasuredSpans_TS004()
+        {
+            const int millisecondsToNanoseconds = 1_000_000;
+
+            // All spans should be recorded except childSpan
+            const long expectedTotalDuration = 100 * millisecondsToNanoseconds;
+            const long expectedOkDuration = 100 * millisecondsToNanoseconds;
+
+            var start = DateTimeOffset.UtcNow;
+
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+
+            try
+            {
+                var parentSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                parentSpan.OperationName = "web.request";
+                parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                // childSpan shouldn't be recorded, because it's not top-level and doesn't have the Measured tag
+                var childSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                childSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var measuredChildSpan1 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                measuredChildSpan1.OperationName = "child.op1";
+                measuredChildSpan1.SetTag(Tags.Measured, "1");
+                measuredChildSpan1.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var measuredChildSpan2 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                measuredChildSpan2.OperationName = "child.op2";
+                measuredChildSpan2.SetTag(Tags.Measured, "1");
+                measuredChildSpan2.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                aggregator.Add(parentSpan, childSpan, measuredChildSpan1, measuredChildSpan2);
+
+                var buffer = aggregator.CurrentBuffer;
+
+                buffer.Buckets.Should().HaveCount(3);
+
+                foreach (var bucket in buffer.Buckets.Values)
+                {
+                    var topLevelHits = bucket.Key.OperationName == "web.request" ? 1 : 0;
+
+                    bucket.Duration.Should().Be(expectedTotalDuration);
+                    bucket.Hits.Should().Be(1);
+                    bucket.Errors.Should().Be(0);
+                    bucket.TopLevelHits.Should().Be(topLevelHits);
+                    bucket.ErrorSummary.GetCount().Should().Be(0);
+                    bucket.ErrorSummary.GetSum().Should().Be(0);
+                    bucket.OkSummary.GetCount().Should().Be(1.0);
+                    bucket.OkSummary.GetSum().Should().BeApproximately(
+                        expectedOkDuration, expectedOkDuration * bucket.OkSummary.IndexMapping.RelativeAccuracy);
+                }
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task CollectsTopLevelSpans_TS005()
+        {
+            const int millisecondsToNanoseconds = 1_000_000;
+
+            // All spans should be recorded except snapshotSpan
+            const long expectedTotalDuration = (100 + 200) * millisecondsToNanoseconds;
+            const long expectedOkDuration = (100 + 200) * millisecondsToNanoseconds;
+
+            const long expectedHttpClientTotalDuration = 400 * millisecondsToNanoseconds;
+            const long expectedHttpClientOkDuration = 400 * millisecondsToNanoseconds;
+
+            var start = DateTimeOffset.UtcNow;
+
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+
+            try
+            {
+                var simpleSpan = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                simpleSpan.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var parentSpan = new Span(new SpanContext(2, 2, serviceName: "service"), start);
+                parentSpan.SetDuration(TimeSpan.FromMilliseconds(200));
+
+                // snapshotSpan shouldn't be recorded, because it has the PartialSnapshot metric (even though it is top-level)
+                var snapshotSpan = new Span(new SpanContext(5, 5, serviceName: "service"), start);
+                snapshotSpan.SetMetric(Tags.PartialSnapshot, 1.0);
+                snapshotSpan.SetDuration(TimeSpan.FromMilliseconds(300));
+
+                // Create a new child span that is a service entry span, which means it will have stats computed for it
+                var httpClientServiceSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service-http-client"), start);
+                httpClientServiceSpan.SetDuration(TimeSpan.FromMilliseconds(400));
+
+                aggregator.Add(simpleSpan, parentSpan, snapshotSpan, httpClientServiceSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+
+                buffer.Buckets.Should().HaveCount(2);
+
+                var serviceKey = StatsAggregator.BuildKey(simpleSpan);
+                buffer.Buckets.Should().ContainKey(serviceKey);
+                var serviceBucket = buffer.Buckets[serviceKey];
+
+                serviceBucket.Duration.Should().Be(expectedTotalDuration);
+                serviceBucket.Hits.Should().Be(2);
+                serviceBucket.Errors.Should().Be(0);
+                serviceBucket.TopLevelHits.Should().Be(2);
+                serviceBucket.ErrorSummary.GetCount().Should().Be(0);
+                serviceBucket.ErrorSummary.GetSum().Should().Be(0);
+                serviceBucket.OkSummary.GetCount().Should().Be(2.0);
+                serviceBucket.OkSummary.GetSum().Should().BeApproximately(
+                    expectedOkDuration, expectedOkDuration * serviceBucket.OkSummary.IndexMapping.RelativeAccuracy);
+
+                var httpClientServiceKey = StatsAggregator.BuildKey(httpClientServiceSpan);
+                buffer.Buckets.Should().ContainKey(httpClientServiceKey);
+                var httpClientServiceBucket = buffer.Buckets[httpClientServiceKey];
+
+                httpClientServiceBucket.Duration.Should().Be(expectedHttpClientTotalDuration);
+                httpClientServiceBucket.Hits.Should().Be(1);
+                httpClientServiceBucket.Errors.Should().Be(0);
+                httpClientServiceBucket.TopLevelHits.Should().Be(1);
+                httpClientServiceBucket.ErrorSummary.GetCount().Should().Be(0);
+                httpClientServiceBucket.ErrorSummary.GetSum().Should().Be(0);
+                httpClientServiceBucket.OkSummary.GetCount().Should().Be(1.0);
+                httpClientServiceBucket.OkSummary.GetSum().Should().BeApproximately(
+                    expectedHttpClientOkDuration, expectedHttpClientOkDuration * httpClientServiceBucket.OkSummary.IndexMapping.RelativeAccuracy);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task RecordsSuccessesAndErrorsSeparately_TS006()
+        {
+            const int millisecondsToNanoseconds = 1_000_000;
+
+            const long expectedTotalDuration = (100 + 200 + 400) * millisecondsToNanoseconds;
+            const long expectedOkDuration = (100 + 200) * millisecondsToNanoseconds;
+            const long expectedErrorDuration = 400 * millisecondsToNanoseconds;
+
+            var start = DateTimeOffset.UtcNow;
+
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+
+            try
+            {
+                var success1Span = new Span(new SpanContext(1, 1, serviceName: "service"), start);
+                success1Span.SetDuration(TimeSpan.FromMilliseconds(100));
+
+                var success2Span = new Span(new SpanContext(2, 2, serviceName: "service"), start);
+                success2Span.SetDuration(TimeSpan.FromMilliseconds(200));
+
+                var errorSpan = new Span(new SpanContext(3, 3, serviceName: "service"), start);
+                errorSpan.Error = true;
+                errorSpan.SetDuration(TimeSpan.FromMilliseconds(400));
+
+                aggregator.Add(success1Span, success2Span, errorSpan);
+
+                var buffer = aggregator.CurrentBuffer;
+
+                buffer.Buckets.Should().HaveCount(1);
+                var bucket = buffer.Buckets.Values.Single();
+
+                bucket.Duration.Should().Be(expectedTotalDuration);
+                bucket.Hits.Should().Be(3);
+                bucket.Errors.Should().Be(1);
+                bucket.TopLevelHits.Should().Be(3);
+                bucket.ErrorSummary.GetCount().Should().Be(1.0);
+                bucket.ErrorSummary.GetSum().Should().BeApproximately(
+                    expectedErrorDuration, expectedErrorDuration * bucket.ErrorSummary.IndexMapping.RelativeAccuracy);
+                bucket.OkSummary.GetCount().Should().Be(2.0);
+                bucket.OkSummary.GetSum().Should().BeApproximately(
+                    expectedOkDuration, expectedOkDuration * bucket.OkSummary.IndexMapping.RelativeAccuracy);
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task RelativeErrorIsAccurate_TS009()
+        {
+            var start = DateTimeOffset.UtcNow;
+
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+
+            try
+            {
+                int sampleCount = 100;
+                var durations = new double[sampleCount];
+                for (int i = 0; i < sampleCount; i++)
+                {
+                    var span = new Span(new SpanContext((ulong)i, (ulong)i, serviceName: "service"), start);
+                    var duration = TimeSpan.FromMilliseconds(i * 100);
+
+                    span.SetDuration(duration);
+                    durations[i] = ConvertTimestamp(duration.ToNanoseconds());
+                    aggregator.Add(span);
+                }
+
+                var buffer = aggregator.CurrentBuffer;
+                buffer.Buckets.Should().HaveCount(1);
+                var bucket = buffer.Buckets.Values.Single();
+
+                // Sort the durations so we can grab the actual sample that corresponds with a quantile
+                Array.Sort(durations);
+                double[] quantiles = new double[] { 0.5, 0.75, 0.95, 0.99, 1 };
+
+                foreach (var quantile in quantiles)
+                {
+                    var actualQuantileValue = durations[GetQuantileIndex(quantile, sampleCount)];
+                    var ddSketchQuantileValue = bucket.OkSummary.GetValueAtQuantile(quantile);
+                    ddSketchQuantileValue.Should().BeApproximately(actualQuantileValue, actualQuantileValue * bucket.OkSummary.IndexMapping.RelativeAccuracy, "We expect quantiles to be accurate at quantile {0}", quantile);
+                }
+            }
+            finally
+            {
+                await aggregator.DisposeAsync();
+            }
+
+            // Accepted values of quantile are 0 <= q <= 1
+            // If q = 0, returns 0
+            // If q = 1, returns arrayLength - 1
+            static int GetQuantileIndex(double quantile, int arrayLength)
+            {
+                var numberOfElementsLessThanOrEqualTo = (int)Math.Floor(1 + (quantile * (arrayLength - 1)));
+                return numberOfElementsLessThanOrEqualTo - 1;
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using FluentAssertions;
@@ -41,7 +42,7 @@ namespace Datadog.Trace.Tests.Agent
                     })
                 .Returns(Task.FromResult(true));
 
-            var aggregator = new StatsAggregator(api.Object, GetSettings(), bucketDuration);
+            var aggregator = new StatsAggregator(api.Object, GetSettings(), new DiscoveryServiceMock(), bucketDuration);
 
             try
             {
@@ -76,7 +77,7 @@ namespace Datadog.Trace.Tests.Agent
 
             // First, validate that Flush does call SendStatsAsync even if disposed
             // If this behavior change then the test needs to be rewritten
-            var aggregator = new StatsAggregator(api.Object, GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(api.Object, GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             // Dispose immediately to make Flush complete without delay
             await aggregator.DisposeAsync();
@@ -90,7 +91,7 @@ namespace Datadog.Trace.Tests.Agent
             api.Reset();
 
             // Now the actual test
-            aggregator = new StatsAggregator(api.Object, GetSettings(), Timeout.InfiniteTimeSpan);
+            aggregator = new StatsAggregator(api.Object, GetSettings(), null, Timeout.InfiniteTimeSpan);
             await aggregator.DisposeAsync();
 
             await aggregator.Flush();
@@ -109,7 +110,7 @@ namespace Datadog.Trace.Tests.Agent
             ulong id = 0;
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             try
             {
@@ -189,7 +190,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             try
             {
@@ -252,7 +253,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             try
             {
@@ -322,7 +323,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             try
             {
@@ -365,7 +366,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), new DiscoveryServiceMock(), Timeout.InfiniteTimeSpan);
 
             try
             {
@@ -428,6 +429,25 @@ namespace Datadog.Trace.Tests.Agent
             }
 
             return ns << shift;
+        }
+
+        private class DiscoveryServiceMock : IDiscoveryService
+        {
+            public string ProbeConfigurationEndpoint => nameof(ProbeConfigurationEndpoint);
+
+            public string DebuggerEndpoint => nameof(DebuggerEndpoint);
+
+            public string StatsEndpoint => nameof(StatsEndpoint);
+
+            public string AgentVersion => nameof(AgentVersion);
+
+            internal bool Called { get; private set; }
+
+            public Task<bool> DiscoverAsync()
+            {
+                Called = true;
+                return Task.FromResult(true);
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -441,6 +441,8 @@ namespace Datadog.Trace.Tests.Agent
 
             public string AgentVersion => nameof(AgentVersion);
 
+            public bool ClientDropP0s => true;
+
             internal bool Called { get; private set; }
 
             public Task<bool> DiscoverAsync()

--- a/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests
 
             var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator.Object, statsd: null, automaticFlush: false);
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             statsAggregator.Verify(s => s.AddRange(It.IsAny<Span[]>(), 0, 1), Times.Once);
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests
             trace = new[] { new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow) };
             var expectedData2 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Tests
                     throw new InvalidOperationException();
                 });
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             mutex.Wait();
 
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests
                 })
                 .Returns(Task.FromResult(true));
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             // Wait for the flush operation
             barrier.SignalAndWait();
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Tests
 
             var mutex = new ManualResetEventSlim();
 
-            agent.WriteTrace(CreateTrace(2));
+            agent.WriteTrace(CreateTrace(2), true);
 
             // Wait for the trace to be dequeued
             WaitForDequeue(agent);
@@ -170,8 +170,8 @@ namespace Datadog.Trace.Tests
             // Make the buffer size big enough for a single trace
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
-            agent.WriteTrace(CreateTrace(1));
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
+            agent.WriteTrace(CreateTrace(1), true);
 
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
             Assert.True(agent.FrontBuffer.IsFull);
@@ -199,8 +199,8 @@ namespace Datadog.Trace.Tests
             var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd.Object, automaticFlush: false, (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             // Fill the two buffers
-            agent.WriteTrace(CreateTrace(1));
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
+            agent.WriteTrace(CreateTrace(1), true);
 
             // Buffers should have swapped
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
@@ -220,7 +220,7 @@ namespace Datadog.Trace.Tests
             statsd.Invocations.Clear();
 
             // Both buffers are at capacity, write a new trace
-            agent.WriteTrace(CreateTrace(2));
+            agent.WriteTrace(CreateTrace(2), true);
 
             // Buffers shouldn't have swapped since the reserve buffer was full
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
@@ -259,7 +259,7 @@ namespace Datadog.Trace.Tests
             }
 
             // Serialization thread is asleep, makes sure it wakes up when enqueuing a trace
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
             Assert.True(WaitForDequeue(agent));
 
             return agent.FlushAndCloseAsync();
@@ -289,22 +289,22 @@ namespace Datadog.Trace.Tests
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, calculator, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1, batchInterval: 100);
 
             // Fill both buffers
-            agent.WriteTrace(trace);
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
+            agent.WriteTrace(trace, true);
 
             // Drop one
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             // Write another one
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
             api.Verify();
             api.Invocations.Clear();
 
             // Write trace and update keep rate
             calculator.UpdateBucket();
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             const double expectedTraceKeepRate = 0.75;
@@ -338,19 +338,19 @@ namespace Datadog.Trace.Tests
             var trace = new ArraySegment<Span>(new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) });
 
             // Write trace to the front buffer
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // Flush front buffer
             var firstFlush = agentWriter.FlushTracesAsync();
 
             // This will swap to the back buffer due front buffer is blocked.
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // Flush the second buffer
             var secondFlush = agentWriter.FlushTracesAsync();
 
             // This trace will force other buffer swap and then a drop because both buffers are blocked
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // This will try to flush the front buffer again.
             var thirdFlush = agentWriter.FlushTracesAsync();

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Exactly(5));
         }
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: statsComputationEnabled);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.AddHeader(AgentHttpHeaderNames.StatsComputation, "true"), statsComputationEnabled ? Times.Once : Times.Never);
         }
@@ -155,9 +155,9 @@ namespace Datadog.Trace.Tests
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: true, log: logMock.Object, statsComputationEnabled: false);
 
             // First time should write the warning
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
             // Second time, it won't
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             // ReSharper disable ExplicitCallerInfoArgument
             logMock.Verify(
@@ -194,7 +194,7 @@ namespace Datadog.Trace.Tests
             Action<Dictionary<string, float>> updateSampleRates = _ => ratesWereSet = true;
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
             ratesWereSet.Should().BeTrue();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -91,6 +91,8 @@ public class LiveDebuggerTests
 
         public string AgentVersion => nameof(AgentVersion);
 
+        public bool ClientDropP0s => true;
+
         internal bool Called { get; private set; }
 
         public Task<bool> DiscoverAsync()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -87,6 +87,8 @@ public class LiveDebuggerTests
 
         public string DebuggerEndpoint => nameof(DebuggerEndpoint);
 
+        public string StatsEndpoint => nameof(StatsEndpoint);
+
         public string AgentVersion => nameof(AgentVersion);
 
         internal bool Called { get; private set; }

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests
 
             span.SetTag(key, value);
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Never);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), Times.Never);
             Assert.Equal(span.GetTag(key), value);
         }
 
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
             await Task.Delay(TimeSpan.FromMilliseconds(1));
             span.Finish();
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Once);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), Times.Once);
             Assert.True(span.Duration > TimeSpan.Zero);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util;
@@ -17,6 +18,7 @@ namespace Datadog.Trace.Tests
     [AzureAppServicesRestorer]
     public class TraceContextTests
     {
+        private const ulong KnuthFactor = 1_111_111_111_111_111_111;
         private readonly Mock<IDatadogTracer> _tracerMock = new Mock<IDatadogTracer>();
 
         [Fact]
@@ -77,18 +79,18 @@ namespace Datadog.Trace.Tests
             }
 
             // At this point in time, we have 4 closed spans in the trace
-            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
 
             AddAndCloseSpan();
 
             // Now we have 5 closed spans, partial flush should kick-in if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5), true), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
             }
 
             for (int i = 0; i < 5; i++)
@@ -99,11 +101,11 @@ namespace Datadog.Trace.Tests
             // We have 5 more closed spans, partial flush should kick-in a second time if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Exactly(2));
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5), true), Times.Exactly(2));
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
             }
 
             traceContext.CloseSpan(rootSpan);
@@ -111,11 +113,11 @@ namespace Datadog.Trace.Tests
             // Now the remaining spans are flushed
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 1)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 1), true), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 11)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 11), true), Times.Once);
             }
         }
 
@@ -139,8 +141,8 @@ namespace Datadog.Trace.Tests
 
             ArraySegment<Span>? spans = null;
 
-            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
-                  .Callback<ArraySegment<Span>>(s => spans = s);
+            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>(), true))
+                  .Callback<ArraySegment<Span>, bool>((s, _) => spans = s);
 
             var traceContext = new TraceContext(tracer.Object);
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
@@ -192,13 +194,12 @@ namespace Datadog.Trace.Tests
 
             ArraySegment<Span>? spans = null;
 
-            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
-                  .Callback<ArraySegment<Span>>(s => spans = s);
-
-            var vars = Environment.GetEnvironmentVariables();
+            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>(), true))
+                  .Callback<ArraySegment<Span>, bool>((s, _) => spans = s);
 
             if (inAASContext)
             {
+                Dictionary<string, string> vars = new();
                 vars.Add(AzureAppServices.AzureAppServicesContextKey, "true");
                 vars.Add(AzureAppServices.ResourceGroupKey, "ThisIsAResourceGroup");
                 vars.Add(Datadog.Trace.Configuration.ConfigurationKeys.ApiKey, "xxx");
@@ -233,6 +234,137 @@ namespace Datadog.Trace.Tests
             {
                 spans.Value.Array[0].GetTag(Tags.AzureAppServicesResourceGroup).Should().BeNull();
             }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void StatsComputationEnabled_SerializeSpansFalseWhen_SamplingPriorityLessThanEqualTo0(int samplingPriority)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(samplingPriority);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), false));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_SamplingPriorityGreaterThan0(int samplingPriority)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(samplingPriority);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_TraceHasErrors(bool hasChildSpans)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            rootSpan.Error = true;
+
+            if (hasChildSpans)
+            {
+                var childSpan = CreateSpan();
+                traceContext.AddSpan(childSpan);
+                traceContext.CloseSpan(childSpan);
+            }
+
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true));
+        }
+
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(true, 0)]
+        [InlineData(false, 0.5)]
+        [InlineData(true, 0.5)]
+        [InlineData(false, 1)]
+        [InlineData(true, 1)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_SpanHasAnalyticsAndSampled(bool hasChildSpans, double analyticsSampleRate)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            rootSpan.SetMetric(Tags.Analytics, analyticsSampleRate);
+
+            if (hasChildSpans)
+            {
+                var childSpan = CreateSpan();
+                traceContext.AddSpan(childSpan);
+                traceContext.CloseSpan(childSpan);
+            }
+
+            traceContext.CloseSpan(rootSpan);
+            var sampled = ((rootSpan.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (analyticsSampleRate * TracerConstants.MaxTraceId);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), sampled));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests
 
             var assertion = areTracesEnabled ? Times.Once() : Times.Never();
 
-            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>()), assertion);
+            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), assertion);
         }
 
         [Theory]

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -52,7 +52,7 @@ namespace Benchmarks.Trace
         [Benchmark]
         public Task WriteAndFlushEnrichedTraces()
         {
-            AgentWriter.WriteTrace(EnrichedSpans);
+            AgentWriter.WriteTrace(EnrichedSpans, true);
             return AgentWriter.FlushTracesAsync();
         }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -9,6 +9,8 @@ namespace Benchmarks.Trace
     {
         private static readonly Task<bool> PingTask = Task.FromResult(true);
 
+        public bool CanComputeStats => false;
+
         public bool CanDropP0s => false;
 
         public Task FlushAndCloseAsync()

--- a/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -9,6 +9,8 @@ namespace Benchmarks.Trace
     {
         private static readonly Task<bool> PingTask = Task.FromResult(true);
 
+        public bool CanDropP0s => false;
+
         public Task FlushAndCloseAsync()
         {
             return Task.CompletedTask;
@@ -32,7 +34,7 @@ namespace Benchmarks.Trace
             return PingTask;
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
         }
     }


### PR DESCRIPTION
## Summary of changes
Adds two new capabilities to the stats computation feature:
1. When stats computation is enabled through configuration, the tracer sends a request to the trace agent's `/info` endpoint to ensure that this feature is supported by the trace agent. If not, the feature is disabled.
2. The tracer also checks whether it can drop P0 traces (user-rejected traces or sampler-rejected traces). When this feature is supported by the trace agent, P0 traces are no longer serialized to the agent and the `"Datadog-Client-Dropped-P0-Traces"` and `"Datadog-Client-Dropped-P0-Spans"` request headers are set on the next trace payload.

Additionally, adds unit tests and integration tests that test all of the agreed upon cross-tracer tests for the stats computation feature.

## Reason for change
Computing stats in the tracer reduces a large amount of span serialization (from the tracer) and span deserialization (from the trace agent), which reduces CPU overhead for users with significant amounts of trace agent traffic. The increased testing also adds confidence that our implementation is on par with the implementations within other tracers (since this is moving a trace agent feature to the individual language tracers).

## Implementation details

### StatsAggregator initialization now executes Endpoint Discovery
> Background: When stats computation is enabled, the `StatsAggregator` object is responsible for buffering stats and periodically sending them to the trace agent's stats endpoint. Stats are computed by passing in an array of spans into the `AddRange` API, which is called by the `AgentWriter` when a local trace is finished and is buffered/serialized.

Much like the LiveDebugger initialization, the constructor of `StatsAggregator` will invoke a task on the threadpool to ping the agent URL at the `/info` endpoint to check what endpoints and features it supports. We specifically check for two properties:
- `endpoints[]` contains `"/v0.6/stats"`. If true, stats computation is enabled via the new property `CanComputeStats`.
- `client_drop_p0s` property is set to true. If so, dropping P0 spans is enabled via the new property `CanDropP0s`.

**Note:** Since spans and traces can be finishing while the service discovery is ongoing, we let the StatsAggregator store stats points while the operation is ongoing. If initialization succeeds, the stats aggregrator can start sending stats to the trace agent. If initialization fails, the stats aggregator does not store new stats points and refuses to send stats to the trace agent.


### TraceContext changes
> Background: The `TraceContext` object is responsible for flushing finished spans to its Tracer object reference when either all spans in the local trace are finished or the number of finished spans in the ongoing trace exceeds the partial flush limit. After this point, the finished spans are sent to the AgentWriter to be buffered/serialized, so we must make the decision here whether to drop P0 spans.

If `Tracer.CanDropP0s == true`, then the following algorithm is run on each of the finished spans to determine if the span should be kept. If at least one span is kept, then the entire trace is kept. If not, then the entire trace is dropped.
- Is the sampling priority greater than 0?
- Does the span have an error?
- Does the span have an app analytics sample rate? If so, does the sampling decision determine it should be sampled?

We then pass the keep/drop decision along with the finished span array to the `AgentWriter.WriteTrace` API.

**Note:** There will need to be some special handling if a trace is supposed to be sampled out but the new single span ingestion controls determine that single spans should be kept. This is documented in the RFC and will need to be handled when the feature is implemented in the .NET Tracer.

### AgentWriter / IApi changes
> Background: The `AgentWriter` puts finished spans into buffers, and when a buffer is full those spans are sent to the trace agent by calling `IApi.SendTracesAsync`.

When the `AgentWriter` receives spans, it now accumulates the number of dropped P0 traces and dropped P0 spans. Then, when a span buffer needs to be serialized and `IApi.SendTracesAsync` is invoked, it passes along these counts and they are added as headers to the trace agent request.

### Small changes
- The `DiscoveryService.Create` method was refactored because the `IConfigurationSource` parameter was redundant.
- The `MockTracerAgent` test class and all of its subclasses have been updated to accept an `AgentConfiguration` object which allows us to mock different agent capabilities. This was used to test scenarios where stats computation was allowed but not the dropping of P0 spans.

## Test coverage
New tests cover those documented by internal RFCs.

## Other details
N/A
