### PR TITLE
Refactor transport strategies code

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
@@ -1,0 +1,83 @@
+﻿// <copyright file="AgentTransportStrategy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Agent.StreamFactories;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Agent;
+
+internal static class AgentTransportStrategy
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AgentTransportStrategy));
+
+    /// <summary>
+    /// A generic helper for creating an <see cref="IApiRequestFactory"/> for sending to the agent
+    /// Allows customising the <see cref="DatadogHttpClient"/>
+    /// </summary>
+    /// <param name="settings">The exporter settings defining the agent</param>
+    /// <param name="productName">The product this is transport for e.g. 'traces', 'telemetry'.
+    /// Used in logging only </param>
+    /// <param name="tcpTimeout">The timeout to use in TCP/IP requests</param>
+    /// <param name="defaultAgentHeaders">The default headers to add to HttpClient requests</param>
+    /// <param name="getHttpHeaderHelper">A func that returns an <see cref="HttpHeaderHelperBase"/> for use
+    /// with <see cref="DatadogHttpClient"/></param>
+    /// <param name="getBaseEndpoint">A func that returns the endpoint to send requests to </param>
+    public static IApiRequestFactory Get(
+        ImmutableExporterSettings settings,
+        string productName,
+        TimeSpan? tcpTimeout,
+        KeyValuePair<string, string>[] defaultAgentHeaders,
+        Func<HttpHeaderHelperBase> getHttpHeaderHelper,
+        Func<Uri> getBaseEndpoint)
+    {
+        var strategy = settings.TracesTransport;
+
+        switch (strategy)
+        {
+            case TracesTransportType.WindowsNamedPipe:
+                // intentionally using string interpolation, as this is only called once, and avoids array allocation
+                Log.Information($"Using {nameof(NamedPipeClientStreamFactory)} for {productName} transport, with pipe name {settings.TracesPipeName} and timeout {settings.TracesPipeTimeoutMs}ms.");
+                return new HttpStreamRequestFactory(
+                    new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs),
+                    new DatadogHttpClient(getHttpHeaderHelper()),
+                    getBaseEndpoint());
+
+            case TracesTransportType.UnixDomainSocket:
+#if NET5_0_OR_GREATER
+                Log.Information("Using {FactoryType} for {ProductName} transport, with UDS path {Path}.", nameof(SocketHandlerRequestFactory), productName, settings.TracesUnixDomainSocketPath);
+                // use http://localhost as base endpoint
+                return new SocketHandlerRequestFactory(
+                    new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
+                    defaultAgentHeaders,
+                    getBaseEndpoint());
+#elif NETCOREAPP3_1_OR_GREATER
+                // intentionally using string interpolation, as this is only called once, and avoids array allocation
+                Log.Information($"Using {nameof(UnixDomainSocketStreamFactory)} for {productName} transport, with Unix Domain Sockets path {settings.TracesUnixDomainSocketPath} and timeout {settings.TracesPipeTimeoutMs}ms.");
+                return new HttpStreamRequestFactory(
+                    new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
+                    new DatadogHttpClient(getHttpHeaderHelper()),
+                    getBaseEndpoint());
+#else
+                Log.Error("Using Unix Domain Sockets for {ProductName} transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.", productName);
+                goto case TracesTransportType.Default;
+#endif
+            case TracesTransportType.Default:
+            default:
+#if NETCOREAPP
+                Log.Information("Using {FactoryType} for {ProductName} transport.", nameof(HttpClientRequestFactory), productName);
+                return new HttpClientRequestFactory(settings.AgentUri, defaultAgentHeaders, timeout: tcpTimeout);
+#else
+                Log.Information("Using {FactoryType} for {ProductName} transport.", nameof(ApiWebRequestFactory), productName);
+                return new ApiWebRequestFactory(settings.AgentUri, defaultAgentHeaders, timeout: tcpTimeout);
+#endif
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -18,6 +18,6 @@ namespace Datadog.Trace.Agent
                 tcpTimeout: null,
                 AgentHttpHeaderNames.DefaultHeaders,
                 () => new TraceAgentHttpHeaderHelper(),
-                () => new Uri("http://localhost"));
+                uri => uri);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -4,51 +4,20 @@
 // </copyright>
 
 using System;
