### PR TITLE
Fix order of spans in WcfTests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 var settings = VerifyHelper.GetSpanVerifierSettings(binding, enableNewWcfInstrumentation, enableWcfObfuscation);
 
-                await VerifyHelper.Verify(spans, settings)
+                await VerifyHelper.VerifySpans(spans, settings)
                               .UseMethodName("_");
 
                 foreach (var span in spans)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 var settings = VerifyHelper.GetSpanVerifierSettings(binding, enableNewWcfInstrumentation, enableWcfObfuscation);
 
-                await Verifier.Verify(spans, settings)
+                await VerifyHelper.Verify(spans, settings)
                               .UseMethodName("_");
 
                 foreach (var span in spans)


### PR DESCRIPTION
## Summary of changes

Use `VerifyHelper.Verify` to sort the spans in WcfTests for more predictable results.

## Reason for change

WcfTest was randomly failing because the order of the spans didn't match the verification file. 

