### PR TITLE
Use default monitoringHome path if env var is empty

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -15,6 +15,9 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
 {
+    /// <summary>
+    /// asdf
+    /// </summary>
     public class EnvironmentHelper
     {
         private static readonly string RuntimeFrameworkDescription = RuntimeInformation.FrameworkDescription.ToLower();

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.TestHelpers
         {
             var monitoringHomeDirectoryEnvVar = "MonitoringHomeDirectory";
             var monitoringHome = Environment.GetEnvironmentVariable(monitoringHomeDirectoryEnvVar);
-            if (!string.IsNullOrEmpty(monitoringHome))
+            if (string.IsNullOrEmpty(monitoringHome))
             {
                 // default
                 monitoringHome = Path.Combine(

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -15,9 +15,6 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
 {
-    /// <summary>
-    /// asdf
-    /// </summary>
     public class EnvironmentHelper
     {
         private static readonly string RuntimeFrameworkDescription = RuntimeInformation.FrameworkDescription.ToLower();


### PR DESCRIPTION
## Summary of changes

Inverts the check for `monitoringHome` path so that if it isn't retrieved from the `MonitoringHomeDirectory` environment variable that it'll use the default path. This seemed to block integration tests running on VS (I likely don't have this env var) but Nuke seemed to work fine.

## Reason for change

Couldn't get integration tests to run via VS. If you don't have the `MonitoringHomeDirectory` environment variable set nothing would be used for the `monitoringHome` path and the test run would exit.

Also this appeared to just override the `MonitoringHomeDirectory` environment variable value with the default setting.

## Implementation details

Check if `monitoringHome` is null/empty string, and if so use the default path.

## Test coverage

- I tested a single integration test in VS and Nuke and it worked now where it previously only worked if run via Nuke

