### PR TITLE
[Profiler] Add contention profiler based on Clr Events

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -27,6 +27,7 @@ namespace Samples.Computer01
         private AsyncComputation _asyncComputation;
         private IteratorComputation _iteratorComputation;
         private GenericsAllocation _genericsAllocation;
+        private ContentionGenerator _contentionGenerator;
 
         public void StartService(Scenario scenario, int nbThreads)
         {
@@ -82,6 +83,10 @@ namespace Samples.Computer01
                     StartGenericsAllocation(nbThreads);
                     break;
 
+                case Scenario.ContentionGenerator:
+                    StartContentionGenerator(nbThreads);
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
             }
@@ -134,6 +139,10 @@ namespace Samples.Computer01
 
                 case Scenario.GenericsAllocation:
                     StopGenericsAllocation();
+                    break;
+
+                case Scenario.ContentionGenerator:
+                    StopContentionGenerator();
                     break;
             }
         }
@@ -190,6 +199,10 @@ namespace Samples.Computer01
 
                     case Scenario.GenericsAllocation:
                         RunGenericsAllocation(nbThreads);
+                        break;
+
+                    case Scenario.ContentionGenerator:
+                        RunContentionGenerator(nbThreads);
                         break;
 
                     default:
@@ -262,6 +275,12 @@ namespace Samples.Computer01
             _genericsAllocation.Start();
         }
 
+        private void StartContentionGenerator(int nbThreads)
+        {
+            _contentionGenerator = new ContentionGenerator(nbThreads);
+            _contentionGenerator.Start();
+        }
+
         private void StopComputer()
         {
             using (_computer)
@@ -321,6 +340,11 @@ namespace Samples.Computer01
             _genericsAllocation.Stop();
         }
 
+        private void StopContentionGenerator()
+        {
+            _contentionGenerator.Stop();
+        }
+
         private void RunComputer()
         {
             using (var computer = new Computer<byte, KeyValuePair<char, KeyValuePair<int, KeyValuePair<float, object>>>>())
@@ -375,6 +399,12 @@ namespace Samples.Computer01
         {
             var allocations = new GenericsAllocation(nbThreads);
             allocations.Run();
+        }
+
+        private void RunContentionGenerator(int nbThreads)
+        {
+            var contentionGenerator = new ContentionGenerator(nbThreads);
+            contentionGenerator.Run();
         }
 
         public class MySpecialClassA

--- a/profiler/src/Demos/Samples.Computer01/ContentionGenerator.cs
+++ b/profiler/src/Demos/Samples.Computer01/ContentionGenerator.cs
@@ -30,13 +30,13 @@ namespace Samples.Computer01
             }
 
             _stopEvent = new ManualResetEvent(false);
-            _startEvent = new ManualResetEvent(false);
             _activeTasks = CreateThreads();
         }
 
         public void Run()
         {
             Start();
+            Thread.Sleep(TimeSpan.FromSeconds(1)); // to be sure that we got contention events
             Stop();
         }
 

--- a/profiler/src/Demos/Samples.Computer01/ContentionGenerator.cs
+++ b/profiler/src/Demos/Samples.Computer01/ContentionGenerator.cs
@@ -1,0 +1,96 @@
+// <copyright file="ContentionGenerator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Computer01
+{
+    internal class ContentionGenerator
+    {
+        private readonly int _nbThreads;
+        private readonly object _obj = new object();
+        private ManualResetEvent _stopEvent;
+        private List<Task> _activeTasks;
+
+        public ContentionGenerator(int nbThreads)
+        {
+            _nbThreads = nbThreads;
+        }
+
+        public void Start()
+        {
+            if (_stopEvent != null)
+            {
+                throw new InvalidOperationException("Already running...");
+            }
+
+            _stopEvent = new ManualResetEvent(false);
+            _startEvent = new ManualResetEvent(false);
+            _activeTasks = CreateThreads();
+        }
+
+        public void Run()
+        {
+            Start();
+            Stop();
+        }
+
+        public void Stop()
+        {
+            if (_stopEvent == null)
+            {
+                throw new InvalidOperationException("Not running...");
+            }
+
+            _stopEvent.Set();
+
+            Task.WhenAll(_activeTasks).Wait();
+
+            _stopEvent.Dispose();
+            _stopEvent = null;
+            _activeTasks = null;
+        }
+
+        private List<Task> CreateThreads()
+        {
+            var result = new List<Task>(_nbThreads);
+
+            for (var i = 0; i < _nbThreads; i++)
+            {
+                result.Add(
+                    Task.Factory.StartNew(
+                        () =>
+                        {
+                            while (!IsEventSet())
+                            {
+                                GenerateContention();
+                            }
+                        },
+                        TaskCreationOptions.LongRunning));
+            }
+
+            return result;
+        }
+
+        private void GenerateContention()
+        {
+            lock (_obj)
+            {
+                Console.WriteLine($"Thread {Environment.CurrentManagedThreadId} acquired the lock");
+                Thread.Sleep(TimeSpan.FromMilliseconds(300));
+            }
+
+            Console.WriteLine($"Thread {Environment.CurrentManagedThreadId} released the lock");
+        }
+
+        private bool IsEventSet()
+        {
+            return _stopEvent.WaitOne(0);
+        }
+    }
+}

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -22,7 +22,8 @@ namespace Samples.Computer01
         Sleep,
         Async,
         Iterator,
