### PR TITLE
Automatically trigger AAS deploy with code freeze

### DIFF
--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -64,5 +64,10 @@ jobs:
         done
       name: 'Update all PRs with Code Freeze status'
 
-        
-        
+    - name: Trigger AAS deploy
+      run: |
+        curl -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+        https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
+        -d '{"event_type": "dd-trace-code-freeze", "client_payload": {"sha":"'"$GITHUB_SHA"'" } }'


### PR DESCRIPTION
## Summary of changes

Triggers an AAS deploy when we start the code freeze

## Reason for change

We don't yet have nightly deploys for AAS builds, so when we start a code freeze we need to manually trigger the AAS deploy to the test environment. This change automates the process

## Implementation details

Use a repository dispatch to send an event.

## Test coverage

- [x] Tested the curl script standalone
- [ ] After merge, do a quick freeze and thaw

## Other details
Requires https://github.com/DataDog/datadog-aas-extension/pull/144
