### PR TITLE
[Profiler] Improve error reported by libddprof

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -122,10 +122,8 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
                    s_signalToSend, " to thread with osThreadId=", osThreadId, ".");
 #endif
         s_pInstanceCurrentlyStackWalking = this;
-        auto scopeFinalizer = CreateScopeFinalizer(
-            [] {
-                s_pInstanceCurrentlyStackWalking = nullptr;
-            });
+
+        on_leave { s_pInstanceCurrentlyStackWalking = nullptr; };
 
         _stackWalkFinished = false;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -4,6 +4,7 @@
 #include "LibddprofExporter.h"
 
 #include "FfiHelper.h"
+#include "ScopeFinalizer.h"
 #include "IApplicationStore.h"
 #include "IMetricsSender.h"
 #include "Log.h"
@@ -262,7 +263,8 @@ bool LibddprofExporter::Export()
         // reset the samples count
         profileInfo.samplesCount = 0;
         auto* profile = profileInfo.profile;
-        auto profileAutoReset = ProfileAutoReset{profile};
+        on_leave { ddprof_ffi_Profile_reset(profile, nullptr); };
+
         auto serializedProfile = SerializedProfile{profile};
         if (!serializedProfile.IsValid())
         {
@@ -381,17 +383,21 @@ bool LibddprofExporter::Send(ddprof_ffi_Request* request, ddprof_ffi_ProfileExpo
 
     auto result = ddprof_ffi_ProfileExporterV3_send(exporter, request, nullptr);
 
+    on_leave { ddprof_ffi_SendResult_drop(result); };
+
     if (result.tag == DDPROF_FFI_SEND_RESULT_ERR)
     {
         // There is an overflow issue when using the error buffer from rust
         // Log::Error("libddprof error: Failed to send profile (", result.failure.ptr, ")");
-        Log::Error("libddprof error: Failed to send profile.");
+        Log::Error("libddprof error: Failed to send profile (", std::string((const char*)(result.err.ptr), result.err.len), ")");
         return false;
     }
 
     // Although we expect only 200, this range represents successful sends
     auto isSuccess = result.http_response.code >= 200 && result.http_response.code < 300;
     Log::Info("The profile was sent. Success?", std::boolalpha, isSuccess, std::noboolalpha, ", Http code: ", result.http_response.code);
+
+
     return isSuccess;
 }
 
@@ -498,20 +504,6 @@ void LibddprofExporter::Tags::Add(std::string const& labelName, std::string cons
 const ddprof_ffi_Vec_tag* LibddprofExporter::Tags::GetFfiTags() const
 {
     return &_ffiTags;
-}
-
-//
-// LibddprofExporter::Profile class
-//
-
-LibddprofExporter::ProfileAutoReset::ProfileAutoReset(struct ddprof_ffi_Profile* profile) :
-    _profile{profile}
-{
-}
-
-LibddprofExporter::ProfileAutoReset::~ProfileAutoReset()
-{
-    ddprof_ffi_Profile_reset(_profile, nullptr);
 }
 
 //

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -387,7 +387,7 @@ bool LibddprofExporter::Send(ddprof_ffi_Request* request, ddprof_ffi_ProfileExpo
 
     if (result.tag == DDPROF_FFI_SEND_RESULT_ERR)
     {
-        Log::Error("libddprof error: Failed to send profile (", std::string((const char*)(result.err.ptr), result.err.len), ")");
+        Log::Error("libddprof error: Failed to send profile (", std::string(reinterpret_cast<const char*>(result.err.ptr), result.err.len), ")");
         return false;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -387,8 +387,6 @@ bool LibddprofExporter::Send(ddprof_ffi_Request* request, ddprof_ffi_ProfileExpo
 
     if (result.tag == DDPROF_FFI_SEND_RESULT_ERR)
     {
-        // There is an overflow issue when using the error buffer from rust
-        // Log::Error("libddprof error: Failed to send profile (", result.failure.ptr, ")");
         Log::Error("libddprof error: Failed to send profile (", std::string((const char*)(result.err.ptr), result.err.len), ")");
         return false;
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -387,7 +387,7 @@ bool LibddprofExporter::Send(ddprof_ffi_Request* request, ddprof_ffi_ProfileExpo
 
     if (result.tag == DDPROF_FFI_SEND_RESULT_ERR)
     {
-        Log::Error("libddprof error: Failed to send profile (", std::string(reinterpret_cast<const char*>(result.err.ptr), result.err.len), ")");
+        Log::Error("libddprof error: Failed to send profile (", std::string(reinterpret_cast<const char*>(result.err.ptr), result.err.len), ")"); // NOLINT
         return false;
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -66,16 +66,6 @@ private:
         ddprof_ffi_Vec_tag _ffiTags;
     };
 
-    class ProfileAutoReset
-    {
-    public:
-        ProfileAutoReset(struct ddprof_ffi_Profile* profile);
-        ~ProfileAutoReset();
-
-    private:
-        struct ddprof_ffi_Profile* _profile;
-    };
-
     class ProfileInfo
     {
     public:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ScopeFinalizer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ScopeFinalizer.h
@@ -4,6 +4,10 @@
 #pragma once
 #include <functional>
 
+struct DeferDummy
+{
+};
+
 template <class T>
 struct FinalizerInvocationWrapper
 {
@@ -56,8 +60,14 @@ private:
     bool _isEnabled;
 };
 
-template <class T>
-inline FinalizerInvocationWrapper<T> CreateScopeFinalizer(T&& finalizerCallback)
+template <class F>
+FinalizerInvocationWrapper<F> operator*(DeferDummy, F&& f)
 {
-    return FinalizerInvocationWrapper(std::move(finalizerCallback));
+    return FinalizerInvocationWrapper<F>{std::forward<F>(f)};
 }
+
+
+#define DEFER_(LINE) zz_defer##LINE
+#define DEFER(LINE) DEFER_(LINE)
+#define on_leave \
+    const auto& DEFER(__COUNTER__) = DeferDummy{}* [&]()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -307,10 +307,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Notify the loop manager that we are starting a stack collection, and set up a finalizer to notify the manager when we finsih it.
             // This will enable the manager to monitor if this collection freezes due to a deadlock.
 
-            auto scopeFinalizer = CreateScopeFinalizer(
-                [this] {
-                    _pManager->NotifyIterationFinished();
-                });
+            on_leave { _pManager->NotifyIterationFinished(); };
 
             // On Windows, we will now suspend the target thread.
             // On Linux, if we use signals, the suspension may be a no-op since signal handlers do not use explicit suspension.
@@ -337,7 +334,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Perform the stack walk according to bitness, OS, platform, sync/async stack-walking, etc..:
             {
                 // We rely on RAII to call NotifyCollectionEnd when we get out this scope.
-                auto endCollectionScope = CreateScopeFinalizer([this] { _pManager->NotifyCollectionEnd(); });
+                on_leave { _pManager->NotifyCollectionEnd(); };
 
                 _pManager->NotifyCollectionStart();
                 pStackSnapshotResult = _pStackFramesCollector->CollectStackSample(pThreadInfo, &hrCollectStack);


### PR DESCRIPTION
## Summary of changes

## Reason for change

There was an overflow when retrieving the error string from libddprof. Until now it was not possible to know what was the issue.
 
In addition to that, we forgot to release the `SendResult` which would leak memory.

## Implementation details

Get the the error string and log it
+ add `on_leave` macro to simplify the use of RAII

## Test coverage

## Other details
<!-- Fixes #{issue} -->
