### PR TITLE
[Profiler] Return string view for symbol resolution

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -293,6 +293,12 @@ jobs:
       - name: Build sample applications
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
 
+      - name: Run unit tests
+        run: |
+          sudo mkdir -p /var/log/datadog/dotnet
+          sudo chmod a+rwx /var/log/datadog/dotnet
+          UBSAN_OPTIONS=print_stacktrace=1 ./profiler/_build/bin/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests
+
       - name: Prepare environment to run the application
         run: |
           #

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -233,6 +233,12 @@ jobs:
       - name: Build sample applications
         run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
 
+      - name: Run unit tests
+        run: |
+          sudo mkdir -p /var/log/datadog/dotnet
+          sudo chmod a+rwx /var/log/datadog/dotnet
+          ASAN_OPTIONS="detect_leaks=0" ./profiler/_build/bin/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests
+
       - name: Prepare environment to run the application
         run: |
           #

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -212,7 +212,6 @@
     <ClInclude Include="ISamplesCollector.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
-    <ClInclude Include="SamplesCollector.h" />
     <ClInclude Include="cgroup.h">
       <Filter>Utils</Filter>
     </ClInclude>
@@ -257,6 +256,9 @@
     </ClInclude>
     <ClInclude Include="IContentionListener.h">
       <Filter>Contention</Filter>
+    </ClInclude>
+    <ClInclude Include="SamplesCollector.h">
+      <Filter>Profiler-Driver</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -32,7 +32,7 @@ public:
     FrameStore(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration* pConfiguration);
 
 public :
-    std::tuple<bool, std::string, std::string> GetFrame(uintptr_t instructionPointer) override;
+    std::tuple<bool, std::string_view, std::string_view> GetFrame(uintptr_t instructionPointer) override;
     bool GetTypeName(ClassID classId, std::string& name) override;
 
 private:
@@ -61,8 +61,8 @@ private:
         );
     bool GetTypeDesc(ClassID classId, TypeDesc& typeDesc, bool isEncoded);
     bool GetCachedTypeDesc(ClassID classId, TypeDesc& typeDesc);
-    std::pair <std::string, std::string> GetManagedFrame(FunctionID functionId);
-    std::pair <std::string, std::string> GetNativeFrame(uintptr_t instructionPointer);
+    std::pair <std::string_view, std::string_view> GetManagedFrame(FunctionID functionId);
+    std::pair <std::string_view, std::string_view> GetNativeFrame(uintptr_t instructionPointer);
 
 public:   // global helpers
     static bool GetAssemblyName(ICorProfilerInfo4* pInfo, ModuleID moduleId, std::string& assemblyName);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
@@ -16,6 +16,6 @@ public:
     //  - true if managed frame
     //  - module name
     //  - frame text
-    virtual std::tuple<bool, std::string, std::string> GetFrame(uintptr_t instructionPointer) = 0;
+    virtual std::tuple<bool, std::string_view, std::string_view> GetFrame(uintptr_t instructionPointer) = 0;
     virtual bool GetTypeName(ClassID classId, std::string& name) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -85,12 +85,12 @@ void Sample::AddValue(std::int64_t value, SampleValue index)
     _values[pos] = value;
 }
 
-void Sample::AddFrame(const std::string& moduleName, const std::string& frame)
+void Sample::AddFrame(std::string_view moduleName, std::string_view frame)
 {
     _callstack.push_back({moduleName, frame});
 }
 
-const std::vector<std::pair<std::string, std::string>>& Sample::GetCallstack() const
+const CallStack& Sample::GetCallstack() const
 {
     return _callstack;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -95,11 +95,6 @@ const CallStack& Sample::GetCallstack() const
     return _callstack;
 }
 
