### PR TITLE
Remove redundant string allocations for ApiResponses

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
@@ -4,7 +4,10 @@
 // </copyright>
 
 using System;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Agent
 {
@@ -14,8 +17,32 @@ namespace Datadog.Trace.Agent
 
         long ContentLength { get; }
 
+        Encoding ContentEncoding { get; }
+
         string GetHeader(string headerName);
 
-        Task<string> ReadAsStringAsync();
+        Task<Stream> GetStreamAsync();
+    }
+
+    internal static class ApiResponseExtensions
+    {
+        public static async Task<string> ReadAsStringAsync(this IApiResponse apiResponse)
+        {
+            using var reader = await GetStreamReader(apiResponse).ConfigureAwait(false);
+            return await reader.ReadToEndAsync().ConfigureAwait(false);
+        }
+
+        public static async Task<T> ReadAsTypeAsync<T>(this IApiResponse apiResponse)
+        {
+            using var sr = await GetStreamReader(apiResponse).ConfigureAwait(false);
+            using var jsonTextReader = new JsonTextReader(sr);
+            return JsonSerializer.Create().Deserialize<T>(jsonTextReader);
+        }
+
+        private static async Task<StreamReader> GetStreamReader(IApiResponse apiResponse)
+        {
+            var stream = await apiResponse.GetStreamAsync().ConfigureAwait(false);
+            return new StreamReader(stream, apiResponse.ContentEncoding, detectEncodingFromByteOrderMarks: false, (int)apiResponse.ContentLength, leaveOpen: true);
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent.Transports
@@ -17,21 +18,20 @@ namespace Datadog.Trace.Agent.Transports
         public ApiWebResponse(HttpWebResponse response)
         {
             _response = response;
+            ContentEncoding = !string.IsNullOrEmpty(response.ContentEncoding) ? Encoding.GetEncoding(response.ContentEncoding) : Encoding.UTF8;
         }
 
         public int StatusCode => (int)_response.StatusCode;
 
         public long ContentLength => _response.ContentLength;
 
+        public Encoding ContentEncoding { get; }
+
         public string GetHeader(string headerName) => _response.Headers[headerName];
 
-        public async Task<string> ReadAsStringAsync()
+        public Task<Stream> GetStreamAsync()
         {
-            using (var responseStream = _response.GetResponseStream())
-            {
-                var reader = new StreamReader(responseStream);
-                return await reader.ReadToEndAsync().ConfigureAwait(false);
-            }
+            return Task.FromResult(_response.GetResponseStream());
         }
 
         public void Dispose()

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
@@ -4,8 +4,10 @@
 // </copyright>
 
 #if NETCOREAPP
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent.Transports
@@ -17,11 +19,16 @@ namespace Datadog.Trace.Agent.Transports
         public HttpClientResponse(HttpResponseMessage response)
         {
             _response = response;
+
+            var encoding = _response.Content.Headers.ContentEncoding.FirstOrDefault();
+            ContentEncoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : Encoding.UTF8;
         }
 
         public int StatusCode => (int)_response.StatusCode;
 
         public long ContentLength => _response.Content.Headers.ContentLength ?? -1;
+
+        public Encoding ContentEncoding { get; }
 
         public void Dispose()
         {
@@ -48,9 +55,9 @@ namespace Datadog.Trace.Agent.Transports
             return null;
         }
 
-        public Task<string> ReadAsStringAsync()
+        public Task<Stream> GetStreamAsync()
         {
-            return _response.Content.ReadAsStringAsync();
+            return _response.Content.ReadAsStreamAsync();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             _response = response;
 
-            var encoding = _response.Content.Headers.ContentEncoding.FirstOrDefault();
+            var encoding = _response.Content?.Headers?.ContentEncoding?.FirstOrDefault();
             ContentEncoding = !string.IsNullOrEmpty(encoding) ? Encoding.GetEncoding(encoding) : Encoding.UTF8;
         }
 

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
@@ -13,13 +13,12 @@ namespace Datadog.Trace.Agent.Transports
     internal class HttpStreamResponse : IApiResponse
     {
         private readonly HttpHeaders _headers;
-        private string _responseCache;
 
         public HttpStreamResponse(int statusCode, long contentLength, Encoding encoding, Stream responseStream, HttpHeaders headers)
         {
             StatusCode = statusCode;
             ContentLength = contentLength;
-            Encoding = encoding;
+            ContentEncoding = encoding;
             ResponseStream = responseStream;
             _headers = headers;
         }
@@ -28,7 +27,7 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength { get; }
 
-        public Encoding Encoding { get; }
+        public Encoding ContentEncoding { get; }
 
         public Stream ResponseStream { get; }
 
@@ -38,17 +37,9 @@ namespace Datadog.Trace.Agent.Transports
 
         public string GetHeader(string headerName) => _headers.GetValue(headerName);
 
-        public async Task<string> ReadAsStringAsync()
+        public Task<Stream> GetStreamAsync()
         {
-            if (_responseCache == null)
-            {
-                using (var reader = new StreamReader(ResponseStream, Encoding, detectEncodingFromByteOrderMarks: false, (int)ContentLength, leaveOpen: true))
-                {
-                    _responseCache = await reader.ReadToEndAsync().ConfigureAwait(false);
-                }
-            }
-
-            return _responseCache;
+            return Task.FromResult(ResponseStream);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -50,17 +50,15 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
                 return null;
             }
 
-            var content = await apiResponse.ReadAsStringAsync().ConfigureAwait(false);
             if (apiResponse.StatusCode is not (>= 200 and <= 299))
             {
+                var content = await apiResponse.ReadAsStringAsync().ConfigureAwait(false);
                 Log.Warning<int, string>("Failed to receive remote configurations {StatusCode} and message: {ResponseContent}", apiResponse.StatusCode, content);
 
                 return null;
             }
 
-            var response = JsonConvert.DeserializeObject<GetRcmResponse>(content);
-
-            return response;
+            return await apiResponse.ReadAsTypeAsync<GetRcmResponse>().ConfigureAwait(false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.Tests
             var responseMock = new Mock<IApiResponse>();
             responseMock.Setup(x => x.StatusCode).Returns(200);
             responseMock.Setup(x => x.GetStreamAsync()).Returns(() => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(serializedResponse))));
-
+            responseMock.Setup(x => x.ContentEncoding).Returns(() => Encoding.UTF8);
             responseMock.Setup(x => x.ContentLength).Returns(serializedResponse.Length);
 
             var requestMock = new Mock<IApiRequest>();

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
@@ -180,7 +181,8 @@ namespace Datadog.Trace.Tests
 
             var responseMock = new Mock<IApiResponse>();
             responseMock.Setup(x => x.StatusCode).Returns(200);
-            responseMock.Setup(x => x.GetStreamAsync()).Returns(() => Task.FromResult(new StringReader(serializedResponse)));
+            responseMock.Setup(x => x.GetStreamAsync()).Returns(() => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(serializedResponse))));
+
             responseMock.Setup(x => x.ContentLength).Returns(serializedResponse.Length);
 
             var requestMock = new Mock<IApiRequest>();

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -179,7 +180,7 @@ namespace Datadog.Trace.Tests
 
             var responseMock = new Mock<IApiResponse>();
             responseMock.Setup(x => x.StatusCode).Returns(200);
