### PR TITLE
Add a very simplistic snapshots checker

### DIFF
--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -1,0 +1,23 @@
+name: Label PRs
+
+on:
+- pull_request
+
+jobs:
+  check-snapshots:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.100'
+
+      - name: "Check Snapshots"
+        run: ./tracer/build.sh SummaryOfSnapshotChanges
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -161,8 +161,8 @@ partial class Build
                     markdown.Append("```").AppendLine();
                 }
 
-                Console.WriteLine(markdown.ToString());
-                // await PostCommentToPullRequest(PullRequestNumber.Value, markdown.ToString());
+                // Console.WriteLine(markdown.ToString());
+                await PostCommentToPullRequest(PullRequestNumber.Value, markdown.ToString());
 
                 void RecordChange(StringBuilder diffsInFile, Dictionary<string, int> diffCounts)
                 {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -156,7 +156,7 @@ partial class Build
                 foreach (var diff in diffCounts)
                 {
                     markdown.AppendLine($"{diff.Value} occurrences of : ");
-                    markdown.AppendLine("```");
+                    markdown.AppendLine("```diff");
                     markdown.AppendLine(diff.Key);
                     markdown.Append("```").AppendLine();
                 }

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -86,6 +86,102 @@ partial class Build
             Console.WriteLine($"PR assigned");
         });
 
+    Target SummaryOfSnapshotChanges => _ => _
+           .Unlisted()
+           .Requires(() => GitHubRepositoryName)
+           .Requires(() => GitHubToken)
+           .Requires(() => PullRequestNumber)
+           .Executes(async() =>
+            {
+                var client = GetGitHubClient();
+
+                var pr = await client.PullRequest.Get(
+                    owner: GitHubRepositoryOwner,
+                    name: GitHubRepositoryName,
+                    number: PullRequestNumber.Value);
+
+                // Fixes an issue (ambiguous argument) when we do git diff in the Action.
+                GitTasks.Git("fetch origin master:master", logOutput: false);
+
+                // This is a dumb implementation that just show the diff
+                // We could imagine getting the whole context with -U1000 and show the differences including parent name
+                // eg now we show -oldAttribute: oldValue, but we could show -tag.oldattribute: oldvalue
+                var changes = GitTasks.Git("diff master -- tracer/test/snapshots")
+                                   .Select(f => f.Text);
+
+
+                const int minFiles = 50;
+                var nbSnapshotsModified = changes.Count(f => f.Contains("@@ "));
+                if (nbSnapshotsModified < minFiles)
+                {
+                    // Dumb early exit, if we modify less than 50 files, we can review them manually
+                    // Also it's certainly an addition of snapshot tests, so may not make sense to print a summary.
+                    Console.WriteLine("${nbSnapshotsModified} snapshots modified. Not doing snapshots diff for PRs modifying less than ${minFiles}.");
+                    return;
+                }
+
+                const string unlinkedLinesExplicitor = "[...]";
+                var diffCounts = new Dictionary<string, int>();
+                StringBuilder diffsInFile = new();
+                var lastLineContainedAChange = false;
+                foreach (var line in changes)
+                {
+                    if (line.StartsWith("@@")) // new file
+                    {
+                        RecordChange(diffsInFile, diffCounts);
+                        lastLineContainedAChange = false;
+                        continue;
+                    }
+
+                    if (line.StartsWith("- ") || line.StartsWith("+ "))
+                    {
+                        diffsInFile.AppendLine(line);
+                        lastLineContainedAChange = true;
+                        continue;
+                    }
+
+                    if (lastLineContainedAChange)
+                    {
+                        diffsInFile.AppendLine(unlinkedLinesExplicitor);
+                        lastLineContainedAChange = false;
+                    }
+                }
+
+                RecordChange(diffsInFile, diffCounts);
+
+                var markdown = new StringBuilder();
+                markdown.AppendLine("## Snapshots difference summary").AppendLine();
+                markdown.AppendLine("The following differences have been observed in snapshots. So diff is simplistic, so please check some files anyway while we improve it.").AppendLine();
+
+                foreach (var diff in diffCounts)
+                {
+                    markdown.AppendLine($"{diff.Value} occurrences of : ");
+                    markdown.AppendLine("```");
+                    markdown.AppendLine(diff.Key);
+                    markdown.Append("```").AppendLine();
+                }
+
+                Console.WriteLine(markdown.ToString());
+                // await PostCommentToPullRequest(PullRequestNumber.Value, markdown.ToString());
+
+                void RecordChange(StringBuilder diffsInFile, Dictionary<string, int> diffCounts)
+                {
+                    var unlinkedLinesExplicitorWithNewLine = unlinkedLinesExplicitor + Environment.NewLine;
+
+                    if (diffsInFile.Length > 0)
+                    {
+                        var change = diffsInFile.ToString();
+                        if (change.EndsWith(unlinkedLinesExplicitorWithNewLine))
+                        {
+                            change = change.Substring(0, change.Length - unlinkedLinesExplicitorWithNewLine.Length);
+                        }
+                        diffCounts.TryAdd(change, 0);
+                        diffCounts[change]++;
+                        diffsInFile.Clear();
+                    }
+                }
+            });
+
     Target AssignLabelsToPullRequest => _ => _
        .Unlisted()
        .Requires(() => GitHubRepositoryName)


### PR DESCRIPTION
## Summary of changes
Adding a github action that will print a summary of the diffs in the snapshots in a PR comment if we have more than 50 snapshots modified. The comment would look like something like this:

## Snapshots difference summary
The following differences have been observed in snapshots. So diff is simplistic, so please check some files anyway while we improve it.

950 occurrences of:
```diff
+    attribute: value
   [...]
+        tag:value
```

1 occurrences of:
```diff
+    attribute: value
   [...]
+        tag:value
-        ohboy: there's a bug
```

This shows the place in the hierarchy thanks to the number of spaces. So not great. 

## Reason for change
To start simplifying snapshots review.

## Implementation details
- Diff on snapshots file
- Foreach file check the change
- Count occurences

## Test coverage
Quick local tests

## Other details
I think we clearly need to improve this. It may be too simplistic. A few ideas:
- show the full path eg `tags.tagname: value`, `metrics.metricname: value`
- identify where the change happens: rootspan only, all spans, subset of spans
