### PR TITLE
Allow null filenames in MultipartItem when using HttpClientRequest

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MultipartFormItem.cs
+++ b/tracer/src/Datadog.Trace/Agent/MultipartFormItem.cs
@@ -14,11 +14,11 @@ namespace Datadog.Trace.Agent
     {
         public readonly string Name;
         public readonly string ContentType;
-        public readonly string FileName;
+        public readonly string? FileName;
         public readonly ArraySegment<byte>? ContentInBytes;
         public readonly Stream? ContentInStream;
 
-        public MultipartFormItem(string name, string contentType, string fileName, ArraySegment<byte> contentInBytes)
+        public MultipartFormItem(string name, string contentType, string? fileName, ArraySegment<byte> contentInBytes)
         {
             Name = name;
             ContentType = contentType;
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Agent
             ContentInStream = null;
         }
 
-        public MultipartFormItem(string name, string contentType, string fileName, Stream contentInStream)
+        public MultipartFormItem(string name, string contentType, string? fileName, Stream contentInStream)
         {
             Name = name;
             ContentType = contentType;

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -105,20 +105,32 @@ namespace Datadog.Trace.Agent.Transports
 
             foreach (var item in items)
             {
+                HttpContent content = null;
+
                 // Adds a form data item
                 if (item.ContentInBytes is { } arraySegment)
                 {
-                    var content = new ByteArrayContent(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+                    content = new ByteArrayContent(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
                     Log.Debug("Adding to Multipart Byte Array | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
-                    content.Headers.ContentType = new MediaTypeHeaderValue(item.ContentType);
-                    formDataContent.Add(content, item.Name, item.FileName);
                 }
                 else if (item.ContentInStream is { } stream)
                 {
-                    var content = new StreamContent(stream);
+                    content = new StreamContent(stream);
                     Log.Debug("Adding to Multipart Stream | Name: {Name} | FileName: {FileName} | ContentType: {ContentType}", item.Name, item.FileName, item.ContentType);
-                    content.Headers.ContentType = new MediaTypeHeaderValue(item.ContentType);
+                }
+                else
+                {
+                    continue;
+                }
+
+                content.Headers.ContentType = new MediaTypeHeaderValue(item.ContentType);
+                if (item.FileName is not null)
+                {
                     formDataContent.Add(content, item.Name, item.FileName);
+                }
+                else
+                {
+                    formDataContent.Add(content, item.Name);
                 }
             }
 


### PR DESCRIPTION
## Summary of changes

Null filenames in MultipartItem are already supported on `ApiWebRequest` implementation but missing in `HttpClientRequest` throwing an argument exception in case we pass the null reference. This PR fixes that by adding support to the `HttpClientRequest` class

## Reason for change

While working on the new ITR feature I noticed that the `HttpClientRequest` was throwing this null argument exception and not happening when using .NET Framework (`ApiWebRequest`).