### PR TITLE
[ASM] Increase waf timeout for all integration tests

### DIFF
--- a/Datadog.Trace.Security.slnf
+++ b/Datadog.Trace.Security.slnf
@@ -2,21 +2,23 @@
   "solution": {
     "path": "Datadog.Trace.sln",
     "projects": [
+      "tracer\\src\\Datadog.Trace\\Datadog.Trace.csproj",
       "tracer\\src\\Datadog.Trace.AspNet\\Datadog.Trace.AspNet.csproj",
       "tracer\\src\\Datadog.Trace.Ci.Shared\\Datadog.Trace.Ci.Shared.shproj",
       "tracer\\src\\Datadog.Trace.ClrProfiler.Managed.Loader\\Datadog.Trace.ClrProfiler.Managed.Loader.csproj",
-      "tracer\\src\\Datadog.Tracer.Native\\Datadog.Tracer.Native.DLL.vcxproj",
-      "tracer\\src\\Datadog.Tracer.Native\\Datadog.Tracer.Native.vcxproj",
-      "tracer\\src\\Datadog.Trace.MSBuild\\Datadog.Trace.MSBuild.csproj",
       "tracer\\src\\Datadog.Trace.Tools.Analyzers\\Datadog.Trace.Tools.Analyzers.csproj",
-      "tracer\\src\\Datadog.Trace\\Datadog.Trace.csproj",
+      "tracer\\src\\Datadog.Trace.SourceGenerators\\Datadog.Trace.SourceGenerators.csproj",
+      "tracer\\src\\Datadog.InstrumentedAssemblyGenerator\\Datadog.InstrumentedAssemblyGenerator.csproj",
+      "tracer\\src\\Datadog.InstrumentedAssemblyVerification\\Datadog.InstrumentedAssemblyVerification.csproj",
+      "tracer\\test\\Datadog.Trace.TestHelpers\\Datadog.Trace.TestHelpers.csproj",
       "tracer\\test\\Datadog.Trace.ClrProfiler.IntegrationTests\\Datadog.Trace.ClrProfiler.IntegrationTests.csproj",
       "tracer\\test\\Datadog.Trace.Security.IntegrationTests\\Datadog.Trace.Security.IntegrationTests.csproj",
       "tracer\\test\\Datadog.Trace.Security.Unit.Tests\\Datadog.Trace.Security.Unit.Tests.csproj",
-      "tracer\\test\\Datadog.Trace.TestHelpers\\Datadog.Trace.TestHelpers.csproj",
+      "tracer\\test\\test-applications\\security\\Samples.Security.AspNetCoreBare\\Samples.Security.AspNetCoreBare.csproj",
       "tracer\\test\\test-applications\\security\\Samples.Security.AspNetCore2\\Samples.Security.AspNetCore2.csproj",
       "tracer\\test\\test-applications\\security\\Samples.Security.AspNetCore5\\Samples.Security.AspNetCore5.csproj",
-      "tracer\\test\\test-applications\\security\\aspnet\\Samples.Security.WebApi\\Samples.Security.WebApi.csproj"
+      "tracer\\test\\test-applications\\security\\aspnet\\Samples.Security.WebApi\\Samples.Security.WebApi.csproj",
+      "tracer\\test\\test-applications\\security\\aspnet\\Samples.Security.AspNetMvc5\\Samples.Security.AspNetMvc5.csproj",
       "tracer\\test\\test-applications\\security\\aspnet\\Samples.Security.WebForms\\Samples.Security.WebForms.csproj"
     ]
   }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -60,6 +60,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             {
                 ContractResolver = new OrderedContractResolver()
             };
+            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 10_000_000.ToString());
         }
 
         public Task<MockTracerAgent> RunOnSelfHosted(bool enableSecurity, string externalRulesFile = null, int? traceRateLimit = null)
@@ -317,7 +318,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             var executable = EnvironmentHelper.IsCoreClr() ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
             var args = EnvironmentHelper.IsCoreClr() ? $"{sampleAppPath} {arguments ?? string.Empty}" : arguments;
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_TRACE_RATE_LIMIT", traceRateLimit?.ToString());
-            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 1_000_000.ToString());
 
             int? aspNetCorePort = default;
             _process = ProfilerHelper.StartProcessWithProfiler(


### PR DESCRIPTION
## Summary of changes

The custom waf timeout of 1 second was only set for aspnet core integration tests.
Increase it to 10 seconds and for all tests, including IIS express ones.

Fix security solution filter, for small changes like that, we would need it

## Reason for change
Timed out on CI pipeline

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
