### PR TITLE
[Tracer] Stats computation: Drop P0 traces

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -382,11 +382,11 @@ namespace Datadog.Trace.Agent
                 return null;
             }
 
-            _statsAggregator?.AddRange(trace.Array, trace.Offset, trace.Count);
+            bool forceKeep = _statsAggregator?.AddRange(trace.Array, trace.Offset, trace.Count) ?? false;
 
             // If stats computation determined that we should drop the P0 Trace,
             // skip all other processing
-            if (!shouldSerializeSpans)
+            if (!shouldSerializeSpans && !forceKeep)
             {
                 Interlocked.Increment(ref _droppedP0Traces);
                 Interlocked.Add(ref _droppedP0Spans, trace.Count);

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -384,7 +384,7 @@ namespace Datadog.Trace.Agent
                 return null;
             }
 
-            bool forceKeep = _statsAggregator?.AddRange(trace.Array, trace.Offset, trace.Count) ?? false;
+            bool forceKeep = _statsAggregator?.AddRange(trace) ?? false;
 
             // If stats computation determined that we can drop the P0 Trace,
             // skip all other processing

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Agent
 
         internal SpanBuffer BackBuffer => _backBuffer;
 
-        public bool CanComputeStats => _statsAggregator.CanComputeStats ?? false;
+        public bool CanComputeStats => _statsAggregator?.CanComputeStats ?? false;
 
         public Task<bool> Ping()
         {

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -42,7 +42,6 @@ namespace Datadog.Trace.Agent
             IDogStatsd statsd,
             Action<Dictionary<string, float>> updateSampleRates,
             bool partialFlushEnabled,
-            bool statsComputationEnabled,
             IDatadogLogger log = null)
         {
             // optionally injecting a log instance in here for testing purposes

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -240,8 +240,6 @@ namespace Datadog.Trace.Agent
 
             // Set additional headers
             request.AddHeader(AgentHttpHeaderNames.TraceCount, numberOfTraces.ToString());
-            request.AddHeader(AgentHttpHeaderNames.DroppedP0Traces, numberOfDroppedP0Traces.ToString());
-            request.AddHeader(AgentHttpHeaderNames.DroppedP0Spans, numberOfDroppedP0Spans.ToString());
 
             if (_containerId != null)
             {
@@ -251,6 +249,8 @@ namespace Datadog.Trace.Agent
             if (statsComputationEnabled)
             {
                 request.AddHeader(AgentHttpHeaderNames.StatsComputation, "true");
+                request.AddHeader(AgentHttpHeaderNames.DroppedP0Traces, numberOfDroppedP0Traces.ToString());
+                request.AddHeader(AgentHttpHeaderNames.DroppedP0Spans, numberOfDroppedP0Spans.ToString());
             }
 
             try

--- a/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
-        void WriteTrace(ArraySegment<Span> trace);
+        void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans);
 
         Task<bool> Ping();
 

--- a/tracer/src/Datadog.Trace/Agent/IApi.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApi.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
-        Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces);
+        Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans);
 
         Task<bool> SendStatsAsync(StatsBuffer stats, long bucketDuration);
     }

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -18,9 +18,21 @@ namespace Datadog.Trace.Agent
         /// </summary>
         bool? CanComputeStats { get; }
 
-        void Add(params Span[] spans);
+        /// <summary>
+        /// Receives an array of spans and computes stats points for them.
+        /// </summary>
+        /// <param name="spans">The array of spans to process.</param>
+        /// <returns>True if the spans should be kept based on rare stats points or error stats points, false otherwise.</returns>
+        bool Add(params Span[] spans);
 
-        void AddRange(Span[] spans, int offset, int count);
+        /// <summary>
+        /// Receives an array of spans and computes stats points for them.
+        /// </summary>
+        /// <param name="spans">The array of spans to process.</param>
+        /// <param name="offset">The array offset of the spans to process.</param>
+        /// <param name="count">The number of spans to process.</param>
+        /// <returns>True if the spans should be kept based on rare stats points or error stats points, false otherwise.</returns>
+        bool AddRange(Span[] spans, int offset, int count);
 
         Task DisposeAsync();
     }

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
@@ -28,11 +29,9 @@ namespace Datadog.Trace.Agent
         /// <summary>
         /// Receives an array of spans and computes stats points for them.
         /// </summary>
-        /// <param name="spans">The array of spans to process.</param>
-        /// <param name="offset">The array offset of the spans to process.</param>
-        /// <param name="count">The number of spans to process.</param>
+        /// <param name="spans">The ArraySegment of spans to process.</param>
         /// <returns>True if the spans should be kept based on rare stats points or error stats points, false otherwise.</returns>
