### PR TITLE
Compile Regex in `CustomSamplingRule`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -103,6 +103,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Theory]
         [InlineData("\"rate:0.5, \"name\":\"auth.*\"}]")]
         [InlineData("[{\"name\":\"wat\"}]")]
+        [InlineData("[{\"sample_rate\":0.3, \"service\":\"[\"}]")] // valid config, but invalid service regex
+        [InlineData("[{\"sample_rate\":0.3, \"name\":\"[\"}]")] // valid config, but invalid operation regex
+
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig)
         {
             var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig).ToArray();


### PR DESCRIPTION
## Summary of changes

Compiles Regex used in `CustomSamplingRule` as it wasn't.

## Reason for change

Regex wasn't being compiled.

## Implementation details

Swapped out the `string` patterns for `Regex` instances that are compiled.

## Test coverage

Existing tests appear to cover everything here.

## Other details

Somewhat apart of the Single Span Ingestion feature. Also planning on swapping this out with the vendored IndieRegex to get some of those performance improvements here.

(I didn't do any benchmarking to see the actual impact of this)
