### PR TITLE
Refactor the exclude list for assembly instrumentation 

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -684,11 +684,22 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
     {
         if (module_info.assembly.name.rfind(skip_assembly_pattern, 0) == 0)
         {
+            // The assembly matches the "skip" prefix, but check if it's specifically included
+            for (auto&& include_assembly : include_assemblies)
+            {
+                if (module_info.assembly.name == include_assembly)
+                {
+                    Logger::Debug("ModuleLoadFinished matched module by pattern: ", module_id, " ", module_info.assembly.name,
+                        "but assembly is explicitly included");
+                    goto inject;
+                }
+            }
             Logger::Debug("ModuleLoadFinished skipping module by pattern: ", module_id, " ", module_info.assembly.name);
             return S_OK;
         }
     }
 
+inject:    
     if (module_info.assembly.name == managed_profiler_name)
     {
         // Fix PInvoke Rewriting

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -684,22 +684,33 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
     {
         if (module_info.assembly.name.rfind(skip_assembly_pattern, 0) == 0)
         {
+            bool is_included = false;
             // The assembly matches the "skip" prefix, but check if it's specifically included
             for (auto&& include_assembly : include_assemblies)
             {
                 if (module_info.assembly.name == include_assembly)
                 {
-                    Logger::Debug("ModuleLoadFinished matched module by pattern: ", module_id, " ", module_info.assembly.name,
-                        "but assembly is explicitly included");
-                    goto inject;
+                    is_included = true;
+                    break;
                 }
             }
-            Logger::Debug("ModuleLoadFinished skipping module by pattern: ", module_id, " ", module_info.assembly.name);
-            return S_OK;
+
+            if (is_included)
+            {
+                Logger::Debug("ModuleLoadFinished matched module by pattern: ", module_id, " ",
+                              module_info.assembly.name,
+                              "but assembly is explicitly included");
+                break;
+            }
+            else
+            {
+                Logger::Debug("ModuleLoadFinished skipping module by pattern: ", module_id, " ",
+                              module_info.assembly.name);
+                return S_OK;
+            }
         }
     }
 
-inject:    
     if (module_info.assembly.name == managed_profiler_name)
     {
         // Fix PInvoke Rewriting

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -35,22 +35,7 @@ const shared::WSTRING skip_assembly_prefixes[]{
     WStr("Microsoft.ApplicationInsights"),
     WStr("Microsoft.Build"),
     WStr("Microsoft.CSharp"),
-    WStr("Microsoft.Extensions.Caching"),
-    WStr("Microsoft.Extensions.Configuration"),
-    WStr("Microsoft.Extensions.DependencyInjection"),
-    WStr("Microsoft.Extensions.DependencyModel"),
-    WStr("Microsoft.Extensions.Diagnostics"),
-    WStr("Microsoft.Extensions.FileProviders"),
-    WStr("Microsoft.Extensions.FileSystemGlobbing"),
-    WStr("Microsoft.Extensions.Hosting"),
-    WStr("Microsoft.Extensions.Http"),
-    WStr("Microsoft.Extensions.Identity"),
-    WStr("Microsoft.Extensions.Localization"),
-    WStr("Microsoft.Extensions.ObjectPool"),
-    WStr("Microsoft.Extensions.Options"),
-    WStr("Microsoft.Extensions.PlatformAbstractions"),
-    WStr("Microsoft.Extensions.Primitives"),
-    WStr("Microsoft.Extensions.WebEncoders"),
+    WStr("Microsoft.Extensions"),
     WStr("Microsoft.Web.Compilation.Snapshots"),
     WStr("System.Core"),
     WStr("System.Console"),
@@ -64,6 +49,11 @@ const shared::WSTRING skip_assembly_prefixes[]{
     WStr("System.Text"),
     WStr("System.Threading"),
     WStr("System.Xml"),
+};
+
+const shared::WSTRING include_assemblies[]{
+    WStr("Microsoft.Extensions.Logging"),
+    WStr("Microsoft.Extensions.Logging.Abstractions"),
 };
 
 const shared::WSTRING skip_traceattribute_assembly_prefixes[]{


### PR DESCRIPTION
## Summary of changes

Refactor the "exclude by pattern" list to allow specific inclusions.

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/1663 we switched from excluding the Microsoft.Extensions prefix to excluding each of the non-logging assemblies individually.

This is not future proof (as new _Microsoft.Extensions_ libraries could (will) be added, that we don't want to instrument), and increases the number of assemblies we need to match against.

## Implementation details

As a workaround, adds an explicit "include" list for assemblies which match the "exclude" prefix, but which should be included anyway.

I used a `goto`. I understand if I'm not allowed to touch C++ again.

## Test coverage

Should be covered by existing

## Other details
Should make it easier for @NachoEchevarria's work on `System.Diagnostics.Process`.
