### PR TITLE
Small refactoring to remove duplicate code around `SocketException` detection

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -157,21 +158,7 @@ namespace Datadog.Trace.Agent
                     }
 
                     // Before retry delay
-                    bool isSocketException = false;
-                    Exception innerException = exception;
-
-                    while (innerException != null)
-                    {
-                        if (innerException is SocketException)
-                        {
-                            isSocketException = true;
-                            break;
-                        }
-
-                        innerException = innerException.InnerException;
-                    }
-
-                    if (isSocketException)
+                    if (exception.IsSocketException())
                     {
                         _log.Debug(exception, "Unable to communicate with the trace agent at {AgentEndpoint}", _apiRequestFactory.Info(endpoint));
                     }

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci.Agent.Payloads;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.Ci.Agent
 {
@@ -140,21 +141,7 @@ namespace Datadog.Trace.Ci.Agent
                     }
 
                     // Before retry delay
-                    bool isSocketException = false;
-                    Exception innerException = exception;
-
-                    while (innerException != null)
-                    {
-                        if (innerException is SocketException)
-                        {
-                            isSocketException = true;
-                            break;
-                        }
-
-                        innerException = innerException.InnerException;
-                    }
-
-                    if (isSocketException)
+                    if (exception.IsSocketException())
                     {
                         Log.Debug(exception, "Unable to communicate with {AgentEndpoint}", _apiRequestFactory.Info(url));
                     }

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -19,6 +19,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
+using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Ci;
@@ -314,21 +315,7 @@ internal class IntelligentTestRunnerClient
                 }
 
                 // Before retry delay
-                bool isSocketException = false;
-                Exception? innerException = exceptionDispatchInfo.SourceException;
-
-                while (innerException != null)
-                {
-                    if (innerException is SocketException)
-                    {
-                        isSocketException = true;
-                        break;
-                    }
-
-                    innerException = innerException.InnerException;
-                }
-
-                if (isSocketException)
+                if (exceptionDispatchInfo.SourceException.IsSocketException())
                 {
                     Log.Debug(exceptionDispatchInfo.SourceException, "Unable to communicate with the server");
                 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -8,6 +8,7 @@ using System;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
@@ -133,7 +134,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 }
 
                 // Before retry delay
-                if (IsSocketException(exception))
+                if (exception.IsSocketException())
                 {
                     Log.Debug(exception, "Unable to communicate with the logs intake at {IntakeEndpoint}", _apiRequestFactory.Info(_logsIntakeEndpoint));
                 }
@@ -143,21 +144,6 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 retriesRemaining--;
                 nextSleepDuration *= 2;
             }
-        }
-
-        private static bool IsSocketException(Exception? exception)
-        {
-            while (exception is not null)
-            {
-                if (exception is SocketException)
-                {
-                    return true;
-                }
-
-                exception = exception.InnerException;
-            }
-
-            return false;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
 
@@ -83,13 +84,8 @@ namespace Datadog.Trace.Telemetry.Transports
 
         private static bool IsFatalException(Exception ex)
         {
-            return ex is SocketException
-#if !NETFRAMEWORK
-                       or WebException { InnerException: System.Net.Http.HttpRequestException { InnerException: SocketException } }
-                       or System.Net.Http.HttpRequestException { InnerException: SocketException }
-#endif
-                       or WebException { Response: HttpWebResponse { StatusCode: HttpStatusCode.NotFound } }
-                       or WebException { InnerException: SocketException };
+            return ex.IsSocketException()
+                || ex is WebException { Response: HttpWebResponse { StatusCode: HttpStatusCode.NotFound } };
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpExceptionExtensions.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpExceptionExtensions.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="HttpExceptionExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Net.Sockets;
+
+namespace Datadog.Trace.Util.Http;
+
+internal static class HttpExceptionExtensions
+{
+    public static bool IsSocketException(this Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception is SocketException)
+            {
+                return true;
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return false;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/HttpExceptionExtensions.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/HttpExceptionExtensions.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="HttpExceptionExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Net.WebSockets;
+using Datadog.Trace.Util.Http;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util.Http;
+
+public class HttpExceptionExtensions
+{
+    public static TheoryData<Exception> SocketExceptions { get; } = new()
+    {
+        new SocketException(),
+        new WebException("msg", new SocketException()),
+#if !NETFRAMEWORK
+        new System.Net.Http.HttpRequestException("msg", new SocketException()),
+        new WebException("msg", new System.Net.Http.HttpRequestException("msg", new SocketException())),
+#endif
+    };
+
+    public static TheoryData<Exception> NonSocketExceptions { get; } = new()
+    {
+        null,
+        new WebSocketException(),
+        new Exception(),
+        new IOException(),
+    };
+
+    [Theory]
+    [MemberData(nameof(SocketExceptions))]
+    public void IsSocketException_True(Exception exception)
+    {
+        exception.IsSocketException().Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(NonSocketExceptions))]
+    public void IsSocketException_False(Exception exception)
+    {
+        exception.IsSocketException().Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary of changes

Extracts helper method for determining if an exception is a `SocketException`

## Reason for change

We have the exact same logic duplicated in multiple places

## Implementation details

Created an extension method called `IsSocketException()`,

## Test coverage

Added some unit tests

## Other details
<!-- Fixes #{issue} -->