-void Sample::AddLabel(const Label& label)
-{
-    _labels.push_back(label);
-}
-
 std::string_view Sample::GetRuntimeId() const
 {
     return _runtimeId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -93,7 +93,7 @@ public:
     // but it seems better for encapsulation to do the transformation between collected raw data
     // and a Sample in each Provider (this is the each behind CollectorBase template class)
     void AddValue(std::int64_t value, SampleValue index);
-    void AddFrame(std::string_view moduleName, std::string_view frame); // TODO: use stringview to avoid copy
+    void AddFrame(std::string_view moduleName, std::string_view frame);
     void AddLabel(const Label& label);
 
     // helpers for well known mandatory labels
@@ -116,7 +116,7 @@ public:
 
 private:
     uint64_t _timestamp;
-    CallStack _callstack; // TODO: use stringview to avoid copy
+    CallStack _callstack;
     Values _values;
     Labels _labels;
     std::string_view _runtimeId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -94,7 +94,12 @@ public:
     // and a Sample in each Provider (this is the each behind CollectorBase template class)
     void AddValue(std::int64_t value, SampleValue index);
     void AddFrame(std::string_view moduleName, std::string_view frame);
-    void AddLabel(const Label& label);
+
+    template<typename T>
+    void AddLabel(T&& label)
+    {
+        _labels.push_back(std::forward<T>(label));
+    }
 
     // helpers for well known mandatory labels
     void SetPid(const std::string& pid);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -59,8 +59,9 @@ static constexpr size_t array_size = sizeof(SampleTypeDefinitions) / sizeof(Samp
 //---------------------------------------------------------------
 
 typedef std::array<int64_t, array_size> Values;
-typedef std::pair<std::string, std::string> Label; // TODO: use stringview to avoid copy
+typedef std::pair<std::string_view, std::string> Label;
 typedef std::list<Label> Labels;
+typedef std::vector<std::pair<std::string_view, std::string_view>> CallStack;
 
 /// <summary>
 /// Unfinished class. The purpose, for now, is just to work on the export component.
@@ -69,7 +70,7 @@ class Sample
 {
 public:
     Sample(std::string_view runtimeId); // only for tests
-    Sample(uint64_t timestamp, std::string_view runtimeId);    
+    Sample(uint64_t timestamp, std::string_view runtimeId);
     Sample& operator=(const Sample& sample) = delete;
     Sample(Sample&& sample) noexcept;
     Sample& operator=(Sample&& other) noexcept;
@@ -81,7 +82,7 @@ public:
     Sample Copy() const;
     uint64_t GetTimeStamp() const;
     const Values& GetValues() const;
-    const std::vector<std::pair<std::string, std::string>>& GetCallstack() const;
+    const CallStack& GetCallstack() const;
     const Labels& GetLabels() const;
     std::string_view GetRuntimeId() const;
 
@@ -92,7 +93,7 @@ public:
     // but it seems better for encapsulation to do the transformation between collected raw data
     // and a Sample in each Provider (this is the each behind CollectorBase template class)
     void AddValue(std::int64_t value, SampleValue index);
-    void AddFrame(const std::string& moduleName, const std::string& frame); // TODO: use stringview to avoid copy
+    void AddFrame(std::string_view moduleName, std::string_view frame); // TODO: use stringview to avoid copy
     void AddLabel(const Label& label);
 
     // helpers for well known mandatory labels
@@ -115,7 +116,7 @@ public:
 
 private:
     uint64_t _timestamp;
-    std::vector<std::pair<std::string, std::string>> _callstack; // TODO: use stringview to avoid copy
+    CallStack _callstack; // TODO: use stringview to avoid copy
     Values _values;
     Labels _labels;
     std::string_view _runtimeId;

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -11,6 +11,10 @@ add_compile_options(-fPIC -fms-extensions)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
 add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined -Wc++17-extensions)
 
+if (RUN_ASAN)
+    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
+endif()
+
 if(ISLINUX)
     add_compile_options(-stdlib=libstdc++ -DLINUX -Wno-pragmas)
 endif()
@@ -51,6 +55,10 @@ target_include_directories(${TEST_EXECUTABLE_NAME}
 )
 
 add_dependencies(${TEST_EXECUTABLE_NAME} fmt gmock gtest Datadog.Profiler.Native.static)
+
+if (RUN_ASAN)
+    target_link_libraries(Datadog.Profiler.Native.static -fsanitize=address)
+endif()
 
 target_link_libraries(${TEST_EXECUTABLE_NAME}
   Datadog.Profiler.Native.static

--- a/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CMakeLists.txt
@@ -15,6 +15,10 @@ if (RUN_ASAN)
     add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
 endif()
 
+if (RUN_UBSAN)
+    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
+endif()
+
 if(ISLINUX)
     add_compile_options(-stdlib=libstdc++ -DLINUX -Wno-pragmas)
 endif()
@@ -57,7 +61,11 @@ target_include_directories(${TEST_EXECUTABLE_NAME}
 add_dependencies(${TEST_EXECUTABLE_NAME} fmt gmock gtest Datadog.Profiler.Native.static)
 
 if (RUN_ASAN)
-    target_link_libraries(Datadog.Profiler.Native.static -fsanitize=address)
+    target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=address)
+endif()
+
+if (RUN_UBSAN)
+    target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=undefined)
 endif()
 
 target_link_libraries(${TEST_EXECUTABLE_NAME}

--- a/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreHelper.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreHelper.cpp
@@ -21,23 +21,18 @@ FrameStoreHelper::FrameStoreHelper(bool isManaged, std::string prefix, size_t co
     }
 }
 
-
-//FrameStoreHelper::FrameStoreHelper(std::unordered_map<uintptr_t, std::string> mapping)
-//    :
-//    _mapping{mapping}
-//{
-//}
-
-
-std::tuple<bool, std::string, std::string> FrameStoreHelper::GetFrame(uintptr_t instructionPointer)
+std::tuple<bool, std::string_view, std::string_view> FrameStoreHelper::GetFrame(uintptr_t instructionPointer)
 {
+    static std::string UnknownModuleName = "module???";
+    static std::string UnknownFunctionName = "frame???";
+
     auto item = _mapping.find(instructionPointer);
     if (item != _mapping.end())
     {
         return item->second;
     }
 
-    return { true, "module???", "frame???" };
+    return {true, UnknownModuleName, UnknownFunctionName};
 }
 
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreHelper.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FrameStoreHelper.h
@@ -12,7 +12,7 @@ public:
 
 public:
     // Inherited via IFrameStore
-    std::tuple<bool, std::string, std::string> GetFrame(uintptr_t instructionPointer) override;
+    std::tuple<bool, std::string_view, std::string_view> GetFrame(uintptr_t instructionPointer) override;
     bool GetTypeName(ClassID classId, std::string& name) override;
 
 private:

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
@@ -65,19 +65,25 @@ TEST(LibddprofExporterTest, CheckProfileIsWrittenToDisk)
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
     // Add samples to only one application
+    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}},
+                                callstack1,
+                                labels1,
                                 21);
 
