### PR TITLE
Add `unchecked` to FNV hash calculations

### DIFF
--- a/tracer/src/Datadog.Trace/Util/FnvHash64.cs
+++ b/tracer/src/Datadog.Trace/Util/FnvHash64.cs
@@ -127,10 +127,13 @@ internal static class FnvHash64
         // for each octet_of_data to be hashed
         foreach (var b in bytes)
         {
-            // hash = hash * FNV_prime
-            hash *= FnvPrime;
-            // hash = hash xor octet_of_data
-            hash ^= b;
+            unchecked
+            {
+                // hash = hash * FNV_prime
+                hash *= FnvPrime;
+                // hash = hash xor octet_of_data
+                hash ^= b;
+            }
         }
 
         return hash;
@@ -141,10 +144,13 @@ internal static class FnvHash64
         // for each octet_of_data to be hashed
         foreach (var b in bytes)
         {
-            // hash = hash xor octet_of_data
-            hash ^= b;
-            // hash = hash * FNV_prime
-            hash *= FnvPrime;
+            unchecked
+            {
+                // hash = hash xor octet_of_data
+                hash ^= b;
+                // hash = hash * FNV_prime
+                hash *= FnvPrime;
+            }
         }
 
         return hash;
@@ -156,10 +162,13 @@ internal static class FnvHash64
         // for each octet_of_data to be hashed
         foreach (var b in bytes)
         {
-            // hash = hash * FNV_prime
-            hash *= FnvPrime;
-            // hash = hash xor octet_of_data
-            hash ^= b;
+            unchecked
+            {
+                // hash = hash * FNV_prime
+                hash *= FnvPrime;
+                // hash = hash xor octet_of_data
+                hash ^= b;
+            }
         }
 
         return hash;
@@ -170,10 +179,13 @@ internal static class FnvHash64
         // for each octet_of_data to be hashed
         foreach (var b in bytes)
         {
-            // hash = hash xor octet_of_data
-            hash ^= b;
-            // hash = hash * FNV_prime
-            hash *= FnvPrime;
+            unchecked
+            {
+                // hash = hash xor octet_of_data
+                hash ^= b;
+                // hash = hash * FNV_prime
+                hash *= FnvPrime;
+            }
         }
 
         return hash;


### PR DESCRIPTION
## Summary of changes

Adds `unchecked` to the FNV hash calculations

## Reason for change

We should be doing `unchecked` calculations (so that we quietly overflow).

## Implementation details

Added `unchecked` around the calculations. Technically I don't think these are necessary because
- [`unchecked` is the default](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/checked-and-unchecked)
- `checked` contexts don't propagate into functions, so if the callee added `checked` it shouldn't matter
- [I think `CheckForOverflowUnderflow` only applies to our assembly](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language#checkforoverflowunderflow), so prob not an issue
But better safe than sorry!

## Test coverage
Couldn't find a good way to test it, but all the existing tests pass

## Other details
Thanks for flagging @kevingosse 