-        bool AddRange(Span[] spans, int offset, int count);
+        bool AddRange(ArraySegment<Span> spans);
 
         Task DisposeAsync();
     }

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -9,6 +9,15 @@ namespace Datadog.Trace.Agent
 {
     internal interface IStatsAggregator
     {
+        /// <summary>
+        /// Gets a value indicating whether the Datadog agent supports stats
+        /// computation in tracers.
+        ///
+        /// This will return null if the endpoint discovery request has not
+        /// completed.
+        /// </summary>
+        bool? CanComputeStats { get; }
+
         void Add(params Span[] spans);
 
         void AddRange(Span[] spans, int offset, int count);

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -11,13 +11,9 @@ namespace Datadog.Trace.Agent
     {
         public bool? CanComputeStats => false;
 
-        public void Add(params Span[] spans)
-        {
-        }
+        public bool Add(params Span[] spans) => false;
 
-        public void AddRange(Span[] spans, int offset, int count)
-        {
-        }
+        public bool AddRange(Span[] spans, int offset, int count) => false;
 
         public Task DisposeAsync()
         {

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.Agent
 {
     internal class NullStatsAggregator : IStatsAggregator
     {
+        public bool? CanComputeStats => false;
+
         public void Add(params Span[] spans)
         {
         }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
@@ -13,7 +14,7 @@ namespace Datadog.Trace.Agent
 
         public bool Add(params Span[] spans) => false;
 
-        public bool AddRange(Span[] spans, int offset, int count) => false;
+        public bool AddRange(ArraySegment<Span> spans) => false;
 
         public Task DisposeAsync()
         {

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -17,8 +17,6 @@ namespace Datadog.Trace.Agent
     {
         private const int BufferCount = 2;
 
-        private const int BucketDurationSeconds = 10;
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
 
         private readonly HashSet<StatsAggregationKey> _keys;
@@ -35,11 +33,11 @@ namespace Datadog.Trace.Agent
 
         private int _currentBuffer;
 
-        internal StatsAggregator(IApi api, ImmutableTracerSettings settings, TimeSpan bucketDuration)
+        internal StatsAggregator(IApi api, ImmutableTracerSettings settings)
         {
             _api = api;
             _processExit = new TaskCompletionSource<bool>();
-            _bucketDuration = bucketDuration;
+            _bucketDuration = TimeSpan.FromSeconds(settings.StatsComputationInterval);
             _keys = new HashSet<StatsAggregationKey>();
             _buffers = new StatsBuffer[BufferCount];
 
@@ -70,7 +68,7 @@ namespace Datadog.Trace.Agent
 
         public static IStatsAggregator Create(IApi api, ImmutableTracerSettings settings)
         {
-            return settings.StatsComputationEnabled ? new StatsAggregator(api, settings, TimeSpan.FromSeconds(BucketDurationSeconds)) : new NullStatsAggregator();
+            return settings.StatsComputationEnabled ? new StatsAggregator(api, settings) : new NullStatsAggregator();
         }
 
         public Task DisposeAsync()

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -19,6 +20,8 @@ namespace Datadog.Trace.Agent
         private const int BucketDurationSeconds = 10;
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<StatsAggregator>();
+
+        private readonly HashSet<StatsAggregationKey> _keys;
 
         private readonly StatsBuffer[] _buffers;
 
@@ -37,6 +40,7 @@ namespace Datadog.Trace.Agent
             _api = api;
             _processExit = new TaskCompletionSource<bool>();
             _bucketDuration = bucketDuration;
+            _keys = new HashSet<StatsAggregationKey>();
             _buffers = new StatsBuffer[BufferCount];
 
             var header = new ClientStatsPayload
@@ -75,13 +79,15 @@ namespace Datadog.Trace.Agent
             return _flushTask;
         }
 
-        public void Add(params Span[] spans)
+        public bool Add(params Span[] spans)
         {
-            AddRange(spans, 0, spans.Length);
+            return AddRange(spans, 0, spans.Length);
         }
 
-        public void AddRange(Span[] spans, int offset, int count)
+        public bool AddRange(Span[] spans, int offset, int count)
         {
+            var forceKeep = false;
+
             // Contention around this lock is expected to be very small:
             // AddRange is called from the serialization thread, and concurrent serialization
             // of traces is a rare corner-case (happening only during shutdown).
@@ -90,9 +96,11 @@ namespace Datadog.Trace.Agent
             {
                 for (int i = 0; i < count; i++)
                 {
-                    AddToBuffer(spans[offset + i]);
+                    forceKeep |= AddToBuffer(spans[offset + i]);
                 }
             }
+
+            return forceKeep;
         }
 
         internal static StatsAggregationKey BuildKey(Span span)
@@ -161,14 +169,16 @@ namespace Datadog.Trace.Agent
             return ns << shift;
         }
 
-        private void AddToBuffer(Span span)
+        private bool AddToBuffer(Span span)
         {
             if ((!span.IsTopLevel && span.GetMetric(Tags.Measured) != 1.0) || span.GetMetric(Tags.PartialSnapshot) > 0)
             {
-                return;
+                return false;
             }
 
             var key = BuildKey(span);
+
+            var isNewKey = _keys.Add(key);
 
             var buffer = CurrentBuffer;
 
@@ -198,6 +208,9 @@ namespace Datadog.Trace.Agent
             {
                 bucket.OkSummary.Add(ConvertTimestamp(duration));
             }
+
+            // This simple "RareSampler" keeps brand new stats points and errors
+            return isNewKey || span.Error;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -79,10 +79,10 @@ namespace Datadog.Trace.Agent
 
         public bool Add(params Span[] spans)
         {
-            return AddRange(spans, 0, spans.Length);
+            return AddRange(new ArraySegment<Span>(spans, 0, spans.Length));
         }
 
-        public bool AddRange(Span[] spans, int offset, int count)
+        public bool AddRange(ArraySegment<Span> spans)
         {
             var forceKeep = false;
 
@@ -92,9 +92,9 @@ namespace Datadog.Trace.Agent
             // The Flush thread only acquires the lock long enough to swap the metrics buffer.
             lock (_buffers)
             {
-                for (int i = 0; i < count; i++)
+                for (int i = 0; i < spans.Count; i++)
                 {
-                    forceKeep |= AddToBuffer(spans[offset + i]);
+                    forceKeep |= AddToBuffer(spans.Array[i + spans.Offset]);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Agent
         /// </summary>
         internal StatsBuffer CurrentBuffer => _buffers[_currentBuffer];
 
+        public bool? CanComputeStats { get; private set; } = true;
+
         public static IStatsAggregator Create(IApi api, ImmutableTracerSettings settings)
         {
             return settings.StatsComputationEnabled ? new StatsAggregator(api, settings, TimeSpan.FromSeconds(BucketDurationSeconds)) : new NullStatsAggregator();

--- a/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -59,6 +59,16 @@ namespace Datadog.Trace
         public const string StatsComputation = "Datadog-Client-Computed-Stats";
 
         /// <summary>
+        /// Tells the agent how many P0 traces were dropped as a result of stats computation in the tracer
+        /// </summary>
+        public const string DroppedP0Traces = "Datadog-Client-Dropped-P0-Traces";
+
+        /// <summary>
+        /// Tells the agent how many P0 spans were dropped as a result of stats computation in the tracer
+        /// </summary>
+        public const string DroppedP0Spans = "Datadog-Client-Dropped-P0-Spans";
+
+        /// <summary>
         /// Gets the default constant header that should be added to any request to the agent
         /// </summary>
         internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -27,9 +27,8 @@ namespace Datadog.Trace.Ci.Agent
         public CIAgentWriter(ImmutableTracerSettings settings, ISampler sampler, int maxBufferSize = DefaultMaxBufferSize)
         {
             var partialFlushEnabled = settings.Exporter.PartialFlushEnabled;
-            var statsComputationEnabled = settings.StatsComputationEnabled;
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
-            var api = new Api(apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), partialFlushEnabled, statsComputationEnabled);
+            var api = new Api(apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), partialFlushEnabled);
             var statsAggregator = StatsAggregator.Create(api, settings);
 
             _agentWriter = new AgentWriter(api, statsAggregator, null, maxBufferSize: maxBufferSize);

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -54,12 +54,12 @@ namespace Datadog.Trace.Ci.Agent
             if (@event is TestEvent testEvent)
             {
                 spanArray[0] = testEvent.Content;
-                WriteTrace(new ArraySegment<Span>(spanArray));
+                WriteTrace(new ArraySegment<Span>(spanArray), true);
             }
             else if (@event is SpanEvent spanEvent)
             {
                 spanArray[0] = spanEvent.Content;
-                WriteTrace(new ArraySegment<Span>(spanArray));
+                WriteTrace(new ArraySegment<Span>(spanArray), true);
             }
         }
 
@@ -78,9 +78,9 @@ namespace Datadog.Trace.Ci.Agent
             return _agentWriter.Ping();
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
-            _agentWriter.WriteTrace(trace);
+            _agentWriter.WriteTrace(trace, shouldSerializeSpans);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentlessWriter.cs
@@ -173,7 +173,7 @@ namespace Datadog.Trace.Ci.Agent
             return Task.FromResult(true);
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             // Transform spans to events
             for (var i = trace.Offset; i < trace.Count; i++)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -301,6 +301,11 @@ namespace Datadog.Trace.Configuration
         public const string StatsComputationEnabled = "DD_TRACE_STATS_COMPUTATION_ENABLED";
 
         /// <summary>
+        /// Configuration key for configuring the interval (in seconds) for sending stats (aka trace metrics)
+        /// </summary>
+        public const string StatsComputationInterval = "_DD_TRACE_STATS_COMPUTATION_INTERVAL";
+
+        /// <summary>
         /// Configuration key for setting the propagation style injection.
         /// </summary>
         public const string PropagationStyleInject = "DD_PROPAGATION_STYLE_INJECT";

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -203,11 +203,6 @@ namespace Datadog.Trace.Configuration
         public bool StatsComputationEnabled { get; }
 
         /// <summary>
-        /// Gets a value indicating the time interval (in seconds) for sending stats
-        /// </summary>
-        public int StatsComputationInterval { get; }
-
-        /// <summary>
         /// Gets a value indicating whether a span context should be created on exiting a successful Kafka
         /// Consumer.Consume() call, and closed on entering Consumer.Consume().
         /// </summary>
@@ -224,6 +219,11 @@ namespace Datadog.Trace.Configuration
         /// are enabled and sent to DogStatsd.
         /// </summary>
         internal bool RuntimeMetricsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating the time interval (in seconds) for sending stats
+        /// </summary>
+        internal int StatsComputationInterval { get; }
 
         /// <summary>
         /// Gets the comma separated list of url patterns to skip tracing.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.Configuration
             IpHeaderDisabled = settings.IpHeaderDisabled;
             TracerMetricsEnabled = settings.TracerMetricsEnabled;
             StatsComputationEnabled = settings.StatsComputationEnabled;
+            StatsComputationInterval = settings.StatsComputationInterval;
             RuntimeMetricsEnabled = settings.RuntimeMetricsEnabled;
             KafkaCreateConsumerScopeEnabled = settings.KafkaCreateConsumerScopeEnabled;
             StartupDiagnosticLogEnabled = settings.StartupDiagnosticLogEnabled;
@@ -200,6 +201,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether stats are computed on the tracer side
         /// </summary>
         public bool StatsComputationEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating the time interval (in seconds) for sending stats
+        /// </summary>
+        public int StatsComputationInterval { get; }
 
         /// <summary>
         /// Gets a value indicating whether a span context should be created on exiting a successful Kafka

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -123,6 +123,8 @@ namespace Datadog.Trace.Configuration
 
             StatsComputationEnabled = source?.GetBool(ConfigurationKeys.StatsComputationEnabled) ?? false;
 
+            StatsComputationInterval = source?.GetInt32(ConfigurationKeys.StatsComputationInterval) ?? 10;
+
             RuntimeMetricsEnabled = source?.GetBool(ConfigurationKeys.RuntimeMetricsEnabled) ??
                                     false;
 
@@ -395,6 +397,11 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time interval (in seconds) for sending stats
+        /// </summary>
+        internal int StatsComputationInterval { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum length of an outgoing propagation header's value ("x-datadog-tags")

--- a/tracer/src/Datadog.Trace/IDatadogTracer.cs
+++ b/tracer/src/Datadog.Trace/IDatadogTracer.cs
@@ -15,12 +15,14 @@ namespace Datadog.Trace
     /// </summary>
     internal interface IDatadogTracer
     {
+        bool CanDropP0s { get; }
+
         string DefaultServiceName { get; }
 
         ISampler Sampler { get; }
 
         ImmutableTracerSettings Settings { get; }
 
-        void Write(ArraySegment<Span> span);
+        void Write(ArraySegment<Span> span, bool shouldSerializeSpans);
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Logging
         public void Debug<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
+        public void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+            => Write(LogEventLevel.Debug, exception: null, messageTemplate, property0, property1, property2, property3, sourceLine, sourceFile);
+
         public void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
@@ -168,6 +171,15 @@ namespace Datadog.Trace.Logging
             {
                 // Avoid boxing + array allocation if disabled
                 WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2 }, sourceLine, sourceFile);
+            }
+        }
+
+        private void Write<T0, T1, T2, T3>(LogEventLevel level, Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, int sourceLine, string sourceFile)
+        {
+            if (_logger.IsEnabled(level))
+            {
+                // Avoid boxing + array allocation if disabled
+                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2, property3 }, sourceLine, sourceFile);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
@@ -21,6 +21,8 @@ namespace Datadog.Trace.Logging
 
         void Debug<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
+        void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+
         void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void Debug(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace
 {
     internal class TraceContext
     {
+        private const ulong KnuthFactor = 1_111_111_111_111_111_111;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceContext>();
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
@@ -25,6 +26,8 @@ namespace Datadog.Trace
         private bool _rootSpanSent;
         private bool _rootSpanInNextBatch;
 
+        private bool _hasErrorSpans;
+        private bool _shouldKeepTrace;
         private int _openSpans;
         private int? _samplingPriority;
 
@@ -92,6 +95,15 @@ namespace Datadog.Trace
 
             ArraySegment<Span> spansToWrite = default;
             var rootSpanInNextBatch = false;
+            bool shouldKeepSpan = true;
+            bool shouldKeepTraceFinal = default;
+
+            // For now, assume that we have enabled stats computation AND the agent has been confirmed to be compatible
+            // We'll need to redo this because we should asynchronously send the agent compatibility check and then set enabled/disabled accordingly
+            if (Tracer.CanDropP0s)
+            {
+                shouldKeepSpan = ShouldKeepSpan(span);
+            }
 
             lock (this)
             {
@@ -103,6 +115,10 @@ namespace Datadog.Trace
                 }
 
                 _openSpans--;
+                if (shouldKeepSpan)
+                {
+                    _shouldKeepTrace = true;
+                }
 
                 if (_openSpans == 0)
                 {
@@ -124,6 +140,11 @@ namespace Datadog.Trace
                     // Therefore, we bypass the resize logic and immediately allocate the array to its maximum size
                     _spans = new ArrayBuilder<Span>(spansToWrite.Count);
                 }
+
+                // TODO: I guess we should also report the number of P0 traces and P0 spans were dropped?
+                // The Go tracer seems to add this in a trace requst header, that only increments
+                // Gotta feed that into the Tracer somehow
+                shouldKeepTraceFinal = _shouldKeepTrace;
             }
 
             if (spansToWrite.Count > 0)
@@ -133,7 +154,7 @@ namespace Datadog.Trace
                 AddAASMetadata(spansToWrite.Array![0]);
                 PropagateSamplingPriority(span, spansToWrite, rootSpanInNextBatch);
 
-                Tracer.Write(spansToWrite);
+                Tracer.Write(spansToWrite, shouldKeepTraceFinal);
             }
         }
 
@@ -209,6 +230,42 @@ namespace Datadog.Trace
                 span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
                 span.Tags.SetTag(Datadog.Trace.Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
             }
+        }
+
+        // Based on the Go implementation. Cross-check with Java
+        //
+        // Keep the entire trace when StatsComputation is not enabled
+        // When StatsComputation is enabled, perform the following checks (in the given order) when each span is finished. If any span returns true, keep the entire trace.
+        // - Is the current sampling priority > 0? Return true.
+        // - Have any errors been seen? Return true
+        // - If the current span doesn't have Metrics["_dd1.sr.eausr"] (aka AnalyticsSampleRate), skip. If it does, run the Knuth sampling decision on the metric value and return the result.
+        private bool ShouldKeepSpan(Span span)
+        {
+            if (_samplingPriority is int a && a > 0)
+            {
+                return true;
+            }
+
+            // TODO: Is there a better way to read and write this value? Open to suggestions
+            lock (this)
+            {
+                if (_hasErrorSpans)
+                {
+                    return true;
+                }
+                else if (span.Error)
+                {
+                    _hasErrorSpans = true;
+                    return true;
+                }
+            }
+
+            if (span.GetMetric(Trace.Tags.Analytics) is double rate)
+            {
+                return ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
+            }
+
+            return false;
         }
 
         private void PropagateSamplingPriority(Span closedSpan, ArraySegment<Span> spansToWrite, bool containsRootSpan)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -141,9 +141,6 @@ namespace Datadog.Trace
                     _spans = new ArrayBuilder<Span>(spansToWrite.Count);
                 }
 
-                // TODO: I guess we should also report the number of P0 traces and P0 spans were dropped?
-                // The Go tracer seems to add this in a trace requst header, that only increments
-                // Gotta feed that into the Tracer somehow
                 shouldKeepTraceFinal = _shouldKeepTrace;
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -26,7 +26,6 @@ namespace Datadog.Trace
         private bool _rootSpanSent;
         private bool _rootSpanInNextBatch;
 
-        private bool _hasErrorSpans;
         private bool _shouldKeepTrace;
         private int _openSpans;
         private int? _samplingPriority;
@@ -95,15 +94,8 @@ namespace Datadog.Trace
 
             ArraySegment<Span> spansToWrite = default;
             var rootSpanInNextBatch = false;
-            bool shouldKeepSpan = true;
-            bool shouldKeepTraceFinal = default;
-
-            // For now, assume that we have enabled stats computation AND the agent has been confirmed to be compatible
-            // We'll need to redo this because we should asynchronously send the agent compatibility check and then set enabled/disabled accordingly
-            if (Tracer.CanDropP0s)
-            {
-                shouldKeepSpan = ShouldKeepSpan(span);
-            }
+            bool shouldKeepTraceFinal = false;
+            bool shouldKeepSpan = ShouldKeepSpan(span);
 
             lock (this)
             {
@@ -115,10 +107,7 @@ namespace Datadog.Trace
                 }
 
                 _openSpans--;
-                if (shouldKeepSpan)
-                {
-                    _shouldKeepTrace = true;
-                }
+                _shouldKeepTrace |= shouldKeepSpan;
 
                 if (_openSpans == 0)
                 {
@@ -238,23 +227,21 @@ namespace Datadog.Trace
         // - If the current span doesn't have Metrics["_dd1.sr.eausr"] (aka AnalyticsSampleRate), skip. If it does, run the Knuth sampling decision on the metric value and return the result.
         private bool ShouldKeepSpan(Span span)
         {
+            // For now, assume that we have enabled stats computation AND the agent has been confirmed to be compatible
+            // We'll need to redo this because we should asynchronously send the agent compatibility check and then set enabled/disabled accordingly
+            if (_shouldKeepTrace || !Tracer.CanDropP0s)
+            {
+                return true;
+            }
+
             if (_samplingPriority is int a && a > 0)
             {
                 return true;
             }
 
-            // TODO: Is there a better way to read and write this value? Open to suggestions
-            lock (this)
+            if (span.Error)
             {
-                if (_hasErrorSpans)
-                {
-                    return true;
-                }
-                else if (span.Error)
-                {
-                    _hasErrorSpans = true;
-                    return true;
-                }
+                return true;
             }
 
             if (span.GetMetric(Trace.Tags.Analytics) is double rate)

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -214,6 +214,11 @@ namespace Datadog.Trace
         ImmutableTracerSettings ITracer.Settings => Settings;
 
         /// <summary>
+        /// Gets a value indicating whether the tracer can drop P0 spans and traces.
+        /// </summary>
+        bool IDatadogTracer.CanDropP0s => Settings.StatsComputationEnabled;
+
+        /// <summary>
         /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
         ISampler IDatadogTracer.Sampler => TracerManager.Sampler;
@@ -319,11 +324,12 @@ namespace Datadog.Trace
         /// Writes the specified <see cref="Span"/> collection to the agent writer.
         /// </summary>
         /// <param name="trace">The <see cref="Span"/> collection to write.</param>
-        void IDatadogTracer.Write(ArraySegment<Span> trace)
+        /// <param name="shouldSerializeSpans">Indicates whether the spans should be serialized into traces.</param>
+        void IDatadogTracer.Write(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             if (Settings.TraceEnabled || AzureAppServices.Metadata.CustomTracingEnabled)
             {
-                TracerManager.WriteTrace(trace);
+                TracerManager.WriteTrace(trace, shouldSerializeSpans);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -444,5 +444,10 @@ namespace Datadog.Trace
         {
             return TracerManager.AgentWriter.FlushTracesAsync();
         }
+
+        internal Task FlushAndCloseAsync()
+        {
+            return TracerManager.AgentWriter.FlushAndCloseAsync();
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -523,7 +523,7 @@ namespace Datadog.Trace
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
             foreach (var processor in TraceProcessors)
             {
@@ -542,7 +542,7 @@ namespace Datadog.Trace
 
             if (trace.Count > 0)
             {
-                AgentWriter.WriteTrace(trace);
+                AgentWriter.WriteTrace(trace, shouldSerializeSpans);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -167,7 +167,7 @@ namespace Datadog.Trace
         protected virtual IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ISampler sampler)
         {
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
-            var api = new Api(apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled, settings.StatsComputationEnabled);
+            var api = new Api(apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled);
 
             var statsAggregator = StatsAggregator.Create(api, settings);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             trace = new[] { new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow) };
             var expectedData2 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentWriterTests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()), Times.Once);
 
             _api.Invocations.Clear();
 
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
             _ciAgentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _ciAgentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()), Times.Once);
 
             await _ciAgentWriter.FlushAndCloseAsync();
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CIAgentlessWriterTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
                 });
 
             var trace = new[] { span };
-            agentlessWriter.WriteTrace(new ArraySegment<Span>(trace));
+            agentlessWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await agentlessWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             Assert.True(finalPayload.SequenceEqual(expectedBytes));

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -535,6 +535,8 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         private class AgentWriterStub : IAgentWriter
         {
+            public bool CanDropP0s => false;
+
             public List<ArraySegment<Span>> Traces { get; } = new();
 
             public Task FlushAndCloseAsync() => Task.CompletedTask;
@@ -543,7 +545,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             public Task<bool> Ping() => Task.FromResult(true);
 
-            public void WriteTrace(ArraySegment<Span> trace) => Traces.Add(trace);
+            public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans) => Traces.Add(trace);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace.IntegrationTests
 {
     public class StatsTests
     {
+        private const int StatsComputationIntervalSeconds = 3;
+
         [Fact]
         public async Task SendStats()
         {
@@ -77,6 +79,7 @@ namespace Datadog.Trace.IntegrationTests
             {
                 GlobalSamplingRate = globalSamplingRate,
                 StatsComputationEnabled = statsComputationEnabled,
+                StatsComputationInterval = StatsComputationIntervalSeconds,
                 ServiceVersion = "V",
                 Environment = "Test",
                 Exporter = new ExporterSettings
@@ -185,11 +188,11 @@ namespace Datadog.Trace.IntegrationTests
             {
                 if (expected)
                 {
-                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
+                    e.WaitOne(TimeSpan.FromSeconds(StatsComputationIntervalSeconds)).Should().Be(true, "timeout while waiting for stats");
                 }
                 else
                 {
-                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
+                    e.WaitOne(TimeSpan.FromSeconds(StatsComputationIntervalSeconds)).Should().Be(false, "No stats should be received");
                 }
             }
 
@@ -206,7 +209,7 @@ namespace Datadog.Trace.IntegrationTests
 
                 var bucket = stats.Stats[0];
                 bucket.AgentTimeShift.Should().Be(0);
-                bucket.Duration.Should().Be(TimeSpan.FromSeconds(10).ToNanoseconds());
+                bucket.Duration.Should().Be(TimeSpan.FromSeconds(StatsComputationIntervalSeconds).ToNanoseconds());
                 bucket.Start.Should().NotBe(0);
 
                 bucket.Stats.Should().HaveCount(1);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.IntegrationTests
 {
     public class StatsTests
     {
-        private const int StatsComputationIntervalSeconds = 3;
+        private const int StatsComputationIntervalSeconds = 10;
 
         [Fact]
         public async Task SendStats()

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.IntegrationTests
 
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
 
-            // Scenario 1: Send server span with 200 status code (success)
+            // Scenario 1: Send server span with 200 status code (success). This is a unique stats point so this trace is kept
             Span span1;
             using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))
             {
@@ -100,41 +100,43 @@ namespace Datadog.Trace.IntegrationTests
             }
 
             await tracer.FlushAsync();
-            if (expectStats)
-            {
-                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
-            }
-            else
-            {
-                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
-            }
+            WaitForStats(statsWaitEvent, expectStats);
+            WaitForTraces(tracesWaitEvent, finishSpansOnClose); // The first span is unique, so we expect to receive it as long as it closed
 
-            if (expectAllTraces && finishSpansOnClose)
-            {
-                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for traces");
-            }
-            else
-            {
-                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No traces should be received");
-            }
-
-            // Scenario 2: Send server span with 500 status code (error)
+            // Scenario 2: Send the same server span as before, but it is not an error and it is not a new point,
+            // so this trace can be dropped when ClientDropP0s is true
             Span span2;
             using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))
             {
                 span2 = scope.Span;
                 span2.ResourceName = "resourceName";
-                span2.SetHttpStatusCode(500, isServer: true, immutableSettings);
-                span2.Type = "span2";
+                span2.SetHttpStatusCode(200, isServer: true, immutableSettings);
+                span2.Type = "span1";
             }
 
             await tracer.FlushAsync();
+            WaitForStats(statsWaitEvent, expectStats);
+            WaitForTraces(tracesWaitEvent, expectAllTraces && finishSpansOnClose);
+
+            // Scenario 3: Send server span with 200 status code but with an error
+            Span span3;
+            using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))
+            {
+                span3 = scope.Span;
+                span3.ResourceName = "resourceName";
+                span3.SetHttpStatusCode(200, isServer: true, immutableSettings);
+                span3.Type = "span1";
+                span3.Error = true;
+            }
+
+            await tracer.FlushAsync();
+            WaitForStats(statsWaitEvent, expectStats);
+            WaitForTraces(tracesWaitEvent, finishSpansOnClose); // The last span was an error, so we expect to receive it as long as it closed
+
             if (expectStats)
             {
-                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
-
-                var payload = agent.WaitForStats(2);
-                payload.Should().HaveCount(2);
+                var payload = agent.WaitForStats(3);
+                payload.Should().HaveCount(3);
 
                 var stats1 = payload[0];
                 stats1.Sequence.Should().Be(1);
@@ -142,21 +144,11 @@ namespace Datadog.Trace.IntegrationTests
 
                 var stats2 = payload[1];
                 stats2.Sequence.Should().Be(2);
-                AssertStats(stats2, span2, isError: true);
-            }
-            else
-            {
-                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
-            }
+                AssertStats(stats2, span2, isError: false);
 
-            // For the error span, we should always send them (when they get closed of course)
-            if (finishSpansOnClose)
-            {
-                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for traces");
-            }
-            else
-            {
-                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No traces should be received");
+                var stats3 = payload[2];
+                stats3.Sequence.Should().Be(3);
+                AssertStats(stats3, span3, isError: true);
             }
 
             // Assert header values
@@ -168,13 +160,37 @@ namespace Datadog.Trace.IntegrationTests
             }
             else if (headersAlwaysZeroes)
             {
-                droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0" });
-                droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0" });
+                droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0", "0" });
+                droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0", "0" });
             }
             else
             {
-                droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { "1" });
-                droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { "1" });
+                droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { "0", "1" });
+                droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { "0", "1" });
+            }
+
+            void WaitForTraces(AutoResetEvent e, bool expected)
+            {
+                if (expected)
+                {
+                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for traces");
+                }
+                else
+                {
+                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No traces should be received");
+                }
+            }
+
+            void WaitForStats(AutoResetEvent e, bool expected)
+            {
+                if (expected)
+                {
+                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
+                }
+                else
+                {
+                    e.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
+                }
             }
 
             void AssertStats(MockClientStatsPayload stats, Span span, bool isError)

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.IntegrationTests
                 var stats1 = payload[0];
                 stats1.Sequence.Should().Be(1);
 
-                var totalDuration = span1.Duration + span2.Duration + span3.Duration;
+                var totalDuration = span1.Duration.ToNanoseconds() + span2.Duration.ToNanoseconds() + span3.Duration.ToNanoseconds();
                 AssertStats(stats1, span1, totalDuration);
             }
 
@@ -193,7 +193,7 @@ namespace Datadog.Trace.IntegrationTests
                 }
             }
 
