### PR TITLE
Fix OSX native loader build issue

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -521,7 +521,7 @@ stages:
         masterCommitId: $(masterCommitId)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    - script: ./tracer/build.sh BuildTracerHome
+    - script: ./tracer/build.sh BuildTracerHome BuildNativeLoader
       displayName: Build tracer home
 
     - publish: $(tracerHome)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -446,9 +446,8 @@ namespace datadog::shared::nativeloader
                         moduleName = modulePath;
                     }
 
-                    WSTRINGSTREAM stringStream;
-                    stringStream << moduleName << std::endl;
-                    instrumented_assembly_generator::WriteTextToFile(instrumented_assembly_generator::ModulesFileName, stringStream.str());
+                    moduleName = moduleName + EndLWStr;
+                    instrumented_assembly_generator::WriteTextToFile(instrumented_assembly_generator::ModulesFileName, moduleName);
                     instrumented_assembly_generator::CopyOriginalModuleForInstrumentationVerification(modulePath);
                 }
             }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_metadata_interfaces.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_metadata_interfaces.cpp
@@ -156,15 +156,33 @@ void MetadataInterfaces::WriteMetadataChange(const mdToken* pToken,
     auto [hr, moduleName, mvid] = GetModuleNameAndMvid(metadataImport);
     if (FAILED(hr)) return;
 
+    shared::WSTRING fileNameString;
+
+#ifndef MACOS
     shared::WSTRINGSTREAM fileNameStream;
     fileNameStream << mvid << FileNameSeparator << GetCleanedFileName(moduleName) << ModuleMembersFileExtension;
+    fileNameString = fileNameStream.str()
+#else
+    fileNameString = mvid + FileNameSeparator + GetCleanedFileName(moduleName) + ModuleMembersFileExtension;
+#endif
 
+    shared::WSTRING stringString;
+
+#ifndef MACOS
     shared::WSTRINGSTREAM stringStream;
     // each line in the file is: "token=name"
     // TODO: handle empty token
     stringStream << std::hex << *pToken << WStr("=") << metadataName << std::endl;
+    stringString = stringStream.str();
+#else
+    // TODO: shared::WSTRINGSTREAM is not supported in osx, so as a workaround we convert to char
+    // In the case we want to support MACOS this should be solved.
+    std::stringstream stringStream;
+    stringStream << std::hex << *pToken << "=" << shared::ToString(metadataName) << std::endl;
+    stringString = shared::ToWSTRING(stringStream.str());
+#endif
 
-    WriteTextToFile(fileNameStream.str(), stringStream.str());
+    WriteTextToFile(fileNameString, stringString);
 }
 
 HRESULT MetadataInterfaces::DefineTypeDef(LPCWSTR szTypeDef, DWORD dwTypeDefFlags,

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_metadata_interfaces.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_metadata_interfaces.cpp
@@ -161,7 +161,7 @@ void MetadataInterfaces::WriteMetadataChange(const mdToken* pToken,
 #ifndef MACOS
     shared::WSTRINGSTREAM fileNameStream;
     fileNameStream << mvid << FileNameSeparator << GetCleanedFileName(moduleName) << ModuleMembersFileExtension;
-    fileNameString = fileNameStream.str()
+    fileNameString = fileNameStream.str();
 #else
     fileNameString = mvid + FileNameSeparator + GetCleanedFileName(moduleName) + ModuleMembersFileExtension;
 #endif

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -10,15 +10,27 @@
 #define WStrLen(value) (size_t) wcslen(value)
 #else
 #define WStr(value) u##value
-#define WStrLen(value) (size_t) std::char_traits<char16_t>::length(value)
+#define WStrLen(value) (size_t) std::char_traits<WCHAR>::length(value)
 #endif
 
 namespace shared {
 
-    typedef std::basic_string<WCHAR> WSTRING;
+    typedef std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>> WSTRING;
+#ifndef MACOS
     typedef std::basic_stringstream<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>> WSTRINGSTREAM;
+#else
+    // MACOS only support:
+    //    std::basic_stringstream<char, std::char_traits<char>, std::allocator<char>>
+    //    std::basic_stringstream<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>
+    // If we try to use char16_t (WCHAR on non windows) then there's compilation errors when using the stringstream instance.
+#endif
 
     static WSTRING EmptyWStr = WStr("");
+#if _WIN32
+    const static WSTRING EndLWStr = WStr("\r\n");
+#else
+    const static WSTRING EndLWStr = WStr("\n");
+#endif
 
     std::string ToString(const std::string& str);
     std::string ToString(const char* str);


### PR DESCRIPTION
## Summary of changes

This PR has several workarounds to build the native loader in macOS, due Apple StdLib doesn't support `std::basic_stringstream` over `char16_t`.

**Note**
The workarounds are non performant and may introduce other unknown issues. But OSX is not officially supported, so this is not an issue by now.

In future PR's we need to solve those issues and also enable all test suites.
