### PR TITLE
Fix build error in OSX when using sdk version 6.0.400

### DIFF
--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.7.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes
Fix build error on OSX when using sdk version 6.0.400

## Reason for change

Master doesn't build using this sdk version. It fails with the following error:

```Build FAILED.

       "/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln" (Restore target) (1) ->
       (_FilterRestoreGraphProjectInputItems target) ->
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj : warning NU1503: Skipping restore for project '/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj'. The project file may be invalid or missing targets required for restore. [/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln]
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj : warning NU1503: Skipping restore for project '/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj'. The project file may be invalid or missing targets required for restore. [/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln]
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj : warning NU1503: Skipping restore for project '/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/test/Datadog.Tracer.Native.Tests/Datadog.Tracer.Native.Tests.vcxproj'. The project file may be invalid or missing targets required for restore. [/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln]
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj : warning NU1503: Skipping restore for project '/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj'. The project file may be invalid or missing targets required for restore. [/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln]
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj : warning NU1503: Skipping restore for project '/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj'. The project file may be invalid or missing targets required for restore. [/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln]


       "/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln" (Restore target) (1) ->
       "/Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj" (_GenerateRestoreProjectPathWalk target) (115:2) ->
       (CollectPackageReferences target) ->
         /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj : error NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: Microsoft.NET.Test.Sdk 15.7.0, Microsoft.NET.Test.Sdk 16.7.1.

    5 Warning(s)
    1 Error(s)

Time Elapsed 00:00:13.62
ProcessException: Process 'dotnet' exited with code 1.
   > /usr/local/share/dotnet/dotnet restore /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln --verbosity Normal /property:configuration=Release
   @ /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer

   at Nuke.Common.Tooling.ProcessExtensions.AssertZeroExitCode(IProcess process)
   at Nuke.Common.Tools.DotNet.DotNetTasks.DotNetRestore(DotNetRestoreSettings toolSettings)
   at Nuke.Common.Tools.DotNet.DotNetTasks.DotNetRestore(Configure`1 configurator)
   at Build.<get_Restore>b__270_1() in /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer/build/_build/Build.Steps.cs:line 150
   at Nuke.Common.Execution.BuildExecutor.<>c.<Execute>b__4_0(Action x)
   at Nuke.Common.Utilities.Collections.EnumerableExtensions.ForEach[T](IEnumerable`1 enumerable, Action`1 action)
   at Nuke.Common.Execution.BuildExecutor.Execute(NukeBuild build, ExecutableTarget target, IReadOnlyCollection`1 previouslyExecutedTargets, Boolean failureMode)


Repeating warnings and errors:
ProcessException: Process 'dotnet' exited with code 1.
   > /usr/local/share/dotnet/dotnet restore /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/Datadog.Trace.sln --verbosity Normal /property:configuration=Release
   @ /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/tracer


════════════════════════════════════════════════════
Target                          Status      Duration
────────────────────────────────────────────────────
Restore                         Failed          0:14
CreateRequiredDirectories       NotRun
CompileManagedSrc               NotRun
PublishManagedProfiler          NotRun
CompileNativeSrcMacOs           NotRun
CompileNativeSrcLinux           Skipped                // EnvironmentInfo.IsLinux
CompileNativeSrcWindows         Skipped                // EnvironmentInfo.IsWin
CompileNativeSrc                NotRun
PublishNativeProfilerUnix       NotRun
PublishNativeProfilerWindows    Skipped                // EnvironmentInfo.IsWin
PublishNativeProfiler           NotRun
DownloadLibDdwaf                NotRun
CopyLibDdwaf                    NotRun
BuildTracerHome                 NotRun
────────────────────────────────────────────────────
Total                                           0:14
════════════════════════════════════════════════════

Build failed on 16/8/2022 13:19:39. (╯°□°）╯︵ ┻━┻```