-            void AssertStats(MockClientStatsPayload stats, Span span, TimeSpan totalDuration)
+            void AssertStats(MockClientStatsPayload stats, Span span, long totalDuration)
             {
                 stats.Env.Should().Be(settings.Environment);
                 stats.Hostname.Should().Be(HostMetadata.Instance.Hostname);
@@ -214,7 +214,7 @@ namespace Datadog.Trace.IntegrationTests
                 var group = bucket.Stats[0];
 
                 group.DbType.Should().BeNull();
-                group.Duration.Should().Be(totalDuration.ToNanoseconds());
+                group.Duration.Should().Be(totalDuration);
                 group.Errors.Should().Be(1);
                 group.ErrorSummary.Should().NotBeEmpty();
                 group.Hits.Should().Be(3);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -25,6 +25,12 @@ namespace Datadog.Trace.IntegrationTests
         }
 
         [Fact]
+        public async Task SendsStatsAndDropsSpansWhenSampleRateIsZero_TS007()
+        {
+            await SendStatsHelper(statsComputationEnabled: true, expectStats: true, expectAllTraces: false, globalSamplingRate: 0.0);
+        }
+
+        [Fact]
         public async Task SendsStatsOnlyAfterSpansAreFinished_TS008()
         {
             await SendStatsHelper(statsComputationEnabled: true, expectStats: false, finishSpansOnClose: false);
@@ -36,17 +42,27 @@ namespace Datadog.Trace.IntegrationTests
             await SendStatsHelper(statsComputationEnabled: false, expectStats: false);
         }
 
