### PR TITLE
[Snapshots] Add a note on version mismatch tests

### DIFF
--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -1,4 +1,4 @@
-name: Label PRs
+name: Check snapshots
 
 on:
 - pull_request

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -109,21 +109,22 @@ partial class Build
                 var changes = GitTasks.Git("diff master -- tracer/test/snapshots")
                                    .Select(f => f.Text);
 
-
                 const int minFiles = 50;
                 var nbSnapshotsModified = changes.Count(f => f.Contains("@@ "));
                 if (nbSnapshotsModified < minFiles)
                 {
                     // Dumb early exit, if we modify less than 50 files, we can review them manually
                     // Also it's certainly an addition of snapshot tests, so may not make sense to print a summary.
-                    Console.WriteLine("${nbSnapshotsModified} snapshots modified. Not doing snapshots diff for PRs modifying less than ${minFiles}.");
+                    Console.WriteLine($"{nbSnapshotsModified} snapshots modified. Not doing snapshots diff for PRs modifying less than {minFiles}.");
                     return;
                 }
 
                 const string unlinkedLinesExplicitor = "[...]";
+                var crossVersionTestsNamePattern = new [] {"VersionMismatchNewerNugetTests"};
                 var diffCounts = new Dictionary<string, int>();
                 StringBuilder diffsInFile = new();
                 var lastLineContainedAChange = false;
+                var considerUpdatingPublicFeed = false;
                 foreach (var line in changes)
                 {
                     if (line.StartsWith("@@")) // new file
@@ -145,6 +146,11 @@ partial class Build
                         diffsInFile.AppendLine(unlinkedLinesExplicitor);
                         lastLineContainedAChange = false;
                     }
+
+                    if (!considerUpdatingPublicFeed && crossVersionTestsNamePattern.Any(p => line.Contains(p)))
+                    {
+                        considerUpdatingPublicFeed = true;
+                    }
                 }
 
                 RecordChange(diffsInFile, diffCounts);
@@ -152,6 +158,11 @@ partial class Build
                 var markdown = new StringBuilder();
                 markdown.AppendLine("## Snapshots difference summary").AppendLine();
                 markdown.AppendLine("The following differences have been observed in snapshots. So diff is simplistic, so please check some files anyway while we improve it.").AppendLine();
+
+                if (considerUpdatingPublicFeed)
+                {
+                    markdown.AppendLine("**Note** that this PR updates a version mismatch test. You may need to upgrade your code in the Azure public feed");
+                }
 
                 foreach (var diff in diffCounts)
                 {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -172,7 +172,7 @@ partial class Build
                     markdown.Append("```").AppendLine();
                 }
 
-                // Console.WriteLine(markdown.ToString());
+                await HideCommentsInPullRequest(PullRequestNumber.Value, "## Snapshots difference");
                 await PostCommentToPullRequest(PullRequestNumber.Value, markdown.ToString());
 
                 void RecordChange(StringBuilder diffsInFile, Dictionary<string, int> diffCounts)

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -297,6 +297,11 @@ partial class Build
                 continue;
             }
 
+            if (fileName.Contains("VersionMismatchNewerNugetTests"))
+            {
+                Logger.Warn("Updated snapshots contain a version mismatch test. You may need to upgrade your code in the Azure public feed.");
+            }
+
             var trimmedName = fileName.Substring(0, fileName.Length - suffixLength);
             var dest = Path.Combine(snapshotsDirectory, $"{trimmedName}verified{Path.GetExtension(source)}");
             MoveFile(source, dest, FileExistsPolicy.Overwrite, createDirectories: true);


### PR DESCRIPTION
## Summary of changes
Add a note in snapshots update (the one you run locally) and in snapshot summary (the one running on PRs) stating that we may need to update the nuget for crossversion tests.
I've also simplified the output to remove the noise (like same addition in different context). This one I believe is better but I can revert the commit if people think having the context is helpful.

The diff now is:
1874 occurrences of : 
```diff
+      _dd.p.dm: -1

```
267 occurrences of : 
```diff
+      _dd.p.dm: -1,

```

whereas it was 

661 occurrences of : 
```diff
-      span.kind: client
+      span.kind: client,
+      _dd.p.dm: -1

```
876 occurrences of : 
```diff
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.p.dm: -1

```
290 occurrences of : 
```diff
-      span.kind: server
+      span.kind: server,
+      _dd.p.dm: -1

```
47 occurrences of : 
```diff
-      runtime-id: Guid_1
+      runtime-id: Guid_1,
+      _dd.p.dm: -1

```
267 occurrences of : 
```diff
+      _dd.p.dm: -1,

```

## Reason for change
When updating default sampling rate, it took me a while to realize that the NewerNugetVersion tests were failing because I didn't update the package on the public feed with the current code. Lucas had the same issue. Thus, I figured it would be good to add this as a reminder wherever possible

## Implementation details
Changed both the snapshot updater and checker. Based the verification on the snapshots name. I believe only the `TraceAnnotations.NewerNuget` tests are concerned with this.
Also added the resolution of previous comments as it is done for benchmarks

## Test coverage
N/A

## Other details
I've documented the upload process in [confluence](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2258142437/CI+Devops#Add-a-new-nuget-version-to-the-public-feed)
