### PR TITLE
Small build tidy up - improve log file checking

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2664,7 +2664,7 @@ stages:
       parameters:
         build: true
         baseImage: alpine
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
 
 - stage: nuget_installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -2734,7 +2734,7 @@ stages:
       parameters:
         build: true
         baseImage: alpine
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_nuget_smoke_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -2796,7 +2796,7 @@ stages:
       parameters:
         build: true
         baseImage: alpine
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_smoke_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -2862,7 +2862,7 @@ stages:
       parameters:
         build: true
         baseImage: alpine
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
         
 - stage: installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -2921,7 +2921,7 @@ stages:
           parameters:
             build: true
             baseImage: debian
-            command: "CheckBuildLogsForErrors"
+            command: "CheckSmokeTestsForErrors"
 
 - stage: nuget_installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -2990,7 +2990,7 @@ stages:
       parameters:
         build: true
         baseImage: debian
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -3052,7 +3052,7 @@ stages:
       parameters:
         build: true
         baseImage: debian
-        command: "CheckBuildLogsForErrors"
+        command: "CheckSmokeTestsForErrors"
 
 - stage: nuget_installer_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -3120,8 +3120,8 @@ stages:
       continueOnError: true
 
     - template: steps/install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd CheckBuildLogsForErrors
-      displayName: CheckBuildLogsForErrors
+    - script: tracer\build.cmd CheckSmokeTestsForErrors
+      displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -3185,8 +3185,8 @@ stages:
       continueOnError: true
 
     - template: steps/install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd CheckBuildLogsForErrors
-      displayName: CheckBuildLogsForErrors
+    - script: tracer\build.cmd CheckSmokeTestsForErrors
+      displayName: CheckSmokeTestsForErrors
 
 - stage: msi_installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
@@ -3250,8 +3250,8 @@ stages:
       continueOnError: true
 
     - template: steps/install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd CheckBuildLogsForErrors
-      displayName: CheckBuildLogsForErrors
+    - script: tracer\build.cmd CheckSmokeTestsForErrors
+      displayName: CheckSmokeTestsForErrors
 
 - stage: tracer_home_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -3314,8 +3314,8 @@ stages:
       continueOnError: true
 
     - template: steps/install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd CheckBuildLogsForErrors
-      displayName: CheckBuildLogsForErrors
+    - script: tracer\build.cmd CheckSmokeTestsForErrors
+      displayName: CheckSmokeTestsForErrors
 
 - stage: trace_pipeline
   condition: eq(variables['isBenchmarksOnlyBuild'], 'False')

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -160,7 +160,7 @@ partial class Build
 
     Target GeneratePackageVersions => _ => _
        .Description("Regenerate the PackageVersions props and .cs files")
-       .DependsOn(Clean, Restore, CreateRequiredDirectories, CompileManagedSrc, PublishManagedProfiler)
+       .DependsOn(Clean, Restore, CreateRequiredDirectories, CompileManagedSrc, PublishManagedTracer)
        .Executes(async () =>
        {
            var testDir = Solution.GetProject(Projects.ClrProfilerIntegrationTests).Directory;

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -117,8 +117,8 @@ partial class Build : NukeBuild
             EnsureCleanDirectory(MonitoringHomeDirectory);
             EnsureCleanDirectory(OutputDirectory);
             EnsureCleanDirectory(ArtifactsDirectory);
-            EnsureCleanDirectory(NativeProfilerProject.Directory / "build");
-            EnsureCleanDirectory(NativeProfilerProject.Directory / "deps");
+            EnsureCleanDirectory(NativeTracerProject.Directory / "build");
+            EnsureCleanDirectory(NativeTracerProject.Directory / "deps");
             EnsureCleanDirectory(BuildDataDirectory);
             EnsureCleanDirectory(ExplorationTestsDirectory);
             DeleteFile(WindowsTracerHomeZip);
@@ -148,9 +148,9 @@ partial class Build : NukeBuild
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(Restore)
         .DependsOn(CompileManagedSrc)
-        .DependsOn(PublishManagedProfiler)
+        .DependsOn(PublishManagedTracer)
         .DependsOn(CompileNativeSrc)
-        .DependsOn(PublishNativeProfiler)
+        .DependsOn(PublishNativeTracer)
         .DependsOn(DownloadLibDdwaf)
         .DependsOn(CopyLibDdwaf)
         .DependsOn(BuildNativeLoader);

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -152,7 +152,8 @@ partial class Build : NukeBuild
         .DependsOn(CompileNativeSrc)
         .DependsOn(PublishNativeProfiler)
         .DependsOn(DownloadLibDdwaf)
-        .DependsOn(CopyLibDdwaf);
+        .DependsOn(CopyLibDdwaf)
+        .DependsOn(BuildNativeLoader);
 
     Target BuildProfilerHome => _ => _
         .Description("Builds the Profiler native and managed src, and publishes the profiler home directory")
@@ -198,7 +199,6 @@ partial class Build : NukeBuild
         .DependsOn(CreatePlatformlessSymlinks)
         .DependsOn(CompileSamplesWindows)
         .DependsOn(CompileIntegrationTests)
-        .DependsOn(BuildNativeLoader)
         .DependsOn(BuildRunnerTool);
 
     Target BuildAspNetIntegrationTests => _ => _
@@ -209,8 +209,7 @@ partial class Build : NukeBuild
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CreatePlatformlessSymlinks)
         .DependsOn(PublishIisSamples)
-        .DependsOn(CompileIntegrationTests)
-        .DependsOn(BuildNativeLoader);
+        .DependsOn(CompileIntegrationTests);
 
     Target BuildWindowsRegressionTests => _ => _
         .Unlisted()
@@ -221,8 +220,7 @@ partial class Build : NukeBuild
         .DependsOn(CompileRegressionDependencyLibs)
         .DependsOn(CompileRegressionSamples)
         .DependsOn(CompileFrameworkReproductions)
-        .DependsOn(CompileIntegrationTests)
-        .DependsOn(BuildNativeLoader);
+        .DependsOn(CompileIntegrationTests);
 
     Target BuildAndRunWindowsIntegrationTests => _ => _
         .Requires(() => IsWin)


### PR DESCRIPTION
## Summary of changes
- Automatically run `BuildNativeLoader` as part of `BuildTracerHome`
- Split the checks we do for build logs vs smoke test logs
- Add log checking for native loader log files
- Rename incorrect named Nuke targets (e.g. `PublishNativeProfiler` -> `PublishNativeTracer`) 

## Reason for change

**Automatically run `BuildNativeLoader` as part of `BuildTracerHome`**
We always need to run this locally for testing, and we always run them together in CI, so simplifies local dev slightly

**Split the checks we do for build logs vs smoke test logs**
The build logs intentionally check some error conditions, so we expect to see some logs and warnings in there. By splitting the checks in two, we can be more conservative with those checks, while for the smoke tests we can fail on errors _and_ warnings, and we can insist that the logs definitely exist.

We still need to exclude some expected errors/warnings:
- AppSec always complains when loading on alpine
- Profiler isn't yet supported on Arm64

**Add log checking for native loader log files**
We should be checking these logs, for example they will describe issues calling the native libraries etc

**Rename incorrectly named Nuke targets**
Historically we called the "tracer" the "profiler", but that's more confusing now we have the continuous profiler, so updated those targets

## Implementation details

## Test coverage
I'm running the full set of smoke tests [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=107657&view=results) to confirm they're not broken.

## Other details
GitHub makes a real mess of the diff in the `CheckBuildLogs` target, it hasn't changed significantly!
