### PR TITLE
Force fpm gem install to not update dependencies

### DIFF
--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -20,6 +20,7 @@ RUN apk update \
         xz-dev \
         gdb \
         musl-dbg \
+    && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
     && gem install --minimal-deps --no-document fpm
 

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -21,7 +21,7 @@ RUN apk update \
         gdb \
         musl-dbg \
     && gem install --version 2.7.6 dotenv \
-    && gem install --no-document fpm
+    && gem install --minimal-deps --no-document fpm
 
 ENV IsAlpine=true
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -54,7 +54,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
-    gem install -V --minimal-deps fpm
+    gem install --minimal-deps fpm
 
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -46,9 +46,7 @@ RUN yum update -y \
         sudo \
         gawk
 
-# Install newer version of fpm and specific versions of:
-# - dotenv
-# - git: Stay on 1.11.0 because 1.12.0 (released on August 18, 2022) adds a new dependency on addressable, which adds a new dependency on public_suffix, which adds a new requirement of Ruby version >= 2.3
+# Install newer version of fpm and specific version of dotenv 
 RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 1.12.2 --user-install ffi && \
     gem install --version 1.6.0 --user-install git && \
@@ -56,7 +54,6 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
-    gem install --version 1.11.0 git && \
     gem install fpm
 
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -54,7 +54,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
-    gem install fpm
+    gem install -V fpm
 
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -46,7 +46,9 @@ RUN yum update -y \
         sudo \
         gawk
 
-# Install newer version of fpm and specific version of dotenv 
+# Install newer version of fpm and specific versions of:
+# - dotenv
+# - git: Stay on 1.11.0 because 1.12.0 (released on August 18, 2022) adds a new dependency on addressable, which adds a new dependency on public_suffix, which adds a new requirement of Ruby version >= 2.3
 RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 1.12.2 --user-install ffi && \
     gem install --version 1.6.0 --user-install git && \
@@ -54,6 +56,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
+    gem install --version 1.11.0 git && \
     gem install fpm
 
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -54,7 +54,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
-    gem install -V fpm
+    gem install -V --minimal-deps fpm
 
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
         liblzma-dev \
         gdb \
     && gem install --version 2.7.6 dotenv \
-    && gem install --no-document fpm \
+    && gem install --minimal-deps --no-document fpm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
         libtool \
         liblzma-dev \
         gdb \
+    && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
     && gem install --minimal-deps --no-document fpm \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary of changes
Fixes the `fpm` gem install by adding the flag `--minimal-deps`, which adds the following behavior: `Don’t upgrade any dependencies that already meet version requirements`.

This fixes the build by preventing the `fpm` gem install from upgrading the `git` gem from 1.6.0 to 1.12.0, [which was newly released](https://github.com/ruby-git/ruby-git/releases/tag/v1.12.0). In 1.12.0, the `git` gem adds a [new dependency chain](https://github.com/ruby-git/ruby-git/compare/v1.11.0...v1.12.0#diff-3c11824e45e259ec5ae838d5a598e16bb83ceba3cdb24ca7c3cb45d780ba516dR29): `addressable => public_suffix`. The `public_suffix` gem adds a requirement on the Ruby version of `>= 2.3` for gem version 4.0.7 and Ruby version of `>= 2.6` for gem version 5.0.0.

## Reason for change
Builds failing, babies crying.

## Implementation details

## Test coverage
Ran the following tests on the linux packages

### amd64.deb
```bash
debdiff pipeline-before-issues/datadog-dotnet-apm_2.14.0_amd64.deb pipeline-zach-fix-fpm/datadog-dotnet-apm_2.14.0_amd64.deb
File lists identical (after any substitutions)

Control files: lines which differ (wdiff format)
------------------------------------------------
Installed-Size: [-53809-] {+53813+}
Maintainer: [-<@2fd5d1836c4c>-] {+<@ff84d0a6bbec>+
```

### arm64.deb
```bash
debdiff pipeline-before-issues/datadog-dotnet-apm_2.14.0_arm64.deb pipeline-zach-fix-fpm/datadog-dotnet-apm_2.14.0_arm64.deb
File lists identical (after any substitutions)

Control files: lines which differ (wdiff format)
------------------------------------------------
Installed-Size: [-52948-] {+52952+}
Maintainer: [-<@ad0fe6318c27>-] {+<@b385ab392182>+}
```

### tar.gz
```bash
diff \
<(pax -v -z -f pipeline-before-issues/datadog-dotnet-apm-2.14.0.tar.gz | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-) \
<(pax -v -z -f pipeline-zach-fpm-fix/datadog-dotnet-apm-2.14.0.tar.gz  | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-)
# Empty result
```

For reference, `pax` essentially spits out the contents of an archive in the style of `ls -l`, `head` is removing the last line, `sed` is replacing multiple spaces with one space, `cut` is removing the columns that correspond to the timestamps and file size, and `diff` is comparing the results

### arm64.tar.gz
```bash
diff \
<(pax -v -z -f pipeline-before-issues/datadog-dotnet-apm-2.14.0.arm64.tar.gz | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-) \
<(pax -v -z -f pipeline-zach-fpm-fix/datadog-dotnet-apm-2.14.0.arm64.tar.gz  | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-)
# Empty result
```

### musl.tar.gz
```bash
diff \
<(pax -v -z -f pipeline-before-issues/datadog-dotnet-apm-2.14.0-musl.tar.gz | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-) \
<(pax -v -z -f pipeline-zach-fpm-fix/datadog-dotnet-apm-2.14.0-musl.tar.gz  | head -n -1 | sed 's/  */ /g' | cut -d' ' -f1-4,9-)
# Empty result
```

### x86_64.rpm
```bash
diff \
<(rpm -q --dump --scripts -p pipeline-before-issues/datadog-dotnet-apm-2.14.0-1.x86_64.rpm | cut -d' ' -f1,5-) \
<(rpm -q --dump --scripts -p pipeline-zach-fpm-fix/datadog-dotnet-apm-2.14.0-1.x86_64.rpm  | cut -d' ' -f1,5-)
# Empty result
```

For reference, `rpm --dump` essentially spits out the contents of the rpm, `cut` is removing the columns that correspond to the file size, last modified time, and MD5 checksum, and `diff` is comparing the results

### aarch64.rpm
```bash
diff \
<(rpm -q --dump --scripts -p pipeline-before-issues/datadog-dotnet-apm-2.14.0-1.aarch64.rpm | cut -d' ' -f1,5-) \
<(rpm -q --dump --scripts -p pipeline-zach-fpm-fix/datadog-dotnet-apm-2.14.0-1.aarch64.rpm  | cut -d' ' -f1,5-)
# Empty result
```

## Other details
Note: This may inadvertently change what gems are pulled in because now we're no longer updating them. I could use some help validating that the resulting output files are the same. For reference, here is the [gemspec](https://github.com/jordansissel/fpm/blob/v1.14.0/fpm.gemspec) for the latest `fpm` gem that we use.
