### PR TITLE
Add profiler to windows-tracer-home.zip file

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -596,8 +596,7 @@ partial class Build
         {
             if (IsWin)
             {
-                CompressZip(TracerHomeDirectory, WindowsTracerHomeZip, fileMode: FileMode.Create);
-                // for now we do not need a monitoring-home.zip file. So no need to create it.
+                CompressZip(MonitoringHomeDirectory, WindowsTracerHomeZip, fileMode: FileMode.Create);
             }
             else if (IsLinux)
             {


### PR DESCRIPTION
## Summary of changes

Add profiler to `windows-tracer-home.zip` file.

## Reason for change

The profiler is gaining tracking and we got requests to add the profiler to `windows-tracer-home.zip` file so it can be deployed on windows nano servers (for ex.)

## Implementation details

Use `MonitoringHomeDirectory` instead `TracerHomerDirectory`.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
