### PR TITLE
Update GitLab to use newer build image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
   - deploy
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
+  DATADOG_AGENT_WINBUILDIMAGES: v9405677-746a71d
   GIT_PROFILER_REF: master
   DEPLOY_TO_REL_ENV:
     value: "false"


### PR DESCRIPTION
## Summary of changes

Update the GitLab build to use a newer build image

## Reason for change

The GitLab build is failing, likely because the image we're using is too old and has dropped off the ECR registry.

## Implementation details

Bumped the version to match [the one used by the agent](https://github.com/DataDog/datadog-agent/blob/a59baee7e2a4dbed260ee21b3e6e36a4943770d0/.gitlab-ci.yml#L144).

## Test coverage

Did a manual run (forcing the build) [here](https://gitlab.ddbuild.io/DataDog/dd-trace-dotnet/-/jobs/167194978). All looks good

## Other details

