### PR TITLE
Fix the path to the native loader

### DIFF
--- a/tracer/build/_build/BuildVariables.cs
+++ b/tracer/build/_build/BuildVariables.cs
@@ -38,8 +38,8 @@ public static class BuildVariables
 
         if (EnvironmentInfo.IsWin)
         {
-            envVars.Add("CORECLR_PROFILER_PATH_32", monitoringHomeDirectory / "win-x86" / "Datadog.AutoInstrumentation.NativeLoader.x86.dll");
-            envVars.Add("CORECLR_PROFILER_PATH_64", monitoringHomeDirectory / "win-x64" / "Datadog.AutoInstrumentation.NativeLoader.x64.dll");
+            envVars.Add("CORECLR_PROFILER_PATH_32", monitoringHomeDirectory / "Datadog.AutoInstrumentation.NativeLoader.x86.dll");
+            envVars.Add("CORECLR_PROFILER_PATH_64", monitoringHomeDirectory / "Datadog.AutoInstrumentation.NativeLoader.x64.dll");
         }
         else
         {


### PR DESCRIPTION
## Summary of changes

Fix the path to the native loader in some Nuke targets

## Other details

Paths for .NET Core on Windows weren't properly updated in https://github.com/DataDog/dd-trace-dotnet/pull/2842