### PR TITLE
Ignore `process_id` in smoke test snapshots on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -688,6 +688,7 @@ services:
     - "8126:8126"
     environment:
     - SNAPSHOT_CI=1
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id
 
   smoke-tests:
     build:


### PR DESCRIPTION
## Summary of changes

Ignores `meta.process_id` when doing snapshot comparison on Linux.

## Reason for change

When running in Docker, the pid of the main process is always 1, however, when we use `dd-trace` to instrument an app, the pid is sometimes _not_ 1. This causes the smoke tests to fail.

## Implementation details

Added `meta.process_id` to the ignored attributes using `SNAPSHOT_IGNORED_ATTRS`, the same way we do for Windows (where the pid is never 1)

## Test coverage
- [x] Dedicated run to confirm it fixes the issues.

## Other details
I'm not entirely sure why it's _sometimes_ 1, and sometimes not, but I would _guess_ that it's some sort of race, given it only seems to happen on the arm64 agents, and only occasionally. Either way, I think it's safe to ignore it in the snapshots.