-        private async Task SendStatsHelper(bool statsComputationEnabled, bool expectStats, bool finishSpansOnClose = true)
+        private async Task SendStatsHelper(bool statsComputationEnabled, bool expectStats, double? globalSamplingRate = null, bool expectAllTraces = true, bool finishSpansOnClose = true)
         {
             expectStats &= statsComputationEnabled && finishSpansOnClose;
-            var waitEvent = new AutoResetEvent(false);
+            var statsWaitEvent = new AutoResetEvent(false);
+            var tracesWaitEvent = new AutoResetEvent(false);
 
             using var agent = MockTracerAgent.Create(null, TcpPortProvider.GetOpenPort());
 
-            agent.StatsDeserialized += (_, _) => waitEvent.Set();
+            agent.StatsDeserialized += (_, _) =>
+            {
+                statsWaitEvent.Set();
+            };
+
+            agent.RequestDeserialized += (_, _) =>
+            {
+                tracesWaitEvent.Set();
+            };
 
             var settings = new TracerSettings
             {
+                GlobalSamplingRate = globalSamplingRate,
                 StatsComputationEnabled = statsComputationEnabled,
                 ServiceVersion = "V",
                 Environment = "Test",
@@ -60,28 +76,37 @@ namespace Datadog.Trace.IntegrationTests
 
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
 
+            // Scenario 1: Send server span with 200 status code (success)
             Span span1;
-
             using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))
             {
                 span1 = scope.Span;
                 span1.ResourceName = "resourceName";
-                span1.SetHttpStatusCode(200, isServer: false, immutableSettings);
+                span1.SetHttpStatusCode(200, isServer: true, immutableSettings);
                 span1.Type = "span1";
             }
 
             await tracer.FlushAsync();
             if (expectStats)
             {
-                waitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
+                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
             }
             else
             {
-                waitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
+                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
             }
 
