### PR TITLE
Fix macOS logs and add `DD_INTERNAL_NATIVE_LOADER_PATH` env var

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -79,6 +79,12 @@ namespace datadog::shared::nativeloader
 
     void DynamicDispatcherImpl::LoadConfiguration(fs::path&& configFilePath)
     {
+        ::shared::WSTRING nativeLoaderPath = ::shared::GetCurrentModuleFileName();
+        ::shared::WSTRING nativeLoaderPathKey = WStr("DD_INTERNAL_NATIVE_LOADER_PATH");
+        Log::Debug("DynamicDispatcherImpl::LoadConfiguration:  Setting environment variable: ", nativeLoaderPathKey, "=", nativeLoaderPath);
+        bool nativeLoaderEnvSet = ::shared::SetEnvironmentValue(nativeLoaderPathKey, nativeLoaderPath);
+        Log::Debug("DynamicDispatcherImpl::LoadConfiguration: SetEnvironmentValue result: ", nativeLoaderEnvSet);
+        
         if (!fs::exists(configFilePath))
         {
             Log::Warn("DynamicDispatcherImpl::LoadConfiguration: Configuration file doesn't exist.");

--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -114,7 +114,7 @@ std::shared_ptr<spdlog::logger> Logger::CreateInternalLogger()
     try
     {
         logger =
-            spdlog::rotating_logger_mt("Logger", Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10);
+            spdlog::rotating_logger_mt(LoggerPolicy::file_name, Logger::GetLogPath<LoggerPolicy>(file_name_suffix), 1048576 * 5, 10);
     }
     catch (...)
     {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -527,6 +527,16 @@ bool ShouldRewriteProfilerMaps()
 
 std::string GetNativeLoaderFilePath()
 {
+    // should be set by native loader
+    shared::WSTRING nativeLoaderPath = shared::GetEnvironmentValue(WStr("DD_INTERNAL_NATIVE_LOADER_PATH"));
+    if (!nativeLoaderPath.empty())
+    {
+        return shared::ToString(nativeLoaderPath);
+    }
+
+    // variable not set - try to infer the location instead
+    Logger::Debug("DD_INTERNAL_NATIVE_LOADER_PATH variable not found. Inferring native loader path");
+
     auto native_loader_filename =
 #ifdef LINUX
         "Datadog.Trace.ClrProfiler.Native.so";


### PR DESCRIPTION
## Summary of changes

- Fix native tracer logs on macos
- Set `DD_INTERNAL_NATIVE_LOADER_PATH` in native loader for use by native tracer/profiler etc

## Reason for change

After the switch to the native loader for the macos tool in https://github.com/DataDog/dd-trace-dotnet/pull/3060 , the logging library was failing, creating empty files. After some debugging, we established this was because: `LoggerImpl Handler: Error creating native log file. logger with name 'Logger' already exists`. We were previously passing `Logger` to all the log instances, but now we're passing the file name prefix e.g. `dotnet-native-loader`/`dotnet-tracer-native` etc. 

> No idea why this was _only_ causing issues on mac, but it seems like a safe change 🤷‍♂️ 

Setting the `DD_INTERNAL_NATIVE_LOADER_PATH` path in the native loader means we no longer need to try and infer where the native loader is for PInvokes, which is error prone (we had a hidden bug around this prior to the layout refactor). We already set variables such as `DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH` in `LoadConfiguration()` which are used similarly. Kept the fallback logic just in case, but logging when we hit it, as we shouldn't!

## Implementation details

For the logs issue, updated the logger name to use `LoggerPolicy::file_name` (which doesn't include process name or pid).

For the `DD_INTERNAL_NATIVE_LOADER_PATH` variable:
- Updated the native loader to set the env var first, just before reading configuration
- Updated the profiler's RuntimeStore to use the env var if available
- Updated the tracer to use the env var preferentially for rewriting PInvokes

## Test coverage

Should be covered by existing tests. I'll also check the smoke tests to make sure the env var is being used rather than the inferred post.

## Other details
Look ma', I'm doing :cplusplus: 
