### PR TITLE
Add hash helpers for data streams monitoring

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/HashHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/HashHelper.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="HashHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class HashHelper
+{
+    private const FnvHash64.Version HashVersion = FnvHash64.Version.V1;
+
+    /// <summary>
+    /// Calculates the Node Hash for a service
+    /// NOTE: <paramref name="edgeTags"/> must be in correct sort order
+    /// </summary>
+    public static ulong CalculateNodeHash(string service, string? env, string? primaryTag, IEnumerable<string> edgeTags)
+    {
+        var hash = FnvHash64.GenerateHash(service, HashVersion);
+        if (!string.IsNullOrEmpty(env))
+        {
+            hash = FnvHash64.GenerateHash(env, HashVersion, hash);
+        }
+
+        if (!string.IsNullOrEmpty(primaryTag))
+        {
+            hash = FnvHash64.GenerateHash(primaryTag, HashVersion, hash);
+        }
+
+        foreach (var edgeTag in edgeTags)
+        {
+            hash = FnvHash64.GenerateHash(edgeTag, HashVersion, hash);
+        }
+
+        return hash;
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [System.Runtime.CompilerServices.SkipLocalsInit]
+#endif
+    public static ulong CalculatePathwayHash(ulong nodeHash, ulong parentHash)
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        Span<byte> bytes = stackalloc byte[16];
+        MemoryMarshal.Write(bytes, ref nodeHash);
+        MemoryMarshal.Write(bytes.Slice(8), ref parentHash);
+        return FnvHash64.GenerateHash(bytes, HashVersion);
+#else
+        // annoyingly allocate-y, but meh
+        var bytes = BitConverter.GetBytes(nodeHash);
+        var hash = FnvHash64.GenerateHash(bytes, HashVersion);
+
+        bytes = BitConverter.GetBytes(parentHash);
+        return FnvHash64.GenerateHash(bytes, HashVersion, hash);
+#endif
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/HashHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/HashHelper.cs
@@ -19,7 +19,7 @@ internal static class HashHelper
     /// Calculates the base NodeHash for a service.
     /// This can be used to create a <see cref="NodeHash"/> by calling <see cref="CalculateNodeHash"/>
     /// </summary>
-    public static NodeHashBase CalculateBaseNodeHash(string service, string? env, string? primaryTag)
+    public static NodeHashBase CalculateNodeHashBase(string service, string? env, string? primaryTag)
     {
         var hash = FnvHash64.GenerateHash(service, HashVersion);
         if (!string.IsNullOrEmpty(env))

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/HashHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/HashHelper.cs
@@ -9,17 +9,17 @@ using System.Collections.Generic;
 using Datadog.Trace.DataStreamsMonitoring.Utils;
 using Datadog.Trace.Util;
 
-namespace Datadog.Trace.DataStreamsMonitoring;
+namespace Datadog.Trace.DataStreamsMonitoring.Hashes;
 
 internal static class HashHelper
 {
     private const FnvHash64.Version HashVersion = FnvHash64.Version.V1;
 
     /// <summary>
-    /// Calculates the Node Hash for a service
-    /// NOTE: <paramref name="edgeTags"/> must be in correct sort order
+    /// Calculates the base NodeHash for a service.
+    /// This can be used to create a <see cref="NodeHash"/> by calling <see cref="CalculateNodeHash"/>
     /// </summary>
-    public static ulong CalculateNodeHash(string service, string? env, string? primaryTag, IEnumerable<string> edgeTags)
+    public static NodeHashBase CalculateBaseNodeHash(string service, string? env, string? primaryTag)
     {
         var hash = FnvHash64.GenerateHash(service, HashVersion);
         if (!string.IsNullOrEmpty(env))
@@ -32,18 +32,29 @@ internal static class HashHelper
             hash = FnvHash64.GenerateHash(primaryTag, HashVersion, hash);
         }
 
+        return new NodeHashBase(hash);
+    }
+
+    /// <summary>
+    /// Calculates the Node Hash for a service
+    /// NOTE: <paramref name="edgeTags"/> must be in correct sort order
+    /// </summary>
+    public static NodeHash CalculateNodeHash(in NodeHashBase baseNodeHash, IEnumerable<string> edgeTags)
+    {
+        // Already includes the static config, i.e. service, env, primary tag
+        var hash = baseNodeHash.Value;
         foreach (var edgeTag in edgeTags)
         {
             hash = FnvHash64.GenerateHash(edgeTag, HashVersion, hash);
         }
 
-        return hash;
+        return new NodeHash(hash);
     }
 
 #if NETCOREAPP3_1_OR_GREATER
     [System.Runtime.CompilerServices.SkipLocalsInit]
 #endif
-    public static ulong CalculatePathwayHash(ulong nodeHash, ulong parentHash)
+    public static PathwayHash CalculatePathwayHash(NodeHash nodeHash, PathwayHash parentHash)
     {
 #if NETCOREAPP3_1_OR_GREATER
         Span<byte> bytes = stackalloc byte[16];
@@ -53,11 +64,11 @@ internal static class HashHelper
 #else
         // annoyingly allocate-y, but meh
         var bytes = new byte[8];
-        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, nodeHash);
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, nodeHash.Value);
         var hash = FnvHash64.GenerateHash(bytes, HashVersion);
 
-        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, parentHash);
-        return FnvHash64.GenerateHash(bytes, HashVersion, hash);
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, parentHash.Value);
+        return new PathwayHash(FnvHash64.GenerateHash(bytes, HashVersion, hash));
 #endif
     }
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/NodeHash.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/NodeHash.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="NodeHash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+internal readonly struct NodeHash
+{
+    public readonly ulong Value;
+
+    public NodeHash(ulong value)
+    {
+        Value = value;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/NodeHashBase.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/NodeHashBase.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="NodeHashBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+internal readonly struct NodeHashBase
+{
+    public readonly ulong Value;
+
+    public NodeHashBase(ulong value)
+    {
+        Value = value;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/PathwayHash.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Hashes/PathwayHash.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="PathwayHash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+internal readonly struct PathwayHash
+{
+    public readonly ulong Value;
+
+    public PathwayHash(ulong value)
+    {
+        Value = value;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.DataStreamsMonitoring.Utils;
 
@@ -14,6 +15,11 @@ internal static class BinaryPrimitivesHelper
 #if NETCOREAPP3_1_OR_GREATER
         System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
 #else
+        if (bytes.Length < 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bytes), "Destination must be at least 8 bytes long");
+        }
+
         // write the bytes one at a time
         if (BitConverter.IsLittleEndian)
         {
@@ -46,6 +52,11 @@ internal static class BinaryPrimitivesHelper
 #if NETCOREAPP3_1_OR_GREATER
         return System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(bytes);
 #else
+        if (bytes.Length < 8)
+        {
+            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(bytes), "Source must be at least 8 bytes long");
+        }
+
         // read the bytes one at a time
         if (BitConverter.IsLittleEndian)
         {

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
@@ -17,25 +17,25 @@ internal static class BinaryPrimitivesHelper
         // write the bytes one at a time
         if (BitConverter.IsLittleEndian)
         {
-            bytes[0] = (byte)(value & 0xFF);
-            bytes[1] = (byte)((value >> 8) & 0xFF);
-            bytes[2] = (byte)((value >> 16) & 0xFF);
-            bytes[3] = (byte)((value >> 24) & 0xFF);
-            bytes[4] = (byte)((value >> 32) & 0xFF);
-            bytes[5] = (byte)((value >> 40) & 0xFF);
-            bytes[6] = (byte)((value >> 48) & 0xFF);
-            bytes[7] = (byte)((value >> 56) & 0xFF);
+            bytes[0] = unchecked((byte)(value & 0xFF));
+            bytes[1] = unchecked((byte)((value >> 8) & 0xFF));
+            bytes[2] = unchecked((byte)((value >> 16) & 0xFF));
+            bytes[3] = unchecked((byte)((value >> 24) & 0xFF));
+            bytes[4] = unchecked((byte)((value >> 32) & 0xFF));
+            bytes[5] = unchecked((byte)((value >> 40) & 0xFF));
+            bytes[6] = unchecked((byte)((value >> 48) & 0xFF));
+            bytes[7] = unchecked((byte)((value >> 56) & 0xFF));
         }
         else
         {
-            bytes[8] = (byte)(value & 0xFF);
-            bytes[7] = (byte)((value >> 8) & 0xFF);
-            bytes[6] = (byte)((value >> 16) & 0xFF);
-            bytes[5] = (byte)((value >> 24) & 0xFF);
-            bytes[4] = (byte)((value >> 32) & 0xFF);
-            bytes[3] = (byte)((value >> 40) & 0xFF);
-            bytes[2] = (byte)((value >> 48) & 0xFF);
-            bytes[1] = (byte)((value >> 56) & 0xFF);
+            bytes[7] = unchecked((byte)(value & 0xFF));
+            bytes[6] = unchecked((byte)((value >> 8) & 0xFF));
+            bytes[5] = unchecked((byte)((value >> 16) & 0xFF));
+            bytes[4] = unchecked((byte)((value >> 24) & 0xFF));
+            bytes[3] = unchecked((byte)((value >> 32) & 0xFF));
+            bytes[2] = unchecked((byte)((value >> 40) & 0xFF));
+            bytes[1] = unchecked((byte)((value >> 48) & 0xFF));
+            bytes[0] = unchecked((byte)((value >> 56) & 0xFF));
         }
 
 #endif
@@ -50,25 +50,25 @@ internal static class BinaryPrimitivesHelper
         if (BitConverter.IsLittleEndian)
         {
             ulong value = bytes[7];
-            value = (value << 8) | bytes[6];
-            value = (value << 8) | bytes[5];
-            value = (value << 8) | bytes[4];
-            value = (value << 8) | bytes[3];
-            value = (value << 8) | bytes[2];
-            value = (value << 8) | bytes[1];
-            value = (value << 8) | bytes[0];
+            value = unchecked((value << 8) | bytes[6]);
+            value = unchecked((value << 8) | bytes[5]);
+            value = unchecked((value << 8) | bytes[4]);
+            value = unchecked((value << 8) | bytes[3]);
+            value = unchecked((value << 8) | bytes[2]);
+            value = unchecked((value << 8) | bytes[1]);
+            value = unchecked((value << 8) | bytes[0]);
             return value;
         }
         else
         {
             ulong value = bytes[0];
-            value = (value << 8) | bytes[1];
-            value = (value << 8) | bytes[2];
-            value = (value << 8) | bytes[3];
-            value = (value << 8) | bytes[4];
-            value = (value << 8) | bytes[5];
-            value = (value << 8) | bytes[6];
-            value = (value << 8) | bytes[7];
+            value = unchecked((value << 8) | bytes[1]);
+            value = unchecked((value << 8) | bytes[2]);
+            value = unchecked((value << 8) | bytes[3]);
+            value = unchecked((value << 8) | bytes[4]);
+            value = unchecked((value << 8) | bytes[5]);
+            value = unchecked((value << 8) | bytes[6]);
+            value = unchecked((value << 8) | bytes[7]);
             return value;
         }
 #endif

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Utils/BinaryPrimitivesHelper.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="BinaryPrimitivesHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Utils;
+
+internal static class BinaryPrimitivesHelper
+{
+    public static void WriteUInt64LittleEndian(byte[] bytes, ulong value)
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(bytes, value);
+#else
+        // write the bytes one at a time
+        if (BitConverter.IsLittleEndian)
+        {
+            bytes[0] = (byte)(value & 0xFF);
+            bytes[1] = (byte)((value >> 8) & 0xFF);
+            bytes[2] = (byte)((value >> 16) & 0xFF);
+            bytes[3] = (byte)((value >> 24) & 0xFF);
+            bytes[4] = (byte)((value >> 32) & 0xFF);
+            bytes[5] = (byte)((value >> 40) & 0xFF);
+            bytes[6] = (byte)((value >> 48) & 0xFF);
+            bytes[7] = (byte)((value >> 56) & 0xFF);
+        }
+        else
+        {
+            bytes[8] = (byte)(value & 0xFF);
+            bytes[7] = (byte)((value >> 8) & 0xFF);
+            bytes[6] = (byte)((value >> 16) & 0xFF);
+            bytes[5] = (byte)((value >> 24) & 0xFF);
+            bytes[4] = (byte)((value >> 32) & 0xFF);
+            bytes[3] = (byte)((value >> 40) & 0xFF);
+            bytes[2] = (byte)((value >> 48) & 0xFF);
+            bytes[1] = (byte)((value >> 56) & 0xFF);
+        }
+
+#endif
+    }
+
+    public static ulong ReadUInt64LittleEndian(byte[] bytes)
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        return System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+#else
+        // read the bytes one at a time
+        if (BitConverter.IsLittleEndian)
+        {
+            ulong value = bytes[7];
+            value = (value << 8) | bytes[6];
+            value = (value << 8) | bytes[5];
+            value = (value << 8) | bytes[4];
+            value = (value << 8) | bytes[3];
+            value = (value << 8) | bytes[2];
+            value = (value << 8) | bytes[1];
+            value = (value << 8) | bytes[0];
+            return value;
+        }
+        else
+        {
+            ulong value = bytes[0];
+            value = (value << 8) | bytes[1];
+            value = (value << 8) | bytes[2];
+            value = (value << 8) | bytes[3];
+            value = (value << 8) | bytes[4];
+            value = (value << 8) | bytes[5];
+            value = (value << 8) | bytes[6];
+            value = (value << 8) | bytes[7];
+            return value;
+        }
+#endif
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/BinaryPrimitivesHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/BinaryPrimitivesHelperTests.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="BinaryPrimitivesHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class BinaryPrimitivesHelperTests
+{
+    [Fact]
+    public void CanRoundTripValue()
+    {
+        var random = new Random();
+        var bytes = new byte[8];
+        var expected = GetULong();
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, expected);
+        var actual = BinaryPrimitivesHelper.ReadUInt64LittleEndian(bytes);
+
+        actual.Should().Be(expected);
+
+        ulong GetULong()
+        {
+            var bytes = new byte[8];
+            random.NextBytes(bytes);
+            return BitConverter.ToUInt64(bytes, 0);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/BinaryPrimitivesHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/BinaryPrimitivesHelperTests.cs
@@ -13,10 +13,11 @@ namespace Datadog.Trace.Tests.DataStreamsMonitoring;
 
 public class BinaryPrimitivesHelperTests
 {
+    private static readonly Random Random = new();
+
     [Fact]
     public void CanRoundTripValue()
     {
-        var random = new Random();
         var bytes = new byte[8];
         var expected = GetULong();
         BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, expected);
@@ -27,7 +28,29 @@ public class BinaryPrimitivesHelperTests
         ulong GetULong()
         {
             var bytes = new byte[8];
-            random.NextBytes(bytes);
+            Random.NextBytes(bytes);
+            return BitConverter.ToUInt64(bytes, 0);
+        }
+    }
+
+    [Fact]
+    public void CanRoundTripValueWithZeroLowerByte()
+    {
+        var bytes = new byte[8];
+        var expected = GetZeroedUlong();
+
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, expected);
+        bytes[0].Should().Be(0);
+
+        var actual = BinaryPrimitivesHelper.ReadUInt64LittleEndian(bytes);
+
+        actual.Should().Be(expected);
+
+        ulong GetZeroedUlong()
+        {
+            var bytes = new byte[8];
+            Random.NextBytes(bytes);
+            bytes[0] = 0x00;
             return BitConverter.ToUInt64(bytes, 0);
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="HashHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class HashHelperTests
+{
+    [Theory]
+    [InlineData("service-1", "env-1", "d:1")]
+    [InlineData("service-1", "env-1", null)]
+    [InlineData("service-1", "env-1", "d:1", "edge-1")]
+    [InlineData("service-1", "env-1", "d:1", "edge-1", "edge-2")]
+    public void NodeHashSanityCheck(string service, string env, string primaryTag, params string[] edgeArgs)
+    {
+        // naive implementation (similar to e.g. go/java)
+        var sb = new StringBuilder()
+                .Append(service)
+                .Append(env);
+        if (!string.IsNullOrEmpty(primaryTag))
+        {
+            sb.Append(primaryTag);
+        }
+
+        var sortedArgs = new List<string>(edgeArgs);
+        sortedArgs.Sort(StringComparer.Ordinal);
+
+        foreach (var sortedArg in sortedArgs)
+        {
+            sb.Append(sortedArg);
+        }
+
+        var expectedHash = FnvHash64.GenerateHash(sb.ToString(), FnvHash64.Version.V1);
+        var actual = HashHelper.CalculateNodeHash(service, env, primaryTag, sortedArgs);
+
+        actual.Should().Be(expectedHash);
+    }
+
+    [Fact]
+    public void PathwayHashSanityCheck()
+    {
+        // naive implementation (similar to e.g. go/java)
+        var random = new Random();
+        var bytes = new byte[16];
+        random.NextBytes(bytes);
+
+        var nodeHash = BitConverter.ToUInt64(bytes, startIndex: 0);
+        var parentHash = BitConverter.ToUInt64(bytes, startIndex: 8);
+
+        var expectedHash = FnvHash64.GenerateHash(bytes, FnvHash64.Version.V1);
+        var actual = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
+
+        actual.Should().Be(expectedHash);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
 using Datadog.Trace.Util;
 using FluentAssertions;
 using Xunit;
@@ -40,9 +40,10 @@ public class HashHelperTests
         }
 
         var expectedHash = FnvHash64.GenerateHash(sb.ToString(), FnvHash64.Version.V1);
-        var actual = HashHelper.CalculateNodeHash(service, env, primaryTag, sortedArgs);
+        var baseHash = HashHelper.CalculateBaseNodeHash(service, env, primaryTag);
+        var actual = HashHelper.CalculateNodeHash(baseHash, sortedArgs);
 
-        actual.Should().Be(expectedHash);
+        actual.Value.Should().Be(expectedHash);
     }
 
     [Fact]
@@ -57,8 +58,8 @@ public class HashHelperTests
         var parentHash = BitConverter.ToUInt64(bytes, startIndex: 8);
 
         var expectedHash = FnvHash64.GenerateHash(bytes, FnvHash64.Version.V1);
-        var actual = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
+        var actual = HashHelper.CalculatePathwayHash(new NodeHash(nodeHash), new PathwayHash(parentHash));
 
-        actual.Should().Be(expectedHash);
+        actual.Value.Should().Be(expectedHash);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/HashHelperTests.cs
@@ -40,7 +40,7 @@ public class HashHelperTests
         }
 
         var expectedHash = FnvHash64.GenerateHash(sb.ToString(), FnvHash64.Version.V1);
-        var baseHash = HashHelper.CalculateBaseNodeHash(service, env, primaryTag);
+        var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag);
         var actual = HashHelper.CalculateNodeHash(baseHash, sortedArgs);
 
         actual.Value.Should().Be(expectedHash);


### PR DESCRIPTION
## Summary of changes

- Add a `BinaryPrimitivesHelper` to poly-fill allocation-free reading/writing of little endian `long` 
- Add a `HashHelper` to encapsulate building the Node and Pathway hashes for data streams monitoring
- Created simple strongly-typed-ids for the hashes to avoid accidental misuse

## Reason for change

I need to calculate these hashes for data streams monitoring, and want to avoid allocation where possible (as this could be on the hot path for an app)

## Implementation details

Hash implementations based on [the go](https://cs.github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/propagator.go) [and java](https://cs.github.com/DataDog/dd-trace-java/blob/3386bd137e58ed7450d1704e269d3567aeadf4c0/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java#L112) implementations in data streams monitoring.

## Test coverage

Should be covered, took the tests from go and java repos where available, and compared the pollyfilled "efficient" versions to the allocatey versions

## Other details
Required for data streams monitoring