-using Datadog.Trace.Agent.StreamFactories;
-using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.HttpOverStreams;
-using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Agent
 {
     internal static class TracesTransportStrategy
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
-
         public static IApiRequestFactory Get(ImmutableExporterSettings settings)
-        {
-            var strategy = settings.TracesTransport;
-
-            switch (strategy)
-            {
-                case TracesTransportType.WindowsNamedPipe:
-                    Log.Information<string, string, int>("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
-                    // use http://localhost as base endpoint
-                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), DatadogHttpClient.CreateTraceAgentClient(), new Uri("http://localhost"));
-                case TracesTransportType.UnixDomainSocket:
-#if NET5_0_OR_GREATER
-                    Log.Information("Using {FactoryType} for trace transport, with UDS path {Path}.", nameof(SocketHandlerRequestFactory), settings.TracesUnixDomainSocketPath);
-                    // use http://localhost as base endpoint
-                    return new SocketHandlerRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), AgentHttpHeaderNames.DefaultHeaders, new Uri("http://localhost"));
-#elif NETCOREAPP3_1_OR_GREATER
-                    Log.Information<string, string, int>("Using {FactoryType} for trace transport, with Unix Domain Sockets path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
-                    // use http://localhost as base endpoint
-                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), DatadogHttpClient.CreateTraceAgentClient(), new Uri("http://localhost"));
-#else
-                    Log.Error("Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
-                    goto case TracesTransportType.Default;
-#endif
-                case TracesTransportType.Default:
-                default:
-#if NETCOREAPP
-                    Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
-                    return new HttpClientRequestFactory(settings.AgentUri, AgentHttpHeaderNames.DefaultHeaders);
-#else
-                    Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
-                    return new ApiWebRequestFactory(settings.AgentUri, AgentHttpHeaderNames.DefaultHeaders);
-#endif
-            }
-        }
+            => AgentTransportStrategy.Get(
+                settings,
+                productName: "trace",
+                tcpTimeout: null,
+                AgentHttpHeaderNames.DefaultHeaders,
+                () => new TraceAgentHttpHeaderHelper(),
+                () => new Uri("http://localhost"));
     }
 }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.HttpOverStreams
 
         private readonly HttpHeaderHelperBase _headerHelper;
 
-        private DatadogHttpClient(HttpHeaderHelperBase headerHelper)
+        public DatadogHttpClient(HttpHeaderHelperBase headerHelper)
         {
             _headerHelper = headerHelper;
         }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -31,12 +31,6 @@ namespace Datadog.Trace.HttpOverStreams
             _headerHelper = headerHelper;
         }
 