-        GenericsAllocation
+        GenericsAllocation,
+        ContentionGenerator
     }
 
     public class Program
@@ -44,7 +45,7 @@ namespace Samples.Computer01
             // 9: start n threads allocating array of Generic<int> in LOH
             Console.WriteLine($"{Environment.NewLine}Usage:{Environment.NewLine} > {Process.GetCurrentProcess().ProcessName} " +
             $"[--service] [--iterations <number of iterations to execute>] " +
-            $"[--scenario <0=all 1=computer 2=generics 3=wall time 4=pi computation 5=compute fibonacci 6=n sleeping threads 7=async calls 8=iterator calls 9=allocate array of Generic<int>>] " +
+            $"[--scenario <0=all 1=computer 2=generics 3=wall time 4=pi computation 5=compute fibonacci 6=n sleeping threads 7=async calls 8=iterator calls 9=allocate array of Generic<int>> 10=n of threads competing for a lock] " +
             $"[--timeout <duration in seconds> | --run-infinitely]");
             Console.WriteLine();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
-    <TargetName >$(ProfilerEngineNativeTarget)</TargetName>
+    <TargetName>$(ProfilerEngineNativeTarget)</TargetName>
   </PropertyGroup>
   <PropertyGroup>
     <!-- This is required when deining 'AdditionalIncludeDirectories' for 'ResourceCompile' below,          -->

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -59,6 +59,11 @@ void ClrEventsParser::ParseEvent(
 
 void ClrEventsParser::ParseGcEvent(DWORD id, DWORD version, ULONG cbEventData, LPCBYTE pEventData)
 {
+    if (_pAllocationListener == nullptr)
+    {
+        return;
+    }
+
     // look for AllocationTick_V4
     if ((id == EVENT_ALLOCATION_TICK) && (version == 4))
     {
@@ -110,11 +115,6 @@ void ClrEventsParser::ParseGcEvent(DWORD id, DWORD version, ULONG cbEventData, L
             return;
         }
         if (!Read(payload.ObjectSize, pEventData, cbEventData, offset))
-        {
-            return;
-        }
-
-        if (_pAllocationListener == nullptr)
         {
             return;
         }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -21,6 +21,7 @@
 
 #define LONG_LENGTH 1024
 
+#pragma pack(1)
 struct AllocationTickV4Payload
 {
     uint32_t AllocationAmount;     // The allocation size, in bytes.
@@ -46,6 +47,9 @@ struct ContentionStopV1Payload
     uint16_t ClrInstanceId;    // Unique ID for the instance of CLR.
     double_t DurationNs;       // Duration of the contention (without spinning)
 };
+#pragma pack()
+
+class IContentionListener;
 
 class ClrEventsParser
 {
@@ -54,7 +58,7 @@ public:
     static const int KEYWORD_CONTENTION = 0x4000;
 
 public:
-    ClrEventsParser(ICorProfilerInfo12* pCorProfilerInfo, IAllocationsListener* pAllocationListener);
+    ClrEventsParser(ICorProfilerInfo12* pCorProfilerInfo, IAllocationsListener* pAllocationListener, IContentionListener* pContentionListener);
     void ParseEvent(EVENTPIPE_PROVIDER provider,
                     DWORD eventId,
                     DWORD eventVersion,
@@ -105,6 +109,7 @@ private:
 private:
     ICorProfilerInfo12* _pCorProfilerInfo = nullptr;
     IAllocationsListener* _pAllocationListener = nullptr;
+    IContentionListener* _pContentionListener = nullptr;
 
 private:
     const int EVENT_ALLOCATION_TICK = 10;   // version 4 contains the size + reference

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -38,6 +38,7 @@ Configuration::Configuration()
     _isWallTimeProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::WallTimeProfilingEnabled, true);
     _isExceptionProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::ExceptionProfilingEnabled, false);
     _isAllocationProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::AllocationProfilingEnabled, false);
+    _isContentionProfilingEnabled = GetEnvironmentValue(EnvironmentVariables::ContentionProfilingEnabled, false);
     _uploadPeriod = ExtractUploadInterval();
     _userTags = ExtractUserTags();
     _version = GetEnvironmentValue(EnvironmentVariables::Version, DefaultVersion);
@@ -115,6 +116,11 @@ int32_t Configuration::ExceptionSampleLimit() const
 bool Configuration::IsAllocationProfilingEnabled() const
 {
     return _isAllocationProfilingEnabled;
+}
+
+bool Configuration::IsContentionProfilingEnabled() const
+{
+    return _isContentionProfilingEnabled;
 }
 
 double Configuration::MinimumCores() const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -42,6 +42,7 @@ public:
     bool IsExceptionProfilingEnabled() const override;
     int32_t ExceptionSampleLimit() const override;
     bool IsAllocationProfilingEnabled() const override;
+    bool IsContentionProfilingEnabled() const override;
     double MinimumCores() const override;
 
 private:
@@ -74,6 +75,7 @@ private:
     bool _isWallTimeProfilingEnabled;
     bool _isExceptionProfilingEnabled;
     bool _isAllocationProfilingEnabled;
+    bool _isContentionProfilingEnabled;
     bool _debugLogEnabled;
     fs::path _logDirectory;
     fs::path _pprofDirectory;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+#include "ContentionProvider.h"
+
+#include "COMHelpers.h"
+#include "IAppDomainStore.h"
+#include "IFrameStore.h"
+#include "IManagedThreadList.h"
+#include "IRuntimeIdStore.h"
+#include "IThreadsCpuManager.h"
+#include "OsSpecificApi.h"
+#include "Sample.h"
+
+ContentionProvider::ContentionProvider(
+    ICorProfilerInfo4* pCorProfilerInfo,
+    IManagedThreadList* pManagedThreadList,
+    IFrameStore* pFrameStore,
+    IThreadsCpuManager* pThreadsCpuManager,
+    IAppDomainStore* pAppDomainStore,
+    IRuntimeIdStore* pRuntimeIdStore)
+    :
+    CollectorBase<RawContentionSample>("ContentionProvider", pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore),
+    _pCorProfilerInfo{pCorProfilerInfo},
+    _pManagedThreadList{pManagedThreadList}
+{
+}
+
+void ContentionProvider::OnContention(double contentionDuration)
+{
+    ManagedThreadInfo* threadInfo;
+    CALL(_pManagedThreadList->TryGetCurrentThreadInfo(&threadInfo))
+
+    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo);
+    pStackFramesCollector->PrepareForNextCollection();
+
+    uint32_t hrCollectStack = E_FAIL;
+    const auto result = pStackFramesCollector->CollectStackSample(threadInfo, &hrCollectStack);
+    if (result->GetFramesCount() == 0)
+    {
+        Log::Warn("Failed to walk stack for sampled contention: ", HResultConverter::ToStringWithCode(hrCollectStack));
+        return;
+    }
+
+    result->DetermineAppDomain(threadInfo->GetClrThreadId(), _pCorProfilerInfo);
+
+    RawContentionSample rawSample;
+    rawSample.Timestamp = result->GetUnixTimeUtc();
+    rawSample.LocalRootSpanId = result->GetLocalRootSpanId();
+    rawSample.SpanId = result->GetSpanId();
+    rawSample.AppDomainId = result->GetAppDomainId();
+    result->CopyInstructionPointers(rawSample.Stack);
+    rawSample.ThreadInfo = threadInfo;
+    threadInfo->AddRef();
+    rawSample.ContentionDuration = contentionDuration;
+
+    Add(std::move(rawSample));
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+#include "CollectorBase.h"
+
+#include "IContentionListener.h"
+#include "RawContentionSample.h"
+
+class IManagedThreadList;
+class IFrameStore;
+class IThreadsCpuManager;
+class IAppDomainStore;
+class IRuntimeIdStore;
+
+
+class ContentionProvider : public CollectorBase<RawContentionSample>, public IContentionListener
+{
+public:
+    ContentionProvider(
+        ICorProfilerInfo4* pCorProfilerInfo,
+        IManagedThreadList* pManagedThreadList,
+        IFrameStore* pFrameStore,
+        IThreadsCpuManager* pThreadsCpuManager,
+        IAppDomainStore* pAppDomainStore,
+        IRuntimeIdStore* pRuntimeIdStore);
+
+    void OnContention(double contentionDuration) override;
+
+private:
+    ICorProfilerInfo4* _pCorProfilerInfo;
+    IManagedThreadList* _pManagedThreadList;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <vector>
 
+class ContentionProvider;
 class IService;
 class IThreadsCpuManager;
 class IManagedThreadList;
@@ -204,6 +205,7 @@ private :
     WallTimeProvider* _pWallTimeProvider = nullptr;
     CpuTimeProvider* _pCpuTimeProvider = nullptr;
     AllocationsProvider* _pAllocationsProvider = nullptr;
+    ContentionProvider* _pContentionProvider = nullptr;
     SamplesCollector* _pSamplesCollector = nullptr;
 
     std::vector<std::unique_ptr<IService>> _services;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -237,6 +237,7 @@
     <ClInclude Include="EnabledProfilers.h" />
     <ClInclude Include="EnumHelpers.h" />
     <ClInclude Include="COMHelpers.h" />
+    <ClInclude Include="ContentionProvider.h" />
     <ClInclude Include="IAllocationsListener.h" />
     <ClInclude Include="AllocationsProvider.h" />
     <ClInclude Include="AppDomainStore.h" />
@@ -261,6 +262,7 @@
     <ClInclude Include="IApplicationStore.h" />
     <ClInclude Include="ICollector.h" />
     <ClInclude Include="IEnabledProfilers.h" />
+    <ClInclude Include="IContentionListener.h" />
     <ClInclude Include="IFrameStore.h" />
     <ClInclude Include="HResultConverter.h" />
     <ClInclude Include="IClrLifetime.h" />
@@ -284,6 +286,7 @@
     <ClInclude Include="LibddprofExporter.h" />
     <ClInclude Include="ProfilerEngineStatus.h" />
     <ClInclude Include="RawAllocationSample.h" />
+    <ClInclude Include="RawContentionSample.h" />
     <ClInclude Include="RawCpuSample.h" />
     <ClInclude Include="RawExceptionSample.h" />
     <ClInclude Include="RawSample.h" />
@@ -318,6 +321,7 @@
     <ClCompile Include="cgroup.cpp" />
     <ClCompile Include="ClrLifetime.cpp" />
     <ClCompile Include="Configuration.cpp" />
+    <ClCompile Include="ContentionProvider.cpp" />
     <ClCompile Include="CorProfilerCallback.cpp" />
     <ClCompile Include="CorProfilerCallbackFactory.cpp" />
     <ClCompile Include="CpuTimeProvider.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -39,6 +39,9 @@
     <Filter Include="Allocations">
       <UniqueIdentifier>{ebcb3383-0a0b-49fd-a5ad-99ea7b92d783}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Contention">
+      <UniqueIdentifier>{bb4d04f1-ed7e-48db-b2e0-99b56d4f258a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CorProfilerCallback.h">
@@ -246,6 +249,15 @@
     <ClInclude Include="COMHelpers.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="ContentionProvider.h">
+      <Filter>Contention</Filter>
+    </ClInclude>
+    <ClInclude Include="RawContentionSample.h">
+      <Filter>Contention</Filter>
+    </ClInclude>
+    <ClInclude Include="IContentionListener.h">
+      <Filter>Contention</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">
@@ -373,6 +385,9 @@
     </ClCompile>
     <ClCompile Include="EnabledProfilers.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="ContentionProvider.cpp">
+      <Filter>Contention</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnabledProfilers.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnabledProfilers.cpp
@@ -29,6 +29,11 @@ EnabledProfilers::EnabledProfilers(IConfiguration* pConfiguration, bool isListen
             _enabledProfilers |= RuntimeProfiler::Allocations;
         }
 
+        if (pConfiguration->IsContentionProfilingEnabled())
+        {
+            _enabledProfilers |= RuntimeProfiler::Contention;
+        }
+
         // TODO: add new CLR event driven profilers
     }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -30,7 +30,8 @@ public:
     inline static const shared::WSTRING ExceptionProfilingEnabled   = WStr("DD_PROFILING_EXCEPTION_ENABLED");
 
     // only available on .NET 5+
-    inline static const shared::WSTRING AllocationProfilingEnabled  = WStr("DD_PROFILING_ALLOCATION_ENABLED");
+    inline static const shared::WSTRING AllocationProfilingEnabled = WStr("DD_PROFILING_ALLOCATION_ENABLED");
+    inline static const shared::WSTRING ContentionProfilingEnabled = WStr("DD_PROFILING_CONTENTION_ENABLED");
 
     inline static const shared::WSTRING ExceptionSampleLimit        = WStr("DD_PROFILING_EXCEPTION_SAMPLE_LIMIT");
     inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_INTERNAL_PROFILING_OUTPUT_DIR");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -39,5 +39,6 @@ public:
     virtual bool IsExceptionProfilingEnabled() const = 0;
     virtual int32_t ExceptionSampleLimit() const = 0;
     virtual bool IsAllocationProfilingEnabled() const = 0;
+    virtual bool IsContentionProfilingEnabled() const = 0;
     virtual double MinimumCores() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+class IContentionListener
+{
+public:
+    virtual ~IContentionListener() = default;
+
+    virtual void OnContention(double contentionDuration) = 0;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IEnabledProfilers.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IEnabledProfilers.h
@@ -14,7 +14,7 @@ ENUM_FLAGS(RuntimeProfiler, size_t)
     Exceptions = 4,
     Allocations = 8,
 
-    // Contentions = 16
+    Contention = 16
     // Heap = 32
 };
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -204,6 +204,16 @@ std::string LibddprofExporter::GetEnabledProfilersTag(IEnabledProfilers* enabled
         emptyList = false;
     }
 
+    if (enabledProfilers->IsEnabled(RuntimeProfiler::Contention))
+    {
+        if (!emptyList)
+        {
+            buffer << separator;
+        }
+        buffer << "contention";
+        emptyList = false;
+    }
+
     return buffer.str();
 }
 
@@ -355,7 +365,7 @@ bool LibddprofExporter::Export()
         // (i.e. the profileinfo will then contains a null profile field when the next sample will be added)
         // This way, we know that nobody else will ever use that profile again, and we can take our time to manipulate it
         // outside of the lock.
-        {            
+        {
             const auto scope = GetInfo(runtimeId);
 
             // Get everything we need then release the lock

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "RawSample.h"
+
+class RawContentionSample : public RawSample
+{
+public:
+    void OnTransform(Sample& sample) const override
+    {
+        sample.AddValue(1, SampleValue::ContentionCount);
+        sample.AddValue(static_cast<std::int64_t>(ContentionDuration), SampleValue::ContentionDuration);
+    }
+
+    double ContentionDuration;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -49,8 +49,8 @@ enum class SampleValue : size_t
     AllocationSize = 4,
 
     // Thread contention profiler
-    //ContentionCount = 5,
-    //ContentionDuration = 6,
+    ContentionCount = 5,
+    ContentionDuration = 6,
 
 
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -25,6 +25,8 @@ SampleValueType const SampleTypeDefinitions[] =
     {"exception", "count"},     // ExceptionCount
     {"alloc-samples", "count"}, // AllocationCount
     {"alloc-size", "bytes"},    // AllocationSize
+    {"lock-count", "count"},
+    {"lock-duration", "nanoseconds"}
 
     // the new ones should be added here at the same time
     // new identifiers are added to SampleValue
@@ -51,8 +53,6 @@ enum class SampleValue : size_t
     // Thread contention profiler
     ContentionCount = 5,
     ContentionDuration = 6,
-
-
 };
 //
 static constexpr size_t array_size = sizeof(SampleTypeDefinitions) / sizeof(SampleTypeDefinitions[0]);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
@@ -28,16 +28,9 @@ namespace Datadog.Profiler.IntegrationTests.Allocations
             _output = output;
         }
 
-        [TestAppFact("Samples.Computer01")]
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
         public void ShouldGetAllocationSamples(string appName, string framework, string appAssembly)
         {
-            // only valid with .NET 5+
-            if (framework != "net6.0")
-            {
-                // TODO: find a way to skip the test based on the framework (here .NET 5+ only)
-                return;
-            }
-
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioGenerics);
             runner.Environment.SetVariable(EnvironmentVariables.AllocationProfilerEnabled, "1");
             runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
@@ -45,15 +38,9 @@ namespace Datadog.Profiler.IntegrationTests.Allocations
             CheckExceptionProfiles(runner);
         }
 
-        [TestAppFact("Samples.Computer01")]
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
         public void ShouldAllocationProfilerBeDisabledByDefault(string appName, string framework, string appAssembly)
         {
-            // only valid with .NET 5+
-            if (framework != "net6.0")
-            {
-                return;
-            }
-
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioGenerics);
             runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
 
@@ -71,15 +58,9 @@ namespace Datadog.Profiler.IntegrationTests.Allocations
             ExtractAllocationSamples(runner.Environment.PprofDir).Should().BeEmpty();
         }
 
-        [TestAppFact("Samples.Computer01")]
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
         public void ExplicitlyDisableExceptionProfiler(string appName, string framework, string appAssembly)
         {
-            // only valid with .NET 5+
-            if (framework != "net6.0")
-            {
-                return;
-            }
-
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioGenerics);
 
             runner.Environment.SetVariable(EnvironmentVariables.AllocationProfilerEnabled, "0");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -1,0 +1,93 @@
+// <copyright file="ContentionProfilerTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.SmokeTests;
+using FluentAssertions;
+using Perftools.Profiles;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.Contention
+{
+    public class ContentionProfilerTest
+    {
+        private const int ContentionCountSlot = 3;  // defined in enum class SampleValue (Sample.h)
+        private const int ContentionDurationSlot = 4;
+        private const string ScenarioContention = "--scenario 10 --threads 20";
+
+        private readonly ITestOutputHelper _output;
+
+        public ContentionProfilerTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void ShouldGetContentionSamples(string appName, string framework, string appAssembly)
+        {
+            // only valid with .NET 5+
+            if (framework != "net6.0")
+            {
+                // TODO: find a way to skip the test based on the framework (here .NET 5+ only)
+                return;
+            }
+
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioContention);
+            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "1");
+            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
+
+            CheckContentionProfiles(runner);
+        }
+
+        private static IEnumerable<(long Count, long Duration, StackTrace Stacktrace)> ExtractContentionSamples(string directory)
+        {
+            static IEnumerable<(long Count, long Duration, StackTrace Stacktrace, long Time)> GetContentionSamples(string directory)
+            {
+                foreach (var file in Directory.EnumerateFiles(directory, "*.pprof", SearchOption.AllDirectories))
+                {
+                    using var stream = File.OpenRead(file);
+                    var profile = Profile.Parser.ParseFrom(stream);
+
+                    foreach (var sample in profile.Sample)
+                    {
+                        var count = sample.Value[ContentionCountSlot];
+                        if (count == 0)
+                        {
+                            continue;
+                        }
+
+                        var size = sample.Value[ContentionDurationSlot];
+
+                        var labels = sample.Labels(profile).ToArray();
+
+                        yield return (count, size, sample.StackTrace(profile), profile.TimeNanos);
+                    }
+                }
+            }
+
+            return GetContentionSamples(directory)
+                .OrderBy(s => s.Time)
+                .Select(s => (s.Count, s.Duration, s.Stacktrace));
+        }
+
+        private void CheckContentionProfiles(TestApplicationRunner runner)
+        {
+            using var agent = new MockDatadogAgent(_output);
+
+            runner.Run(agent);
+
+            Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
+
+            var contentionSamples = ExtractContentionSamples(runner.Environment.PprofDir).ToArray();
+            contentionSamples.Should().NotBeEmpty();
+
+            Assert.Collection(contentionSamples, s => Assert.True(s.Duration > 0));
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -17,8 +17,8 @@ namespace Datadog.Profiler.IntegrationTests.Contention
 {
     public class ContentionProfilerTest
     {
-        private const int ContentionCountSlot = 3;  // defined in enum class SampleValue (Sample.h)
-        private const int ContentionDurationSlot = 4;
+        private const int ContentionCountSlot = 5;  // defined in enum class SampleValue (Sample.h)
+        private const int ContentionDurationSlot = 6;
         private const string ScenarioContention = "--scenario 10 --threads 20";
 
         private readonly ITestOutputHelper _output;
@@ -28,21 +28,41 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             _output = output;
         }
 
-        [TestAppFact("Samples.Computer01")]
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
         public void ShouldGetContentionSamples(string appName, string framework, string appAssembly)
         {
-            // only valid with .NET 5+
-            if (framework != "net6.0")
-            {
-                // TODO: find a way to skip the test based on the framework (here .NET 5+ only)
-                return;
-            }
-
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioContention);
             runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "1");
             runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
 
             CheckContentionProfiles(runner);
+        }
+
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
+        public void ShouldContentionProfilerBeDisabledByDefault(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioContention);
+            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
+
+            using var agent = new MockDatadogAgent(_output);
+
+            runner.Run(agent);
+
+            ExtractContentionSamples(runner.Environment.PprofDir).Should().BeEmpty();
+        }
+
+        [TestAppFact("Samples.Computer01", new[] { "net6.0" })]
+        public void ExplicitlyDisableContentionProfiler(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioContention);
+
+            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "0");
+
+            using var agent = new MockDatadogAgent(_output);
+
+            runner.Run(agent);
+
+            ExtractContentionSamples(runner.Environment.PprofDir).Should().BeEmpty();
         }
 
         private static IEnumerable<(long Count, long Duration, StackTrace Stacktrace)> ExtractContentionSamples(string directory)
