### PR TITLE
Add a thread-safe `Random` implementation (for Data streams monitoring)

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.Debugger.RateLimiting
@@ -64,8 +65,6 @@ namespace Datadog.Trace.Debugger.RateLimiting
         private Timer _timer;
         private Action _rollWindowCallback;
 
-        private ThreadLocal<Random> _rng;
-
         internal AdaptiveSampler(
             TimeSpan windowDuration,
             int samplesPerWindow,
@@ -76,7 +75,6 @@ namespace Datadog.Trace.Debugger.RateLimiting
             _timer = new Timer(state => RollWindow(), state: null, windowDuration, windowDuration);
             _totalCountRunningAverage = 0;
             _rollWindowCallback = rollWindowCallback;
-            _rng = new ThreadLocal<Random>(() => new Random());
             _avgSamples = 0;
             _countsSlots = new Counts[2] { new(), new() };
             if (averageLookback < 1)
@@ -131,7 +129,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         internal double NextDouble()
         {
-            return _rng.Value.NextDouble();
+            return ThreadSafeRandom.NextDouble();
         }
 
         private double ComputeIntervalAlpha(int lookback)

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace
         internal SpanContext(ISpanContext parent, TraceContext traceContext, string serviceName, ulong? traceId = null, ulong? spanId = null, string rawTraceId = null, string rawSpanId = null)
             : this(parent?.TraceId ?? traceId, serviceName)
         {
-            SpanId = spanId ?? SpanIdGenerator.ThreadInstance.CreateNew();
+            SpanId = spanId ?? SpanIdGenerator.CreateNew();
             Parent = parent;
             TraceContext = traceContext;
             if (parent is SpanContext spanContext)
@@ -130,7 +130,7 @@ namespace Datadog.Trace
         {
             TraceId = traceId > 0
                           ? traceId.Value
-                          : SpanIdGenerator.ThreadInstance.CreateNew();
+                          : SpanIdGenerator.CreateNew();
 
             ServiceName = serviceName;
 

--- a/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -9,66 +9,13 @@ namespace Datadog.Trace.Util
 {
     internal class SpanIdGenerator
     {
-#if NETFRAMEWORK
-        private static readonly Random GlobalSeedGenerator = new Random();
-#endif
-
-        [ThreadStatic]
-        private static SpanIdGenerator _threadInstance;
-
-        private readonly Random _random;
-
-        public SpanIdGenerator()
-        {
-            _random = new Random();
-        }
-
-        public SpanIdGenerator(int seed)
-        {
-            _random = new Random(seed);
-        }
-
-        public static SpanIdGenerator ThreadInstance
-        {
-            get
-            {
-                SpanIdGenerator idGenerator = _threadInstance;
-
-                if (idGenerator == null)
-                {
-#if NETFRAMEWORK
-                    // On .NET Framework, the clock is used to seed the new random instances.
-                    // Resolution is too low, so if many threads are created at the same time,
-                    // some could end up using the same seed.
-                    // Instead, use a shared random instance to generate the seed.
-                    // The same approach was used for System.Random on .NET Core:
-                    // https://docs.microsoft.com/en-us/dotnet/api/system.random.-ctor?view=netcore-3.1
-                    int seed;
-
-                    lock (GlobalSeedGenerator)
-                    {
-                        seed = GlobalSeedGenerator.Next();
-                    }
-
-                    idGenerator = new SpanIdGenerator(seed);
-#else
-                    idGenerator = new SpanIdGenerator();
-#endif
-
-                    _threadInstance = idGenerator;
-                }
-
-                return idGenerator;
-            }
-        }
-
-        public ulong CreateNew()
+        public static ulong CreateNew()
         {
             ulong value;
             do
             {
-                long high = _random.Next(int.MinValue, int.MaxValue);
-                long low = _random.Next(int.MinValue, int.MaxValue);
+                long high = ThreadSafeRandom.Next(int.MinValue, int.MaxValue);
+                long low = ThreadSafeRandom.Next(int.MinValue, int.MaxValue);
 
                 // Concatenate both values, and truncate the 32 top bits from low
                 value = (ulong)(high << 32 | (low & 0xFFFFFFFF)) & 0x7FFFFFFFFFFFFFFF;

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="ThreadSafeRandom.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading;
+
+namespace Datadog.Trace.Util;
+
+internal static class ThreadSafeRandom
+{
+#if NET6_0_OR_GREATER
+    public static int Next(int maxValue) => Random.Shared.Next(maxValue);
+#else
+    private static readonly Random Global = new();
+
+    private static readonly ThreadLocal<Random> Local;
+
+    static ThreadSafeRandom()
+    {
+        Local = new ThreadLocal<Random>(
+            () =>
+            {
+                int seed;
+                lock (Global)
+                {
+                    seed = Global.Next();
+                }
+
+                return new Random(seed);
+            });
+    }
+
+    public static int Next(int maxValue)
+    {
+        return Local.Value!.Next(maxValue);
+    }
+#endif
+}

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -14,6 +14,8 @@ internal static class ThreadSafeRandom
 {
 #if NET6_0_OR_GREATER
     public static int Next(int maxValue) => Random.Shared.Next(maxValue);
+
+    public static double NextDouble() => Random.Shared.NextDouble();
 #else
     private static readonly Random Global = new();
 
@@ -37,6 +39,11 @@ internal static class ThreadSafeRandom
     public static int Next(int maxValue)
     {
         return Local.Value!.Next(maxValue);
+    }
+
+    public static double NextDouble()
+    {
+        return Local.Value!.NextDouble();
     }
 #endif
 }

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -21,12 +21,14 @@ internal static class ThreadSafeRandom
 #else
     private static readonly Random Global = new();
 
-    private static readonly ThreadLocal<Random> Local;
+    [ThreadStatic]
+    private static Random? _local;
 
-    static ThreadSafeRandom()
+    private static Random Local
     {
-        Local = new ThreadLocal<Random>(
-            () =>
+        get
+        {
+            if (_local is null)
             {
                 int seed;
                 lock (Global)
@@ -34,13 +36,16 @@ internal static class ThreadSafeRandom
                     seed = Global.Next();
                 }
 
-                return new Random(seed);
-            });
+                _local = new Random(seed);
+            }
+
+            return _local;
+        }
     }
 
     public static int Next(int maxValue)
     {
-        return Local.Value!.Next(maxValue);
+        return Local.Next(maxValue);
     }
 
     public static int Next(int minValue, int maxValue)
@@ -50,7 +55,7 @@ internal static class ThreadSafeRandom
 
     public static double NextDouble()
     {
-        return Local.Value!.NextDouble();
+        return Local.NextDouble();
     }
 #endif
 }

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -15,6 +15,8 @@ internal static class ThreadSafeRandom
 #if NET6_0_OR_GREATER
     public static int Next(int maxValue) => Random.Shared.Next(maxValue);
 
+    public static int Next(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
+
     public static double NextDouble() => Random.Shared.NextDouble();
 #else
     private static readonly Random Global = new();
@@ -39,6 +41,11 @@ internal static class ThreadSafeRandom
     public static int Next(int maxValue)
     {
         return Local.Value!.Next(maxValue);
+    }
+
+    public static int Next(int minValue, int maxValue)
+    {
+        return Local.Next(minValue, maxValue);
     }
 
     public static double NextDouble()

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -135,12 +135,10 @@ namespace Datadog.Trace.Tests.Sampling
             var sampleSize = iterations;
             var autoKeeps = 0;
             var userKeeps = 0;
-            int seed = new Random().Next();
-            var idGenerator = new SpanIdGenerator(seed);
 
             while (sampleSize-- > 0)
             {
-                var traceId = idGenerator.CreateNew();
+                var traceId = SpanIdGenerator.CreateNew();
                 var span = GetMyServiceSpan(traceId);
                 var decision = sampler.MakeSamplingDecision(span);
 
@@ -161,7 +159,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             Assert.True(
                 autoKeepRate >= autoKeepRateLowerLimit && autoKeepRate <= autoKeepRateUpperLimit,
-                $"Sampling AUTO_KEEP rate expected between {autoKeepRateLowerLimit} and {autoKeepRateUpperLimit}, actual rate is {autoKeepRate}. Random generator seeded with {seed}.");
+                $"Sampling AUTO_KEEP rate expected between {autoKeepRateLowerLimit} and {autoKeepRateUpperLimit}, actual rate is {autoKeepRate}.");
 
             // USER_KEEP (aka MANUAL_KEEP)
             var userKeepRate = userKeeps / (float)iterations;
@@ -170,7 +168,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             Assert.True(
                 userKeepRate >= userKeepRateLowerLimit && userKeepRate <= userKeepRateUpperLimit,
-                $"Sampling USER_KEEP rate expected between {userKeepRateLowerLimit} and {userKeepRateUpperLimit}, actual rate is {userKeepRate}. Random generator seeded with {seed}.");
+                $"Sampling USER_KEEP rate expected between {userKeepRateLowerLimit} and {userKeepRateUpperLimit}, actual rate is {userKeepRate}.");
         }
 
         private class NoLimits : IRateLimiter

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -64,13 +64,13 @@ namespace Datadog.Trace.Tests
 
             void AddAndCloseSpan()
             {
-                var span = new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+                var span = new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
                 traceContext.AddSpan(span);
                 traceContext.CloseSpan(span);
             }
 
-            var rootSpan = new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            var rootSpan = new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             traceContext.AddSpan(rootSpan);
 
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Tests
         {
             const int partialFlushThreshold = 3;
 
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -178,7 +178,7 @@ namespace Datadog.Trace.Tests
         [InlineData(false)]
         public void ChunksSentAfterRootSpanShouldContainAASMetadataAndSamplingPriority(bool inAASContext)
         {
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -236,7 +236,7 @@ namespace Datadog.Trace.Tests
         {
             const int partialFlushThreshold = 2;
 
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -284,7 +284,7 @@ namespace Datadog.Trace.Tests
         [InlineData(0)]
         public void StatsComputationEnabled_SerializeSpansFalseWhen_SamplingPriorityLessThanEqualTo0(int samplingPriority)
         {
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -311,7 +311,7 @@ namespace Datadog.Trace.Tests
         [InlineData(2)]
         public void StatsComputationEnabled_SerializeSpansTrueWhen_SamplingPriorityGreaterThan0(int samplingPriority)
         {
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -338,7 +338,7 @@ namespace Datadog.Trace.Tests
         [InlineData(true)]
         public void StatsComputationEnabled_SerializeSpansTrueWhen_TraceHasErrors(bool hasChildSpans)
         {
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 
@@ -378,7 +378,7 @@ namespace Datadog.Trace.Tests
         [InlineData(true, 1)]
         public void StatsComputationEnabled_SerializeSpansTrueWhen_SpanHasAnalyticsAndSampled(bool hasChildSpans, double analyticsSampleRate)
         {
-            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+            Span CreateSpan() => new Span(new SpanContext(42, SpanIdGenerator.CreateNew()), DateTimeOffset.UtcNow);
 
             var tracer = new Mock<IDatadogTracer>();
 


### PR DESCRIPTION
## Summary of changes

Adds a thread-safe random implementation.

## Reason for change

Required by data streams monitoring. The Debugger already had its own implementation, so centralised, hardened, and defaulted to the built-in version in .NET 6.

## Implementation details

`ThreadLocal` `Random`, and a "global" random for seeding the thread-local ones.

## Test coverage
Yeah... should probably be some...

## Other details
Required for data streams monitoring
