### PR TITLE
[CI] Allow throughput to run on benchmark branches

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -449,7 +449,6 @@ stages:
       artifact: linux-profiler-home-arm64
 
 - stage: package_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [master_commit_id, build_arm64_tracer, build_arm64_profiler]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
@@ -2278,8 +2277,8 @@ stages:
   dependsOn: [package_linux, package_arm64, build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-    # By default all throughput tests happen on release or master branches only. Overridable by setting 'run_extended_throughput_tests' to true
-    runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_extended_throughput_tests, 'true'))]
+    # By default all throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
+    runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true'))]
   pool: Throughput
   jobs:
   - template: steps/update-github-status-jobs.yml


### PR DESCRIPTION
## Summary of changes

- Remove "benchmark only build" condition from package_arm64, as it's required by the throughput tests too.
- Run the extended throughput tests in the benchmark branches on scheduled builds

## Reason for change

We haven't been running the throughput tests for previous releases, because we weren't running the required `package_arm64` stage in scheduled builds.

## Implementation details

Same issues as in #3005, and same fix: run the necessary stage in all builds. Also updates to ensure we always run the extended tests in the benchmark runs

## Test coverage

## Other details
Will need back-porting to benchmarks/2.12.0 at the least