### PR TITLE
Fix possible zero in traceid or spanid

### DIFF
--- a/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -64,11 +64,16 @@ namespace Datadog.Trace.Util
 
         public ulong CreateNew()
         {
-            long high = _random.Next(int.MinValue, int.MaxValue);
-            long low = _random.Next(int.MinValue, int.MaxValue);
+            long value;
+            do
+            {
+                long high = _random.Next(int.MinValue, int.MaxValue);
+                long low = _random.Next(int.MinValue, int.MaxValue);
 
-            // Concatenate both values, and truncate the 32 top bits from low
-            var value = high << 32 | (low & 0xFFFFFFFF);
+                // Concatenate both values, and truncate the 32 top bits from low
+                value = high << 32 | (low & 0xFFFFFFFF);
+            }
+            while (value == 0);
 
             return (ulong)value & 0x7FFFFFFFFFFFFFFF;
         }

--- a/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -64,18 +64,17 @@ namespace Datadog.Trace.Util
 
         public ulong CreateNew()
         {
-            long value;
+            ulong value;
             do
             {
                 long high = _random.Next(int.MinValue, int.MaxValue);
                 long low = _random.Next(int.MinValue, int.MaxValue);
 
                 // Concatenate both values, and truncate the 32 top bits from low
-                value = high << 32 | (low & 0xFFFFFFFF);
+                value = (ulong)(high << 32 | (low & 0xFFFFFFFF)) & 0x7FFFFFFFFFFFFFFF;
             }
             while (value == 0);
-
-            return (ulong)value & 0x7FFFFFFFFFFFFFFF;
+            return value;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

The PR fixes the possible generation of a traceid or spanid, with 0 as value. Zero is an invalid value, and sending spans with these values will be rejected by the agent or the backend (in case of agentless).