### PR TITLE
Downgrade version of `dotenv` installed with `fpm`

### DIFF
--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -20,6 +20,7 @@ RUN apk update \
         xz-dev \
         gdb \
         musl-dbg \
+    && gem install --version 2.7.6 dotenv \
     && gem install --no-document fpm
 
 ENV IsAlpine=true

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -46,13 +46,15 @@ RUN yum update -y \
         sudo \
         gawk
 
-# Install newer version of fpm
+# Install newer version of fpm and specific version of dotenv 
 RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 1.12.2 --user-install ffi && \
     gem install --version 1.6.0 --user-install git && \
     gem install --version 0.9.10 --user-install rb-inotify && \
     gem install --version 3.2.3  --user-install rexml && \
-    gem install backports -v 3.21.0 && gem install fpm
+    gem install backports -v 3.21.0 && \
+    gem install --version 2.7.6 dotenv && \
+    gem install fpm
 
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
         libtool \
         liblzma-dev \
         gdb \
+    && gem install --version 2.7.6 dotenv \
     && gem install --no-document fpm \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary of changes

Force installing of version 2.7.6 of `dotenv` as 2.8.0 is breaking all our builds

## Reason for change

Currently our CI is completely broken on arm64 (where we don't already have the docker image cached)

## Implementation details

Installing 2.7.6 manually means that fpm doesn't try and update it

## Test coverage

The build works, so we're good

## Other details
Looked at switching [to nFPM](https://nfpm.goreleaser.com/install/), which has no dependencies (so we could remove ruby). I think it's worth doing, but will take longer than this fix, and I suspect will be easier once we've fixed the package layout changes