-            Span span2;
+            if (expectAllTraces && finishSpansOnClose)
+            {
+                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for traces");
+            }
+            else
+            {
+                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No traces should be received");
+            }
 
+            // Scenario 2: Send server span with 500 status code (error)
+            Span span2;
             using (var scope = tracer.StartActiveInternal("operationName", finishOnClose: finishSpansOnClose))
             {
                 span2 = scope.Span;
@@ -93,7 +118,7 @@ namespace Datadog.Trace.IntegrationTests
             await tracer.FlushAsync();
             if (expectStats)
             {
-                waitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
+                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for stats");
 
                 var payload = agent.WaitForStats(2);
                 payload.Should().HaveCount(2);
@@ -108,7 +133,17 @@ namespace Datadog.Trace.IntegrationTests
             }
             else
             {
-                waitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
+                statsWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No stats should be received");
+            }
+
+            // For the error span, we should always send them (when they get closed of course)
+            if (finishSpansOnClose)
+            {
+                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(true, "timeout while waiting for traces");
+            }
+            else
+            {
+                tracesWaitEvent.WaitOne(TimeSpan.FromSeconds(15)).Should().Be(false, "No traces should be received");
             }
 
             void AssertStats(MockClientStatsPayload stats, Span span, bool isError)

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -129,6 +129,8 @@ namespace Datadog.Trace.IntegrationTests
             }
 
             await tracer.FlushAsync();
