### PR TITLE
[Tracer] When stats computation is enabled, normalize and obfuscate traces

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -384,6 +384,7 @@ namespace Datadog.Trace.Agent
                 return null;
             }
 
+            trace = _statsAggregator?.ProcessTrace(trace) ?? trace;
             bool forceKeep = _statsAggregator?.AddRange(trace) ?? false;
 
             // If stats computation determined that we can drop the P0 Trace,

--- a/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -33,6 +33,8 @@ namespace Datadog.Trace.Agent
         /// <returns>True if the spans should be kept based on rare stats points or error stats points, false otherwise.</returns>
         bool AddRange(ArraySegment<Span> spans);
 
+        ArraySegment<Span> ProcessTrace(ArraySegment<Span> trace);
+
         Task DisposeAsync();
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/NullStatsAggregator.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Agent
 
         public bool AddRange(ArraySegment<Span> spans) => false;
 
+        public ArraySegment<Span> ProcessTrace(ArraySegment<Span> trace) => trace;
+
         public Task DisposeAsync()
         {
             return Task.CompletedTask;

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -116,16 +116,13 @@ namespace Datadog.Trace.Agent
             {
                 foreach (var processor in _traceProcessors)
                 {
-                    if (processor is not null)
+                    try
                     {
-                        try
-                        {
-                            trace = processor.Process(trace);
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Error(e, e.Message);
-                        }
+                        trace = processor.Process(trace);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, e.Message);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -5,11 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Processors;
 
 namespace Datadog.Trace.Agent
 {
@@ -24,6 +26,7 @@ namespace Datadog.Trace.Agent
         private readonly StatsBuffer[] _buffers;
 
         private readonly IApi _api;
+        private readonly ITraceProcessor[] _traceProcessors;
 
         private readonly TaskCompletionSource<bool> _processExit;
 
@@ -40,6 +43,10 @@ namespace Datadog.Trace.Agent
             _bucketDuration = TimeSpan.FromSeconds(settings.StatsComputationInterval);
             _keys = new HashSet<StatsAggregationKey>();
             _buffers = new StatsBuffer[BufferCount];
+            _traceProcessors = new ITraceProcessor[]
+            {
+                new Processors.NormalizerTraceProcessor(),
+            };
 
             var header = new ClientStatsPayload
             {
@@ -99,6 +106,30 @@ namespace Datadog.Trace.Agent
             }
 
             return forceKeep;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ArraySegment<Span> ProcessTrace(ArraySegment<Span> trace)
+        {
+            if (CanComputeStats == true || CanComputeStats is null)
+            {
+                foreach (var processor in _traceProcessors)
+                {
+                    if (processor is not null)
+                    {
+                        try
+                        {
+                            trace = processor.Process(trace);
+                        }
+                        catch (Exception e)
+                        {
+                            Log.Error(e, e.Message);
+                        }
+                    }
+                }
+            }
+
+            return trace;
         }
 
         internal static StatsAggregationKey BuildKey(Span span)

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -46,6 +46,7 @@ namespace Datadog.Trace.Agent
             _traceProcessors = new ITraceProcessor[]
             {
                 new Processors.NormalizerTraceProcessor(),
+                new Processors.ObfuscatorTraceProcessor(false),
             };
 
             var header = new ClientStatsPayload

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Processors
                 string env = span.GetTag("env");
                 if (!string.IsNullOrEmpty(env))
                 {
-                    span.SetTag("env", TraceUtil.NormalizeTag(env));
+                    span.Tags.SetTag("env", TraceUtil.NormalizeTag(env));
                 }
             }
 
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Processors
                 if (!string.IsNullOrEmpty(httpStatusCode) && !TraceUtil.IsValidStatusCode(httpStatusCode))
                 {
                     Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={invalidStatusCode}: {span}", httpStatusCode, span);
-                    span.SetTag(Tags.HttpStatusCode, null);
+                    span.Tags.SetTag(Tags.HttpStatusCode, null);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -6,9 +6,8 @@
 using System;
 using System.Collections;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Processors;
 
-namespace Datadog.Trace.TraceProcessors
+namespace Datadog.Trace.Processors
 {
     // https://github.com/DataDog/dd-trace-java/blob/35487fa08f16503105b2ff37fb084ffa5c894f24/internal-api/src/main/java/datadog/trace/api/normalize/SQLNormalizer.java
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.IntegrationTests
             CreateDefaultSpan(httpStatusCode: "99");
             CreateDefaultSpan(httpStatusCode: "600");
 
-            await tracer.FlushAsync();
+            await tracer.FlushAndCloseAsync(); // Flushes and closes both traces and stats
 
             var statsPayload = agent.WaitForStats(1);
             var spans = agent.WaitForSpans(13);
@@ -216,7 +216,7 @@ namespace Datadog.Trace.IntegrationTests
             CreateDefaultSpan(type: "redis", resource: "SET le_key le_value");
             CreateDefaultSpan(type: "redis", resource: "SET another_key another_value");
 
-            await tracer.FlushAsync();
+            await tracer.FlushAndCloseAsync(); // Flushes and closes both traces and stats
 
             var statsPayload = agent.WaitForStats(1);
             var spans = agent.WaitForSpans(13);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -40,6 +40,9 @@ namespace Datadog.Trace.IntegrationTests
             string typeTooLongString = new string('t', 150);
             string truncatedTypeString = new string('t', 100);
 
+            var beforeY2KDuration = TimeSpan.FromMilliseconds(2000);
+            var year2KDateTime = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
             var agentConfiguration = new MockTracerAgent.AgentConfiguration();
             using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), configuration: agentConfiguration);
 
@@ -57,7 +60,6 @@ namespace Datadog.Trace.IntegrationTests
 
             var immutableSettings = settings.Build();
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
-            List<Span> spans = new();
             Span span;
             SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000);
 
@@ -65,159 +67,120 @@ namespace Datadog.Trace.IntegrationTests
             // - If service is empty, it is set to DefaultServiceName
             // - If service is too long, it is truncated to 100 characters
             // - Normalized to match dogstatsd tag format
-            span = CreateDefaultSpan();
-            span.ServiceName = serviceTooLongString;
-            span.Finish();
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.ServiceName = serviceInvalidString;
-            span.Finish();
-            spans.Add(span);
+            CreateDefaultSpan(serviceName: serviceTooLongString);
+            CreateDefaultSpan(serviceName: serviceInvalidString);
 
             // Name
             // - If empty, it is set to "unnamed_operation"
             // - If too long, it is truncated to 100 characters
             // - Normalized to match Datadog metric name normalization
-            span = CreateDefaultSpan();
-            span.OperationName = string.Empty;
-            span.Finish();
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.OperationName = nameTooLongString;
-            span.Finish();
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.OperationName = nameInvalidString;
-            span.Finish();
-            spans.Add(span);
+            CreateDefaultSpan(operationName: string.Empty);
+            CreateDefaultSpan(operationName: nameTooLongString);
+            CreateDefaultSpan(operationName: nameInvalidString);
 
             // Resource
             // - If empty, it is set to the same value as Name
-            span = CreateDefaultSpan();
-            span.ResourceName = string.Empty;
-            span.Finish();
-            spans.Add(span);
+            CreateDefaultSpan(resourceName: string.Empty);
 
             // Duration
             // - If smaller than 0, it is set to 0
             // - If larger than math.MaxInt64 - Start, it is set to 0
-            span = CreateDefaultSpan();
-            span.Finish(TimeSpan.FromSeconds(-1));
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.Finish(TimeSpan.FromTicks(long.MaxValue / TimeConstants.NanoSecondsPerTick));
-            spans.Add(span);
+            CreateDefaultSpan(finishOnClose: false).Finish(TimeSpan.FromSeconds(-1));
+            CreateDefaultSpan(finishOnClose: false).Finish(TimeSpan.FromTicks(long.MaxValue / TimeConstants.NanoSecondsPerTick));
 
             // Start
             // - If smaller than Y2K, set to (now - Duration) or 0 if the result is negative
-            var beforeY2KDuration = TimeSpan.FromMilliseconds(2000);
-            var year2000Time = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-            span = CreateDefaultSpan();
-            span.SetStartTime(year2000Time.AddDays(-1));
+            span = CreateDefaultSpan(finishOnClose: false);
+            span.SetStartTime(year2KDateTime.AddDays(-1));
             span.Finish(beforeY2KDuration);
-            spans.Add(span);
 
             // Type
             // - If too long, it is truncated to 100 characters
-            span = CreateDefaultSpan();
-            span.Type = typeTooLongString;
-            span.Finish();
-            spans.Add(span);
+            CreateDefaultSpan(type: typeTooLongString);
 
             // Meta
             // - "http.status_code" key is deleted if it's an invalid numeric value smaller than 100 or bigger than 600
-            span = CreateDefaultSpan();
-            span.SetTag(Tags.HttpStatusCode, "invalid");
-            span.Finish();
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.SetTag(Tags.HttpStatusCode, "99");
-            span.Finish();
-            spans.Add(span);
-
-            span = CreateDefaultSpan();
-            span.SetTag(Tags.HttpStatusCode, "600");
-            span.Finish();
-            spans.Add(span);
+            CreateDefaultSpan(httpStatusCode: "invalid");
+            CreateDefaultSpan(httpStatusCode: "99");
+            CreateDefaultSpan(httpStatusCode: "600");
 
             await tracer.FlushAsync();
 
             var statsPayload = agent.WaitForStats(1);
+            var spans = agent.WaitForSpans(13);
+
             statsPayload.Should().HaveCount(1);
             statsPayload[0].Stats.Should().HaveCount(1);
 
-            var buckets = statsPayload[0].Stats[0].Stats;
-            buckets.Sum(stats => stats.Hits).Should().Be(13);
+            var stats = statsPayload[0].Stats[0].Stats;
+            stats.Sum(stats => stats.Hits).Should().Be(13);
 
             using var assertionScope = new AssertionScope();
 
             // Assert normaliztion of service names
-            buckets.Where(s => s.Service == truncatedServiceString).Should().ContainSingle("service names are truncated at 100 characters");
-            buckets.Where(s => s.Service == serviceNormalizedString).Should().ContainSingle("service names are normalized");
-            buckets.Where(s => s.Service != truncatedServiceString && s.Service != serviceNormalizedString).Should().OnlyContain(s => s.Service == "default-service");
+            stats.Where(s => s.Service == truncatedServiceString).Should().ContainSingle("service names are truncated at 100 characters");
+            stats.Where(s => s.Service == serviceNormalizedString).Should().ContainSingle("service names are normalized");
+            stats.Where(s => s.Service != truncatedServiceString && s.Service != serviceNormalizedString).Should().OnlyContain(s => s.Service == "default-service");
 
-            spans.Where(s => s.ServiceName == truncatedServiceString).Should().ContainSingle("service names are truncated at 100 characters");
-            spans.Where(s => s.ServiceName == serviceNormalizedString).Should().ContainSingle("service names are normalized");
-            spans.Where(s => s.ServiceName != truncatedServiceString && s.ServiceName != serviceNormalizedString).Should().OnlyContain(s => s.ServiceName == "default-service");
+            spans.Where(s => s.Service == truncatedServiceString).Should().ContainSingle("service names are truncated at 100 characters");
+            spans.Where(s => s.Service == serviceNormalizedString).Should().ContainSingle("service names are normalized");
+            spans.Where(s => s.Service != truncatedServiceString && s.Service != serviceNormalizedString).Should().OnlyContain(s => s.Service == "default-service");
 
             // Assert normaliztion of operation names
             // Note: "-" are replaced with "_" for operation name normalization, which has the Datadog metric name normalization rules
-            buckets.Where(s => s.Name == "unnamed_operation").Should().ContainSingle("empty operation names should be set to \"unnamed_operation\"");
-            buckets.Where(s => s.Name == truncatedNameString).Should().ContainSingle("operation names are truncated at 100 characters");
-            buckets.Where(s => s.Name == nameNormalizedString).Should().ContainSingle("operation names are normalized");
-            buckets.Where(s => s.Name != "unnamed_operation" && s.Name != truncatedNameString && s.Name != nameNormalizedString).Should().OnlyContain(s => s.Name == "default_operation");
+            stats.Where(s => s.Name == "unnamed_operation").Should().ContainSingle("empty operation names should be set to \"unnamed_operation\"");
+            stats.Where(s => s.Name == truncatedNameString).Should().ContainSingle("operation names are truncated at 100 characters");
+            stats.Where(s => s.Name == nameNormalizedString).Should().ContainSingle("operation names are normalized");
+            stats.Where(s => s.Name != "unnamed_operation" && s.Name != truncatedNameString && s.Name != nameNormalizedString).Should().OnlyContain(s => s.Name == "default_operation");
 
-            spans.Where(s => s.OperationName == "unnamed_operation").Should().ContainSingle("empty operation names should be set to \"unnamed_operation\"");
-            spans.Where(s => s.OperationName == truncatedNameString).Should().ContainSingle("operation names are truncated at 100 characters");
-            spans.Where(s => s.OperationName == nameNormalizedString).Should().ContainSingle("operation names are normalized");
-            spans.Where(s => s.OperationName != "unnamed_operation" && s.OperationName != truncatedNameString && s.OperationName != nameNormalizedString).Should().OnlyContain(s => s.OperationName == "default_operation");
+            spans.Where(s => s.Name == "unnamed_operation").Should().ContainSingle("empty operation names should be set to \"unnamed_operation\"");
+            spans.Where(s => s.Name == truncatedNameString).Should().ContainSingle("operation names are truncated at 100 characters");
+            spans.Where(s => s.Name == nameNormalizedString).Should().ContainSingle("operation names are normalized");
+            spans.Where(s => s.Name != "unnamed_operation" && s.Name != truncatedNameString && s.Name != nameNormalizedString).Should().OnlyContain(s => s.Name == "default_operation");
 
             // Assert normaliztion of resource names
-            buckets.Where(s => s.Resource == "default_operation").Should().ContainSingle("empty resource names should be set to the same value as Name");
-            buckets.Where(s => s.Resource != "default_operation").Should().OnlyContain(s => s.Resource == "default-resource");
+            stats.Where(s => s.Resource == "default_operation").Should().ContainSingle("empty resource names should be set to the same value as Name");
+            stats.Where(s => s.Resource != "default_operation").Should().OnlyContain(s => s.Resource == "default-resource");
 
-            spans.Where(s => s.ResourceName == "default_operation").Should().ContainSingle("empty resource names should be set to the same value as Name");
-            spans.Where(s => s.ResourceName != "default_operation").Should().OnlyContain(s => s.ResourceName == "default-resource");
+            spans.Where(s => s.Resource == "default_operation").Should().ContainSingle("empty resource names should be set to the same value as Name");
+            spans.Where(s => s.Resource != "default_operation").Should().OnlyContain(s => s.Resource == "default-resource");
 
             // Assert normalization of duration
             // Assert normalization of start
-            var durationStartBuckets = buckets.Where(s => s.Name == "default_operation" && s.Resource == "default-resource" && s.Service == "default-service" && s.Synthetics == false && s.Type == "default-type" && s.HttpStatusCode == 200);
+            var durationStartBuckets = stats.Where(s => s.Name == "default_operation" && s.Resource == "default-resource" && s.Service == "default-service" && s.Synthetics == false && s.Type == "default-type" && s.HttpStatusCode == 200);
             durationStartBuckets.Should().HaveCount(1);
             durationStartBuckets.Single().Hits.Should().Be(3);
             durationStartBuckets.Single().Duration.Should().Be(beforeY2KDuration.ToNanoseconds());
 
-            var durationStartSpans = spans.Where(s => s.OperationName == "default_operation" && s.ResourceName == "default-resource" && s.ServiceName == "default-service" && s.Context.Origin != "synthetics" && s.Type == "default-type" && s.GetTag(Tags.HttpStatusCode) == "200");
+            var durationStartSpans = spans.Where(s => s.Name == "default_operation" && s.Resource == "default-resource" && s.Service == "default-service" && s.GetTag(Tags.Origin) != "synthetics" && s.Type == "default-type" && s.GetTag(Tags.HttpStatusCode) == "200");
             durationStartSpans.Should().HaveCount(3);
-            durationStartSpans.Sum(s => s.Duration.ToNanoseconds()).Should().Be(beforeY2KDuration.ToNanoseconds());
+            durationStartSpans.Sum(s => s.Duration).Should().Be(beforeY2KDuration.ToNanoseconds());
 
             // Assert normaliztion of types
-            buckets.Where(s => s.Type == truncatedTypeString).Should().ContainSingle("types are truncated at 100 characters");
-            buckets.Where(s => s.Type != truncatedTypeString).Should().OnlyContain(s => s.Type == "default-type");
+            stats.Where(s => s.Type == truncatedTypeString).Should().ContainSingle("types are truncated at 100 characters");
+            stats.Where(s => s.Type != truncatedTypeString).Should().OnlyContain(s => s.Type == "default-type");
 
             spans.Where(s => s.Type == truncatedTypeString).Should().ContainSingle("types are truncated at 100 characters");
             spans.Where(s => s.Type != truncatedTypeString).Should().OnlyContain(s => s.Type == "default-type");
 
             // Assert normaliztion of http status codes
-            buckets.Where(s => s.HttpStatusCode == 0).Sum(s => s.Hits).Should().Be(3, "http.status_code key is deleted if it's an invalid numeric value smaller than 100 or bigger than 600");
-            buckets.Where(s => s.HttpStatusCode != 0).Should().OnlyContain(s => s.HttpStatusCode == 200);
+            stats.Where(s => s.HttpStatusCode == 0).Sum(s => s.Hits).Should().Be(3, "http.status_code key is deleted if it's an invalid numeric value smaller than 100 or bigger than 600");
+            stats.Where(s => s.HttpStatusCode != 0).Should().OnlyContain(s => s.HttpStatusCode == 200);
 
             spans.Where(s => s.GetTag(Tags.HttpStatusCode) is null).Should().HaveCount(3, "http.status_code key is deleted if it's an invalid numeric value smaller than 100 or bigger than 600");
             spans.Where(s => s.GetTag(Tags.HttpStatusCode) is not null).Should().OnlyContain(s => s.GetTag(Tags.HttpStatusCode) == "200");
 
-            Span CreateDefaultSpan()
+            Span CreateDefaultSpan(string serviceName = null, string operationName = null, string resourceName = null, string type = null, string httpStatusCode = null, bool finishOnClose = true)
             {
-                using (var scope = tracer.StartActiveInternal("default-operation", finishOnClose: false))
+                using (var scope = tracer.StartActiveInternal(operationName ?? "default-operation", finishOnClose: finishOnClose))
                 {
                     var span = scope.Span;
-                    span.ResourceName = "default-resource";
-                    span.Type = "default-type";
-                    span.SetTag(Tags.HttpStatusCode, "200");
+
+                    span.ResourceName = resourceName ?? "default-resource";
+                    span.Type = type ?? "default-type";
+                    span.SetTag(Tags.HttpStatusCode, httpStatusCode ?? "200");
+                    span.ServiceName = serviceName ?? "default-service";
+
                     return span;
                 }
             }
@@ -243,21 +206,22 @@ namespace Datadog.Trace.IntegrationTests
 
             var immutableSettings = settings.Build();
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
-            List<Span> spans = new();
             SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000);
 
-            spans.Add(CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc1287681964'"));
-            spans.Add(CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964'"));
+            CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc1287681964'");
+            CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964'");
 
-            spans.Add(CreateDefaultSpan(type: "cassandra", resource: "SELECT * FROM TABLE WHERE userId = 'abc1287681964'"));
-            spans.Add(CreateDefaultSpan(type: "cassandra", resource: "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964'"));
+            CreateDefaultSpan(type: "cassandra", resource: "SELECT * FROM TABLE WHERE userId = 'abc1287681964'");
+            CreateDefaultSpan(type: "cassandra", resource: "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964'");
 
-            spans.Add(CreateDefaultSpan(type: "redis", resource: "SET le_key le_value"));
-            spans.Add(CreateDefaultSpan(type: "redis", resource: "SET another_key another_value"));
+            CreateDefaultSpan(type: "redis", resource: "SET le_key le_value");
+            CreateDefaultSpan(type: "redis", resource: "SET another_key another_value");
 
             await tracer.FlushAsync();
 
             var statsPayload = agent.WaitForStats(1);
+            var spans = agent.WaitForSpans(13);
+
             statsPayload.Should().HaveCount(1);
             statsPayload[0].Stats.Should().HaveCount(1);
 
@@ -271,16 +235,25 @@ namespace Datadog.Trace.IntegrationTests
             sqlBuckets.Should().ContainSingle();
             sqlBuckets.Single().Hits.Should().Be(2);
             sqlBuckets.Single().Resource.Should().Be("SELECT * FROM TABLE WHERE userId = ?");
+            spans.Where(s => s.Type == "sql").Should()
+                .HaveCount(2)
+                .And.OnlyContain(s => s.Resource == "SELECT * FROM TABLE WHERE userId = ?");
 
             var cassandraBuckets = buckets.Where(stats => stats.Type == "cassandra");
             cassandraBuckets.Should().ContainSingle();
             cassandraBuckets.Single().Hits.Should().Be(2);
             cassandraBuckets.Single().Resource.Should().Be("SELECT * FROM TABLE WHERE userId = ?");
+            spans.Where(s => s.Type == "cassandra").Should()
+                .HaveCount(2)
+                .And.OnlyContain(s => s.Resource == "SELECT * FROM TABLE WHERE userId = ?");
 
             var redisBuckets = buckets.Where(stats => stats.Type == "redis");
             redisBuckets.Should().ContainSingle();
             redisBuckets.Single().Hits.Should().Be(2);
             redisBuckets.Single().Resource.Should().Be("SET");
+            spans.Where(s => s.Type == "redis").Should()
+                .HaveCount(2)
+                .And.OnlyContain(s => s.Resource == "SET");
 
             Span CreateDefaultSpan(string type, string resource)
             {

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
@@ -43,8 +44,7 @@ namespace Datadog.Trace.IntegrationTests
             var beforeY2KDuration = TimeSpan.FromMilliseconds(2000);
             var year2KDateTime = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            var agentConfiguration = new MockTracerAgent.AgentConfiguration();
-            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), configuration: agentConfiguration);
+            using var agent = MockTracerAgent.Create(null, TcpPortProvider.GetOpenPort());
 
             var settings = new TracerSettings
             {
@@ -61,7 +61,7 @@ namespace Datadog.Trace.IntegrationTests
             var immutableSettings = settings.Build();
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
             Span span;
-            SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000);
+            // SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000); // TODO: Replace with discovery logic
 
             // Service
             // - If service is empty, it is set to DefaultServiceName
@@ -189,8 +189,7 @@ namespace Datadog.Trace.IntegrationTests
         [Fact]
         public async Task SendsStatsWithProcessing_Obfuscator()
         {
-            var agentConfiguration = new MockTracerAgent.AgentConfiguration();
-            using var agent = MockTracerAgent.Create(TcpPortProvider.GetOpenPort(), configuration: agentConfiguration);
+            using var agent = MockTracerAgent.Create(null, TcpPortProvider.GetOpenPort());
 
             var settings = new TracerSettings
             {
@@ -206,7 +205,7 @@ namespace Datadog.Trace.IntegrationTests
 
             var immutableSettings = settings.Build();
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
-            SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000);
+            // SpinWait.SpinUntil(() => tracer.CanComputeStats, 5_000); // TODO: Replace with discovery logic
 
             CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc1287681964'");
             CreateDefaultSpan(type: "sql", resource: "SELECT * FROM TABLE WHERE userId = 'abc\\'1287\\'681\\'\\'\\'\\'964'");

--- a/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -34,10 +34,12 @@ namespace Datadog.Trace.Tests
         public void PushStats()
         {
             var statsAggregator = new Mock<IStatsAggregator>();
+            ArraySegment<Span> trace = CreateTrace(1);
+            statsAggregator.Setup(x => x.ProcessTrace(trace)).Returns(trace);
 
             var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator.Object, statsd: null, automaticFlush: false);
 
-            agent.WriteTrace(CreateTrace(1), true);
+            agent.WriteTrace(trace, true);
 
             statsAggregator.Verify(s => s.AddRange(It.Is<ArraySegment<Span>>(x => x.Offset == 0 && x.Count == 1)), Times.Once);
         }

--- a/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceProcessors/ObfuscatorTraceProcessorTests.cs
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Tests.TraceProcessors
         [MemberData(nameof(GetSqlObfuscatedQuery))]
         public void SqlObfuscatorTest(string inValue, string expectedValue)
         {
-            var actualValue = Trace.TraceProcessors.ObfuscatorTraceProcessor.ObfuscateSqlResource(inValue);
+            var actualValue = Trace.Processors.ObfuscatorTraceProcessor.ObfuscateSqlResource(inValue);
             Assert.Equal(expectedValue, actualValue);
         }
     }


### PR DESCRIPTION
## Summary of changes
When stats computation is enabled, we run the `NormalizerTraceProcessor` and the `ObfuscatorTraceProcessor` on the finished spans before they are added to sketches.

## Reason for change
When performing stats computation, we aggregate stats based on an aggregation key, which is a unique combination of the following span fields:
- Resource
- Service
- OperationName
- Type
- HttpStatusCode
- IsSyntheticsRequest

Without obfuscation and normalization, we risk creating a substantially large amount of buckets because resource names may have high cardinality. By performing obfuscation and normalization reduce memory overhead by grouping more stats into a smaller number of buckets.

## Implementation details
The main changes are:
1. When the `StatsAggregator` is constructed, we automatically store the `NormalizerTraceProcessor` and the `ObfuscatorTraceProcessor` in an instance array field.
2. We add a new API `IStatsAggregator.ProcessTrace`
3. Immediately before creating stats from a finished trace (invoking `IStatsAggregator.AddRange`), we invoke the new `IStatsAggregator.ProcessTrace` API

## Test coverage
Adds integration tests for each normalization and obfuscation rule that's enabled by default

## Other details
Instead of adding a new `IStatsAggregator.ProcessTrace` API, we could invoke the processors inside the existing `IStatsAggregator.AddRange` API, but we might need to change some types around since the `ITraceProcessor` accepts and returns an object of type `ArraySegment<Span>`.

We could also place the trace processors in a different object, but I thought it made the most sense for the `StatsAggregator` to hold the references because it is the `StatsAggregator` object which is responsible for knowing whether it is safe to compute stats at a certain moment in time.
