### PR TITLE
Set the version of the native loader

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 0.1.0)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 2.15.0)
 
 # ******************************************************
 # Environment detection

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -226,6 +226,7 @@
     <ClInclude Include="instrumented_assembly_generator\method_signature.h" />
     <ClInclude Include="log.h" />
     <ClInclude Include="exported_functions.h" />
+    <ClInclude Include="resource.h" />
     <ClInclude Include="runtimeid_store.h" />
     <ClInclude Include="util.h" />
   </ItemGroup>
@@ -257,6 +258,9 @@
   </ItemGroup>
   <ItemGroup>
     <Text Include="CMakeLists.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj.filters
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj.filters
@@ -81,6 +81,9 @@
     <ClInclude Include="instrumented_assembly_generator\method_info.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -146,5 +149,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Datadog.Trace.ClrProfiler.Native.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Resource.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -1,0 +1,99 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEVERSION             2,15,0,0
+ PRODUCTVERSION          2,15,0,0
+ FILEOS                  VOS_NT
+ FILETYPE                VFT_DLL
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Datadog"
+            VALUE "FileDescription", "Native loader for Datadog .NET APM"
+            VALUE "FileVersion", "2.15.0.0"
+            VALUE "InternalName", "Native loader"
+            VALUE "LegalCopyright", "(c) Datadog 2020-2022"
+            VALUE "OriginalFilename", "Datadog.Trace.ClrProfiler.Native.dll"
+            VALUE "ProductName", "Native loader for Datadog .NET APM"
+            VALUE "ProductVersion", "2.15.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/resource.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by Datadog.Trace.ClrProfiler.Native.rc
+
+// Next default values for new objects
+// 
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -322,6 +322,23 @@ namespace PrepareRelease
                     "../profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",
                     text => FullVersionReplace(text, "."));
 
+                // Native loader
+
+                SynchronizeVersion(
+                    "../shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc",
+                    text =>
+                    {
+                        text = FullVersionReplace(text, ",");
+                        text = FullVersionReplace(text, ".");
+                        return text;
+                    });
+
+                SynchronizeVersion(
+                    "../shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
+                    text => FullVersionReplace(text, ".", prefix: "VERSION "));
+
+                // Misc
+
                 SynchronizeVersion(
                     "../.github/scripts/package_and_deploy.sh",
                     text => FullVersionReplace(text, ".", prefix: "current_profiler_version=\""));


### PR DESCRIPTION
## Summary of changes

Currently the native loader is shipped without setting the version number. This PR aligns it with the native tracer and the continuous profiler.

## Reason for change

The version number is one of the information checked by the dd-trace diagnostic tool.

## Test coverage

The tool integration tests on Windows would detect that, if they were running.
