### PR TITLE
[Profiler] Fix Arm64 installer smoke tests

### DIFF
--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -22,7 +22,11 @@ namespace Datadog.Trace.ContinuousProfiler
 
         public ProfilerStatus()
         {
-            _isProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false;
+            var processArchitecture = FrameworkDescription.Instance.ProcessArchitecture;
+            var isSupportedArch = processArchitecture == ProcessArchitecture.X64 || processArchitecture == ProcessArchitecture.X86;
+
+            _isProfilingEnabled = (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false) && isSupportedArch;
+
             Log.Information("Continuous Profiler is {IsEnabled}.", _isProfilingEnabled ? "enabled" : "disabled");
             _lockObj = new();
             _isInitialized = false;

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
@@ -22,10 +22,12 @@ namespace Datadog.Trace.ContinuousProfiler
 
         public ProfilerStatus()
         {
-            var processArchitecture = FrameworkDescription.Instance.ProcessArchitecture;
-            var isSupportedArch = processArchitecture == ProcessArchitecture.X64 || processArchitecture == ProcessArchitecture.X86;
+            var fd = FrameworkDescription.Instance;
+            var isSupported =
+                (fd.OSPlatform == OSPlatformName.Windows && (fd.ProcessArchitecture == ProcessArchitecture.X64 || fd.ProcessArchitecture == ProcessArchitecture.X86)) ||
+                (fd.OSPlatform == OSPlatformName.Linux && fd.ProcessArchitecture == ProcessArchitecture.X64);
 
-            _isProfilingEnabled = (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false) && isSupportedArch;
+            _isProfilingEnabled = (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false) && isSupported;
 
             Log.Information("Continuous Profiler is {IsEnabled}.", _isProfilingEnabled ? "enabled" : "disabled");
             _lockObj = new();


### PR DESCRIPTION

## Summary of changes

## Reason for change

Profiler was not loaded because Arm64 is not currently supported, but the CodeHotspot feature was activated because it relies only on the env var `DD_PROFILING_ENABLED`.
The tests failed (certainly crashed) when PInvok'ing the profiler library.

## Implementation details

Deactivate Profiler in the managed code if it does not run on x64/x86 architecture.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
