### PR TITLE
[Profiler] Update SamplesCollectorTest

### DIFF
--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -259,7 +259,7 @@ TEST(SamplesCollectorTest, MustNotFailWhenAddingSampleThrows)
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
     auto [exporter, mockExporter] = CreateExporter();
-    EXPECT_CALL(mockExporter, Add(_)).Times(AtLeast(2)).WillOnce(Return()).WillRepeatedly(Throw(std::exception()));
+    EXPECT_CALL(mockExporter, Add(_)).Times(AtLeast(3)).WillOnce(Return()).WillRepeatedly(Throw(std::exception()));
     EXPECT_CALL(mockExporter, Export()).Times(1); // Called once when stopping
 
     auto metricsSender = MockMetricsSender();
@@ -270,10 +270,10 @@ TEST(SamplesCollectorTest, MustNotFailWhenAddingSampleThrows)
     collector.Register(&samplesProvider);
 
     collector.Start();
-    std::this_thread::sleep_for(150ms);
+    std::this_thread::sleep_for(200ms);
     collector.Stop();
 
-    ASSERT_GT(samplesProvider.GetNbCalls(), 0);
+    ASSERT_GT(samplesProvider.GetNbCalls(), 1);
 }
 
 TEST(SamplesCollectorTest, MustdNotAddSampleInExporterIfEmptyCallstack)

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -259,7 +259,7 @@ TEST(SamplesCollectorTest, MustNotFailWhenAddingSampleThrows)
     EXPECT_CALL(mockConfiguration, GetUploadInterval()).Times(1).WillOnce(Return(1s));
 
     auto [exporter, mockExporter] = CreateExporter();
-    EXPECT_CALL(mockExporter, Add(_)).Times(3).WillOnce(Return()).WillRepeatedly(Throw(std::exception()));
+    EXPECT_CALL(mockExporter, Add(_)).Times(AtLeast(2)).WillOnce(Return()).WillRepeatedly(Throw(std::exception()));
     EXPECT_CALL(mockExporter, Export()).Times(1); // Called once when stopping
 
     auto metricsSender = MockMetricsSender();


### PR DESCRIPTION
## Summary of changes

- Increase the delay to reduce flackiness
- Change the MockExporter to `AtLeast(3)` to account for the increased delay
- Change the expected number of calls to sampleProvider to "more than 1" (since the first call to Add will not throw an exception, it's guaranteed that the sampleProvider would be called once, even if the error handling code didn't work)

## Reason for change

Karma and peace of mind