### PR TITLE
Fix race condition during profilers initialization

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -119,7 +119,7 @@ private:
     {
         auto runtimeId = _pRuntimeIdStore->GetId(rawSample.AppDomainId);
 
-        Sample sample(rawSample.Timestamp, runtimeId == nullptr ? std::string() : std::string(runtimeId));
+        Sample sample(rawSample.Timestamp, runtimeId == nullptr ? std::string_view() : std::string_view(runtimeId));
         if (rawSample.LocalRootSpanId != 0 && rawSample.SpanId != 0)
         {
             sample.AddLabel(Label{Sample::LocalRootSpanIdLabel, std::to_string(rawSample.LocalRootSpanId)});

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -117,7 +117,9 @@ private:
 
     Sample TransformRawSample(const TRawSample& rawSample)
     {
-        Sample sample(rawSample.Timestamp, _pRuntimeIdStore->GetId(rawSample.AppDomainId));
+        auto runtimeId = _pRuntimeIdStore->GetId(rawSample.AppDomainId);
+
+        Sample sample(rawSample.Timestamp, runtimeId == nullptr ? std::string() : std::string(runtimeId));
         if (rawSample.LocalRootSpanId != 0 && rawSample.SpanId != 0)
         {
             sample.AddLabel(Label{Sample::LocalRootSpanIdLabel, std::to_string(rawSample.LocalRootSpanId)});

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -174,6 +174,9 @@ namespace datadog::shared::nativeloader
             info5 = nullptr;
         }
 
+        m_info = info5 != nullptr ? info5 : info4;
+        m_this = this;
+
         // Gets the initial value for the event mask
         DWORD mask_low = 0;
         DWORD mask_hi = 0;
@@ -354,11 +357,7 @@ namespace datadog::shared::nativeloader
         {
             Log::Warn("CorProfiler::Initialize: Error setting the event mask.");
             return E_FAIL;
-        }
-
-        m_info = info5 != nullptr ? info5 : info4;
-
-        m_this = this;
+        }               
 
         return S_OK;
     }


### PR DESCRIPTION
## Summary of changes

Finish initializing the native loader before initializing the profilers.

## Reason for change

There is a race condition where the continuous profiler might call the native loader before it has finished initializing.

## Implementation details

 - The native loader now properly assigns `m_this` and `m_info` before initializing the profilers
 - As an added safety measure, the continous profiler now expects that `GetRuntimeId` could return a null pointer
