### PR TITLE
Remove `reloadOnChange` from configuration in .NET Core 2.1

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Program.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-#if !NETCOREAPP2_1
 using Microsoft.Extensions.Configuration;
+#if !NETCOREAPP2_1
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 #endif
@@ -18,10 +18,20 @@ namespace Samples.AspNetCoreRazorPages
         {
             CreateHostBuilder(args).Build().Run();
         }
-        
+
 #if NETCOREAPP2_1
         public static IWebHostBuilder CreateHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+            // based on https://github.com/dotnet/aspnetcore/blob/main/src/DefaultBuilder/src/WebHost.cs#L154
+            // simplified to remove file reloading etc
+            WebHost.CreateDefaultBuilder()
+                   .ConfigureAppConfiguration(
+                        config =>
+                        {
+                            config.Sources.Clear();
+                            config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                                  .AddEnvironmentVariables()
+                                  .AddCommandLine(args);
+                        })
                    .UseStartup<Startup>();
 #else
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
## Summary of changes

Customise the Razor Pages app's config to remove `reloadOnChange` from the settings file watcher

## Reason for change

This was causing `The configured user limit (128) on the number of inotify instances has been reached` when running on Ubuntu 20.04.

## Implementation details

Manually configure the razor pages app's configuration so it doesn't use the filesystem watcher. This only impacts .NET Core 2.1, as the default is to use a polling file watcher when using the generic host in docker (`HostBuilder` instead of `IWebHostBuilder`)

## Test coverage

If the build passes, we're good.

## Other details