### PR TITLE
Use macos-11 for builds instead of macos-10.15 as that is deprecated

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -514,7 +514,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macOS-10.15
+      vmImage: macos-11
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -646,7 +646,7 @@ stages:
   - job: managed
     timeoutInMinutes: 60 #default value
     pool:
-      vmImage: macOS-10.15
+      vmImage: macos-11
     steps:
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml


### PR DESCRIPTION
## Summary of changes

- use `macos-11` instead of `macos-10.15` in Azure devops

## Reason for change

The 10.15 images are deprecated, and builds are failing

## Implementation details

Find + Replace.

## Test coverage

Tests? Where we're going, we don't _need_ tests.

## Other details
https://github.com/actions/virtual-environments/issues/5583
