### PR TITLE
[Tracer] Do not add x-datadog-tags header when empty or disabled

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Propagators
             var propagationHeaderMaxLength = context.TraceContext?.Tracer.Settings.TagPropagationHeaderMaxLength ?? TagPropagation.OutgoingPropagationHeaderMaxLength;
             var propagatedTraceTags = context.TraceContext?.Tags.ToPropagationHeader(propagationHeaderMaxLength) ?? context.PropagatedTags;
 
-            if (propagatedTraceTags != null)
+            if (!string.IsNullOrEmpty(propagatedTraceTags))
             {
                 carrierSetter.Set(carrier, HttpHeaderNames.PropagatedTags, propagatedTraceTags);
             }


### PR DESCRIPTION
## Summary of changes
Do not add `x-datadog-tags` header when unnecessary ie when empty or when `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` is set to 0. 

## Reason for change
Following #2897, we can propagate tags to downstream service. Unfortunately, we are adding the `x-datadog-tags` all the time even when it is empty as we tested the content for nullity, whereas we returned an empty string in most cases.

Note that, we've added this `DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH` parameter that should disable propagation when set to 0. Unfortunately, it fell in the same use case.

## Implementation details
Just replaced the null check in `DatadogContextPropagator` to a `string.IsNullOrEmpty`.

## Test coverage
Added one test case in Propagation. The UTest on TraceTagsCollection already existed. Ran this test without the code change, and it failed as expected.

## Other details
Fixes #3000 
