### PR TITLE
[Profiler] Fix Sanitizer jobs

### DIFF
--- a/profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh
+++ b/profiler/src/ProfilerEngine/DeployResources/DDProf-SetEnv.sh
@@ -14,11 +14,11 @@ fi
 
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}
-export CORECLR_PROFILER_PATH_64=${DD_DEPLOY_DIRECTORY}/linux-x64/Datadog.Profiler.Native.so
+export CORECLR_PROFILER_PATH_64=${DD_DEPLOY_DIRECTORY}/Datadog.Profiler.Native.so
 
 export COMPlus_EnableDiagnostics=1
 export DD_PROFILING_ENABLED=1
 
-export LD_PRELOAD=${DD_DEPLOY_DIRECTORY}/linux-x64/Datadog.Linux.ApiWrapper.x64.so
+export LD_PRELOAD=${DD_DEPLOY_DIRECTORY}/Datadog.Linux.ApiWrapper.x64.so
 
 echo "DD_DEPLOY_DIRECTORY=${DD_DEPLOY_DIRECTORY}"


### PR DESCRIPTION
## Summary of changes

## Reason for change

Sanitizer jobs are failing. They expect the profiler library to be found in `<deploy_dir>/linux-x64` but this is not the output directory (still `<deply_dir>`)

## Implementation details

Remove unneeded folder component.

## Test coverage

Sanitizer jobs

## Other details
<!-- Fixes #{issue} -->
