### PR TITLE
[Profiler] Try to use default UDS path on Linux

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -144,11 +144,29 @@ ddprof_ffi_EndpointV3 LibddprofExporter::CreateEndpoint(IConfiguration* configur
     }
     else
     {
-        // agent mode
-        std::stringstream oss;
-        oss << "http://" << configuration->GetAgentHost() << ":" << configuration->GetAgentPort();
-        _agentUrl = oss.str();
+        // Agent mode
+
+#if _WINDOWS        
+        bool useDefaultDomainSocket = false;
+#else
+        std::error_code ec; // std::filesystem::exists might throw if no error_code parameter is provided
+        bool useDefaultDomainSocket = std::filesystem::exists("/var/run/datadog/apm.socket", ec);
+#endif
+
+        if (useDefaultDomainSocket)
+        {
+            _agentUrl = "unix:///var/run/datadog/apm.socket";
+        }
+        else
+        {
+            // Use default HTTP endpoint
+            std::stringstream oss;
+            oss << "http://" << configuration->GetAgentHost() << ":" << configuration->GetAgentPort();
+            _agentUrl = oss.str();
+        }
     }
+
+    Log::Info("Using agent endpoint ", _agentUrl);
 
     return ddprof_ffi_EndpointV3_agent(FfiHelper::StringToCharSlice(_agentUrl));
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -18,6 +18,10 @@
 #include <string.h>
 #include <time.h>
 
+#ifndef _WINDOWS
+#include <filesystem>
+#endif
+
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -18,10 +18,6 @@
 #include <string.h>
 #include <time.h>
 
-#ifndef _WINDOWS
-#include <filesystem>
-#endif
-
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 
@@ -150,11 +146,11 @@ ddprof_ffi_EndpointV3 LibddprofExporter::CreateEndpoint(IConfiguration* configur
     {
         // Agent mode
 
-#if _WINDOWS        
+#if _WINDOWS
         bool useDefaultDomainSocket = false;
 #else
-        std::error_code ec; // std::filesystem::exists might throw if no error_code parameter is provided
-        bool useDefaultDomainSocket = std::filesystem::exists("/var/run/datadog/apm.socket", ec);
+        std::error_code ec; // fs::exists might throw if no error_code parameter is provided
+        bool useDefaultDomainSocket = fs::exists("/var/run/datadog/apm.socket", ec);
 #endif
 
         if (useDefaultDomainSocket)


### PR DESCRIPTION
## Summary of changes

When no agent url is provided, the tracer tries to bind to the default UDS path (`/var/run/datadog/apm.socket`), before falling back to the default HTTP endpoint (`http://localhost:8126`).

This PR makes the profiler behavior consistent with the tracer.

## Reason for change

Consistency :yay2:

## Test coverage

:awkward-monkey:

