### PR TITLE
Add a few smoke tests for the `dd-trace` NuGet package

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2724,6 +2724,68 @@ stages:
         baseImage: alpine
         command: "CheckBuildLogsForErrors"
 
+- stage: dotnet_tool_nuget_smoke_tests_linux
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux]
+
+  - job: linux
+    timeoutInMinutes: 10 # should take ~5 mins
+    strategy:
+      matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_nuget_installer_linux_smoke_tests_matrix'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: ubuntu-18.04
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tool runner-dotnet-tool
+      inputs:
+        artifact: runner-dotnet-tool
+        path: $(smokeTestAppDir)/artifacts
+
+    - script: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+      displayName: create test data directories
+
+    - script: |
+        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          dotnet-tool-nuget-smoke-tests
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build  dotnet-tool-nuget-smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dotnet-tool-nuget-smoke-tests'
+        snapshotPrefix: "smoke_test"
+
+    - publish: tracer/build_data
+      artifact: dotnet-tool-nuget-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: alpine
+        command: "CheckBuildLogsForErrors"
+
 - stage: dotnet_tool_smoke_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, generate_variables, master_commit_id]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -744,3 +744,22 @@ services:
     - DD_TRACE_AGENT_URL=http://test-agent:8126
     depends_on:
     - test-agent
+
+  dotnet-tool-nuget-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-nuget-tester
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+    - test-agent

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -240,6 +240,8 @@ partial class Build : NukeBuild
                 GenerateLinuxDotnetToolSmokeTestsMatrix();
                 GenerateLinuxDotnetToolSmokeTestsArm64Matrix();
 
+                GenerateLinuxDotnetToolNugetSmokeTestsMatrix();
+
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
                 
@@ -653,6 +655,39 @@ partial class Build : NukeBuild
                     Logger.Info($"Installer smoke tests dotnet-tool matrix Arm64");
                     Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetVariable("dotnet_tool_installer_smoke_tests_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateLinuxDotnetToolNugetSmokeTestsMatrix()
+                {
+                    var matrix = new Dictionary<string, object>();
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
+                        },
+                        platformSuffix: "linux-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/sdk"
+                    );
+
+                    AddToDotNetToolSmokeTestsMatrix(
+                        matrix,
+                        "alpine",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
+                        },
+                        platformSuffix: "linux-musl-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/sdk"
+                    );
+
+                    Logger.Info($"Installer smoke tests dotnet-tool NuGet matrix Linux");
+                    Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetVariable("dotnet_tool_nuget_installer_linux_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void AddToDotNetToolSmokeTestsMatrix(

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -1,0 +1,38 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /app/install
+
+ARG INSTALL_CMD
+RUN mkdir -p /opt/datadog \
+    && mkdir -p /var/log/datadog \
+    && mkdir -p /tool \
+    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. \
+    && rm -rf /app/install
+
+# Set the optional env vars
+ENV DD_PROFILING_ENABLED=1
+ENV DD_APPSEC_ENABLED=1
+ENV DD_TRACE_DEBUG=1
+ENV ASPNETCORE_URLS=http://localhost:5000
+ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["/tool/dd-trace", "dotnet", "/app/AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Added some basic smoke tests for the `dd-trace` NuGet.

## Reason for change

We already smoke test the self-contained `dd-trace` executable, but we haven't been testing the `dd-trace` .NET tool NuGet package itself. They are ostensibly the same thing, so it's not a big issue, but we should have some basic tests at least.

## Implementation details

Added a new smoke tests section, only runs on `master` by default like most of the other smoke tests.

## Test coverage

I did a manual run of the new stage [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=107596&view=results)

## Other details

