### PR TITLE
Temporarily disable Live Debugger

### DIFF
--- a/tracer/build/_build/BuildVariables.cs
+++ b/tracer/build/_build/BuildVariables.cs
@@ -7,7 +7,7 @@ public static class BuildVariables
     public static void AddDebuggerEnvironmentVariables(this Dictionary<string, string> envVars, AbsolutePath tracerHomeDirectory)
     {
         envVars.AddTracerEnvironmentVariables(tracerHomeDirectory);
-        envVars.Add("DD_DEBUGGER_ENABLED", "1");
+        envVars.Add("DD_INTERNAL_DEBUGGER_ENABLED", "1");
         envVars.Add("DD_INTERNAL_DEBUGGER_INSTRUMENT_ALL", "1");
     }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Configuration
             /// Default value is false (disabled).
             /// </summary>
             /// <seealso cref="DebuggerSettings.Enabled"/>
-            public const string Enabled = "DD_DEBUGGER_ENABLED";
+            public const string Enabled = "DD_INTERNAL_DEBUGGER_ENABLED";
 
             /// <summary>
             /// Configuration key for the max object depth to serialize for probe snapshots.

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -88,11 +88,11 @@ namespace Datadog.Trace.Debugger
 
         private void Initialize()
         {
-            if (!_settings.Enabled)
-            {
-                Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
-                return;
-            }
+            // if (!_settings.Enabled)
+            // {
+            //     Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
+            //     return;
+            // }
 
             if (_settings.TransportType != TracesTransportType.Default)
             {

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -88,11 +88,11 @@ namespace Datadog.Trace.Debugger
 
         private void Initialize()
         {
-            // if (!_settings.Enabled)
-            // {
-            //     Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
-            //     return;
-            // }
+            if (!_settings.Enabled)
+            {
+                // Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
+                return;
+            }
 
             if (_settings.TransportType != TracesTransportType.Default)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/LiveDebuggerTests.cs
@@ -35,7 +35,7 @@ public class LiveDebuggerTests : TestHelper
         SetServiceVersion("1.0.0");
     }
 
-    [Fact]
+    [Fact(Skip = "Live Debugger is temporarily disabled.")]
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]
@@ -45,7 +45,7 @@ public class LiveDebuggerTests : TestHelper
         await RunTest();
     }
 
-    [Fact]
+    [Fact(Skip = "Live Debugger is temporarily disabled.")]
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "ArmUnsupported")]
     [Trait("RunOnWindows", "True")]

--- a/tracer/test/test-applications/debugger/Samples.Probes/Properties/launchSettings.json
+++ b/tracer/test/test-applications/debugger/Samples.Probes/Properties/launchSettings.json
@@ -11,7 +11,7 @@
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "DD_DEBUGGER_PROBE_FILE": "$(SolutionDir)tracer\\test\\test-applications\\debugger\\Samples.Probes\\probes_definition.json",
         "CORECLR_ENABLE_PROFILING": "1",
-        "DD_DEBUGGER_ENABLED": "1",
+        "DD_INTERNAL_DEBUGGER_ENABLED": "1",
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
       },


### PR DESCRIPTION
## Summary of changes

1. Temporarily disable Live Debugger by simply renaming `DD_DEBUGGER_ENABLED` to `DD_INTERNAL_DEBUGGER_ENABLED`. This ensure that even if customers follow the (not yet released) Live Debugger onboarding docs, both Live Debugger and the Remote Configuration Client would be completely dormant and inactive. At the same time, this change allows us to keep _most_ of Live Debugger's unit and integration running in CI.

2. Comment out the log message that explicitly informs customers that Live Debugger is disabled.

## Reason for change
The Remote Configuration Management team has requested that we do not release any new versions of the tracer that includes an RCM client until we ensure the [Remote Config System Tests ](https://github.com/DataDog/system-tests/commit/cb5b19740887648ac7488c14269136b032f1ba0e) are all passing. That work is still ongoing, so we'll disable Live Debugger and RCM for the time being to unblock shipping a new release to customers.