@@ -87,7 +107,7 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             var contentionSamples = ExtractContentionSamples(runner.Environment.PprofDir).ToArray();
             contentionSamples.Should().NotBeEmpty();
 
-            Assert.Collection(contentionSamples, s => Assert.True(s.Duration > 0));
+            Assert.All(contentionSamples,  s => Assert.True(s.Duration > 0));
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -82,11 +82,11 @@ namespace Datadog.Profiler.IntegrationTests.Contention
                             continue;
                         }
 
-                        var lockCount = sample.Value[ContentionCountSlot];
+                        var duration = sample.Value[ContentionDurationSlot];
 
                         var labels = sample.Labels(profile).ToArray();
 
-                        yield return (count, lockCount, sample.StackTrace(profile), profile.TimeNanos);
+                        yield return (count, duration, sample.StackTrace(profile), profile.TimeNanos);
                     }
                 }
             }
@@ -107,7 +107,7 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             var contentionSamples = ExtractContentionSamples(runner.Environment.PprofDir).ToArray();
             contentionSamples.Should().NotBeEmpty();
 
-            Assert.All(contentionSamples,  s => Assert.True(s.Count > 0));
+            Assert.All(contentionSamples,  s => Assert.True(s.Duration > 0));
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -82,11 +82,11 @@ namespace Datadog.Profiler.IntegrationTests.Contention
                             continue;
                         }
 