-            responseMock.Setup(x => x.ReadAsStringAsync()).Returns(Task.FromResult(serializedResponse));
+            responseMock.Setup(x => x.GetStreamAsync()).Returns(() => Task.FromResult(new StringReader(serializedResponse)));
             responseMock.Setup(x => x.ContentLength).Returns(serializedResponse.Length);
 
             var requestMock = new Mock<IApiRequest>();

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -214,11 +215,18 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 
             public long ContentLength => _body?.Length ?? 0;
 
+            public Encoding ContentEncoding => Encoding.UTF8;
+
             public void Dispose()
             {
             }
 
             public string GetHeader(string headerName) => throw new NotImplementedException();
+
+            public Task<Stream> GetStreamAsync()
+            {
+                return Task.FromResult(new StreamReader(_body).BaseStream);
+            }
 
             public Task<string> ReadAsStringAsync() => Task.FromResult(_body);
         }

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
@@ -126,7 +127,14 @@ namespace Benchmarks.Trace
 
             public long ContentLength => 0;
 
+            public Encoding ContentEncoding => Encoding.UTF8;
+
             public string GetHeader(string headerName) => string.Empty;
+
+            public Task<Stream> GetStreamAsync()
+            {
+                throw new NotImplementedException();
+            }
 
             public Task<string> ReadAsStringAsync()
             {


### PR DESCRIPTION
## Summary of changes
Introduce `GetStreamAsync` method for `IApiResponse`.
Introduce `ReadAsStringAsync` and `ReadAsTypeAsync` extension methods.

## Reason for change
Right now we are allocating `IApiResponse` content to strings and afterwards converting them to object.
This PR removes redundant string allocations, by using `JsonSerializer` ability to read streams.
