### PR TITLE
Add .NET Framework 4.8.1 to `FrameworkDescription`

### DIFF
--- a/tracer/src/Datadog.Trace/FrameworkDescription.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace
         private static readonly Tuple<int, string>[] DotNetFrameworkVersionMapping =
         {
             // known min value for each framework version
+            Tuple.Create(533325, "4.8.1"),
             Tuple.Create(528040, "4.8"),
             Tuple.Create(461808, "4.7.2"),
             Tuple.Create(461308, "4.7.1"),


### PR DESCRIPTION
## Summary of changes

Adds .NET Framework 4.8.1 to our known list of .NET Framework versions

## Reason for change

.NET Framework 4.8.1 was released out of nowhere 😄 

## Implementation details

Update `FrameworkDescription.DotNetFrameworkVersionMapping`. An [upcoming official docs update](https://github.com/dotnet/docs/pull/30619) describes the minimum Release REG_DWORD for .NET Framework 4.8.1.

## Test coverage

## Other details

