### PR TITLE
Tiny fix for code analysis blocker on IndieSystem.Text.RegularExpressions.Symbolic.UnicodeCategoryRangesGenerator

### DIFF
--- a/tracer/src/Datadog.Trace/Vendors/IndieSystem.Text.RegularExpressions/System/Text/RegularExpressions/Symbolic/UnicodeCategoryRangesGenerator.cs
+++ b/tracer/src/Datadog.Trace/Vendors/IndieSystem.Text.RegularExpressions/System/Text/RegularExpressions/Symbolic/UnicodeCategoryRangesGenerator.cs
@@ -56,7 +56,7 @@ namespace {namespacename}
 #if NET5_0_OR_GREATER
                 Enum.GetValues<UnicodeCategory>()
 #else
-                Enum.GetValues(typeof(UnicodeCategory))
+                (UnicodeCategory[])Enum.GetValues(typeof(UnicodeCategory))
 #endif
                 )
 


### PR DESCRIPTION
## Summary of changes

Tiny fix to get rid of code analysis blocking warning when building from IDE

## Reason for change

Failed build from rider getting a
`  UnicodeCategoryRangesGenerator.cs(55, 38): [CS8605] Unboxing a possibly null value.`

## Implementation details
Just cast what is unicode category

## Test coverage

## Other details
<!-- Fixes #{issue} -->