+    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
+    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
     auto sample2 = CreateSample(firstRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}},
+                                callstack2,
+                                labels2,
                                 42);
 
+    auto callstack3 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}});
+    auto labels3 = std::initializer_list<Label>{{"label1", "value1"}};
     auto sample3 = CreateSample(firstRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}}),
-                                {{"label1", "value1"}},
+                                callstack3,
+                                labels3,
                                 84);
     exporter.Add(sample1);
     exporter.Add(sample2);
@@ -157,14 +163,18 @@ TEST(LibddprofExporterTest, EnsureOnlyProfileWithSamplesIsWrittenToDisk)
 
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
+    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}},
+                                callstack1,
+                                labels1,
                                 21);
 
+    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
+    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
     auto sample2 = CreateSample(secondRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}},
+                                callstack2,
+                                labels2,
                                 42);
 
     exporter.Add(sample1);
@@ -245,14 +255,18 @@ TEST(LibddprofExporterTest, EnsureTwoPprofFilesAreWrittenToDiskForTwoApplication
 
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
+    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}},
+                                callstack1,
+                                labels1,
                                 21);
 
+    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample2 = CreateSample(secondRid,
-                                std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}}),
-                                {{"label1", "value1"}, {"label2", "value2"}},
+                                callstack2,
+                                labels2,
                                 42);
 
     exporter.Add(sample1);
@@ -425,9 +439,9 @@ TEST(LibddprofExporterTest, MakeSureNoCrashForReallyLongCallstack)
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
     std::string runtimeId = "MyRid";
-    auto sample1 = CreateSample(runtimeId, CreateCallstack(2048),
-                                {{"label1", "value1"}, {"label2", "value2"}},
-                                42);
+    auto callstack = CreateCallstack(2048);
+    auto labels = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto sample1 = CreateSample(runtimeId, callstack, labels, 42);
 
     EXPECT_NO_THROW(exporter.Add(sample1));
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
@@ -65,22 +65,22 @@ TEST(LibddprofExporterTest, CheckProfileIsWrittenToDisk)
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
     // Add samples to only one application
-    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
-    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
                                 callstack1,
                                 labels1,
                                 21);
 
-    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
-    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
+    auto callstack2 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
+    auto labels2 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
     auto sample2 = CreateSample(firstRid,
                                 callstack2,
                                 labels2,
                                 42);
 
-    auto callstack3 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}});
-    auto labels3 = std::initializer_list<Label>{{"label1", "value1"}};
+    auto callstack3 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}});
+    auto labels3 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}};
     auto sample3 = CreateSample(firstRid,
                                 callstack3,
                                 labels3,
@@ -163,15 +163,15 @@ TEST(LibddprofExporterTest, EnsureOnlyProfileWithSamplesIsWrittenToDisk)
 
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
-    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
-    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
                                 callstack1,
                                 labels1,
                                 21);
 