-                        var size = sample.Value[ContentionDurationSlot];
+                        var lockCount = sample.Value[ContentionCountSlot];
 
                         var labels = sample.Labels(profile).ToArray();
 
-                        yield return (count, size, sample.StackTrace(profile), profile.TimeNanos);
+                        yield return (count, lockCount, sample.StackTrace(profile), profile.TimeNanos);
                     }
                 }
             }
@@ -107,7 +107,7 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             var contentionSamples = ExtractContentionSamples(runner.Environment.PprofDir).ToArray();
             contentionSamples.Should().NotBeEmpty();
 
-            Assert.All(contentionSamples,  s => Assert.True(s.Duration > 0));
+            Assert.All(contentionSamples,  s => Assert.True(s.Count > 0));
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -16,5 +16,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string ExceptionProfilerEnabled = "DD_PROFILING_EXCEPTION_ENABLED";
         public const string ExceptionSampleLimit = "DD_PROFILING_EXCEPTION_SAMPLE_LIMIT";
         public const string AllocationProfilerEnabled = "DD_PROFILING_ALLOCATION_ENABLED";
+        public const string ContentionProfilerEnabled = "DD_PROFILING_CONTENTION_ENABLED";
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SkippableTestCase.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SkippableTestCase.cs
@@ -1,0 +1,56 @@
+// <copyright file="SkippableTestCase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers
+{
+    [Serializable]
+    public class SkippableTestCase : TestMethodTestCase, IXunitTestCase
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer", error: true)]
+        public SkippableTestCase()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SkippableTestCase"/> class.
+        /// </summary>
+        /// <param name="testMethod">The test method this test case belongs to.</param>
+        /// <param name="testMethodArguments">The arguments for the test method.</param>
+        public SkippableTestCase(string skipReason, ITestMethod testMethod, object[] testMethodArguments = null)
+            : base(TestMethodDisplay.Method, TestMethodDisplayOptions.None, testMethod, testMethodArguments)
+        {
+            SkipReason = skipReason;
+        }
+
+        public int Timeout => throw new NotImplementedException();
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+
+            data.AddValue("SkipReason", SkipReason);
+        }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+
+            SkipReason = data.GetValue<string>("SkipReason");
+        }
+
+        public Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus, object[] constructorArguments, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+        {
+            return new XunitTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFact.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFact.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Xunit;
 using Xunit.Sdk;
 
@@ -11,14 +12,17 @@ namespace Datadog.Profiler.SmokeTests
     [XunitTestCaseDiscoverer("Datadog.Profiler.SmokeTests.TestAppFrameworkDiscover", "Datadog.Profiler.IntegrationTests")]
     internal class TestAppFact : FactAttribute
     {
-        public TestAppFact(string appAssembly)
+        public TestAppFact(string appAssembly, string[] frameworks = null)
         {
             AppAssembly = appAssembly;
             AppName = appAssembly;
+            Frameworks = frameworks;
         }
 
         public string AppAssembly { get; }
 
         public string AppName { get; set; }
+
+        public string[] Frameworks { get; set; }
     }
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -359,14 +359,14 @@ TEST(ConfigurationTest, CheckContentionProfilingIsDisabledByDefault)
     ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
 }
 
