### PR TITLE
[Profiler] Deactivate profiler on ARM64

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
@@ -117,6 +117,11 @@ extern "C" HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID r
         return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
 
+#ifdef ARM64
+    Log::Warn("Profiler is deactivated because it runs on an unsupported architecture.");
+    return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+#endif
+
     CorProfilerCallbackFactory* factory = new CorProfilerCallbackFactory();
     if (factory == nullptr)
     {


### PR DESCRIPTION
## Reason for change

The preliminary tests on ARM64 shows we have issue (stackwalking...) To avoid customer hitting the same problem and until we fix those issues, the profiler will be disabled on ARM64/Linux.

