### PR TITLE
Always use native loader for tests (part of package layout update)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2351,7 +2351,8 @@ stages:
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux-arm64
 
     - script: |
-        test ! -s "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux-arm64/tracer/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux-arm64/tracer/Datadog.Tracer.Native.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
         ./run.sh "linux_arm64" "$(runExtendedThroughputTests)"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -812,8 +812,6 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
-    variables:
-      USE_NATIVE_LOADER: true
 
     steps:
     - template: steps/clone-repo.yml
@@ -884,7 +882,6 @@ stages:
       name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
-      USE_NATIVE_LOADER: true
 
     steps:
     - template: steps/clone-repo.yml
@@ -928,7 +925,6 @@ stages:
       name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
-      USE_NATIVE_LOADER: true
 
     steps:
     - template: steps/clone-repo.yml
@@ -983,7 +979,6 @@ stages:
       name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
-      USE_NATIVE_LOADER: true
 
     steps:
     - template: steps/clone-repo.yml
@@ -1094,7 +1089,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
-        dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=false IntegrationTests
+        dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=false IntegrationTests
         projectName: ddtrace_$(Build.BuildNumber)
 
     - publish: tracer/build_data
@@ -1177,7 +1172,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=true IntegrationTests
+        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=true IntegrationTests
         projectName: ddtrace_$(Build.BuildNumber)
 
     - task: DockerCompose@0
@@ -1334,7 +1329,7 @@ stages:
             dockerComposeFileArgs: |
               baseImage=$(baseImage)
               framework=$(publishTargetFramework)
-            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=false IntegrationTests.ARM64
+            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=false IntegrationTests.ARM64
             projectName: ddtrace_$(Build.BuildNumber)
 
         - publish: tracer/build_data
@@ -1410,7 +1405,7 @@ stages:
             dockerComposeFileArgs: |
               baseImage=$(baseImage)
               framework=$(publishTargetFramework)
-            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e USE_NATIVE_LOADER=true -e IncludeTestsRequiringDocker=true IntegrationTests.ARM64
+            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=true IntegrationTests.ARM64
             projectName: ddtrace_$(Build.BuildNumber)
 
         - task: DockerCompose@0

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -148,34 +148,6 @@ namespace Datadog.Trace.TestHelpers
             return path;
         }
 