-TEST(ConfigurationTest, CheckContentionProfilingIsEnabledIsEnvVarSetToTrue)
+TEST(ConfigurationTest, CheckContentionProfilingIsEnabledIfEnvVarSetToTrue)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_THAT(configuration.IsContentionProfilingEnabled(), true);
 }
 
-TEST(ConfigurationTest, CheckContentionProfilingIsDisabledIsEnvVarSetToFalse)
+TEST(ConfigurationTest, CheckContentionProfilingIsDisabledIfEnvVarSetToFalse)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("0"));
     auto configuration = Configuration{};

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -352,3 +352,23 @@ TEST(ConfigurationTest, CheckMinimumCoresThresholdWhenVariableIsSet)
     auto configuration = Configuration{};
     ASSERT_EQ(configuration.MinimumCores(), 0.5);
 }
+
+TEST(ConfigurationTest, CheckContentionProfilingIsDisabledByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
+}
+
+TEST(ConfigurationTest, CheckContentionProfilingIsEnabledIsEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), true);
+}
+
+TEST(ConfigurationTest, CheckContentionProfilingIsDisabledIsEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -42,6 +42,7 @@ public:
     MOCK_METHOD(bool, IsExceptionProfilingEnabled, (), (const override));
     MOCK_METHOD(int, ExceptionSampleLimit, (), (const override));
     MOCK_METHOD(bool, IsAllocationProfilingEnabled, (), (const override));
+    MOCK_METHOD(bool, IsContentionProfilingEnabled, (), (const override));
     MOCK_METHOD(double, MinimumCores, (), (const override));
 };
 


### PR DESCRIPTION
## Summary of changes

Add contention profiler.

## Reason for change

This is a new feature.

## Implementation details

This implementation relies on the CLR Events infrastructure put in place by @chrisnas. Once a `ContentionStop` event is received, we stackwalk the current thread, extract from the event the lock duration and create the sample.

## Test coverage

Add a new test scenario in Computer01 to generate contention and ensure it works accordingly.

## Other details
<!-- Fixes #{issue} -->
