### PR TITLE
[Debugger] Fix non-deterministic failure in UDS Integration Test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ProbesTests.cs
@@ -72,18 +72,18 @@ public class ProbesTests : TestHelper, IDisposable
             throw new InvalidOperationException($"{nameof(InstallAndUninstallMethodProbeWithOverloadsTest)} expected one probe request to exist, but found {probes.Length} probes.");
         }
 
-        var agent = GetMockAgent();
-
+        using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment();
         using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
-
-        SetProbeConfiguration(probes.Select(p => p.Probe).ToArray());
-        await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
-
-        await sample.RunCodeSample();
         try
         {
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
+
+            SetProbeConfiguration(probes.Select(p => p.Probe).ToArray());
+            await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
+
+            await sample.RunCodeSample();
+
             var snapshots = await agent.WaitForSnapshots(expectedNumberOfSnapshots);
             Assert.Equal(expectedNumberOfSnapshots, snapshots?.Length);
             await ApproveSnapshots(snapshots, testType, isMultiPhase: true, phaseNumber: 1);
@@ -113,18 +113,19 @@ public class ProbesTests : TestHelper, IDisposable
         const int expectedNumberOfSnapshots = 100;
 
         var probes = GetProbeConfiguration(testType, true, new DeterministicGuidGenerator());
-        var agent = GetMockAgent();
 
+        using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment();
         using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
-
-        SetProbeConfiguration(probes.Select(p => p.Probe).ToArray());
-        await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
-
-        await sample.RunCodeSample();
         try
         {
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
+
+            SetProbeConfiguration(probes.Select(p => p.Probe).ToArray());
+            await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
+
+            await sample.RunCodeSample();
+
             var statuses = await agent.WaitForProbesStatuses(probes.Length);
             Assert.Equal(probes.Length, statuses?.Length);
 
@@ -205,14 +206,14 @@ public class ProbesTests : TestHelper, IDisposable
     private async Task RunMethodProbeTests(Type testType)
     {
         var probes = GetProbeConfiguration(testType, false, new DeterministicGuidGenerator());
-        var agent = GetMockAgent();
 
+        using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment();
         using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
-
         try
         {
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
+
             var isSinglePhase = probes.Select(p => p.ProbeTestData.Phase).Distinct().Count() == 1;
             if (isSinglePhase)
             {
@@ -222,64 +223,64 @@ public class ProbesTests : TestHelper, IDisposable
             {
                 await PerformMultiPhasesProbeTest();
             }
+
+            async Task PerformSinglePhaseProbeTest()
+            {
+                var snapshotProbes = probes.Select(p => p.Probe).ToArray();
+                var probeData = probes.Select(p => p.ProbeTestData).ToArray();
+
+                await RunPhase(snapshotProbes, probeData);
+            }
+
+            async Task PerformMultiPhasesProbeTest()
+            {
+                var phaseNumber = 0;
+                var groupedPhases =
+                    probes
+                       .GroupBy(p => p.ProbeTestData.Phase)
+                       .OrderBy(group => group.Key);
+
+                foreach (var groupedPhase in groupedPhases)
+                {
+                    phaseNumber++;
+
+                    var snapshotProbes = groupedPhase.Select(p => p.Probe).ToArray();
+                    var probeData = groupedPhase.Select(p => p.ProbeTestData).ToArray();
+                    await RunPhase(snapshotProbes, probeData, isMultiPhase: true, phaseNumber);
+                }
+            }
+
+            async Task RunPhase(SnapshotProbe[] snapshotProbes, ProbeAttributeBase[] probeData, bool isMultiPhase = false, int phaseNumber = 1)
+            {
+                SetProbeConfiguration(snapshotProbes);
+                await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
+
+                await sample.RunCodeSample();
+
+                var expectedNumberOfSnapshots = DebuggerTestHelper.CalculateExpectedNumberOfSnapshots(probeData);
+                string[] snapshots;
+                if (expectedNumberOfSnapshots == 0)
+                {
+                    Assert.True(await agent.WaitForNoSnapshots(), $"Expected 0 snapshots. Actual: {agent.Snapshots.Count}.");
+                }
+                else
+                {
+                    snapshots = await agent.WaitForSnapshots(expectedNumberOfSnapshots);
+                    Assert.Equal(expectedNumberOfSnapshots, snapshots?.Length);
+                    await ApproveSnapshots(snapshots, testType, isMultiPhase, phaseNumber);
+                    agent.ClearSnapshots();
+                }
+
+                var statuses = await agent.WaitForProbesStatuses(probeData.Length);
+
+                Assert.Equal(probeData.Length, statuses?.Length);
+                await ApproveStatuses(statuses, testType, isMultiPhase, phaseNumber);
+                agent.ClearProbeStatuses();
+            }
         }
         finally
         {
             await sample.StopSample();
-        }
-
-        async Task PerformSinglePhaseProbeTest()
-        {
-            var snapshotProbes = probes.Select(p => p.Probe).ToArray();
-            var probeData = probes.Select(p => p.ProbeTestData).ToArray();
-
-            await RunPhase(snapshotProbes, probeData);
-        }
-
-        async Task PerformMultiPhasesProbeTest()
-        {
-            var phaseNumber = 0;
-            var groupedPhases =
-                probes
-                   .GroupBy(p => p.ProbeTestData.Phase)
-                   .OrderBy(group => group.Key);
-
-            foreach (var groupedPhase in groupedPhases)
-            {
-                phaseNumber++;
-
-                var snapshotProbes = groupedPhase.Select(p => p.Probe).ToArray();
-                var probeData = groupedPhase.Select(p => p.ProbeTestData).ToArray();
-                await RunPhase(snapshotProbes, probeData, isMultiPhase: true, phaseNumber);
-            }
-        }
-
-        async Task RunPhase(SnapshotProbe[] snapshotProbes, ProbeAttributeBase[] probeData, bool isMultiPhase = false, int phaseNumber = 1)
-        {
-            SetProbeConfiguration(snapshotProbes);
-            await logEntryWatcher.WaitForLogEntry(ProbesInstrumentedLogEntry);
-
-            await sample.RunCodeSample();
-
-            var expectedNumberOfSnapshots = DebuggerTestHelper.CalculateExpectedNumberOfSnapshots(probeData);
-            string[] snapshots;
-            if (expectedNumberOfSnapshots == 0)
-            {
-                Assert.True(await agent.WaitForNoSnapshots(), $"Expected 0 snapshots. Actual: {agent.Snapshots.Count}.");
-            }
-            else
-            {
-                snapshots = await agent.WaitForSnapshots(expectedNumberOfSnapshots);
-                Assert.Equal(expectedNumberOfSnapshots, snapshots?.Length);
-                await ApproveSnapshots(snapshots, testType, isMultiPhase, phaseNumber);
-                agent.ClearSnapshots();
-            }
-
-            var statuses = await agent.WaitForProbesStatuses(probeData.Length);
-
-            Assert.Equal(probeData.Length, statuses?.Length);
-            await ApproveStatuses(statuses, testType, isMultiPhase, phaseNumber);
-            agent.ClearProbeStatuses();
         }
     }
 
@@ -486,13 +487,5 @@ public class ProbesTests : TestHelper, IDisposable
         {
             throw new InvalidOperationException("Path for remote configurations is not set.");
         }
-    }
-
-    private MockTracerAgent GetMockAgent()
-    {
-        var mockAgent = EnvironmentHelper.GetMockAgent();
-
-        mockAgent.ShouldDeserializeTraces = false;
-        return mockAgent;
     }
 }


### PR DESCRIPTION
## Summary of changes
Dispose the MockAgent
Set ShouldDeserializeTraces to the default (true)

## Reason for change
Try fix non deterministic integration test failures from `MethodProbeTest_UDS`
Issue happens only on `Windows` with exception:

```
[ERR] An error occurred while sending data to the agent at C:/Users/AzDevOps/AppData/Local/Temp/s1hbabdt.ata to http://localhost/v0.4/traces System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host..
 ---> System.Net.Sockets.SocketException (10054): An existing connection was forcibly closed by the remote host.
   --- End of inner exception stack trace ---
   at Datadog.Trace.HttpOverStreams.DatadogHttpClient.<>c__DisplayClass7_0.<<ReadResponseAsync>g__SkipUntil|1>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Datadog.Trace.HttpOverStreams.DatadogHttpClient.ReadResponseAsync(Stream responseStream)
   at Datadog.Trace.HttpOverStreams.DatadogHttpClient.SendAsync(HttpRequest request, Stream requestStream, Stream responseStream)
   at Datadog.Trace.Agent.Transports.HttpStreamRequest.SendAsync(String verb, String contentType, IHttpContent content)
   at Datadog.Trace.Agent.Transports.HttpStreamRequest.PostAsync(ArraySegment`1 bytes, String contentType)
   at Datadog.Trace.Agent.Api.SendTracesAsyncImpl(IApiRequest request, Boolean finalTry, SendTracesState state)
   at Datadog.Trace.Agent.Api.SendWithRetry[T](Uri endpoint, SendCallback`1 callback, T state)
```

It could happen, because we don't dispose `MockAgent`