### PR TITLE
Fix incorrect default in `GetMonitoringHomePath()`

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.TestHelpers
         {
             var monitoringHomeDirectoryEnvVar = "MonitoringHomeDirectory";
             var monitoringHome = Environment.GetEnvironmentVariable(monitoringHomeDirectoryEnvVar);
-            if (!string.IsNullOrEmpty(monitoringHome))
+            if (string.IsNullOrEmpty(monitoringHome))
             {
                 // default
                 monitoringHome = Path.Combine(


### PR DESCRIPTION
## Summary of changes

Fix not setting default correctly in `GetMonitoringHomePath()`

## Reason for change

Breaks tests when running locally in VS
