### PR TITLE
[Tracer] Send AAS and Sampling Prio on all trace chunks

### DIFF
--- a/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -42,7 +42,6 @@ namespace Datadog.Trace
         public void Close(Scope scope)
         {
             var current = Active;
-            var isRootSpan = scope.Parent == null;
 
             if (current == null || current != scope)
             {

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace
             }
         }
 
-        private void AddAASMetadataToTraceChunk(Span span)
+        private void AddAASMetadata(Span span)
         {
             if (AzureAppServices.Metadata.IsRelevant)
             {

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -195,9 +195,10 @@ namespace Datadog.Trace
                 Log.Warning("Root span wasn't found even though expected here.");
             }
 
-            // Here we must be in the case when rootspan has already been sent or we are in a partial flush
-            // The agent looks for the sampling priority on the first span that has no parent
-            // Finding those spans is not trivial, so instead we apply the priority to every span
+            // Here we must be in the case when rootspan has already been sent or we are in a partial flush.
+            // Agent versions < 7.34.0 look for the sampling priority in one of the spans whose parent is not found in the same chunk.
+            // If there are multiple orphans, the agent picks one nondeterministically and does not check the others.
+            // Finding those spans is not trivial, so instead we apply the priority to every span.
             for (var i = 0; i < spansToWrite.Count; i++)
             {
                 AddSamplingPriorityTags(spansToWrite.Array[i + spansToWrite.Offset], _samplingPriority.Value);

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -196,17 +196,17 @@ namespace Datadog.Trace
         {
             if (AzureAppServices.Metadata.IsRelevant)
             {
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteName, AzureAppServices.Metadata.SiteName);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteKind, AzureAppServices.Metadata.SiteKind);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteType, AzureAppServices.Metadata.SiteType);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceGroup, AzureAppServices.Metadata.ResourceGroup);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesSubscriptionId, AzureAppServices.Metadata.SubscriptionId);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceId, AzureAppServices.Metadata.ResourceId);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceId, AzureAppServices.Metadata.InstanceId);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceName, AzureAppServices.Metadata.InstanceName);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesOperatingSystem, AzureAppServices.Metadata.OperatingSystem);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
-                span.SetTag(Datadog.Trace.Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteName, AzureAppServices.Metadata.SiteName);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteKind, AzureAppServices.Metadata.SiteKind);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesSiteType, AzureAppServices.Metadata.SiteType);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceGroup, AzureAppServices.Metadata.ResourceGroup);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesSubscriptionId, AzureAppServices.Metadata.SubscriptionId);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesResourceId, AzureAppServices.Metadata.ResourceId);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceId, AzureAppServices.Metadata.InstanceId);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesInstanceName, AzureAppServices.Metadata.InstanceName);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesOperatingSystem, AzureAppServices.Metadata.OperatingSystem);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
+                span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
         private readonly long _timestamp = Stopwatch.GetTimestamp();
+        private bool _rootSpanSent = false;
+        private bool _rootSpanInNextBatch = false;
         private ArrayBuilder<Span> _spans;
 
         private int _openSpans;
@@ -85,25 +87,18 @@ namespace Datadog.Trace
         {
             bool ShouldTriggerPartialFlush() => Tracer.Settings.Exporter.PartialFlushEnabled && _spans.Count >= Tracer.Settings.Exporter.PartialFlushMinSpans;
 
-            if (span == RootSpan)
-            {
-                if (_samplingPriority == null)
-                {
-                    Log.Warning("Cannot set span metric for sampling priority before it has been set.");
-                }
-                else
-                {
-                    AddSamplingPriorityTags(span, _samplingPriority.Value);
-                }
-            }
-
             ArraySegment<Span> spansToWrite = default;
-
-            bool shouldPropagateMetadata = false;
+            var rootSpanInNextBatch = false;
 
             lock (this)
             {
                 _spans.Add(span);
+                if (!_rootSpanSent)
+                {
+                    _rootSpanInNextBatch |= (span == RootSpan);
+                    rootSpanInNextBatch = _rootSpanInNextBatch;
+                }
+
                 _openSpans--;
 
                 if (_openSpans == 0)
@@ -119,10 +114,6 @@ namespace Datadog.Trace
                         span.TraceId,
                         _spans.Count);
 
-                    // We may not be sending the root span, so we need to propagate the metadata to other spans of the partial trace
-                    // There's no point in doing that inside of the lock, so we set a flag for later
-                    shouldPropagateMetadata = true;
-
                     spansToWrite = _spans.GetArray();
 
                     // Making the assumption that, if the number of closed spans was big enough to trigger partial flush,
@@ -132,16 +123,13 @@ namespace Datadog.Trace
                 }
             }
 
-            if (shouldPropagateMetadata)
-            {
-                PropagateMetadata(spansToWrite);
-            }
-
             if (spansToWrite.Count > 0)
             {
                 // When receiving chunks of spans, the backend checks whether the aas.resource.id tag is present on any of the
                 // span to decide which metric to emit (datadog.apm.host.instance or datadog.apm.azure_resource_instance one).
                 AddAASMetadata(spansToWrite.Array[0]);
+                PropagateSamplingPriority(span, spansToWrite, rootSpanInNextBatch);
+
                 Tracer.Write(spansToWrite);
             }
         }