-    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
-    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
+    auto callstack2 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}, {"module", "frame4"}});
+    auto labels2 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}, {"label3", "value3"}};
     auto sample2 = CreateSample(secondRid,
                                 callstack2,
                                 labels2,
@@ -255,15 +255,15 @@ TEST(LibddprofExporterTest, EnsureTwoPprofFilesAreWrittenToDiskForTwoApplication
 
     auto exporter = LibddprofExporter(&mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers);
 
-    auto callstack1 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
-    auto labels1 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(firstRid,
                                 callstack1,
                                 labels1,
                                 21);
 
-    auto callstack2 = std::initializer_list<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
-    auto labels2 = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto callstack2 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
+    auto labels2 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample2 = CreateSample(secondRid,
                                 callstack2,
                                 labels2,
@@ -440,7 +440,7 @@ TEST(LibddprofExporterTest, MakeSureNoCrashForReallyLongCallstack)
 
     std::string runtimeId = "MyRid";
     auto callstack = CreateCallstack(2048);
-    auto labels = std::initializer_list<Label>{{"label1", "value1"}, {"label2", "value2"}};
+    auto labels = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
     auto sample1 = CreateSample(runtimeId, callstack, labels, 42);
 
     EXPECT_NO_THROW(exporter.Add(sample1));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
@@ -44,3 +44,22 @@ std::vector<std::pair<std::string, std::string>> CreateCallstack(int depth)
 
     return result;
 }
+
+Sample CreateSample(std::string_view runtimeId, const std::vector<std::pair<std::string, std::string>>& callstack, const std::vector<std::pair<std::string, std::string>>& labels, std::int64_t value)
+{
+    Sample sample{runtimeId};
+
+    for (auto& [module, frame] : callstack)
+    {
+        sample.AddFrame(module, frame);
+    }
+
+    for (auto const& [name, value] : labels)
+    {
+        sample.AddLabel(Label{name, value});
+    }
+
+    sample.SetValue(value);
+
+    return sample;
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -129,7 +129,7 @@ std::tuple<std::unique_ptr<IExporter>, MockExporter&> CreateExporter();
 std::tuple<std::unique_ptr<ISamplesCollector>, MockSamplesCollector&> CreateSamplesCollector();
 
 template <typename T>
-Sample CreateSample(std::string_view runtimeId, const T& callstack, std::initializer_list<std::pair<std::string, std::string>> labels, std::int64_t value)
+Sample CreateSample(std::string_view runtimeId, const T& callstack, const std::initializer_list<Label>& labels, std::int64_t value)
 {
     Sample sample{runtimeId};
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -6,14 +6,14 @@
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 
 #include "Configuration.h"
-#include "IExporter.h"
-#include "ISamplesProvider.h"
-#include "IMetricsSender.h"
-#include "Sample.h"
-#include "TagsHelper.h"
 #include "IApplicationStore.h"
+#include "IExporter.h"
+#include "IMetricsSender.h"
 #include "IRuntimeIdStore.h"
 #include "ISamplesCollector.h"
+#include "ISamplesProvider.h"
+#include "Sample.h"
+#include "TagsHelper.h"
 
 class MockConfiguration : public IConfiguration
 {
@@ -128,24 +128,6 @@ std::tuple<std::shared_ptr<ISamplesProvider>, MockSampleProvider&> CreateSamples
 std::tuple<std::unique_ptr<IExporter>, MockExporter&> CreateExporter();
 std::tuple<std::unique_ptr<ISamplesCollector>, MockSamplesCollector&> CreateSamplesCollector();
 
-template <typename T>
-Sample CreateSample(std::string_view runtimeId, const T& callstack, const std::initializer_list<Label>& labels, std::int64_t value)
-{
-    Sample sample{runtimeId};
-
-    for (auto frame = callstack.begin(); frame != callstack.end(); ++frame)
-    {
-        sample.AddFrame(frame->first, frame->second);
-    }
-
-    for (auto const& [name, value] : labels)
-    {
-        sample.AddLabel({name, value});
-    }
-
-    sample.SetValue(value);
-
-    return sample;
-}
+Sample CreateSample(std::string_view runtimeId, const std::vector<std::pair<std::string, std::string>>& callstack, const std::vector<std::pair<std::string, std::string>>& labels, std::int64_t value);
 
 std::vector<std::pair<std::string, std::string>> CreateCallstack(int depth);

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -215,7 +215,7 @@ TEST(SamplesCollectorTest, MustNotFailWhenSendingProfileThrows)
     collector.Register(&samplesProvider);
 
     collector.Start();
-    std::this_thread::sleep_for(100ms);
+    std::this_thread::sleep_for(70ms);
     collector.Export();
     collector.Stop();
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -68,9 +68,12 @@ public:
 
     Sample CreateSample(std::string_view rid)
     {
+        static std::string ModuleName = "My module";
+        static std::string FunctionName = "My frame";
+
         Sample s{rid};
 
-        s.AddFrame("My module", "My frame");
+        s.AddFrame(ModuleName, FunctionName);
 
         return s;
     }


### PR DESCRIPTION
## Summary of changes

## Reason for change

When resolving symbols, we return `std::string`, and those string are copied multiple times, until added to the profile..
By using `std::string_view` wherever we can we avoid string copies and memory/cpu overhead.

## Implementation details

Use `std::string_view` when resolving symbols.

## Test coverage

Ensure that current test are working correctly.

## Other details
<!-- Fixes #{issue} -->
