### PR TITLE
[Profiler] Do not build the profiler native code in parallel for ASAN

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Build Native Profiler Engine
         run: |
           CXX=clang++ CC=clang cmake -S profiler -B __build -DRUN_ASAN=ON
-          cmake --build __build --config Release --parallel
+          cmake --build __build --config Release
 
       - name: Restore sample applications
         run: dotnet restore profiler/src/Demos/Datadog.Demos.sln /p:Configuration="Release"


### PR DESCRIPTION
## Summary of changes

## Reason for change

Currently, the `Build Linux Profiler ASAN` job is failing while compiling the profiling. The error code `137` means `out of memory`. To avoid getting in trouble, we will build the profiler sequentially.

## Implementation details

remove `--parallel` option on the command line

## Test coverage

## Other details
<!-- Fixes #{issue} -->
