### PR TITLE
Increase WaitForExit time in `DebuggerSampleProcessHelper`

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Debugger
             using var httpWebResponse = await WebRequest.CreateHttp(_stopUrl).GetResponseAsync();
             var timeout = 10_000;
             var isExited = Process.WaitForExit(timeout);
-            
+
             if (!isExited)
             {
                 throw new InvalidOperationException($"The process did not exit after {timeout}ms");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
@@ -28,7 +28,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Debugger
         internal async Task StopSample()
         {
             using var httpWebResponse = await WebRequest.CreateHttp(_stopUrl).GetResponseAsync();
-            Process.WaitForExit(1000);
+            var timeout = 10_000;
+            var isExited = Process.WaitForExit(timeout);
+            
+            if (!isExited)
+            {
+                throw new InvalidOperationException($"The process did not exit after {timeout}ms");
+            }
 
             if (Process.ExitCode != 0)
             {


### PR DESCRIPTION
## Summary of changes

Increase the `Process.WaitForExit` time, and check if exited correctly

## Reason for change

Saw some timeouts in recent builds.