-        public static DatadogHttpClient CreateTraceAgentClient()
-            => new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
-
-        public static DatadogHttpClient CreateTelemetryAgentClient()
-            => new DatadogHttpClient(new TelemetryAgentHttpHeaderHelper());
-
         public async Task<HttpResponse> SendAsync(HttpRequest request, Stream requestStream, Stream responseStream)
         {
             await SendRequestAsync(request, requestStream).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryAgentHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryAgentHttpHeaderHelper.cs
@@ -6,9 +6,9 @@
 #nullable enable
 
 using System.Linq;
-using Datadog.Trace.Telemetry;
+using Datadog.Trace.HttpOverStreams;
 
-namespace Datadog.Trace.HttpOverStreams
+namespace Datadog.Trace.Telemetry.Transports
 {
     internal class TelemetryAgentHttpHeaderHelper : HttpHeaderHelperBase
     {

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
@@ -5,12 +5,10 @@
 
 using System;
 using Datadog.Trace.Agent;
-using Datadog.Trace.Agent.StreamFactories;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry.Transports;
 
@@ -31,38 +29,11 @@ internal static class TelemetryTransportStrategy
     }
 
     public static IApiRequestFactory GetAgentIntakeFactory(ImmutableExporterSettings settings)
-    {
-        // use the same transport for telemetry as we do for traces
-        var strategy = settings.TracesTransport;
-
-        switch (strategy)
-        {
-            case TracesTransportType.WindowsNamedPipe:
-                Log.Information<string, string, int>("Using {FactoryType} for telemetry transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
-                return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), DatadogHttpClient.CreateTelemetryAgentClient(), GetBaseEndpoint());
-            case TracesTransportType.UnixDomainSocket:
-#if NET5_0_OR_GREATER
-                Log.Information("Using {FactoryType} for telemetry transport, with UDS path {Path}.", nameof(SocketHandlerRequestFactory), settings.TracesUnixDomainSocketPath);
-                return new SocketHandlerRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), TelemetryHttpHeaderNames.GetDefaultAgentHeaders(), GetBaseEndpoint());
-#elif NETCOREAPP3_1_OR_GREATER
-                Log.Information<string, string, int>("Using {FactoryType} for telemetry transport, with Unix Domain Sockets path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
-                return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), DatadogHttpClient.CreateTelemetryAgentClient(), GetBaseEndpoint());
-#else
-                Log.Error("Using Unix Domain Sockets for telemetry transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
-                goto case TracesTransportType.Default;
-#endif
-            case TracesTransportType.Default:
-            default:
-                var agentUri = UriHelpers.Combine(settings.AgentUri, TelemetryConstants.AgentTelemetryEndpoint);
-#if NETCOREAPP
-                Log.Information("Using {FactoryType} for telemetry transport.", nameof(HttpClientRequestFactory));
-                return new HttpClientRequestFactory(agentUri, TelemetryHttpHeaderNames.GetDefaultAgentHeaders(), timeout: Timeout);
-#else
-                Log.Information("Using {FactoryType} for telemetry transport.", nameof(ApiWebRequestFactory));
-                return new ApiWebRequestFactory(agentUri, TelemetryHttpHeaderNames.GetDefaultAgentHeaders(), timeout: Timeout);
-#endif
-        }
-
-        static Uri GetBaseEndpoint() => new Uri("http://localhost/" + TelemetryConstants.AgentTelemetryEndpoint);
-    }
+        => AgentTransportStrategy.Get(
+            settings,
+            productName: "telemetry",
+            tcpTimeout: Timeout,
+            TelemetryHttpHeaderNames.GetDefaultAgentHeaders(),
+            () => new TelemetryAgentHttpHeaderHelper(),
+            () => new Uri("http://localhost/" + TelemetryConstants.AgentTelemetryEndpoint));
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
@@ -9,6 +9,7 @@ using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry.Transports;
 
@@ -35,5 +36,5 @@ internal static class TelemetryTransportStrategy
             tcpTimeout: Timeout,
             TelemetryHttpHeaderNames.GetDefaultAgentHeaders(),
             () => new TelemetryAgentHttpHeaderHelper(),
-            () => new Uri("http://localhost/" + TelemetryConstants.AgentTelemetryEndpoint));
+            uri => UriHelpers.Combine(uri, TelemetryConstants.AgentTelemetryEndpoint));
 }

--- a/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task DatadogHttpClient_CanParseResponse()
         {
-            var client = DatadogHttpClient.CreateTraceAgentClient();
+            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests
         [InlineData(100)]
         public async Task DatadogHttpClient_WhenOnlyPartOfResponseIsAvailable_ParsesCorrectly(int bytesToRead)
         {
-            var client = DatadogHttpClient.CreateTraceAgentClient();
+            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();


### PR DESCRIPTION
## Summary of changes

- Remove the duplication from `TracesTransportStrategy` and `TelemetryTransportStrategy`

## Reason for change

The code for choosing the correct `IApiRequestFactory` based on `ExporterSettings` and target framework is&hellip;convoluted. Currently we duplicate most of this in `TracesTransportStrategy` and `TelemetryTransportStrategy`. However, for data streams monitoring I need to create a new one which will be _another_ copy, and @shurivich also needs a new one to support UDS etc..

## Implementation details

Extract the common bits, pass the rest in as parameters, or `Func<T>` where appropriate. I also removed the static helpers on `DatadogHttpClient` as didn't feel right to keep creating extra methods there (and they're now unused anyway).

## Test coverage

Should be covered by all existing tests

## Other details

I think this is a prerequisite for necessary changes to #3125.
