### PR TITLE
Exclude named pipe timeout from build log check

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1503,7 +1503,7 @@ partial class Build
        .Description("Reads the logs from build_data and checks for error lines")
        .Executes(() =>
        {
-           // we expect to see _some_ errors, so explcitly ignore them
+           // we expect to see _some_ errors, so explicitly ignore them
            var knownPatterns = new List<Regex>
            {
                new(@".*Unable to resolve method MongoDB\..*", RegexOptions.Compiled),
@@ -1513,6 +1513,9 @@ partial class Build
                new(@".*at CallTargetNativeTest\.NoOp\.Noop\dArgumentsVoidIntegration\.OnMethodBegin.*", RegexOptions.Compiled),
                new(@".*at CallTargetNativeTest\.NoOp\.Noop\dArgumentsVoidIntegration\.OnMethodEnd.*", RegexOptions.Compiled),
                new(@".*System.Threading.ThreadAbortException: Thread was being aborted\.", RegexOptions.Compiled),
+               // This one is annoying but we _think_ due to a dodgy named pipes implementation, so ignoring for now
+               new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\trace-.*The operation has timed out.*", RegexOptions.Compiled),
+               new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\metrics-.*The operation has timed out.*", RegexOptions.Compiled),
            };
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: false, minLogLevel: LogLevel.Error);


### PR DESCRIPTION
## Summary of changes

Exclude `"The operation has timed out"` errors from named pipes tests

## Reason for change

We occasionally see them in the logs, even though the tests pass, causing flakiness. We think this is down to the mock named pipes server implementation so aren't currently investigating it further.

## Implementation details

Exclude the phrase from the build log check

## Test coverage

Did a manual test locally 👍 

## Other details
There's doesn't deal with the flaky debugger tests 