### PR TITLE
Try disabling telemetry in ci

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -32,6 +32,7 @@ steps:
         --env tracerHome=/project/$(relativeTracerHome) \
         --env artifacts=/project/$(relativeArtifacts) \
         --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
+        --env DD_INSTRUMENTATION_TELEMETRY_ENABLED \
         --env Verify_DisableClipboard=true \
         --env DiffEngine_Disabled=true \
         --env TestAllPackageVersions=$(TestAllPackageVersions) \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -116,6 +116,7 @@ variables:
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
   NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
   DefaultTimeout: 60
+  DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -22,6 +22,7 @@ $IMAGE_NAME="dd-trace-dotnet/alpine-base"
     --env NugetPackageDirectory=/project/packages `
     --env tracerHome=/project/shared/bin/monitoring-home/tracer `
     --env artifacts=/project/tracer/bin/artifacts `
+    --env DD_INSTRUMENTATION_TELEMETRY_ENABLED=0 `
     -p 5003:5003 `
     -v /ddlogs:/var/log/datadog/dotnet `
     $IMAGE_NAME `

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -19,6 +19,7 @@ docker run -it --rm \
     --env NugetPackageDirectory=/project/packages \
     --env tracerHome=/project/shared/bin/monitoring-home/tracer \
     --env artifacts=/project/tracer/bin/artifacts \
+    --env DD_INSTRUMENTATION_TELEMETRY_ENABLED=0 `
     -p 5003:5003 \
     -v /ddlogs:/var/log/datadog/dotnet \
     $IMAGE_NAME \

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -19,7 +19,7 @@ docker run -it --rm \
     --env NugetPackageDirectory=/project/packages \
     --env tracerHome=/project/shared/bin/monitoring-home/tracer \
     --env artifacts=/project/tracer/bin/artifacts \
-    --env DD_INSTRUMENTATION_TELEMETRY_ENABLED=0 `
+    --env DD_INSTRUMENTATION_TELEMETRY_ENABLED=0 \
     -p 5003:5003 \
     -v /ddlogs:/var/log/datadog/dotnet \
     $IMAGE_NAME \


### PR DESCRIPTION
## Summary of changes

Set `DD_INSTRUMENTATION_TELEMETRY_ENABLED=0` in CI

## Reason for change

We don't want to collect telemetry about ourselves

## Implementation details

I think the top-level variable should be picked up and injected everywhere it needs to be

## Test coverage

None... we shall see if it works later

## Other details
We should backport this to the other benchmark branches too
