### PR TITLE
Add `VarEncodingHelper` for use in Data Streams Monitoring

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/VarEncodingHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/VarEncodingHelper.cs
@@ -182,7 +182,7 @@ internal static class VarEncodingHelper
 #endif
 
     /// <summary>
-    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// Serializes 32-bit signed integers using zig-zag encoding,
     /// which ensures small-scale integers are turned into unsigned integers
     /// that have leading zeros, whether they are positive or negative,
     /// hence allows for space-efficient encoding of those values.
@@ -195,7 +195,7 @@ internal static class VarEncodingHelper
         => WriteVarLongZigZag(bytes, offset, value);
 
     /// <summary>
-    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// Serializes 32-bit signed integers using zig-zag encoding,
     /// which ensures small-scale integers are turned into unsigned integers
     /// that have leading zeros, whether they are positive or negative,
     /// hence allows for space-efficient encoding of those values.
@@ -208,7 +208,7 @@ internal static class VarEncodingHelper
 
 #if NETCOREAPP3_1_OR_GREATER
     /// <summary>
-    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// Serializes 32-bit signed integers using zig-zag encoding,
     /// which ensures small-scale integers are turned into unsigned integers
     /// that have leading zeros, whether they are positive or negative,
     /// hence allows for space-efficient encoding of those values.
@@ -310,7 +310,7 @@ internal static class VarEncodingHelper
 #endif
 
     /// <summary>
-    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// Deserializes 32-bit unsigned integers that have been encoded using
     /// <see cref="WriteVarInt(byte[],int,uint)" />
     /// </summary>
     /// <param name="bytes">The byte array to write the buffer into</param>
@@ -344,7 +344,7 @@ internal static class VarEncodingHelper
     /// <param name="offset">The offset within the array to start writing</param>
     /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
     /// <returns>The decoded value, or null if decoding failed</returns>
-    public static long? ReadVarIntZigZag(byte[] bytes, int offset, out int bytesRead)
+    public static int? ReadVarIntZigZag(byte[] bytes, int offset, out int bytesRead)
         => ReadVarLongZigZag(bytes, offset, out bytesRead) is { } decoded and >= int.MinValue and <= int.MaxValue
             ? (int)decoded
             : null;
@@ -357,7 +357,7 @@ internal static class VarEncodingHelper
     /// <param name="bytes">The buffer to read the encoded value from</param>
     /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
     /// <returns>The decoded value, or null if decoding failed</returns>