+            await tracer.FlushAndCloseAsync(); // Flushes and closes both traces and stats
+
             WaitForStats(statsWaitEvent, expectStats);
             WaitForTraces(tracesWaitEvent, finishSpansOnClose); // The last span was an error, so we expect to receive it as long as it closed
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -155,14 +155,21 @@ namespace Datadog.Trace.IntegrationTests
             }
 
             // Assert header values
-            var headersAlwaysZeroes = !expectStats || expectAllTraces;
             if (!finishSpansOnClose)
             {
+                // If we never finish the spans, there will be no requests to the trace agent
                 droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { });
                 droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { });
             }
-            else if (headersAlwaysZeroes)
+            else if (!expectStats)
             {
+                // If we don't send stats, then we won't add the headers
+                droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { null, null, null });
+                droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { null, null, null });
+            }
+            else if (expectAllTraces)
+            {
+                // If we still expect all the traces to come in, each request will have 0 dropped traces/spans
                 droppedP0TracesHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0", "0" });
                 droppedP0SpansHeaderValues.Should().BeEquivalentTo(new string[] { "0", "0", "0" });
             }

--- a/tracer/test/Datadog.Trace.IntegrationTests/TestApi.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TestApi.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.IntegrationTests
             return objects;
         }
 
-        public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces)
+        public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces, bool statsComputationEnabled, long numberOfDroppedP0Traces, long numberOfDroppedP0Spans)
         {
             var spans = MessagePackSerializer.Deserialize<List<List<MockSpan>>>(traces);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -13,6 +13,7 @@ namespace Datadog.Trace.TestHelpers
                                                                 {
                                                                     "testhost",
                                                                     "testhost.x86",
+                                                                    "testhost.net461",
                                                                     "testhost.net461.x86",
                                                                     "vstest.console",
                                                                     "xunit.console.x86",

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -23,7 +23,8 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task CallFlushAutomatically()
         {
-            var bucketDuration = TimeSpan.FromSeconds(1);
+            const int bucketDurationSeconds = 1;
+            var bucketDuration = TimeSpan.FromSeconds(bucketDurationSeconds);
 
             var mutex = new ManualResetEventSlim();
 
@@ -41,7 +42,7 @@ namespace Datadog.Trace.Tests.Agent
                     })
                 .Returns(Task.FromResult(true));
 
-            var aggregator = new StatsAggregator(api.Object, GetSettings(), bucketDuration);
+            var aggregator = new StatsAggregator(api.Object, GetSettings(bucketDurationSeconds));
 
             try
             {
@@ -76,7 +77,7 @@ namespace Datadog.Trace.Tests.Agent
 
             // First, validate that Flush does call SendStatsAsync even if disposed
             // If this behavior change then the test needs to be rewritten
-            var aggregator = new StatsAggregator(api.Object, GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(api.Object, GetSettings());
 
             // Dispose immediately to make Flush complete without delay
             await aggregator.DisposeAsync();
@@ -90,7 +91,7 @@ namespace Datadog.Trace.Tests.Agent
             api.Reset();
 
             // Now the actual test
-            aggregator = new StatsAggregator(api.Object, GetSettings(), Timeout.InfiniteTimeSpan);
+            aggregator = new StatsAggregator(api.Object, GetSettings());
             await aggregator.DisposeAsync();
 
             await aggregator.Flush();
@@ -109,7 +110,7 @@ namespace Datadog.Trace.Tests.Agent
             ulong id = 0;
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings());
 
             try
             {
@@ -189,7 +190,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings());
 
             try
             {
@@ -252,7 +253,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings());
 
             try
             {
@@ -322,7 +323,7 @@ namespace Datadog.Trace.Tests.Agent
 
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings());
 
             try
             {
@@ -365,7 +366,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             var start = DateTimeOffset.UtcNow;
 
-            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings(), Timeout.InfiniteTimeSpan);
+            var aggregator = new StatsAggregator(Mock.Of<IApi>(), GetSettings());
 
             try
             {
@@ -411,7 +412,16 @@ namespace Datadog.Trace.Tests.Agent
             }
         }
 
-        private static ImmutableTracerSettings GetSettings() => new TracerSettings().Build();
+        private static ImmutableTracerSettings GetSettings(int? statsComputationIntervalSeconds = null)
+        {
+            var settings = new TracerSettings();
+            if (statsComputationIntervalSeconds.HasValue)
+            {
+                settings.StatsComputationInterval = statsComputationIntervalSeconds.Value;
+            }
+
+            return settings.Build();
+        }
 
         // Re-implement timestamp conversion to independently verify the operation
         private static double ConvertTimestamp(long ns)

--- a/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tests
 
             agent.WriteTrace(CreateTrace(1), true);
 
-            statsAggregator.Verify(s => s.AddRange(It.IsAny<Span[]>(), 0, 1), Times.Once);
+            statsAggregator.Verify(s => s.AddRange(It.Is<ArraySegment<Span>>(x => x.Offset == 0 && x.Count == 1)), Times.Once);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests
 
             var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator.Object, statsd: null, automaticFlush: false);
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             statsAggregator.Verify(s => s.AddRange(It.IsAny<Span[]>(), 0, 1), Times.Once);
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests
             trace = new[] { new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow) };
             var expectedData2 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, SpanFormatterResolver.Instance);
 
-            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace), true);
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Tests
                     throw new InvalidOperationException();
                 });
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             mutex.Wait();
 
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests
                 })
                 .Returns(Task.FromResult(true));
 
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
 
             // Wait for the flush operation
             barrier.SignalAndWait();
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Tests
 
             var mutex = new ManualResetEventSlim();
 
