### PR TITLE
Skip the Razor Pages diagnostic listener tests on Linux .NET Core 2.1

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -98,6 +98,13 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         [MemberData(nameof(AspNetCoreRazorPagesTestData.WithoutFeatureFlag), MemberType = typeof(AspNetCoreRazorPagesTestData))]
         public async Task DiagnosticObserver_ForRazorPages_SubmitsSpans(string path, HttpStatusCode statusCode, bool isError, string resourceName, SerializableDictionary expectedTags)
         {
+#if NETCOREAPP2_1
+            if (EnvironmentTools.IsLinux())
+            {
+                throw new SkipException("This test fails on Linux due to `The configured user limit (128) on the number of inotify instances has been reached`. Reenable if/when we find time to resolve it");
+            }
+#endif
+
             await AssertDiagnosticObserverSubmitsSpans<Samples.AspNetCoreRazorPages.Startup>(path, statusCode, isError, resourceName, expectedTags);
         }
 
@@ -143,6 +150,13 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             string childSpan2ResourceName,
             SerializableDictionary secondChildSpanTags)
         {
+#if NETCOREAPP2_1
+            if (EnvironmentTools.IsLinux())
+            {
+                throw new SkipException("This test fails on Linux due to `The configured user limit (128) on the number of inotify instances has been reached`. Reenable if/when we find time to resolve it");
+            }
+#endif
+
             await AssertDiagnosticObserverSubmitsSpans<Samples.AspNetCoreRazorPages.Startup>(
                 path,
                 statusCode,

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
@@ -69,6 +69,11 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
         }
 
+        public static bool IsLinux()
+        {
+            return RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
+        }
+
         public static string GetPlatform()
         {
             return RuntimeInformation.ProcessArchitecture.ToString();


### PR DESCRIPTION
## Summary of changes

Skip the Razor Pages diagnostic listener tests when running on .NET Core 2.1, Linux only.

## Reason for change

This was causing `The configured user limit (128) on the number of inotify instances has been reached` for .NET Core 2.1 only, after updating the host agents to Ubuntu 20.04, 

## Implementation details

Throwing a `SkipException` on Linux .NET Core 2.1. This only impacts .NET Core 2.1, but [efforts to resolve it](https://github.com/DataDog/dd-trace-dotnet/pull/3138) by reducing the number of file watchers, or increasing `fs.inotify.max_user_instances` failed, so taking the cowards way out

## Test coverage

🤞 those integration tests

## Other details
Supersedes https://github.com/DataDog/dd-trace-dotnet/pull/3138
