### PR TITLE
Fix build when using C#11

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -528,7 +528,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
-                return EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
+                EndMethodHandler<TIntegration, TTarget>.Invoke(instance, exception, in state);
             }
 
             return CallTargetReturn.GetDefault();
@@ -551,7 +551,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
                 IntegrationOptions<TIntegration, TTarget>.RecordTelemetry();
-                return EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
+                var result = EndMethodHandler<TIntegration, TTarget, TReturn>.Invoke(instance, returnValue, exception, in state);
+                return new CallTargetReturn<TReturn>(result.GetReturnValue());
             }
 
             return new CallTargetReturn<TReturn>(returnValue);


### PR DESCRIPTION
## Summary of changes

This PR contains workarounds to build the solution when using C#11

## Reason for change

C#11 introduces a couple of breaking changes that are affecting us in the methods we kept for backward compatibility in the `CallTargetInvoker` class, especifically the `CS8166` and `CS8347`

More info can be found in: https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/breaking-changes/compiler%20breaking%20changes%20-%20dotnet%207

![image](https://user-images.githubusercontent.com/69803/185591495-55ac0b52-86a5-4628-86bb-03d8d05536c3.png)


