### PR TITLE
Rename RuleBasedSampler to TraceSampler

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/AnalyticsEventsSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/AnalyticsEventsSampler.cs
@@ -8,7 +8,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Agent.TraceSamplers
 {
-    internal class AnalyticsEventsSampler : ITraceSampler
+    internal class AnalyticsEventsSampler : ITraceChunkSampler
     {
         public bool Sample(ArraySegment<Span> trace)
         {

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/ErrorSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/ErrorSampler.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace Datadog.Trace.Agent.TraceSamplers
 {
-    internal class ErrorSampler : ITraceSampler
+    internal class ErrorSampler : ITraceChunkSampler
     {
         public bool Sample(ArraySegment<Span> trace)
         {

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/ITraceChunkSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/ITraceChunkSampler.cs
@@ -1,4 +1,4 @@
-// <copyright file="ITraceSampler.cs" company="Datadog">
+// <copyright file="ITraceChunkSampler.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -7,7 +7,7 @@ using System;
 
 namespace Datadog.Trace.Agent
 {
-    internal interface ITraceSampler
+    internal interface ITraceChunkSampler
     {
         /// <summary>
         /// Determines if a trace chunk should be sampled

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/PrioritySampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/PrioritySampler.cs
@@ -8,7 +8,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Agent.TraceSamplers
 {
-    internal class PrioritySampler : ITraceSampler
+    internal class PrioritySampler : ITraceChunkSampler
     {
         public bool Sample(ArraySegment<Span> trace) =>
             SamplingHelpers.IsKeptBySamplingPriority(trace);

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
@@ -9,7 +9,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Agent.TraceSamplers
 {
-    internal class RareSampler : ITraceSampler
+    internal class RareSampler : ITraceChunkSampler
     {
         private const string RareKey = "_dd.rare";
         private const int CacheLimit = 200; // Uses default value of 200 as found in the trace agent

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Ci.Agent
         private static Span[] _spanArray;
         private readonly AgentWriter _agentWriter;
 
-        public CIAgentWriter(ImmutableTracerSettings settings, ISampler sampler, IDiscoveryService discoveryService, int maxBufferSize = DefaultMaxBufferSize)
+        public CIAgentWriter(ImmutableTracerSettings settings, ITraceSampler sampler, IDiscoveryService discoveryService, int maxBufferSize = DefaultMaxBufferSize)
         {
             var partialFlushEnabled = settings.Exporter.PartialFlushEnabled;
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, string defaultServiceName)
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, string defaultServiceName)
             : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, defaultServiceName, new Trace.Processors.ITraceProcessor[]
             {
                 new Trace.Processors.NormalizerTraceProcessor(),

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Ci
         protected override TracerManager CreateTracerManagerFrom(
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
-            ISampler sampler,
+            ITraceSampler sampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetrics,
@@ -46,12 +46,12 @@ namespace Datadog.Trace.Ci
             return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
         }
 
-        protected override ISampler GetSampler(ImmutableTracerSettings settings)
+        protected override ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {
             return new CISampler();
         }
 
-        protected override IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ISampler sampler, IDiscoveryService discoveryService)
+        protected override IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ITraceSampler sampler, IDiscoveryService discoveryService)
         {
             // Check for agentless scenario
             if (_settings.Agentless)

--- a/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Sampling/CISampler.cs
@@ -8,7 +8,7 @@ using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.Ci.Sampling
 {
-    internal class CISampler : ISampler
+    internal class CISampler : ITraceSampler
     {
         public SamplingDecision MakeSamplingDecision(Span span)
         {

--- a/tracer/src/Datadog.Trace/IDatadogTracer.cs
+++ b/tracer/src/Datadog.Trace/IDatadogTracer.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace
     {
         string DefaultServiceName { get; }
 
-        ISampler Sampler { get; }
+        ITraceSampler Sampler { get; }
 
         ImmutableTracerSettings Settings { get; }
 

--- a/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
@@ -1,4 +1,4 @@
-// <copyright file="ISampler.cs" company="Datadog">
+// <copyright file="ITraceSampler.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 namespace Datadog.Trace.Sampling
 {
-    internal interface ISampler
+    internal interface ITraceSampler
     {
         void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates);
 

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -9,7 +9,7 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Sampling
 {
-    internal class TraceSampler : ISampler
+    internal class TraceSampler : ITraceSampler
     {
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuleBasedSampler.cs" company="Datadog">
+// <copyright file="TraceSampler.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,17 +9,17 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Sampling
 {
-    internal class RuleBasedSampler : ISampler
+    internal class TraceSampler : ISampler
     {
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RuleBasedSampler>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceSampler>();
 
         private readonly IRateLimiter _limiter;
         private readonly DefaultSamplingRule _defaultRule = new DefaultSamplingRule();
         private readonly List<ISamplingRule> _rules = new List<ISamplingRule>();
 
-        public RuleBasedSampler(IRateLimiter limiter)
+        public TraceSampler(IRateLimiter limiter)
         {
             _limiter = limiter ?? new TracerRateLimiter(null);
             RegisterRule(_defaultRule);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace
         /// Note that this API does NOT replace the global Tracer instance.
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
-        internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
+        internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
             : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService))
         {
         }
@@ -215,9 +215,9 @@ namespace Datadog.Trace
         ImmutableTracerSettings ITracer.Settings => Settings;
 
         /// <summary>
-        /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
+        /// Gets the <see cref="ITraceSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
-        ISampler IDatadogTracer.Sampler => TracerManager.Sampler;
+        ITraceSampler IDatadogTracer.Sampler => TracerManager.Sampler;
 
         internal static string RuntimeId => DistributedTracer.Instance.GetRuntimeId();
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace
         public TracerManager(
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
-            ISampler sampler,
+            ITraceSampler sampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetricsWriter,
@@ -118,9 +118,9 @@ namespace Datadog.Trace
         public IScopeManager ScopeManager { get; }
 
         /// <summary>
-        /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
+        /// Gets the <see cref="ITraceSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
-        public ISampler Sampler { get; }
+        public ITraceSampler Sampler { get; }
 
         public DirectLogSubmissionManager DirectLogSubmission { get; }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace
 
         protected virtual ISampler GetSampler(ImmutableTracerSettings settings)
         {
-            var sampler = new RuleBasedSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecond));
+            var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecond));
 
             if (!string.IsNullOrWhiteSpace(settings.CustomSamplingRules))
             {

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -74,12 +74,12 @@ namespace Datadog.Trace
 
         /// <summary>
         /// Internal for use in tests that create "standalone" <see cref="TracerManager"/> by
-        /// <see cref="Tracer(TracerSettings, IAgentWriter, ISampler, IScopeManager, IDogStatsd, ITelemetryController, IDiscoveryService)"/>
+        /// <see cref="Tracer(TracerSettings, IAgentWriter, ITraceSampler, IScopeManager, IDogStatsd, ITelemetryController, IDiscoveryService)"/>
         /// </summary>
         internal TracerManager CreateTracerManager(
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
-            ISampler sampler,
+            ITraceSampler sampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetrics,
@@ -131,7 +131,7 @@ namespace Datadog.Trace
         protected virtual TracerManager CreateTracerManagerFrom(
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
-            ISampler sampler,
+            ITraceSampler sampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetrics,
@@ -141,7 +141,7 @@ namespace Datadog.Trace
             string defaultServiceName)
             => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
 
-        protected virtual ISampler GetSampler(ImmutableTracerSettings settings)
+        protected virtual ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {
             var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecond));
 
@@ -170,7 +170,7 @@ namespace Datadog.Trace
             return sampler;
         }
 
-        protected virtual IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ISampler sampler, IDiscoveryService discoveryService)
+        protected virtual IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ITraceSampler sampler, IDiscoveryService discoveryService)
         {
             var apiRequestFactory = TracesTransportStrategy.Get(settings.Exporter);
             var api = new Api(apiRequestFactory, statsd, rates => sampler.SetDefaultSampleRates(rates), settings.Exporter.PartialFlushEnabled);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Kafka/CachedWrapperDelegateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Kafka/CachedWrapperDelegateTests.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Kafka
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // Set up Tracer
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
             using (var automaticScope = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(uri), IntegrationId.HttpMessageHandler, out _))
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // Set up Tracer
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
             using (var automaticScope = ScopeFactory.CreateOutboundHttpScope(tracer, "GET", null, IntegrationId.HttpMessageHandler, out _))
@@ -109,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // Set up Tracer
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
             const string method = "GET";
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // Set up Tracer
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
             const string method = "GET";

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -542,7 +542,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
         {
             var settings = new TracerSettings(configSource);
             var agentWriter = writer ?? new Mock<IAgentWriter>().Object;
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             return new Tracer(settings, agentWriter, samplerMock.Object, scopeManager: null, statsd: null);
         }

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             };
 
             var writerMock = new Mock<IAgentWriter>(MockBehavior.Strict);
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(datadogTracer);

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(datadogTracer);

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.TestHelpers
         public static Tracer Create(
             TracerSettings settings = null,
             IAgentWriter agentWriter = null,
-            ISampler sampler = null,
+            ITraceSampler sampler = null,
             IScopeManager scopeManager = null,
             IDogStatsd statsd = null)
         {

--- a/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ContextTrackerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ContextTrackerTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.ContinuousProfiler
 
         private static Tracer CreateTracer()
         {
-            return new Tracer(new TracerSettings(), Mock.Of<IAgentWriter>(), Mock.Of<ISampler>(), null, null);
+            return new Tracer(new TracerSettings(), Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), null, null);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         private void RunSamplerTest(
-            ISampler sampler,
+            ITraceSampler sampler,
             int iterations,
             float expectedAutoKeepRate,
             float expectedUserKeepRate,

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="RuleBasedSamplerTests.cs" company="Datadog">
+// <copyright file="TraceSamplerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,7 +13,7 @@ using Xunit;
 namespace Datadog.Trace.Tests.Sampling
 {
     [Collection(nameof(Datadog.Trace.Tests.Sampling))]
-    public class RuleBasedSamplerTests
+    public class TraceSamplerTests
     {
         private const float FallbackRate = 0.25f;
         private const string ServiceName = "my-service-name";
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void RateLimiter_Never_Applied_For_DefaultRule()
         {
-            var sampler = new RuleBasedSampler(new DenyAll());
+            var sampler = new TraceSampler(new DenyAll());
             RunSamplerTest(
                 sampler,
                 iterations: 500,
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void RateLimiter_Denies_All_Traces()
         {
-            var sampler = new RuleBasedSampler(new DenyAll());
+            var sampler = new TraceSampler(new DenyAll());
             sampler.RegisterRule(new CustomSamplingRule(1, "Allow_all", ".*", ".*"));
             RunSamplerTest(
                 sampler,
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Keep_Everything_Rule()
         {
-            var sampler = new RuleBasedSampler(new NoLimits());
+            var sampler = new TraceSampler(new NoLimits());
             sampler.RegisterRule(new CustomSamplingRule(1, "Allow_all", ".*", ".*"));
             RunSamplerTest(
                 sampler,
@@ -63,7 +63,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Keep_Nothing_Rule()
         {
-            var sampler = new RuleBasedSampler(new NoLimits());
+            var sampler = new TraceSampler(new NoLimits());
             sampler.RegisterRule(new CustomSamplingRule(0, "Allow_nothing", ".*", ".*"));
             RunSamplerTest(
                 sampler,
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Keep_Half_Rule()
         {
-            var sampler = new RuleBasedSampler(new NoLimits());
+            var sampler = new TraceSampler(new NoLimits());
             sampler.RegisterRule(new CustomSamplingRule(0.5f, "Allow_half", ".*", ".*"));
             RunSamplerTest(
                 sampler,
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void No_Registered_Rules_Uses_Legacy_Rates()
         {
-            var sampler = new RuleBasedSampler(new NoLimits());
+            var sampler = new TraceSampler(new NoLimits());
             sampler.SetDefaultSampleRates(MockAgentRates);
 
             RunSamplerTest(
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Choose_Between_Sampling_Mechanisms()
         {
             var span = GetMyServiceSpan(traceId: 1);
-            var sampler = new RuleBasedSampler(new NoLimits());
+            var sampler = new TraceSampler(new NoLimits());
 
             // if there are no other rules, and before we wave agent rates, mechanism is "Default"
             var (_, mechanism1) = sampler.MakeSamplingDecision(span);

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tests
 
             var settings = new TracerSettings();
             _writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var tracer = new Tracer(
                 settings,
                 new Mock<IAgentWriter>().Object,
-                new Mock<ISampler>().Object,
+                new Mock<ITraceSampler>().Object,
                 scopeManager: null,
                 statsd: null,
                 telemetry: telemetry);

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -18,12 +18,12 @@ namespace Datadog.Trace.Tests
     public class TracerSettingsTests
     {
         private readonly Mock<IAgentWriter> _writerMock;
-        private readonly Mock<ISampler> _samplerMock;
+        private readonly Mock<ITraceSampler> _samplerMock;
 
         public TracerSettingsTests()
         {
             _writerMock = new Mock<IAgentWriter>();
-            _samplerMock = new Mock<ISampler>();
+            _samplerMock = new Mock<ITraceSampler>();
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tests
         {
             var settings = new TracerSettings();
             var writerMock = new Mock<IAgentWriter>();
-            var samplerMock = new Mock<ISampler>();
+            var samplerMock = new Mock<ITraceSampler>();
 
             _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }
@@ -520,7 +520,7 @@ namespace Datadog.Trace.Tests
                 StartupDiagnosticLogEnabled = false
             };
 
-            var tracer = new Tracer(settings, agent.Object, Mock.Of<ISampler>(), Mock.Of<IScopeManager>(), Mock.Of<IDogStatsd>());
+            var tracer = new Tracer(settings, agent.Object, Mock.Of<ITraceSampler>(), Mock.Of<IScopeManager>(), Mock.Of<IDogStatsd>());
 
             await tracer.ForceFlushAsync();
 
@@ -536,7 +536,7 @@ namespace Datadog.Trace.Tests
             {
                 StartupDiagnosticLogEnabled = false
             };
-            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ISampler>(), scopeManager, Mock.Of<IDogStatsd>());
+            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
             var rootTestScope = (Scope)tracer.StartActive("test.trace");
             var childTestScope = (Scope)tracer.StartActive("test.trace.child");
@@ -578,7 +578,7 @@ namespace Datadog.Trace.Tests
             {
                 StartupDiagnosticLogEnabled = false
             };
-            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ISampler>(), scopeManager, Mock.Of<IDogStatsd>());
+            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ITraceSampler>(), scopeManager, Mock.Of<IDogStatsd>());
 
             var rootTestScope = (Scope)tracer.StartActive("test.trace");
             var childTestScope = (Scope)tracer.StartActive("test.trace.child");


### PR DESCRIPTION
## Summary of changes

This renames the following:

- Within `Datadog.Agent.TraceSamplers`
    - `ITraceSampler`-> `ITraceChunkSampler` (over alternative `ITraceAgentSampler`)
    - `RareSampler`, `ErrorSampler`, etc all stay the same
- Within `Datadog.Trace.Sampling`
    - `ISampler` -> `ITraceSampler`
    - `RuleBasedSampler` -> `TraceSampler`
    - `CustomSamplingRule`, `DefaultSamplingRule`, `GlobalSamplingRule` stay the same

## Reason for change

Motivation is that this is not _just_ a rule-based sampler and ultimately just operates on traces.
For single span ingestion we'll have a `SpanSampler` so this would help clarify the differences between the two.

## Test coverage

The now renamed `TraceSamplerTests` all still pass.