-        public static string GetTracerNativeDLLPath()
-        {
-            var tracerHome = GetTracerHomePath();
-
-            var (extension, dir) = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform()) switch
-            {
-                ("win", "X64") => ("dll", "win-x64"),
-                ("win", "X86") => ("dll", "win-x86"),
-                ("linux", "X64") => ("so", null),
-                ("linux", "Arm64") => ("so", null),
-                ("osx", _) => ("dylib", null),
-                _ => throw new PlatformNotSupportedException()
-            };
-
-            var fileName = $"Datadog.Tracer.Native.{extension}";
-
-            var path = dir is null
-                           ? Path.Combine(tracerHome, fileName)
-                           : Path.Combine(tracerHome, dir, fileName);
-
-            if (!File.Exists(path))
-            {
-                throw new Exception($"Unable to find profiler at {path}");
-            }
-
-            return path;
-        }
-
         public static void ClearProfilerEnvironmentVariables()
         {
             var environmentVariables = new[]

--- a/tracer/test/Datadog.Trace.TestHelpers/InstrumentationVerification.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/InstrumentationVerification.cs
@@ -17,12 +17,6 @@ namespace Datadog.Trace.TestHelpers;
 internal static class InstrumentationVerification
 {
     /// <summary>
-    /// Configuration key for enabling the native loader profiler.
-    /// Default value is disabled.
-    /// </summary>
-    public const string UseNativeLoader = "USE_NATIVE_LOADER";
-
-    /// <summary>
     /// Configuration key for enabling or disabling the instrumentation verification.
     /// Default is value is disabled.
     /// </summary>

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -50,7 +50,6 @@ namespace Datadog.Trace.TestHelpers
             Output.WriteLine($"Configuration: {EnvironmentTools.GetBuildConfiguration()}");
             Output.WriteLine($"TargetFramework: {EnvironmentHelper.GetTargetFramework()}");
             Output.WriteLine($".NET Core: {EnvironmentHelper.IsCoreClr()}");
-            Output.WriteLine($"Tracer Native DLL: {EnvironmentHelper.GetTracerNativeDLLPath()}");
             Output.WriteLine($"Native Loader DLL: {EnvironmentHelper.GetNativeLoaderPath()}");
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -51,11 +51,7 @@ namespace Datadog.Trace.TestHelpers
             Output.WriteLine($"TargetFramework: {EnvironmentHelper.GetTargetFramework()}");
             Output.WriteLine($".NET Core: {EnvironmentHelper.IsCoreClr()}");
             Output.WriteLine($"Tracer Native DLL: {EnvironmentHelper.GetTracerNativeDLLPath()}");
-
-            if (EnvironmentHelper.UseNativeLoader)
-            {
-                Output.WriteLine($"Native Loader DLL: {EnvironmentHelper.GetNativeLoaderPath()}");
-            }
+            Output.WriteLine($"Native Loader DLL: {EnvironmentHelper.GetNativeLoaderPath()}");
         }
 
         protected EnvironmentHelper EnvironmentHelper { get; }
@@ -458,7 +454,6 @@ namespace Datadog.Trace.TestHelpers
         {
             bool verificationEnabled = ShouldUseInstrumentationVerification();
             SetEnvironmentVariable(InstrumentationVerification.InstrumentationVerificationEnabled, verificationEnabled ? "1" : "0");
-            SetEnvironmentVariable(InstrumentationVerification.UseNativeLoader, verificationEnabled ? "1" : "0");
             SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, verificationEnabled ? EnvironmentHelper.LogDirectory : null);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/MultipartFormTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MultipartFormTests.cs
@@ -18,10 +18,9 @@ namespace Datadog.Trace.Tests
 {
     [Collection(nameof(WebRequestCollection))]
     [UsesVerify]
-    public class MultipartFormTests : TestHelper
+    public class MultipartFormTests
     {
-        public MultipartFormTests(ITestOutputHelper output)
-            : base(string.Empty, output)
+        public MultipartFormTests()
         {
             VerifyHelper.InitializeGlobalSettings();
         }
@@ -29,7 +28,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task ApiWebRequestMultipartTest()
         {
-            using var agent = (MockTracerAgent.TcpUdpAgent)EnvironmentHelper.GetMockAgent();
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
             agent.ShouldDeserializeTraces = false;
             string requestBody = null;
             agent.RequestReceived += (sender, args) =>
@@ -56,7 +55,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task ApiWebRequestValidationTest()
         {
-            using var agent = (MockTracerAgent.TcpUdpAgent)EnvironmentHelper.GetMockAgent();
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
             agent.ShouldDeserializeTraces = false;
             string requestBody = null;
             agent.RequestReceived += (sender, args) =>
@@ -94,7 +93,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task HttpClientRequestMultipartTest()
         {
-            using var agent = (MockTracerAgent.TcpUdpAgent)EnvironmentHelper.GetMockAgent();
+            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort());
             agent.ShouldDeserializeTraces = false;
             string requestBody = null;
             agent.RequestReceived += (sender, args) =>

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -178,7 +178,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             registryService.Setup(r => r.GetLocalMachineValueNames(It.Is(@"SOFTWARE\Microsoft\.NETFramework", StringComparer.Ordinal)))
                 .Returns(Array.Empty<string>());
             registryService.Setup(r => r.GetLocalMachineValue(It.Is<string>(s => s == ProcessBasicChecksTests.ClsidKey || s == ProcessBasicChecksTests.Clsid32Key)))
-                .Returns(EnvironmentHelper.GetTracerNativeDLLPath());
+                .Returns(EnvironmentHelper.GetNativeLoaderPath());
 
             return registryService.Object;
         }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         private const string CorEnableKey = "CORECLR_ENABLE_PROFILING";
 #endif
 
-        private static readonly string ProfilerPath = EnvironmentHelper.GetTracerNativeDLLPath();
+        private static readonly string ProfilerPath = EnvironmentHelper.GetNativeLoaderPath();
 
         public ProcessBasicChecksTests(ITestOutputHelper output)
             : base(output)


### PR DESCRIPTION
## Summary of changes

- Assumes that we always use the native loader for tests.

## Reason for change

We currently use the native loader on Linux/Arm64/MSI, and after the package layout fixes, we will use it everywhere. We already test in CI using the native loader everywhere (or at least, we _should be_), so this PR just removes some "dead" code.

This PR is part of the package layout updates, and is an attempt to reduce the complexity in file paths etc that we need to manage (and change) as part of the package layout changes.

## Implementation details

- Remove references to `USE_NATIVE_LOADER` - assume that it's always true
- Fix the arm throughput tests to use the native loader
- Replace usages of `GetTracerNativeDLLPath` `GetNativeLoaderPath` in tests
- Minor fix for MultipartFormTests in Datadog.Trace.Tests so that it doesn't look for the native dlls (it doesn't need them)

There are still some harcoded paths to the `DD_DOTNET_TRACER_HOME` dir, which will be a pain in the package layout changes, but this is better than nothing.

## Test coverage

Covered by existing tests.

## Other details
Rebased on top of #3016, so that will need merging first