@@ -173,22 +161,46 @@ namespace Datadog.Trace
             }
         }
 
-        private void PropagateMetadata(ArraySegment<Span> spans)
+        private void PropagateSamplingPriority(Span closedSpan, ArraySegment<Span> spansToWrite, bool containsRootSpan)
         {
-            // The agent looks for the sampling priority on the first span that has no parent
-            // Finding those spans is not trivial, so instead we apply the priority to every span
-
-            var samplingPriority = _samplingPriority;
-
-            if (samplingPriority == null)
+            if (_samplingPriority == null)
             {
                 return;
             }
 
-            // Using a for loop to avoid the boxing allocation on ArraySegment.GetEnumerator
-            for (int i = 0; i < spans.Count; i++)
+            // This should be the most common case as usually we close the root span last
+            if (closedSpan == RootSpan)
             {
-                AddSamplingPriorityTags(spans.Array[i + spans.Offset], samplingPriority.Value);
+                AddSamplingPriorityTags(closedSpan, _samplingPriority.Value);
+                _rootSpanSent = true;
+                return;
+            }
+
+            // Normally this use case never happens as the last span closed is the rootspan usually.
+            // So we should have fallen in the previous case.
+            if (containsRootSpan)
+            {
+                // Using a for loop to avoid the boxing allocation on ArraySegment.GetEnumerator
+                for (var i = 0; i < spansToWrite.Count; i++)
+                {
+                    var span = spansToWrite.Array[i + spansToWrite.Offset];
+                    if (span == RootSpan)
+                    {
+                        AddSamplingPriorityTags(span, _samplingPriority.Value);
+                        _rootSpanSent = true;
+                        return;
+                    }
+                }
+
+                Log.Warning("Root span wasn't found even though expected here.");
+            }
+
+            // Here we must be in the case when rootspan has already been sent or we are in a partial flush
+            // The agent looks for the sampling priority on the first span that has no parent
+            // Finding those spans is not trivial, so instead we apply the priority to every span
+            for (var i = 0; i < spansToWrite.Count; i++)
+            {
+                AddSamplingPriorityTags(spansToWrite.Array[i + spansToWrite.Offset], _samplingPriority.Value);
             }
         }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -107,6 +107,13 @@ namespace Datadog.Trace
                 _spans.Add(span);
                 _openSpans--;
 
+                // If we close the local root span, make sure to unreference it in case we were to send another
+                // span in the same context later on (important in the case of AAS, to propagate resource.id)
+                if (span == RootSpan)
+                {
+                    RootSpan = default;
+                }
+
                 if (_openSpans == 0)
                 {
                     spansToWrite = _spans.GetArray();

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace
             {
                 // When receiving chunks of spans, the backend checks whether the aas.resource.id tag is present on any of the
                 // span to decide which metric to emit (datadog.apm.host.instance or datadog.apm.azure_resource_instance one).
-                AddAASMetadataToTraceChunk(spansToWrite.Array[0]);
+                AddAASMetadata(spansToWrite.Array[0]);
                 Tracer.Write(spansToWrite);
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -240,7 +240,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 
             // We should have one space decorated per traceId
             spansWithTag.Should().HaveCount(iterations);
-            spansWithTag.Select(span => span.TraceId).Distinct().Should().HaveCount(iterations);
+            spansWithTag.Select(span => span.TraceId).Should().OnlyHaveUniqueItems();
         }
 
         private IDictionary GetMockVariables(

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -238,7 +238,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             var spansWithTag =
                 spans.Where(s => s.GetTag(Tags.AzureAppServicesResourceId) == ExpectedResourceId).ToList();
 
-            // We should have one space decorated per traceId
+            // We should have one span decorated per traceId
             spansWithTag.Should().HaveCount(iterations);
             spansWithTag.Select(span => span.TraceId).Should().OnlyHaveUniqueItems();
         }

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -173,7 +173,7 @@ namespace Datadog.Trace.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void AllChunksShouldContainAASMetadataAndSamplingPriority(bool inAASContext)
+        public void ChunksSentAfterRootSpanShouldContainAASMetadataAndSamplingPriority(bool inAASContext)
         {
             const int partialFlushThreshold = 3;
 
@@ -209,9 +209,6 @@ namespace Datadog.Trace.Tests
                 traceContext.AddSpan(span);
                 traceContext.CloseSpan(span);
             }
-
-            // At this point, only one span is missing to reach the threshold for partial flush
-            spans.Should().BeNull("partial flush should not have been triggered");
 
             // Closing the root span brings the number of closed spans to the threshold
             // but a full flush should be triggered rather than a partial, because every span in the trace has been closed


### PR DESCRIPTION
## Summary of changes
Make sure we send the proper tags on each trace chunk

## Reason for change
If we get a new span on a scope after the local root span is closed and sent to the agent, then we wouldn't decorate the next chunk with the proper metadata (neither AAS and sampling priority). This causes problem, the main one being double billing on AAS.

## Implementation details
Moving the decoration logic to the actual code where we send chunks. I also needed to change the way we set tags as the Span API prevents the addition of tags on finished spans.

## Test coverage
Added and modified uni tests

## Other details


<!-- Fixes #{issue} -->
