### PR TITLE
[CIVisibility] Add support to bypass some ci environment variables

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
@@ -149,5 +149,10 @@ namespace Datadog.Trace.Ci.Tags
         /// Library Version
         /// </summary>
         public const string LibraryVersion = "library_version";
+
+        /// <summary>
+        /// Environment variables from CI
+        /// </summary>
+        public const string CiEnvVars = "_dd.ci.env_vars";
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -75,6 +75,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
             }
         }
 
+        internal static void DecorateSpanWithRuntimeAndCiInformation(Span span)
+        {
+            // CI Environment variables data
+            CIEnvironmentValues.Instance.DecorateSpan(span);
+
+            // Runtime information
+            var framework = FrameworkDescription.Instance;
+            span.SetTag(CommonTags.LibraryVersion, TracerConstants.AssemblyVersion);
+            span.SetTag(CommonTags.RuntimeName, framework.Name);
+            span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
+        }
+
         internal static void StartCoverage()
         {
             Ci.Coverage.CoverageReporter.Handler.StartSession();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -51,16 +51,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             span.SetTag(TestTags.Framework, testFramework);
             span.SetTag(TestTags.FrameworkVersion, type.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
-            CIEnvironmentValues.Instance.DecorateSpan(span);
-
-            var framework = FrameworkDescription.Instance;
-            span.SetTag(CommonTags.LibraryVersion, TracerConstants.AssemblyVersion);
-            span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
-            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
             // Get test parameters
             ParameterInfo[] methodParameters = testMethod.GetParameters();
@@ -91,6 +81,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             {
                 span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(testTraits));
             }
+
+            // CI Environment Variables and Runtime information
+            Common.DecorateSpanWithRuntimeAndCiInformation(span);
 
             // Test code and code owners
             Common.DecorateSpanWithSourceAndCodeOwners(span, testMethod);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -64,16 +64,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.SetTag(TestTags.Framework, testFramework);
             span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
-            CIEnvironmentValues.Instance.DecorateSpan(span);
-
-            var framework = FrameworkDescription.Instance;
-            span.SetTag(CommonTags.LibraryVersion, TracerConstants.AssemblyVersion);
-            span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
-            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
             // Get test parameters
             ParameterInfo[] methodParameters = testMethod.GetParameters();
@@ -138,6 +128,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                     span.SetTag(TestTags.Traits, Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
                 }
             }
+
+            // CI Environment Variables and Runtime information
+            Common.DecorateSpanWithRuntimeAndCiInformation(span);
 
             // Test code and code owners
             Common.DecorateSpanWithSourceAndCodeOwners(span, testMethod);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -43,17 +43,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
 
-            var framework = FrameworkDescription.Instance;
-            CIEnvironmentValues.Instance.DecorateSpan(span);
-
-            span.SetTag(CommonTags.LibraryVersion, TracerConstants.AssemblyVersion);
-            span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
-            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
-
             // Get test parameters
             object[] testMethodArguments = runnerInstance.TestMethodArguments;
             ParameterInfo[] methodParameters = runnerInstance.TestMethod.GetParameters();
@@ -85,6 +74,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             {
                 span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
             }
+
+            // CI Environment Variables and Runtime information
+            Common.DecorateSpanWithRuntimeAndCiInformation(span);
 
             // Test code and code owners
             Common.DecorateSpanWithSourceAndCodeOwners(span, runnerInstance.TestMethod);


### PR DESCRIPTION
## Summary of changes
This PR adds support to bypass/include some environment variables from CI to be used by the backend

## Reason for change

Follow the approved RFC https://docs.google.com/document/d/1LjApVXNCpv_UOypSdMrkaQ6iMkCQ26SLK_ahE8FAFaQ/edit#

## Implementation details

The implementation also contains a refactor of common code between testing framework integrations.