### PR TITLE
Remove x-datadog headers from SQS message attributes

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -37,8 +37,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
             else
             {
-
-#if NETCOREAPP2_1
+                // In .NET Fx and Net Core 2.1, removing an element while iterating on keys throws.
+#if !NETCOREAPP2_1_OR_GREATER
                 List<string> attributesToRemove = null;
 #endif
                 // Make sure we do not propagate any other datadog header here in the rare cases where users would have added them manually
@@ -46,16 +46,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 {
                     if (attribute is string attributeName && attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase))
                     {
-#if NETCOREAPP2_1
+#if !NETCOREAPP2_1_OR_GREATER
                         attributesToRemove ??= new List<string>();
-                        attributesToRemove.Add(attributeName)
+                        attributesToRemove.Add(attributeName);
 #else
                         carrier.MessageAttributes.Remove(attribute);
 #endif
                     }
                 }
 
-#if NETCOREAPP2_1
+#if !NETCOREAPP2_1_OR_GREATER
                 if (attributesToRemove != null)
                 {
                     foreach (var attribute in attributesToRemove)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -37,23 +37,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
             else
             {
-                List<string> attributesToRemove = null;
-
                 // Make sure we do not propagate any other datadog header here in the rare cases where users would have added them manually
                 foreach (var attribute in carrier.MessageAttributes.Keys)
                 {
                     if (attribute is string attributeName && attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase))
                     {
-                        attributesToRemove ??= new List<string>();
-                        attributesToRemove.Add(attributeName);
-                    }
-                }
-
-                if (attributesToRemove != null)
-                {
-                    foreach (var attribute in attributesToRemove)
-                    {
-                        carrier.MessageAttributes.Remove(attribute);
+                        carrier.MessageAttributes.Remove(attributeName);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using Datadog.Trace.Propagators;
 
@@ -32,6 +34,28 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             if (carrier.MessageAttributes == null)
             {
                 carrier.MessageAttributes = CachedMessageHeadersHelper<TMessageRequest>.CreateMessageAttributes();
+            }
+            else
+            {
+                List<string> attributesToRemove = null;
+
+                // Make sure we do not propagate any other datadog header here in the rare cases where users would have added them manually
+                foreach (var attribute in carrier.MessageAttributes.Keys)
+                {
+                    if (attribute is string attributeName && attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase))
+                    {
+                        attributesToRemove ??= new List<string>();
+                        attributesToRemove.Add(attributeName);
+                    }
+                }
+
+                if (attributesToRemove != null)
+                {
+                    foreach (var attribute in attributesToRemove)
+                    {
+                        carrier.MessageAttributes.Remove(attribute);
+                    }
+                }
             }
 
             // SQS allows a maximum of 10 message attributes: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#sqs-message-attributes

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/Common.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/Common.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Amazon.SQS.Model;
 using Newtonsoft.Json;
 
@@ -38,6 +39,17 @@ namespace Samples.AWS.SQS
                 if (message.MessageAttributes.ContainsKey("_datadog"))
                 {
                     throw new Exception($"The \"_datadog\" header was found in the message, with value: {message.MessageAttributes["_datadog"].StringValue}");
+                }
+            }
+        }
+
+        public static void AssertNoXDatadogTracingHeaders(List<Message> messages)
+        {
+            foreach (var message in messages)
+            {
+                if (message.MessageAttributes.Any( a => a.Key.StartsWith("x-datadog")))
+                {
+                    throw new Exception($"A \"x-datadog\" header was found in the message, whereas they should have been removed");
                 }
             }
         }


### PR DESCRIPTION
## Summary of changes

Make sure we don't propagate x-datadog headers on sqs as we concatenate them in one attribute

## Reason for change
To prevent multiple scopes to be forwarded. 
Raised after an escalation where users manually forward all attributes which broke the limit of 10 attributes.

## Implementation details
Removing all x-datadog attributes before adding the concatenated one.

## Test coverage
Modified the ITests to cover that use case

## Other details
<!-- Fixes #{issue} -->
