### PR TITLE
[Profiler] Performance improvements for samples management

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -14,11 +14,12 @@ const std::string Sample::ExceptionTypeLabel = "exception type";
 const std::string Sample::ExceptionMessageLabel = "exception message";
 const std::string Sample::AllocationClassLabel = "allocation class";
 
-Sample::Sample(uint64_t timestamp, std::string_view runtimeId) :
+Sample::Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCount) :
     Sample(runtimeId)
 {
     _timestamp = timestamp;
     _runtimeId = runtimeId;
+    _callstack.reserve(framesCount);
 }
 
 Sample::Sample(std::string_view runtimeId)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -70,7 +70,7 @@ class Sample
 {
 public:
     Sample(std::string_view runtimeId); // only for tests
-    Sample(uint64_t timestamp, std::string_view runtimeId);
+    Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCount);
     Sample& operator=(const Sample& sample) = delete;
     Sample(Sample&& sample) noexcept;
     Sample& operator=(Sample&& other) noexcept;
@@ -91,7 +91,7 @@ public:
 
     // should be protected if we want to derive classes from Sample such as WallTimeSample
     // but it seems better for encapsulation to do the transformation between collected raw data
-    // and a Sample in each Provider (this is the each behind CollectorBase template class)
+    // and a Sample in each Provider (this is behind CollectorBase template class)
     void AddValue(std::int64_t value, SampleValue index);
     void AddFrame(std::string_view moduleName, std::string_view frame);
 


### PR DESCRIPTION
## Summary of changes
Reduce allocations in samples management

## Reason for change
Focus on hot spots in high allocations scenario

## Implementation details
- precompute thread id and name
- reserve vector for frames

## Test coverage
using superluminal native profiler to check the change impacts

## Other details
<!-- Fixes #{issue} -->