-    public static long? ReadVarIntZigZag(Span<byte> bytes, out int bytesRead)
+    public static int? ReadVarIntZigZag(Span<byte> bytes, out int bytesRead)
         => ReadVarLongZigZag(bytes, out bytesRead) is { } decoded and >= int.MinValue and <= int.MaxValue
             ? (int)decoded
             : null;

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/VarEncodingHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/VarEncodingHelper.cs
@@ -1,0 +1,477 @@
+﻿// <copyright file="VarEncodingHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class VarEncodingHelper
+{
+    /// <summary>
+    /// The maximum number of bytes used to encode a ulong
+    /// </summary>
+    private const int MaxVarLen64 = 9;
+
+    /// <summary>
+    /// Stores the number of bytes a <c>long</c> with a
+    /// given number of leading zeros will be encoded as
+    /// </summary>
+    private static readonly int[] VarLongLengths;
+
+    static VarEncodingHelper()
+    {
+        VarLongLengths = new int[65];
+        VarLongLengths[0] = MaxVarLen64; // special case (extra bit for encoding)
+        VarLongLengths[64] = 1; // special case (always need at least 1 byte)
+
+        for (var i = 1; i < 64; i++)
+        {
+            var value = (70 - i) / 7;
+            VarLongLengths[i] = value;
+        }
+    }
+
+    private interface IByteWriter
+    {
+        void WriteByte(int offset, byte value);
+    }
+
+    /// <summary>
+    /// Serializes 64-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 9
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (8*7+8 = 64).
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLong(byte[] bytes, int offset, ulong value)
+        => WriteVarLong(value, new ByteArrayByteWriter(bytes, offset));
+
+    /// <summary>
+    /// Serializes 64-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 9
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (8*7+8 = 64).
+    /// </summary>
+    /// <param name="writer">The writer to use to write the bytes</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLong(BinaryWriter writer, ulong value)
+        => WriteVarLong(value, new BinaryWriterByteWriter(writer));
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Serializes 64-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 9
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (8*7+8 = 64).
+    /// </summary>
+    /// <param name="bytes">The buffer to write the encoded value to</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLong(Span<byte> bytes, ulong value)
+    {
+        // duplicate implementation as can't include Span<T> in IByteWriter implementations
+        var length = VarLongLength(value);
+        for (var i = 0; i < length - 1; i++)
+        {
+            bytes[i] = (byte)((value & 0x7F) | 0x80);
+            value >>= 7;
+        }
+
+        bytes[length - 1] = (byte)(value);
+        return length;
+    }
+#endif
+
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLongZigZag(byte[] bytes, int offset, long value)
+        => WriteVarLong(bytes, offset, ZigZag(value));
+
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="writer">The writer to use to write the bytes</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLongZigZag(BinaryWriter writer, long value)
+        => WriteVarLong(writer, ZigZag(value));
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="bytes">The span to write the buffer into</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarLongZigZag(Span<byte> bytes, long value)
+        => WriteVarLong(bytes, ZigZag(value));
+#endif
+
+    /// <summary>
+    /// Serializes 32-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 5
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (5*7+8 = 64).
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarInt(byte[] bytes, int offset, uint value)
+        => WriteVarLong(value, new ByteArrayByteWriter(bytes, offset));
+
+    /// <summary>
+    /// Serializes 32-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 5
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (5*7+8 = 64).
+    /// </summary>
+    /// <param name="writer">The writer to use to write the bytes</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarInt(BinaryWriter writer, uint value)
+        => WriteVarLong(value, new BinaryWriterByteWriter(writer));
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Serializes 32-bit unsigned integers 7 bits at a time,
+    /// starting with the least significant bits. The most significant bit in each
+    /// output byte is the continuation bit and indicates whether there are
+    /// additional non-zero bits encoded in following bytes. There are at most 5
+    /// output bytes and the last one does not have a continuation bit, allowing for
+    /// it to encode 8 bits (5*7+8 = 64).
+    /// </summary>
+    /// <param name="bytes">The buffer to write the encoded value to</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarInt(Span<byte> bytes, uint value)
+        => WriteVarLong(bytes, value);
+#endif
+
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarIntZigZag(byte[] bytes, int offset, int value)
+        => WriteVarLongZigZag(bytes, offset, value);
+
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="writer">The writer to use to write the bytes</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarIntZigZag(BinaryWriter writer, int value)
+        => WriteVarLongZigZag(writer, value);
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Serializes 64-bit signed integers using zig-zag encoding,
+    /// which ensures small-scale integers are turned into unsigned integers
+    /// that have leading zeros, whether they are positive or negative,
+    /// hence allows for space-efficient encoding of those values.
+    /// </summary>
+    /// <param name="bytes">The span to write the buffer into</param>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes written</returns>
+    public static int WriteVarIntZigZag(Span<byte> bytes, int value)
+        => WriteVarLongZigZag(bytes, value);
+#endif
+
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarLong(byte[],int,ulong)"/>
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static ulong? ReadVarLong(byte[] bytes, int offset, out int bytesRead)
+    {
+        ulong value = 0;
+        var i = 0;
+        var shift = 0;
+        while ((i + offset) < bytes.Length)
+        {
+            var next = bytes[i + offset];
+            if (next < 0x80 || i == MaxVarLen64 - 1)
+            {
+                bytesRead = i + 1;
+                return value | ((ulong)next << shift);
+            }
+
+            value |= ((ulong)next & 0x7FL) << shift;
+            i++;
+            shift += 7;
+        }
+
+        // something went wrong, invalid encoding
+        bytesRead = default;
+        return null;
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarLong(byte[],int,ulong)"/>
+    /// </summary>
+    /// <param name="bytes">The buffer to read the encoded value from</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static ulong? ReadVarLong(Span<byte> bytes, out int bytesRead)
+    {
+        // duplicate implementation
+        ulong value = 0;
+        var i = 0;
+        var shift = 0;
+        while (i < bytes.Length)
+        {
+            var next = bytes[i];
+            if (next < 0x80 || i == MaxVarLen64 - 1)
+            {
+                bytesRead = i + 1;
+                return value | ((ulong)next << shift);
+            }
+
+            value |= ((ulong)next & 0x7FL) << shift;
+            i++;
+            shift += 7;
+        }
+
+        // something went wrong, invalid encoding
+        bytesRead = default;
+        return null;
+    }
+#endif
+
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarLongZigZag(byte[],int,long)"/>
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static long? ReadVarLongZigZag(byte[] bytes, int offset, out int bytesRead)
+        => ReadVarLong(bytes, offset, out bytesRead) is { } decoded ? UnZigZag(decoded) : null;
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarLongZigZag(byte[],int,long)"/>
+    /// </summary>
+    /// <param name="bytes">The buffer to read the encoded value from</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static long? ReadVarLongZigZag(Span<byte> bytes, out int bytesRead)
+        => ReadVarLong(bytes, out bytesRead) is { } decoded ? UnZigZag(decoded) : null;
+#endif
+
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarInt(byte[],int,uint)" />
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static uint? ReadVarInt(byte[] bytes, int offset, out int bytesRead)
+        => ReadVarLong(bytes, offset, out bytesRead) is { } decoded and <= int.MaxValue
+            ? (uint)decoded
+            : null;
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarInt(byte[],int,uint)" />
+    /// </summary>
+    /// <param name="bytes">The buffer to read the encoded value from</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static uint? ReadVarInt(Span<byte> bytes, out int bytesRead)
+        => ReadVarLong(bytes, out bytesRead) is { } decoded and <= int.MaxValue
+            ? (uint)decoded
+            : null;
+#endif
+
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarIntZigZag(byte[],int,int)" />
+    /// </summary>
+    /// <param name="bytes">The byte array to write the buffer into</param>
+    /// <param name="offset">The offset within the array to start writing</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static long? ReadVarIntZigZag(byte[] bytes, int offset, out int bytesRead)
+        => ReadVarLongZigZag(bytes, offset, out bytesRead) is { } decoded and >= int.MinValue and <= int.MaxValue
+            ? (int)decoded
+            : null;
+
+#if NETCOREAPP3_1_OR_GREATER
+    /// <summary>
+    /// Deserializes 64-bit unsigned integers that have been encoded using
+    /// <see cref="WriteVarIntZigZag(byte[],int,int)" />
+    /// </summary>
+    /// <param name="bytes">The buffer to read the encoded value from</param>
+    /// <param name="bytesRead">The number of bytes read when successfully decoded</param>
+    /// <returns>The decoded value, or null if decoding failed</returns>
+    public static long? ReadVarIntZigZag(Span<byte> bytes, out int bytesRead)
+        => ReadVarLongZigZag(bytes, out bytesRead) is { } decoded and >= int.MinValue and <= int.MaxValue
+            ? (int)decoded
+            : null;
+#endif
+
+    /// <summary>
+    /// Returns the number of bytes that <see cref="WriteVarIntZigZag(byte[],int,int)"/> encodes a value into.
+    /// </summary>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes used to encode</returns>
+    public static int VarIntZigZagLength(int value) => VarLongLength(ZigZag(value));
+
+    /// <summary>
+    /// Returns the number of bytes that <see cref="WriteVarInt(byte[],int,uint)"/> encodes a value into.
+    /// </summary>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes used to encode</returns>
+    public static int VarIntLength(uint value) => VarLongLength(value);
+
+    /// <summary>
+    /// Returns the number of bytes that <see cref="WriteVarLongZigZag(byte[],int,long)"/> encodes a value into.
+    /// </summary>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes used to encode</returns>
+    public static int VarLongZigZagLength(long value) => VarLongLength(ZigZag(value));
+
+    /// <summary>
+    /// Returns the number of bytes that <see cref="WriteVarLong(byte[],int,ulong)"/> encodes a value into.
+    /// </summary>
+    /// <param name="value">The value to encode</param>
+    /// <returns>The number of bytes used to encode</returns>
+    public static int VarLongLength(ulong value) => VarLongLengths[NumberOfLeadingZerosLong(value)];
+
+    /// <summary>
+    /// C# implementation of Java Long.numberOfLeadingZeros
+    /// </summary>
+    private static uint NumberOfLeadingZerosLong(ulong x)
+    {
+#if NETCOREAPP3_1_OR_GREATER
+            return (uint)System.Numerics.BitOperations.LeadingZeroCount(x);
+#else
+        // Based on: https://stackoverflow.com/a/10439333/869621
+        // adjusted for long
+        const int numLongBits = sizeof(long) * 8; // compile time constant
+
+        // Do the smearing which turns (for example)
+        // this: 0000 0101 0011
+        // into: 0000 0111 1111
+        x |= x >> 1;
+        x |= x >> 2;
+        x |= x >> 4;
+        x |= x >> 8;
+        x |= x >> 16;
+        x |= x >> 32;
+
+        // Count the ones
+        x -= x >> 1 & 0x5555555555555555;
+        x = (x >> 2 & 0x3333333333333333) + (x & 0x3333333333333333);
+        x = (x >> 4) + x & 0x0f0f0f0f0f0f0f0f;
+        x += x >> 8;
+        x += x >> 16;
+        x += x >> 32;
+
+        return numLongBits - (uint)(x & 0x0000007f); // subtract # of 1s from 64
+#endif
+    }
+
+    private static int WriteVarLong<T>(ulong value, in T writer)
+        where T : IByteWriter
+    {
+        var length = VarLongLength(value);
+        for (var i = 0; i < length - 1; i++)
+        {
+            writer.WriteByte(i, (byte)((value & 0x7F) | 0x80));
+            value >>= 7;
+        }
+
+        writer.WriteByte(length - 1, (byte)value);
+        return length;
+    }
+
+    private static ulong ZigZag(long signed) => unchecked((ulong)((signed << 1) ^ (signed >> 63)));
+
+    private static long UnZigZag(ulong unsigned) => unchecked((long)((unsigned >> 1) ^ (0 - (unsigned & 1))));
+
+    private readonly struct ByteArrayByteWriter : IByteWriter
+    {
+        private readonly byte[] _bytes;
+        private readonly int _offset;
+
+        public ByteArrayByteWriter(byte[] bytes, int offset)
+        {
+            _bytes = bytes;
+            _offset = offset;
+        }
+
+        public void WriteByte(int offset, byte value)
+        {
+            _bytes[offset + _offset] = value;
+        }
+    }
+
+    private readonly struct BinaryWriterByteWriter : IByteWriter
+    {
+        private readonly BinaryWriter _writer;
+
+        public BinaryWriterByteWriter(BinaryWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void WriteByte(int offset, byte value)
+        {
+            _writer.Write(value);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/VarEncodingHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/VarEncodingHelperTests.cs
@@ -1,0 +1,373 @@
+﻿// <copyright file="VarEncodingHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Datadog.Trace.DataStreamsMonitoring;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class VarEncodingHelperTests
+{
+    public static IEnumerable<object[]> UnsignedVarLongs() =>
+        new List<object[]>
+        {
+            Unsigned(0L, 0x00),
+            Unsigned(1, 0x01),
+            Unsigned(127, 0x7F),
+            Unsigned(128, 0x80, 0x01),
+            Unsigned(129, 0x81, 0x01),
+            Unsigned(255, 0xFF, 0x01),
+            Unsigned(256, 0x80, 0x02),
+            Unsigned(16383, 0xFF, 0x7F),
+            Unsigned(16384, 0x80, 0x80, 0x01),
+            Unsigned(16385, 0x81, 0x80, 0x01),
+            Unsigned(35_459_249_995_776, 0x80, 0x80, 0x80, 0x80, 0x80, 0x88, 0x08),
+            Unsigned(unchecked((ulong)-2), 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+            Unsigned(unchecked((ulong)-1), 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+        };
+
+    public static IEnumerable<object[]> SignedVarLongs() =>
+        new List<object[]>
+        {
+            Signed(0L, 0x00),
+            Signed(1L, 0x02),
+            Signed(63L, 0x7E),
+            Signed(64L, 0x80, 0x01),
+            Signed(65L, 0x82, 0x01),
+            Signed(127L, 0xFE, 0x01),
+            Signed(128L, 0x80, 0x02),
+            Signed(8191L, 0xFE, 0x7F),
+            Signed(8192L, 0x80, 0x80, 0x01),
+            Signed(8193L, 0x82, 0x80, 0x01),
+            Signed((long.MaxValue >> 1) - 1L, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F),
+            Signed(long.MaxValue >> 1, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F),
+            Signed((long.MaxValue >> 1) + 1L, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80),
+            Signed(long.MaxValue - 1L, 0xFC, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+            Signed(long.MaxValue, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+            Signed(-1L, 0x01),
+            Signed(-63L, 0x7D),
+            Signed(-64L, 0x7F),
+            Signed(-65L, 0x81, 0x01),
+            Signed(-127L, 0xFD, 0x01),
+            Signed(-128L, 0xFF, 0x01),
+            Signed(-8191L, 0xFD, 0x7F),
+            Signed(-8192L, 0xFF, 0x7F),
+            Signed(-8193L, 0x81, 0x80, 0x01),
+            Signed((long.MinValue >> 1) + 1L, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F),
+            Signed(long.MinValue >> 1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F),
+            Signed((long.MinValue >> 1) - 1L, 0x81, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80),
+            Signed(long.MinValue + 1L, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+            Signed(long.MinValue, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF),
+        };
+
+    public static IEnumerable<object[]> SignedVarInts() =>
+        new List<object[]>
+        {
+            SignedInt(0, 0x00),
+            SignedInt(1, 0x02),
+            SignedInt(63, 0x7E),
+            SignedInt(64, 0x80, 0x01),
+            SignedInt(65, 0x82, 0x01),
+            SignedInt(127, 0xFE, 0x01),
+            SignedInt(128, 0x80, 0x02),
+            SignedInt(8191, 0xFE, 0x7F),
+            SignedInt(8192, 0x80, 0x80, 0x01),
+            SignedInt(8193, 0x82, 0x80, 0x01),
+            SignedInt((int.MaxValue >> 1) - 1, 0xFC, 0xFF, 0xFF, 0xFF, 0x07),
+            SignedInt(int.MaxValue >> 1, 0xFE, 0xFF, 0xFF, 0xFF, 0x07),
+            SignedInt((int.MaxValue >> 1) + 1, 0x80, 0x80, 0x80, 0x80, 0x08),
+            SignedInt(int.MaxValue - 1, 0xFC, 0xFF, 0xFF, 0xFF, 0x0F),
+            SignedInt(int.MaxValue, 0xFE, 0xFF, 0xFF, 0xFF, 0x0F),
+            SignedInt(-1, 0x01),
+            SignedInt(-63, 0x7D),
+            SignedInt(-64, 0x7F),
+            SignedInt(-65, 0x81, 0x01),
+            SignedInt(-127, 0xFD, 0x01),
+            SignedInt(-128, 0xFF, 0x01),
+            SignedInt(-8191, 0xFD, 0x7F),
+            SignedInt(-8192, 0xFF, 0x7F),
+            SignedInt(-8193, 0x81, 0x80, 0x01),
+            SignedInt((int.MinValue >> 1) + 1, 0xFD, 0xFF, 0xFF, 0xFF, 0x07),
+            SignedInt(int.MinValue >> 1, 0xFF, 0xFF, 0xFF, 0xFF, 0x07),
+            SignedInt((int.MinValue >> 1) - 1, 0x81, 0x80, 0x80, 0x80, 0x08),
+            SignedInt(int.MinValue + 1, 0xFD, 0xFF, 0xFF, 0xFF, 0x0F),
+            SignedInt(int.MinValue, 0xFF, 0xFF, 0xFF, 0xFF, 0x0F),
+        };
+
+    public static IEnumerable<object[]> BadBytes() =>
+        new List<object[]>
+        {
+            new object[] { new byte[] { 0b1000_0000 } },
+            new object[] { new byte[] { 0b1111_1111 } },
+            new object[] { new byte[] { 0b1000_0000, 0b1000_0000 } },
+        };
+
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void WriteVarLong_BytesTest(ulong value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarLong(bytes, 0, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void WriteVarLong_BinaryWriterTest(ulong value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        using var ms = new MemoryStream(bytes);
+        using var writer = new BinaryWriter(ms, Encoding.UTF8);
+        var bytesWritten = VarEncodingHelper.WriteVarLong(writer, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void WriteVarLong_SpanTest(ulong value, byte[] encoded)
+    {
+        Span<byte> bytes = stackalloc byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarLong(bytes, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        for (var i = 0; i < encoded.Length; i++)
+        {
+            var b = encoded[i];
+            bytes[i].Should().Be(b, $"the byte at {i} should be equal");
+        }
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void ReadVarLong_BytesTest(ulong expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarLong(encoded, 0, out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarLong_BytesTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarLong(bytes, 0, out _).Should().BeNull();
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void ReadVarLong_SpanTest(ulong expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarLong(encoded.AsSpan(), out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarLong_SpanTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarLong(bytes.AsSpan(), out _).Should().BeNull();
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void WriteVarLongZigZag_BytesTest(long value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarLongZigZag(bytes, 0, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void WriteVarLongZigZag_BinaryWriterTest(long value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        using var ms = new MemoryStream(bytes);
+        using var writer = new BinaryWriter(ms, Encoding.UTF8);
+        var bytesWritten = VarEncodingHelper.WriteVarLongZigZag(writer, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void WriteVarLongZigZag_SpanTest(long value, byte[] encoded)
+    {
+        Span<byte> bytes = stackalloc byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarLongZigZag(bytes, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        for (var i = 0; i < encoded.Length; i++)
+        {
+            var b = encoded[i];
+            bytes[i].Should().Be(b, $"the byte at {i} should be equal");
+        }
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void ReadVarLongZigZag_BytesTest(long expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarLongZigZag(encoded, 0, out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarLongZigZag_BytesTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarLong(bytes, 0, out _).Should().BeNull();
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void ReadVarLongZigZag_SpanTest(long expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarLongZigZag(encoded.AsSpan(), out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarLongZigZag_SpanTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarLong(bytes.AsSpan(), out _).Should().BeNull();
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void WriteVarIntZigZag_BytesTest(int value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarIntZigZag(bytes, 0, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void WriteVarIntZigZag_BinaryWriterTest(int value, byte[] encoded)
+    {
+        var bytes = new byte[encoded.Length];
+        using var ms = new MemoryStream(bytes);
+        using var writer = new BinaryWriter(ms, Encoding.UTF8);
+        var bytesWritten = VarEncodingHelper.WriteVarIntZigZag(writer, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        bytes.Should().Equal(encoded);
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void WriteVarIntZigZag_SpanTest(int value, byte[] encoded)
+    {
+        Span<byte> bytes = stackalloc byte[encoded.Length];
+        var bytesWritten = VarEncodingHelper.WriteVarIntZigZag(bytes, value);
+
+        using var s = new AssertionScope();
+        bytesWritten.Should().Be(bytes.Length);
+        for (var i = 0; i < encoded.Length; i++)
+        {
+            var b = encoded[i];
+            bytes[i].Should().Be(b, $"the byte at {i} should be equal");
+        }
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void ReadVarIntZigZag_BytesTest(int expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarIntZigZag(encoded, 0, out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarIntZigZag_BytesTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarIntZigZag(bytes, 0, out _).Should().BeNull();
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void ReadVarIntZigZag_SpanTest(int expected, byte[] encoded)
+    {
+        var actual = VarEncodingHelper.ReadVarIntZigZag(encoded.AsSpan(), out var bytesRead);
+        actual.Should().Be(expected);
+        bytesRead.Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(BadBytes))]
+    public void ReadVarIntZigZag_SpanTest_Error(byte[] bytes)
+    {
+        VarEncodingHelper.ReadVarIntZigZag(bytes.AsSpan(), out _).Should().BeNull();
+    }
+#endif
+
+    [Theory]
+    [MemberData(nameof(UnsignedVarLongs))]
+    public void VarLongLengthTest(ulong value, byte[] encoded)
+    {
+        VarEncodingHelper.VarLongLength(value).Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(SignedVarLongs))]
+    public void VarLongZigZagLengthTest(long value, byte[] encoded)
+    {
+        VarEncodingHelper.VarLongZigZagLength(value).Should().Be(encoded.Length);
+    }
+
+    [Theory]
+    [MemberData(nameof(SignedVarInts))]
+    public void VarIntZigZagLengthTest(int value, byte[] encoded)
+    {
+        VarEncodingHelper.VarIntZigZagLength(value).Should().Be(encoded.Length);
+    }
+
+    private static object[] Unsigned(ulong value, params byte[] bytes) => new object[] { value, bytes };
+
+    private static object[] Signed(long value, params byte[] bytes) => new object[] { value, bytes };
+
+    private static object[] SignedInt(int value, params byte[] bytes) => new object[] { value, bytes };
+}


### PR DESCRIPTION
## Summary of changes

- Adds `VarEncodingHelper` for use in Data Streams Monitoring

## Reason for change

This is a prerequisite for the ongoing data streams monitoring work. This implementation (and the tests) are based on the version [in sketches-go](https://github.com/DataDog/sketches-go/blob/master/ddsketch/encoding/encoding.go) and [sketches-java](https://github.com/DataDog/sketches-java/blob/master/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java) libraries. We can potentially move this to the [sketches-dotnet](https://github.com/DataDog/sketches-dotnet) library and re-vendor, but as it's unused in there, seemed it's easier to add it in here for now

## Implementation details

Copied the java implementation mostly, reused the existing `NumberOfLeadingZerosLong()` implementation added to sketches-dotnet by @kevingosse 

## Test coverage

Copy-pasted from java/go to ensure we're compatible

## Other details
This is a prerequisite for data streams monitoring