-            agent.WriteTrace(CreateTrace(2));
+            agent.WriteTrace(CreateTrace(2), true);
 
             // Wait for the trace to be dequeued
             WaitForDequeue(agent);
@@ -170,8 +170,8 @@ namespace Datadog.Trace.Tests
             // Make the buffer size big enough for a single trace
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
-            agent.WriteTrace(CreateTrace(1));
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
+            agent.WriteTrace(CreateTrace(1), true);
 
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
             Assert.True(agent.FrontBuffer.IsFull);
@@ -199,8 +199,8 @@ namespace Datadog.Trace.Tests
             var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd.Object, automaticFlush: false, (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             // Fill the two buffers
-            agent.WriteTrace(CreateTrace(1));
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
+            agent.WriteTrace(CreateTrace(1), true);
 
             // Buffers should have swapped
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
@@ -220,7 +220,7 @@ namespace Datadog.Trace.Tests
             statsd.Invocations.Clear();
 
             // Both buffers are at capacity, write a new trace
-            agent.WriteTrace(CreateTrace(2));
+            agent.WriteTrace(CreateTrace(2), true);
 
             // Buffers shouldn't have swapped since the reserve buffer was full
             Assert.True(agent.ActiveBuffer == agent.BackBuffer);
@@ -259,7 +259,7 @@ namespace Datadog.Trace.Tests
             }
 
             // Serialization thread is asleep, makes sure it wakes up when enqueuing a trace
-            agent.WriteTrace(CreateTrace(1));
+            agent.WriteTrace(CreateTrace(1), true);
             Assert.True(WaitForDequeue(agent));
 
             return agent.FlushAndCloseAsync();
@@ -289,22 +289,22 @@ namespace Datadog.Trace.Tests
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, calculator, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1, batchInterval: 100);
 
             // Fill both buffers
-            agent.WriteTrace(trace);
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
+            agent.WriteTrace(trace, true);
 
             // Drop one
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             // Write another one
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
             api.Verify();
             api.Invocations.Clear();
 
             // Write trace and update keep rate
             calculator.UpdateBucket();
-            agent.WriteTrace(trace);
+            agent.WriteTrace(trace, true);
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             const double expectedTraceKeepRate = 0.75;
@@ -338,19 +338,19 @@ namespace Datadog.Trace.Tests
             var trace = new ArraySegment<Span>(new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) });
 
             // Write trace to the front buffer
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // Flush front buffer
             var firstFlush = agentWriter.FlushTracesAsync();
 
             // This will swap to the back buffer due front buffer is blocked.
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // Flush the second buffer
             var secondFlush = agentWriter.FlushTracesAsync();
 
             // This trace will force other buffer swap and then a drop because both buffers are blocked
-            agentWriter.WriteTrace(trace);
+            agentWriter.WriteTrace(trace, true);
 
             // This will try to flush the front buffer again.
             var thirdFlush = agentWriter.FlushTracesAsync();

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: true);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
             var statsBuffer = new StatsBuffer(new ClientStatsPayload());
 
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: true);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
             var statsBuffer = new StatsBuffer(new ClientStatsPayload());
 
@@ -126,9 +126,9 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: statsComputationEnabled);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, statsComputationEnabled, 0, 0);
 
             requestMock.Verify(x => x.AddHeader(AgentHttpHeaderNames.StatsComputation, "true"), statsComputationEnabled ? Times.Once : Times.Never);
         }
@@ -152,7 +152,7 @@ namespace Datadog.Trace.Tests
 
             var logMock = new Mock<IDatadogLogger>();
 
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: true, log: logMock.Object, statsComputationEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: true, log: logMock.Object);
 
             // First time should write the warning
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
@@ -192,7 +192,7 @@ namespace Datadog.Trace.Tests
 
             var ratesWereSet = false;
             Action<Dictionary<string, float>> updateSampleRates = _ => ratesWereSet = true;
-            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, partialFlushEnabled: false, statsComputationEnabled: false);
+            var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, partialFlushEnabled: false);
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
             ratesWereSet.Should().BeTrue();
@@ -219,7 +219,7 @@ namespace Datadog.Trace.Tests
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == TracesPath))).Returns(new Uri("http://localhost/traces"));
             factoryMock.Setup(x => x.GetEndpoint(It.Is<string>(s => s == StatsPath))).Returns(new Uri("http://localhost/stats"));
 
-            var api = new Api(factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: partialFlushEnabled, statsComputationEnabled: false);
+            var api = new Api(factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: partialFlushEnabled);
 
             // First call depends on the parameters of the test
             api.LogPartialFlushWarningIfRequired(agentVersion).Should().Be(expectedResult);

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Exactly(5));
         }
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tests
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: statsComputationEnabled);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.AddHeader(AgentHttpHeaderNames.StatsComputation, "true"), statsComputationEnabled ? Times.Once : Times.Never);
         }
@@ -155,9 +155,9 @@ namespace Datadog.Trace.Tests
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: true, log: logMock.Object, statsComputationEnabled: false);
 
             // First time should write the warning
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
             // Second time, it won't
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             // ReSharper disable ExplicitCallerInfoArgument
             logMock.Verify(
@@ -194,7 +194,7 @@ namespace Datadog.Trace.Tests
             Action<Dictionary<string, float>> updateSampleRates = _ => ratesWereSet = true;
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: updateSampleRates, partialFlushEnabled: false, statsComputationEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
+            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
             ratesWereSet.Should().BeTrue();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests
 
             span.SetTag(key, value);
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Never);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), Times.Never);
             Assert.Equal(span.GetTag(key), value);
         }
 
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
             await Task.Delay(TimeSpan.FromMilliseconds(1));
             span.Finish();
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Once);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), Times.Once);
             Assert.True(span.Duration > TimeSpan.Zero);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -425,7 +425,7 @@ namespace Datadog.Trace.Tests
 
         private void SetAASContext(bool inAASContext)
         {
-            var vars = Environment.GetEnvironmentVariables();
+            Dictionary<string, string> vars = new();
 
             if (!inAASContext)
             {

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
@@ -18,6 +19,7 @@ namespace Datadog.Trace.Tests
     [AzureAppServicesRestorer]
     public class TraceContextTests
     {
+        private const ulong KnuthFactor = 1_111_111_111_111_111_111;
         private readonly Mock<IDatadogTracer> _tracerMock = new Mock<IDatadogTracer>();
 
         [Fact]
@@ -78,18 +80,18 @@ namespace Datadog.Trace.Tests
             }
 
             // At this point in time, we have 4 closed spans in the trace
-            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
 
             AddAndCloseSpan();
 
             // Now we have 5 closed spans, partial flush should kick-in if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5), true), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
             }
 
             for (int i = 0; i < 5; i++)
@@ -100,11 +102,11 @@ namespace Datadog.Trace.Tests
             // We have 5 more closed spans, partial flush should kick-in a second time if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Exactly(2));
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5), true), Times.Exactly(2));
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true), Times.Never);
             }
 
             traceContext.CloseSpan(rootSpan);
@@ -112,11 +114,11 @@ namespace Datadog.Trace.Tests
             // Now the remaining spans are flushed
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 1)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 1), true), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 11)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 11), true), Times.Once);
             }
         }
 
@@ -140,8 +142,8 @@ namespace Datadog.Trace.Tests
 
             ArraySegment<Span>? spans = null;
 
