### PR TITLE
Add continous profiler checks to dd-trace

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Coverage.Collector
                 Directory.EnumerateFiles(folder, "*.*", searchOption),
                 file =>
                 {
-                    var path = Path.GetDirectoryName(file);
+                    var path = Path.GetDirectoryName(file)!;
                     var fileWithoutExtension = Path.GetFileNameWithoutExtension(file);
                     // Skip the Datadog.Trace assembly
                     if (tracerAssemblyName == fileWithoutExtension)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -381,7 +381,9 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 var fileName = Path.GetFileName(module);
 
                 if (fileName.Equals("Datadog.Profiler.Native.dll", StringComparison.OrdinalIgnoreCase)
-                 || fileName.Equals("Datadog.Profiler.Native.so", StringComparison.OrdinalIgnoreCase))
+                 || fileName.Equals("Datadog.Profiler.Native.so", StringComparison.OrdinalIgnoreCase)
+                 || fileName.Equals("Datadog.AutoInstrumentation.Profiler.Native.x64.dll", StringComparison.OrdinalIgnoreCase)
+                 || fileName.Equals("Datadog.AutoInstrumentation.Profiler.Native.x86.dll", StringComparison.OrdinalIgnoreCase))
                 {
                     return module;
                 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -356,7 +356,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 {
                     // This could be either the native tracer or the loader.
                     // If it's the loader then there should be a loader.conf file next to it.
-                    var folder = Path.GetDirectoryName(fileName)!;
+                    var folder = Path.GetDirectoryName(module)!;
 
                     if (File.Exists(Path.Combine(folder, "loader.conf")))
                     {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -207,7 +207,12 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
                 else
                 {
-                    if (!File.Exists(ldPreload))
+                    if (Path.GetFileName(ldPreload) != "Datadog.Linux.ApiWrapper.x64.so")
+                    {
+                        Utils.WriteError(WrongLdPreload(ldPreload));
+                        ok = false;
+                    }
+                    else if (!File.Exists(ldPreload))
                     {
                         Utils.WriteError(ApiWrapperNotFound(ldPreload));
                         ok = false;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             if (isContinuousProfilerEnabled)
             {
-                CheckContinousProfiler(process, loaderModule);
+                ok &= CheckContinousProfiler(process, loaderModule);
             }
 
             var tracerModules = FindTracerModules(process).ToArray();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -352,7 +352,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 var fileName = Path.GetFileName(module);
 
                 if (fileName.Equals("Datadog.Trace.ClrProfiler.Native.dll", StringComparison.OrdinalIgnoreCase)
-                 || fileName.Equals("Datadog.Trace.ClrProfiler.Native.so", StringComparison.OrdinalIgnoreCase))
+                 || fileName.Equals("Datadog.Trace.ClrProfiler.Native.so", StringComparison.Ordinal))
                 {
                     // This could be either the native tracer or the loader.
                     // If it's the loader then there should be a loader.conf file next to it.
@@ -365,7 +365,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
                 else if (fileName.Equals("Datadog.AutoInstrumentation.NativeLoader.x64.dll", StringComparison.OrdinalIgnoreCase)
                       || fileName.Equals("Datadog.AutoInstrumentation.NativeLoader.x86.dll", StringComparison.OrdinalIgnoreCase)
-                      || fileName.Equals("Datadog.AutoInstrumentation.NativeLoader.so", StringComparison.OrdinalIgnoreCase))
+                      || fileName.Equals("Datadog.AutoInstrumentation.NativeLoader.so", StringComparison.Ordinal))
                 {
                     return module;
                 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -46,18 +46,18 @@ namespace Datadog.Trace.Tools.Runner.Checks
             {
                 if (ParseBooleanConfigurationValue(profilingEnabled))
                 {
-                    AnsiConsole.WriteLine(ContinousProfilerEnabled);
+                    AnsiConsole.WriteLine(ContinuousProfilerEnabled);
                     isContinuousProfilerEnabled = true;
                 }
                 else
                 {
-                    AnsiConsole.WriteLine(ContinousProfilerDisabled);
+                    AnsiConsole.WriteLine(ContinuousProfilerDisabled);
                     isContinuousProfilerEnabled = false;
                 }
             }
             else
             {
-                AnsiConsole.WriteLine(ContinousProfilerNotSet);
+                AnsiConsole.WriteLine(ContinuousProfilerNotSet);
                 isContinuousProfilerEnabled = false;
             }
 
@@ -186,13 +186,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             if (continuousProfilerModule == null)
             {
-                Utils.WriteWarning(ContinousProfilerNotLoaded);
+                Utils.WriteWarning(ContinuousProfilerNotLoaded);
                 ok = false;
             }
 
             if (loaderModule == null)
             {
-                Utils.WriteError(ContinousProfilerWithoutLoader);
+                Utils.WriteError(ContinuousProfilerWithoutLoader);
                 ok = false;
             }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -33,11 +33,11 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
 
-        public const string ContinousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
-        public const string ContinousProfilerDisabled = "The continous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
-        public const string ContinousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continous profiler is disabled.";
-        public const string ContinousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
-        public const string ContinousProfilerWithoutLoader = "The continous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
+        public const string ContinuousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
+        public const string ContinuousProfilerDisabled = "The continuous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
+        public const string ContinuousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continuous profiler is disabled.";
+        public const string ContinuousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
+        public const string ContinuousProfilerWithoutLoader = "The continuous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
 
         public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -19,7 +19,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string NetCoreRuntime = "Target process is running with .NET Core";
         public const string RuntimeDetectionFailed = "Failed to detect target process runtime, assuming .NET Framework";
         public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
-        public const string ProfilerNotLoaded = "The native library is not loaded into the process";
+        public const string LoaderNotLoaded = "The native loader library is not loaded into the process";
+        public const string NativeTracerNotLoaded = "The native tracer library is not loaded into the process";
         public const string TracerNotLoaded = "Tracer is not loaded into the process";
         public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
         public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
@@ -31,6 +32,16 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+
+        public const string ContinousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
+        public const string ContinousProfilerDisabled = "The continous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
+        public const string ContinousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continous profiler is disabled.";
+        public const string ContinousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
+        public const string ContinousProfilerWithoutLoader = "The continous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
+
+        public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
+
+        public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 
         public static string ProfilerVersion(string version) => $"The native library version {version} is loaded into the process.";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -43,6 +43,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 
+        public static string WrongLdPreload(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";
+
         public static string ProfilerVersion(string version) => $"The native library version {version} is loaded into the process.";
 
         public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -288,7 +288,7 @@ namespace Datadog.Trace.Tools.Runner
             AnsiConsole.MarkupLine($"[green]{message.EscapeMarkup()}[/]");
         }
 
-        private static bool IsAlpine()
+        internal static bool IsAlpine()
         {
             try
             {

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -273,6 +273,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             result.Should().BeFalse();
 
             console.Output.Should().Contain(ApiWrapperNotFound("/dummyPath"));
+            console.Output.Should().NotContain(Resources.WrongLdPreload("/dummyPath"));
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -272,6 +272,31 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().BeFalse();
 
+            console.Output.Should().NotContain(ApiWrapperNotFound("/dummyPath"));
+            console.Output.Should().Contain(Resources.WrongLdPreload("/dummyPath"));
+        }
+
+        [SkippableFact]
+        public async Task LdPreloadNotFound()
+        {
+            using var helper = await StartConsole(
+                                   enableProfiler: true,
+                                   ("DD_PROFILING_ENABLED", "1"),
+                                   ("LD_PRELOAD", "/dummyPath/Datadog.Linux.ApiWrapper.x64.so"));
+
+            var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
+
+            processInfo.Should().NotBeNull();
+
+            using var console = ConsoleHelper.Redirect();
+
+            var result = ProcessBasicCheck.Run(processInfo, MockRegistryService(Array.Empty<string>(), ProfilerPath));
+
+            using var scope = new AssertionScope();
+            scope.AddReportable("Output", console.Output);
+
+            result.Should().BeFalse();
+
             console.Output.Should().Contain(ApiWrapperNotFound("/dummyPath"));
             console.Output.Should().NotContain(Resources.WrongLdPreload("/dummyPath"));
         }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -180,7 +180,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().BeTrue();
 
-            console.Output.Should().Contain(TracerVersion(TracerConstants.AssemblyVersion));
+            console.Output.Should().Contain(
+                TracerVersion(TracerConstants.AssemblyVersion),
+                ContinuousProfilerNotSet);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -190,7 +192,6 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             console.Output.Should().NotContainAny(
                 NativeTracerNotLoaded,
                 TracerNotLoaded,
-                ContinuousProfilerNotSet,
                 "DD_DOTNET_TRACER_HOME",
                 CorProfilerKey,
                 CorEnableKey,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -297,8 +297,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             result.Should().BeFalse();
 
-            console.Output.Should().Contain(ApiWrapperNotFound("/dummyPath"));
-            console.Output.Should().NotContain(Resources.WrongLdPreload("/dummyPath"));
+            console.Output.Should().Contain(ApiWrapperNotFound("/dummyPath/Datadog.Linux.ApiWrapper.x64.so"));
+            console.Output.Should().NotContain(Resources.WrongLdPreload("/dummyPath/Datadog.Linux.ApiWrapper.x64.so"));
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -203,7 +203,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task WorkingWithContinuousProfiler()
         {
-            var apiWrapperPath = Path.Combine(EnvironmentHelper.MonitoringHome, "linux-x64", "Datadog.Linux.ApiWrapper.x64.so");
+            var archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
+
+            var apiWrapperPath = Path.Combine(EnvironmentHelper.MonitoringHome, archFolder, "Datadog.Linux.ApiWrapper.x64.so");
 
             using var helper = await StartConsole(
                                    enableProfiler: true,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -203,7 +203,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task WorkingWithContinuousProfiler()
         {
-            var apiWrapperPath = Path.Combine(EnvironmentHelper.MonitoringHome, "continuousprofiler", "Datadog.Linux.ApiWrapper.x64.so");
+            var apiWrapperPath = Path.Combine(EnvironmentHelper.MonitoringHome, "linux-x64", "Datadog.Linux.ApiWrapper.x64.so");
 
             using var helper = await StartConsole(
                                    enableProfiler: true,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -104,7 +104,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             result.Should().BeFalse();
 
             console.Output.Should().ContainAll(
-                ProfilerNotLoaded,
+                LoaderNotLoaded,
+                NativeTracerNotLoaded,
                 TracerNotLoaded,
                 EnvironmentVariableNotSet("DD_DOTNET_TRACER_HOME"),
                 WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, null),
@@ -144,7 +145,8 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             result.Should().BeFalse();
 
             console.Output.Should().ContainAll(
-                ProfilerNotLoaded,
+                LoaderNotLoaded,
+                NativeTracerNotLoaded,
                 TracerNotLoaded,
                 TracerHomeNotFoundFormat("TheDirectoryDoesNotExist"),
                 WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, Guid.Empty.ToString("B")),
@@ -183,7 +185,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             }
 
             console.Output.Should().NotContainAny(
-                ProfilerNotLoaded,
+                NativeTracerNotLoaded,
                 TracerNotLoaded,
                 "DD_DOTNET_TRACER_HOME",
                 CorProfilerKey,

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -203,7 +203,16 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task WorkingWithContinuousProfiler()
         {
-            var archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
+            string archFolder;
+
+            if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)
+            {
+                archFolder = "linux-arm64";
+            }
+            else
+            {
+                archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
+            }
 
             var apiWrapperPath = Path.Combine(EnvironmentHelper.MonitoringHome, archFolder, "Datadog.Linux.ApiWrapper.x64.so");
 


### PR DESCRIPTION
## Summary of changes

Add checks for the continuous profiler in the diagnostic tool.

## Reason for change

## Implementation details

Those checks are only run if `DD_PROFILING_ENABLED` is set, to avoid false-negatives.

We verify that:
 - The native loaded is loaded, and the loader.conf file is at the expected location
 - The continuous profiler is loaded
 - `LD_PRELOAD` is set to a correct path (Linux only)

## Test coverage

The new tests run only on Linux.
