### PR TITLE
[CIVisibility] Include ci-app-libraries-dotnet team as a CODEOWNER of PDB folder.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 # Debugger
 /tracer/src/Datadog.Trace/Debugger/        @DataDog/debugger-dotnet
 /tracer/test/Datadog.Trace.Tests/Debugger/ @DataDog/debugger-dotnet
-/tracer/src/Datadog.Trace/PDBs/            @DataDog/debugger-dotnet
+/tracer/src/Datadog.Trace/PDBs/            @DataDog/debugger-dotnet @DataDog/ci-app-libraries-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ @DataDog/debugger-dotnet
 /tracer/test/test-applications/debugger/   @DataDog/debugger-dotnet
 


### PR DESCRIPTION
## Summary of changes

This PR adds the ci-app-libraries-dotnet team as a CODEOWNER of the `/tracer/src/Datadog.Trace/PDBs/` folder.

## Reason for change

CI Visibility also uses and produces code for the PDBs namespaces that are not related to the Debugger.