### PR TITLE
[CI Visibility] Stop using OS separator in relative paths

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Coverage/DefaultCoverageEventHandler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/DefaultCoverageEventHandler.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Ci.Coverage
                 var fileName = boundariesPerFile.Key;
                 var coverageFileName = new FileCoverage
                 {
-                    FileName = CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(fileName)
+                    FileName = CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(fileName, false)
                 };
 
                 coveragePayload.Files.Add(coverageFileName);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
         {
             if (MethodSymbolResolver.Instance.TryGetMethodSymbol(testMethod, out var methodSymbol))
             {
-                span.SetTag(TestTags.SourceFile, CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(methodSymbol.File));
+                span.SetTag(TestTags.SourceFile, CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(methodSymbol.File, false));
                 span.SetMetric(TestTags.SourceStart, methodSymbol.StartLine);
                 span.SetMetric(TestTags.SourceEnd, methodSymbol.EndLine);
 


### PR DESCRIPTION
## Summary of changes

This PR removes the usage of the OS separator on relative paths in CI Visibility as asked from backend because doesn't have a reliable way to determine if the test span or coverage is generated from a windows session.