-            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
-                  .Callback<ArraySegment<Span>>(s => spans = s);
+            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>(), true))
+                  .Callback<ArraySegment<Span>, bool>((s, _) => spans = s);
 
             var traceContext = new TraceContext(tracer.Object);
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
@@ -249,8 +251,8 @@ namespace Datadog.Trace.Tests
 
             ArraySegment<Span>? spans = null;
 
-            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
-                  .Callback<ArraySegment<Span>>(s => spans = s);
+            tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>(), true))
+                  .Callback<ArraySegment<Span>, bool>((s, _) => spans = s);
 
             SetAASContext(inAASContext);
 
@@ -305,6 +307,137 @@ namespace Datadog.Trace.Tests
                 vars.Add(Datadog.Trace.Configuration.ConfigurationKeys.ApiKey, "xxx");
                 AzureAppServices.Metadata = new AzureAppServices(vars);
             }
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void StatsComputationEnabled_SerializeSpansFalseWhen_SamplingPriorityLessThanEqualTo0(int samplingPriority)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(samplingPriority);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), false));
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_SamplingPriorityGreaterThan0(int samplingPriority)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(samplingPriority);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_TraceHasErrors(bool hasChildSpans)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            rootSpan.Error = true;
+
+            if (hasChildSpans)
+            {
+                var childSpan = CreateSpan();
+                traceContext.AddSpan(childSpan);
+                traceContext.CloseSpan(childSpan);
+            }
+
+            traceContext.CloseSpan(rootSpan);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), true));
+        }
+
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(true, 0)]
+        [InlineData(false, 0.5)]
+        [InlineData(true, 0.5)]
+        [InlineData(false, 1)]
+        [InlineData(true, 1)]
+        public void StatsComputationEnabled_SerializeSpansTrueWhen_SpanHasAnalyticsAndSampled(bool hasChildSpans, double analyticsSampleRate)
+        {
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.CanDropP0s).Returns(true);
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                Exporter = new Trace.Configuration.ExporterSettings()
+                {
+                    PartialFlushEnabled = false,
+                }
+            }.Build());
+
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+
+            var rootSpan = CreateSpan();
+            traceContext.AddSpan(rootSpan);
+            rootSpan.SetMetric(Tags.Analytics, analyticsSampleRate);
+
+            if (hasChildSpans)
+            {
+                var childSpan = CreateSpan();
+                traceContext.AddSpan(childSpan);
+                traceContext.CloseSpan(childSpan);
+            }
+
+            traceContext.CloseSpan(rootSpan);
+            var sampled = ((rootSpan.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (analyticsSampleRate * TracerConstants.MaxTraceId);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>(), sampled));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests
 
             var assertion = areTracesEnabled ? Times.Once() : Times.Never();
 
-            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>()), assertion);
+            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>(), It.IsAny<bool>()), assertion);
         }
 
         [Theory]

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -52,7 +52,7 @@ namespace Benchmarks.Trace
         [Benchmark]
         public Task WriteAndFlushEnrichedTraces()
         {
-            AgentWriter.WriteTrace(EnrichedSpans);
+            AgentWriter.WriteTrace(EnrichedSpans, true);
             return AgentWriter.FlushTracesAsync();
         }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -26,7 +26,7 @@ namespace Benchmarks.Trace
             settings.StartupDiagnosticLogEnabled = false;
             settings.TraceEnabled = false;
 
-            var api = new Api(new FakeApiRequestFactory(settings.Exporter.AgentUri), statsd: null, updateSampleRates: null, partialFlushEnabled: false, statsComputationEnabled: false);
+            var api = new Api(new FakeApiRequestFactory(settings.Exporter.AgentUri), statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
             AgentWriter = new AgentWriter(api, statsAggregator: null, statsd: null, automaticFlush: false);
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -9,6 +9,8 @@ namespace Benchmarks.Trace
     {
         private static readonly Task<bool> PingTask = Task.FromResult(true);
 
+        public bool CanDropP0s => false;
+
         public Task FlushAndCloseAsync()
         {
             return Task.CompletedTask;
@@ -32,7 +34,7 @@ namespace Benchmarks.Trace
             return PingTask;
         }
 
-        public void WriteTrace(ArraySegment<Span> trace)
+        public void WriteTrace(ArraySegment<Span> trace, bool shouldSerializeSpans)
         {
         }
     }


### PR DESCRIPTION
## Summary of changes
When stats computation is enabled and the tracer can drop P0 traces (assumed to be true, will check with agent in followup PR), P0 traces are not serialized and the `"Datadog-Client-Dropped-P0-Traces"` and `"Datadog-Client-Dropped-P0-Spans"` request headers are set on the next trace payload.

Based on top of #3047, this is PR 2/3 in an attempt to break down the massive PR https://github.com/DataDog/dd-trace-dotnet/pull/2988

## Reason for change
Dropping P0 traces is the biggest advantage of enabling stats computation in the tracer, because a large amount of span serialization (by the tracer) and deserialization (by the trace agent) is removed entirely.

## Implementation details
### TraceContext changes
> Background: The `TraceContext` object is responsible for flushing finished spans to its Tracer object reference when either all spans in the local trace are finished or the number of finished spans in the ongoing trace exceeds the partial flush limit. After this point, the finished spans are sent to the AgentWriter to be buffered/serialized, so we must make the decision here whether to drop P0 spans.

If `Tracer.CanDropP0s == true`, then the following algorithm is run on each of the finished spans to determine if the span should be kept. If at least one span is kept, then the entire trace is kept. If not, then the entire trace is dropped.
- Is the sampling priority greater than 0? If so, keep it.
- Does the span have an error? If so, keep it.
  - The agent is more advanced and applies a sampling rate sharded by stats key, but that's not necessary right now.
- Does the span have an app analytics sample rate? If so, does the sampling decision determine it should be sampled?
- If the span generates a stat point (must be top-level/measured), is the stat point unique? If so, keep the span.

We then pass the keep/drop decision along with the finished span array to the `AgentWriter.WriteTrace` API.

**Note:** There will need to be some special handling if a trace is supposed to be sampled out but the new single span ingestion controls determine that single spans should be kept. This is documented in the RFC and will need to be handled when the feature is implemented in the .NET Tracer.

### AgentWriter / IApi changes
> Background: The `AgentWriter` puts finished spans into buffers, and when a buffer is full those spans are sent to the trace agent by calling `IApi.SendTracesAsync`.

When the `AgentWriter` receives spans, it now accumulates the number of dropped P0 traces and dropped P0 spans. Then, when a span buffer needs to be serialized and `IApi.SendTracesAsync` is invoked, it passes along these counts and they are added as headers to the trace agent request.

## Test coverage
Adds unit tests in `TraceContextTests` and integration tests in `StatsTests` to assert that P0 traces are dropped and the headers are sent correctly.

## Other details
This PR also adds a configuration key `_DD_TRACE_STATS_COMPUTATION_INTERVAL` to configure the interval for sending stats. This should be considered a non-public setting and could change at any time.

## Remaining Work Items
- [ ] Refactor the decision to sample spans
- [ ] Fix the ErrorSampler as noted [here](https://github.com/DataDog/dd-trace-dotnet/pull/3048#discussion_r940042304). The refactoring should make this implementation simpler
- [ ] Spans that are sampled by the RareSampler must have the `_dd.rare` metric, as noted [here](https://github.com/DataDog/dd-trace-dotnet/pull/3048#discussion_r946815536). The other complication is that the RareSampler only runs if a span was not kept by the PrioritySampler (SamplingPriority > 0). The refactoring should make this implementation simpler
