### PR TITLE
Remove obsolete snapshot URI

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ImmutableDebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ImmutableDebuggerSettings.cs
@@ -18,7 +18,6 @@ namespace Datadog.Trace.Debugger
             string? environment,
             int maxSerializationTimeInMilliseconds,
             int maximumDepthOfMembersToCopy,
-            Uri? snapshotUri,
             int uploadBatchSize,
             int diagnosticsIntervalSeconds,
             int uploadFlushIntervalMilliseconds)
@@ -28,7 +27,6 @@ namespace Datadog.Trace.Debugger
             Environment = environment;
             MaxSerializationTimeInMilliseconds = maxSerializationTimeInMilliseconds;
             MaximumDepthOfMembersOfMembersToCopy = maximumDepthOfMembersToCopy;
-            SnapshotUri = snapshotUri;
             UploadBatchSize = uploadBatchSize;
             DiagnosticsIntervalSeconds = diagnosticsIntervalSeconds;
             UploadFlushIntervalMilliseconds = uploadFlushIntervalMilliseconds;
@@ -39,8 +37,6 @@ namespace Datadog.Trace.Debugger
         public string? ServiceVersion { get; }
 
         public string? Environment { get; }
-
-        public Uri? SnapshotUri { get; set; }
 
         public int MaxSerializationTimeInMilliseconds { get; }
 
@@ -62,7 +58,6 @@ namespace Datadog.Trace.Debugger
                 debuggerSettings.Environment,
                 debuggerSettings.MaxSerializationTimeInMilliseconds,
                 debuggerSettings.MaximumDepthOfMembersToCopy,
-                debuggerSettings.SnapshotUri,
                 debuggerSettings.UploadBatchSize,
                 debuggerSettings.DiagnosticsIntervalSeconds,
                 debuggerSettings.UploadFlushIntervalMilliseconds);
@@ -73,7 +68,6 @@ namespace Datadog.Trace.Debugger
             string? environment,
             int maxSerializationTimeInMilliseconds,
             int maximumDepthOfMembersOfMembersToCopy,
-            Uri? snapshotUri,
             int uploadBatchSize,
             int diagnosticsIntervalSeconds,
             int uploadFlushIntervalMilliseconds) =>
@@ -83,7 +77,6 @@ namespace Datadog.Trace.Debugger
                 environment,
                 maxSerializationTimeInMilliseconds,
                 maximumDepthOfMembersOfMembersToCopy,
-                snapshotUri,
                 uploadBatchSize,
                 diagnosticsIntervalSeconds,
                 uploadFlushIntervalMilliseconds);

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -38,7 +38,7 @@ internal class LiveDebuggerFactory
             () => new MinimalAgentHeaderHelper(),
             uri => uri);
 
-        var batchApi = AgentBatchUploadApi.Create(settings, apiFactory, discoveryService);
+        var batchApi = AgentBatchUploadApi.Create(apiFactory, discoveryService);
         var batchUploader = BatchUploader.Create(batchApi);
         var debuggerSink = DebuggerSink.Create(snapshotStatusSink, probeStatusSink, settings, batchUploader);
 

--- a/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
@@ -19,23 +19,21 @@ namespace Datadog.Trace.Debugger.Sink
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IDiscoveryService _discoveryService;
-        private readonly Uri? _snapshotUri;
 
-        private AgentBatchUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, Uri? snapshotUri)
+        private AgentBatchUploadApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService)
         {
             _apiRequestFactory = apiRequestFactory;
             _discoveryService = discoveryService;
-            _snapshotUri = snapshotUri;
         }
 
-        public static AgentBatchUploadApi Create(ImmutableDebuggerSettings settings, IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService)
+        public static AgentBatchUploadApi Create(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService)
         {
-            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, settings.SnapshotUri);
+            return new AgentBatchUploadApi(apiRequestFactory, discoveryService);
         }
 
         public async Task<bool> SendBatchAsync(ArraySegment<byte> snapshots)
         {
-            var uri = _snapshotUri ?? _apiRequestFactory.GetEndpoint(_discoveryService.DebuggerEndpoint);
+            var uri = _apiRequestFactory.GetEndpoint(_discoveryService.DebuggerEndpoint);
             var request = _apiRequestFactory.Create(uri);
 
             using var response = await request.PostAsync(snapshots, MimeTypes.Json).ConfigureAwait(false);


### PR DESCRIPTION
## Summary of changes
Remove obsolete snapshot URI

## Reason for change
Snapshot URI is not used anymore, it was deprecated.