### PR TITLE
[CI Visibility] Fix Coverage version type

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.SpanId);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _versionBytes);
-            offset += MessagePackBinary.WriteString(ref bytes, offset, value.Version);
+            offset += MessagePackBinary.WriteInt32(ref bytes, offset, value.Version);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _filesBytes);
 

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Models/CoveragePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Models/CoveragePayload.cs
@@ -35,6 +35,6 @@ namespace Datadog.Trace.Ci.Coverage.Models
         /// Gets the payload version.
         /// </summary>
         [JsonProperty("version")]
-        public string Version { get; } = "1";
+        public int Version { get; } = 1;
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes the type of the version property changing it from `string` to `int`.