### PR TITLE
Initial data streams monitoring propagation

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.EventModel;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
@@ -23,8 +24,8 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, string defaultServiceName)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, defaultServiceName, new Trace.Processors.ITraceProcessor[]
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, new Trace.Processors.ITraceProcessor[]
             {
                 new Trace.Processors.NormalizerTraceProcessor(),
                 new Trace.Processors.TruncatorTraceProcessor(),

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
@@ -41,9 +42,10 @@ namespace Datadog.Trace.Ci
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager,
             string defaultServiceName)
         {
-            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
         }
 
         protected override ITraceSampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -532,5 +532,14 @@ namespace Datadog.Trace.Configuration
             /// </remarks>
             public const string HeaderMaxLength = "DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH";
         }
+
+        internal static class DataStreamsMonitoring
+        {
+            /// <summary>
+            /// Enables data streams monitoring support
+            /// </summary>
+            /// <see cref="TracerSettings.IsDataStreamsMonitoringEnabled"/>
+            public const string Enabled = "DD_DATA_STREAMS_ENABLED";
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -71,6 +71,7 @@ namespace Datadog.Trace.Configuration
             PropagationStyleExtract = settings.PropagationStyleExtract;
             TraceMethods = settings.TraceMethods;
             IsActivityListenerEnabled = settings.IsActivityListenerEnabled;
+            IsDataStreamsMonitoringEnabled = settings.IsDataStreamsMonitoringEnabled;
 
             LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
             // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
@@ -321,6 +322,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the activity listener is enabled or not.
         /// </summary>
         internal bool IsActivityListenerEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether data streams monitoring is enabled or not.
+        /// </summary>
+        internal bool IsDataStreamsMonitoringEnabled { get; }
 
         /// <summary>
         /// Gets the maximum length of an outgoing propagation header's value ("x-datadog-tags")

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -8,7 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Datadog.Trace.Debugger;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
@@ -226,6 +225,10 @@ namespace Datadog.Trace.Configuration
                     PropagationStyleInject = PropagationStyleInject.Concat(nameof(Propagators.ContextPropagators.Names.W3C));
                 }
             }
+
+            IsDataStreamsMonitoringEnabled = source?.GetBool(ConfigurationKeys.DataStreamsMonitoring.Enabled) ??
+                                        // default value
+                                        false;
         }
 
         /// <summary>
@@ -496,6 +499,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the activity listener is enabled or not.
         /// </summary>
         internal bool IsActivityListenerEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether data streams monitoring is enabled or not.
+        /// </summary>
+        internal bool IsDataStreamsMonitoringEnabled { get; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -1,0 +1,52 @@
+// <copyright file="DataStreamsContextPropagator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.Headers;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// Used for injecting the data streams pipeline context into headers
+/// </summary>
+internal class DataStreamsContextPropagator
+{
+    private const string PropagationKey = "dd-pathway-ctx";
+
+    public static DataStreamsContextPropagator Instance { get; } = new();
+
+    /// <summary>
+    /// Propagates the specified context by adding new headers to a <see cref="IHeadersCollection"/>.
+    /// This locks the sampling priority for <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">A <see cref="PathwayContext"/> value that will be propagated into <paramref name="headers"/>.</param>
+    /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
+    /// <typeparam name="TCarrier">Type of header collection</typeparam>
+    public void Inject<TCarrier>(PathwayContext context, TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
+
+        headers.Add(PropagationKey, PathwayContextEncoder.Encode(context));
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="PathwayContext"/> from the values found in the specified headers.
+    /// </summary>
+    /// <param name="headers">The headers that contain the values to be extracted.</param>
+    /// <typeparam name="TCarrier">Type of header collection</typeparam>
+    /// <returns>A new <see cref="PathwayContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
+    public PathwayContext? Extract<TCarrier>(TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
+
+        var bytes = headers.TryGetBytes(PropagationKey);
+
+        return bytes is { } ? PathwayContextEncoder.Decode(bytes) : null;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="DataStreamsManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// Manages all the data streams monitoring behaviour
+/// </summary>
+internal class DataStreamsManager
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsManager>();
+    private readonly NodeHashBase _nodeHashBase;
+    private bool _isEnabled;
+
+    public DataStreamsManager(
+        bool enabled,
+        string env,
+        string defaultServiceName)
+    {
+        _isEnabled = enabled;
+        // We don't yet support primary tag in .NET yet
+        _nodeHashBase = HashHelper.CalculateNodeHashBase(defaultServiceName, env, primaryTag: null);
+    }
+
+    public bool IsEnabled => Volatile.Read(ref _isEnabled);
+
+    public static DataStreamsManager Create(
+        ImmutableTracerSettings settings,
+        string defaultServiceName)
+        => new(settings.IsDataStreamsMonitoringEnabled, settings.Environment, defaultServiceName);
+
+    public Task DisposeAsync()
+    {
+        Volatile.Write(ref _isEnabled, false);
+        return Task.CompletedTask;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -4,11 +4,15 @@
 // </copyright>
 
 #nullable enable
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.DataStreamsMonitoring;
 
@@ -42,5 +46,90 @@ internal class DataStreamsManager
     {
         Volatile.Write(ref _isEnabled, false);
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Trys to extract a <see cref="PathwayContext"/>, from the provided <paramref name="headers"/>
+    /// If data streams is disabled, or no pathway is present, returns null.
+    /// </summary>
+    public PathwayContext? ExtractPathwayContext<TCarrier>(TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+        => IsEnabled ? DataStreamsContextPropagator.Instance.Extract(headers) : null;
+
+    /// <summary>
+    /// Injects a <see cref="PathwayContext"/> into headers
+    /// </summary>
+    /// <param name="context">The pathway context to inject</param>
+    /// <param name="headers">The header collection to inject the headers into</param>
+    public void InjectPathwayContext<TCarrier>(PathwayContext? context, TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        if (context is not null)
+        {
+            DataStreamsContextPropagator.Instance.Inject(context.Value, headers);
+            return;
+        }
+
+        // This shouldn't happen normally, as you should call SetCheckpoint before calling InjectPathwayContext
+        // But if data streams was disabled, you call SetCheckpoint, and then data streams is enabled
+        // you will hit this code path
+        System.Diagnostics.Debug.Fail("Attempted to inject null pathway context");
+        Log.Debug("Attempted to inject null pathway context");
+    }
+
+    /// <summary>
+    /// Sets a checkpoint using the provided <see cref="PathwayContext"/>
+    /// NOTE: <paramref name="edgeTags"/> must be in correct sort order
+    /// </summary>
+    /// <param name="parentPathway">The current pathway</param>
+    /// <param name="edgeTags">Edge tags to set for the new pathway. MUST be sorted in alphabetical order</param>
+    /// <returns>If disabled, returns <c>null</c>. Otherwise returns a new <see cref="PathwayContext"/></returns>
+    public PathwayContext? SetCheckpoint(in PathwayContext? parentPathway, string[] edgeTags)
+    {
+        if (!IsEnabled)
+        {
+            return null;
+        }
+
+        try
+        {
+            var edgeStartNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            var pathwayStartNs = parentPathway?.PathwayStart ?? edgeStartNs;
+
+            var nodeHash = HashHelper.CalculateNodeHash(_nodeHashBase, edgeTags);
+            var parentHash = parentPathway?.Hash ?? default;
+            var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
+
+            // TODO: send to aggregator
+            var pathway = new PathwayContext(
+                hash: pathwayHash,
+                pathwayStartNs: pathwayStartNs,
+                edgeStartNs: edgeStartNs);
+
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug(
+                    "SetCheckpoint with {PathwayHash}, {PathwayStart}, {EdgeStart}",
+                    pathway.Hash,
+                    pathway.PathwayStart,
+                    pathway.EdgeStart);
+            }
+
+            return pathway;
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Error setting a data streams checkpoint. Disabling data streams monitoring", ex);
+            // Set this to false out of an abundance of caution.
+            // We will look at being less conservative in the future
+            // if we see intermittent errors for some reason.
+            Volatile.Write(ref _isEnabled, false);
+            return null;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -78,7 +78,6 @@ internal class DataStreamsManager
         // This shouldn't happen normally, as you should call SetCheckpoint before calling InjectPathwayContext
         // But if data streams was disabled, you call SetCheckpoint, and then data streams is enabled
         // you will hit this code path
-        System.Diagnostics.Debug.Fail("Attempted to inject null pathway context");
         Log.Debug("Attempted to inject null pathway context");
     }
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContext.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContext.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="PathwayContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// PathwayContext is used to monitor how payloads are sent across different services.
+/// An example Pathway would be:
+/// service A -- edge 1 --> service B -- edge 2 --> service C
+/// So it's a branch of services (we also call them "nodes") connected via edges.
+/// As the payload is sent around, we save the start time (start of service A),
+/// and the start time of the previous service.
+/// This allows us to measure the latency of each edge, as well as the latency from origin of any service.
+/// </summary>
+internal readonly struct PathwayContext
+{
+    /// <summary>
+    /// The hash of the current node, of the parent node,
+    /// and of the edge that connects the parent node to this node
+    /// </summary>
+    public readonly PathwayHash Hash;
+
+    /// <summary>
+    /// Start time of the first node in the pathway as a unix epoch in nanoseconds
+    /// </summary>
+    public readonly long PathwayStart;
+
+    /// <summary>
+    /// Start time of the previous node as a unix epoch in nanoseconds
+    /// </summary>
+    public readonly long EdgeStart;
+
+    public PathwayContext(PathwayHash hash, long pathwayStartNs, long edgeStartNs)
+    {
+        Hash = hash;
+        PathwayStart = pathwayStartNs;
+        EdgeStart = edgeStartNs;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="PathwayContextEncoder.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class PathwayContextEncoder
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(PathwayContextEncoder));
+
+    /// <summary>
+    /// Encodes a <see cref="PathwayContext"/> as a series of bytes
+    /// NOTE: the encoding is lossy, in that we convert <see cref="PathwayContext.PathwayStart"/>
+    /// and <see cref="PathwayContext.EdgeStart"/> from ns to ms
+    /// </summary>
+    /// <param name="pathway">The pathway to encode</param>
+    /// <returns>The encoded pathway</returns>
+    public static byte[] Encode(PathwayContext pathway)
+    {
+        var pathwayStartMs = pathway.PathwayStart / 1000;
+        var edgeStartMs = pathway.EdgeStart / 1000;
+
+        var pathwayBytes = VarEncodingHelper.VarLongZigZagLength(pathwayStartMs);
+        var edgeBytes = VarEncodingHelper.VarLongZigZagLength(edgeStartMs);
+
+        // maximum size = 8 + edge + pathway
+        var bytes = new byte[8 + pathwayBytes + edgeBytes];
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, pathway.Hash.Value);
+        VarEncodingHelper.WriteVarLongZigZag(bytes, offset: 8, pathwayStartMs);
+        VarEncodingHelper.WriteVarLongZigZag(bytes, offset: 8 + pathwayBytes, edgeStartMs);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Tries to decode a <see cref="PathwayContext"/> from a <c>byte[]</c>.
+    /// NOTE: the encoding process is lossy, so the decoded <see cref="PathwayContext"/>
+    /// contains truncated values for <see cref="PathwayContext.PathwayStart"/>
+    /// and <see cref="PathwayContext.EdgeStart"/> (conversion from ns to ms)
+    /// </summary>
+    /// <param name="bytes">The pathway to decode</param>
+    /// <returns>The decoded <see cref="PathwayContext"/>, or <c>null</c> if decoding fails </returns>
+    public static PathwayContext? Decode(byte[] bytes)
+    {
+        if (bytes.Length < 10)
+        {
+            Log.Warning<string, int>("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: insufficient bytes ({ByteCount})", Convert.ToBase64String(bytes), bytes.Length);
+            return null;
+        }
+
+        // first 8 bytes
+        var hash = BinaryPrimitivesHelper.ReadUInt64LittleEndian(bytes);
+
+        var pathwayStartMs = VarEncodingHelper.ReadVarLongZigZag(bytes, offset: 8, out var bytesRead);
+        if (pathwayStartMs is null)
+        {
+            Log.Warning("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: invalid pathway start", Convert.ToBase64String(bytes));
+            return null;
+        }
+
+        var edgeBytesMs = VarEncodingHelper.ReadVarLongZigZag(bytes, offset: 8 + bytesRead, out _);
+        if (edgeBytesMs is null)
+        {
+            Log.Warning("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: invalid edge start", Convert.ToBase64String(bytes));
+            return null;
+        }
+
+        // Pathway context values are in ns
+        return new PathwayContext(new PathwayHash(hash), pathwayStartMs.Value * 1000, edgeBytesMs.Value * 1000);
+    }
+}

--- a/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="IBinaryHeadersCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Headers;
+
+/// <summary>
+/// Specified a common interface that can be used to manipulate collections of binary headers.
+/// </summary>
+internal interface IBinaryHeadersCollection
+{
+    /// <summary>
+    /// Returns the first header value for a specified header stored in the collection.
+    /// </summary>
+    /// <param name="name">The specified header to return values for.</param>
+    /// <returns>Zero or more header strings.</returns>
+    byte[]? TryGetBytes(string name);
+
+    /// <summary>
+    /// Adds the specified header and its value into the collection.
+    /// </summary>
+    /// <param name="name">The header to add to the collection.</param>
+    /// <param name="value">The content of the header.</param>
+    void Add(string name, byte[] value);
+}

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -144,6 +144,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.CodeHotspotsEnabled, value: _profiler?.ContextTracker.IsEnabled),
                 new(ConfigTelemetryData.StatsComputationEnabled, value: settings.StatsComputationEnabled),
                 new(ConfigTelemetryData.WcfObfuscationEnabled, value: settings.WcfObfuscationEnabled),
+                new(ConfigTelemetryData.DataStreamsMonitoringEnabled, value: settings.IsDataStreamsMonitoringEnabled),
             };
 
             if (_azureApServicesMetadata.IsRelevant)

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.Telemetry
         public const string TraceMethods = "trace_methods";
         public const string StatsComputationEnabled = "stats_computation_enabled";
         public const string WcfObfuscationEnabled = "wcf_obfuscation_enabled";
+        public const string DataStreamsMonitoringEnabled = "data_streams_enabled";
 
         public const string CloudHosting = "cloud_hosting";
         public const string AasSiteExtensionVersion = "aas_siteextensions_version";

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -448,6 +448,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("wcf_obfuscation_enabled");
                     writer.WriteValue(instanceSettings.WcfObfuscationEnabled);
 
+                    writer.WritePropertyName("data_streams_enabled");
+                    writer.WriteValue(instanceSettings.IsDataStreamsMonitoringEnabled);
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -58,6 +59,7 @@ namespace Datadog.Trace
             DirectLogSubmissionManager directLogSubmission,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager,
             string defaultServiceName,
             ITraceProcessor[] traceProcessors = null)
         {
@@ -68,6 +70,7 @@ namespace Datadog.Trace
             Statsd = statsd;
             RuntimeMetrics = runtimeMetricsWriter;
             DefaultServiceName = defaultServiceName;
+            DataStreamsManager = dataStreamsManager;
             DirectLogSubmission = directLogSubmission;
             Telemetry = telemetry;
             DiscoveryService = discoveryService;
@@ -136,6 +139,8 @@ namespace Datadog.Trace
         public ITelemetryController Telemetry { get; }
 
         public IDiscoveryService DiscoveryService { get; }
+
+        public DataStreamsManager DataStreamsManager { get; }
 
         private RuntimeMetricsWriter RuntimeMetrics { get; }
 
@@ -235,10 +240,17 @@ namespace Datadog.Trace
                     await oldManager.DiscoveryService.DisposeAsync().ConfigureAwait(false);
                 }
 
+                var dataStreamsReplaced = false;
+                if (oldManager.DataStreamsManager != newManager.DataStreamsManager && oldManager.DataStreamsManager is not null)
+                {
+                    dataStreamsReplaced = true;
+                    await oldManager.DataStreamsManager.DisposeAsync().ConfigureAwait(false);
+                }
+
                 Log.Information(
                     exception: null,
-                    "Replaced global instances. AgentWriter: {AgentWriterReplaced}, StatsD: {StatsDReplaced}, RuntimeMetricsWriter: {RuntimeMetricsWriterReplaced}, Telemetry: {TelemetryReplaced}, Discovery: {DiscoveryReplaced}",
-                    new object[] { agentWriterReplaced, statsdReplaced, runtimeMetricsWriterReplaced, telemetryReplaced, discoveryReplaced });
+                    "Replaced global instances. AgentWriter: {AgentWriterReplaced}, StatsD: {StatsDReplaced}, RuntimeMetricsWriter: {RuntimeMetricsWriterReplaced}, Telemetry: {TelemetryReplaced}, Discovery: {DiscoveryReplaced}, DataStreamsManager: {DataStreamsManagerReplaced}",
+                    new object[] { agentWriterReplaced, statsdReplaced, runtimeMetricsWriterReplaced, telemetryReplaced, discoveryReplaced, dataStreamsReplaced });
             }
             catch (Exception ex)
             {
@@ -544,9 +556,12 @@ namespace Datadog.Trace
                     var telemetryTask = instance.Telemetry?.DisposeAsync() ?? Task.CompletedTask;
                     Log.Debug("Disposing DiscoveryService.");
                     var discoveryService = instance.DiscoveryService?.DisposeAsync() ?? Task.CompletedTask;
+                    Log.Debug("Disposing Data streams.");
+                    var dataStreamsTask = instance.DataStreamsManager?.DisposeAsync() ?? Task.CompletedTask;
 
                     Log.Debug("Waiting for disposals.");
-                    await Task.WhenAll(flushTracesTask, logSubmissionTask, telemetryTask, discoveryService).ConfigureAwait(false);
+                    await Task.WhenAll(flushTracesTask, logSubmissionTask, telemetryTask, discoveryService, dataStreamsTask).ConfigureAwait(false);
+                    Log.Debug("Finished waiting for disposals.");
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -52,7 +53,8 @@ namespace Datadog.Trace
                 runtimeMetrics: null,
                 logSubmissionManager: previous?.DirectLogSubmission,
                 telemetry: null,
-                discoveryService: null);
+                discoveryService: null,
+                dataStreamsManager: null);
 
             try
             {
@@ -85,7 +87,8 @@ namespace Datadog.Trace
             RuntimeMetricsWriter runtimeMetrics,
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
-            IDiscoveryService discoveryService)
+            IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager)
         {
             settings ??= ImmutableTracerSettings.FromDefaultSources();
 
@@ -121,7 +124,9 @@ namespace Datadog.Trace
 
             SpanContextPropagator.Instance = ContextPropagators.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 
-            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            dataStreamsManager ??= DataStreamsManager.Create(settings, defaultServiceName);
+
+            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
             return tracerManager;
         }
 
@@ -138,8 +143,9 @@ namespace Datadog.Trace
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager,
             string defaultServiceName)
-            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
 
         protected virtual ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {

--- a/tracer/src/Datadog.Trace/Util/TimeHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/TimeHelpers.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="TimeHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Util;
+
+internal static class TimeHelpers
+{
+    public static long MillisecondsToNanoseconds(long milliseconds)
+        => checked(milliseconds * 1_000_000);
+
+    public static long NanosecondsToMilliseconds(long nanoseconds)
+        => nanoseconds / 1_000_000;
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="DataStreamsContextPropagatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsContextPropagatorTests
+{
+    [Fact]
+    public void CanRoundTripPathwayContext()
+    {
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(
+            new PathwayHash(1234),
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000, // leaky abstraction, the encoder truncates
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000);
+
+        DataStreamsContextPropagator.Instance.Inject(context, headers);
+
+        var extracted = DataStreamsContextPropagator.Instance.Extract(headers);
+
+        extracted.Should().NotBeNull();
+        extracted.Value.Hash.Value.Should().Be(context.Hash.Value);
+        extracted.Value.PathwayStart.Should().Be(context.PathwayStart);
+        extracted.Value.EdgeStart.Should().Be(context.EdgeStart);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -56,7 +56,7 @@ public class DataStreamsManagerTests
     {
         var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
         var headers = new TestHeadersCollection();
-        var context = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+        var context = new PathwayContext(new PathwayHash(123), 1_234_000_000, 5_678_000_000);
 
         dsm.InjectPathwayContext(context, headers);
         headers.Values.Should().NotBeEmpty();

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -1,0 +1,141 @@
+﻿// <copyright file="DataStreamsManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsManagerTests
+{
+    [Fact]
+    public void WhenDisabled_DoesNotInjectContext()
+    {
+        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        dsm.InjectPathwayContext(context, headers);
+
+        headers.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WhenEnabled_InjectsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        dsm.InjectPathwayContext(context, headers);
+
+        headers.Values.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WhenDisabled_DoesNotExtractContext()
+    {
+        var enabledDsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var disabledDsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        enabledDsm.InjectPathwayContext(context, headers);
+        headers.Values.Should().NotBeEmpty();
+
+        disabledDsm.ExtractPathwayContext(headers).Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenEnabled_ExtractsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        dsm.InjectPathwayContext(context, headers);
+        headers.Values.Should().NotBeEmpty();
+
+        var extracted = dsm.ExtractPathwayContext(headers);
+        extracted.Should().NotBeNull();
+        extracted.Value.Hash.Value.Should().Be(context.Hash.Value);
+        extracted.Value.PathwayStart.Should().Be(context.PathwayStart);
+        extracted.Value.EdgeStart.Should().Be(context.EdgeStart);
+    }
+
+    [Fact]
+    public void WhenEnabled_AndNoContext_ReturnsNewContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+
+        var context = dsm.SetCheckpoint(parentPathway: null, new[] { "some-tags" });
+        context.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WhenEnabled_AndNoContext_HashShouldUseParentHashOfZero()
+    {
+        var env = "foo";
+        var service = "bar";
+        var edgeTags = new[] { "some-tags" };
+        var dsm = new DataStreamsManager(enabled: true, env, service);
+
+        var context = dsm.SetCheckpoint(parentPathway: null, edgeTags);
+        context.Should().NotBeNull();
+
+        var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
+        var nodeHash = HashHelper.CalculateNodeHash(baseHash, edgeTags);
+        var hash = HashHelper.CalculatePathwayHash(nodeHash, parentHash: new PathwayHash(0));
+
+        context.Value.Hash.Value.Should().Be(hash.Value);
+    }
+
+    [Fact]
+    public void WhenEnabled_AndHashContext_HashShouldUseParentHash()
+    {
+        var env = "foo";
+        var service = "bar";
+        var edgeTags = new[] { "some-tags" };
+        var dsm = new DataStreamsManager(enabled: true, env, service);
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        var context = dsm.SetCheckpoint(parent, edgeTags);
+        context.Should().NotBeNull();
+
+        var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
+        var nodeHash = HashHelper.CalculateNodeHash(baseHash, edgeTags);
+        var hash = HashHelper.CalculatePathwayHash(nodeHash, parentHash: parent.Hash);
+
+        context.Value.Hash.Value.Should().Be(hash.Value);
+    }
+
+    [Fact]
+    public void WhenDisabled_SetCheckpoint_ReturnsNull()
+    {
+        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
+        context.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisablesDsm()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        dsm.IsEnabled.Should().BeTrue();
+
+        await dsm.DisposeAsync();
+        dsm.IsEnabled.Should().BeFalse();
+
+        var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
+        context.Should().BeNull();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="PathwayContextEncoderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class PathwayContextEncoderTests
+{
+    private static readonly Random Random = new();
+
+    [Fact]
+    public void TestRandomValues()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            EncodeTest(unchecked((ulong)GetLong()), Math.Abs(GetLong()), Math.Abs(GetLong()));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(ulong.MaxValue, long.MaxValue, long.MaxValue)]
+    [InlineData(ulong.MinValue, long.MinValue, long.MinValue)]
+    public void TestEdgeCases(ulong hash, long pathwayStartNs, long edgeStartNs)
+        => EncodeTest(hash, pathwayStartNs, edgeStartNs);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void DecoderFailure_InsufficientBytes(int byteCount)
+    {
+        // Minimum byte count is 10 bytes:
+        // first 8 bytes are the hash (0), 1 byte min for pathway, 1 byte min for edge
+        var bytes = new byte[byteCount];
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecoderFailure_InvalidEdgeBytes()
+    {
+        // first 8 bytes are the hash (0)
+        // 9th byte is valid pathway  (0)
+        // 10th byte is invalid edge bytes (Pattern 1xxx_xxxx is invalid except in 9th byte)
+        var bytes = new byte[10];
+        bytes[9] = 0b1000_0000;
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecoderFailure_InvalidPathwayBytes()
+    {
+        // first 8 bytes are the hash (0)
+        // 9th byte is invalid pathway (0)
+        var bytes = new byte[9];
+        bytes[8] = 0b1000_0000;
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    private static void EncodeTest(ulong hash, long pathwayStartNs, long edgeStartNs)
+    {
+        var pathway = new PathwayContext(
+            new PathwayHash(hash),
+            pathwayStartNs: pathwayStartNs,
+            edgeStartNs: edgeStartNs);
+
+        var encoded = PathwayContextEncoder.Encode(pathway);
+
+        encoded.Should().NotBeNullOrEmpty();
+
+        var decoded = PathwayContextEncoder.Decode(encoded);
+
+        decoded.Should().NotBeNull();
+        // can't compare directly, because encoding and decoding truncates the ns values to be ms
+        decoded.Value.Hash.Should().Be(pathway.Hash);
+        decoded.Value.EdgeStart.Should().Be((pathway.EdgeStart / 1000) * 1000);
+        decoded.Value.PathwayStart.Should().Be((pathway.PathwayStart / 1000) * 1000);
+    }
+
+    private static long GetLong()
+    {
+        var bytes = new byte[8];
+        Random.NextBytes(bytes);
+        return BitConverter.ToInt64(bytes, 0);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -1,0 +1,85 @@
+﻿// <copyright file="SpanContextDataStreamsManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class SpanContextDataStreamsManagerTests
+{
+    [Fact]
+    public void SetCheckpoint_SetsTheSpanPathwayContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.PathwayContext.Should().BeNull();
+
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+
+        spanContext.PathwayContext.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenNull_UsesOtherContext()
+    {
+        var ctx = new PathwayContext();
+
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.PathwayContext.Should().BeNull();
+
+        spanContext.MergePathwayContext(ctx);
+        spanContext.PathwayContext.Value.Should().Be(ctx);
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenOtherContextIsNull_KeepsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+        spanContext.PathwayContext.Should().NotBeNull();
+        var previous = spanContext.PathwayContext;
+
+        spanContext.MergePathwayContext(null);
+        spanContext.PathwayContext.Should().Be(previous);
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenOtherContextIsNotNull_KeepsEach50Percent()
+    {
+        int iterations = 1000_000;
+        // When we have a context and there's a new context we pick one randomly
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+
+        // Make sure we have a different hash for comparison purposes
+        while (spanContext.PathwayContext.Value.Hash.Value < (ulong)iterations)
+        {
+            spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+        }
+
+        var sameCount = 0;
+        var otherCount = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            var other = new PathwayContext(new PathwayHash((ulong)i), 1234, 5678);
+            spanContext.MergePathwayContext(other);
+            if (spanContext.PathwayContext.Value.Hash.Value == (ulong)i)
+            {
+                otherCount++;
+            }
+            else
+            {
+                sameCount++;
+            }
+        }
+
+        sameCount.Should().BeCloseTo(otherCount, (uint)(iterations / 100)); // roughly 1%
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="TestHeadersCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Headers;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class TestHeadersCollection : IBinaryHeadersCollection
+{
+    public Dictionary<string, byte[]> Values { get; } = new();
+
+    public byte[] TryGetBytes(string name)
+        => Values.TryGetValue(name, out var value) ? value : null;
+
+    public void Add(string name, byte[] value)
+        => Values[name] = value;
+}

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(null, null, null, null, null, null, null, null, null, null)
+                : base(null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }


### PR DESCRIPTION
## Summary of changes

- Add settings (and telemetry) for enabling data streams monitoring.
- Add `PathwayContext` object, encoder, and propagator.
- Intitializes `DataStreamsManager` in `TracerManager`.

## Reason for change

This is the first in a series of PRs to enable data streams monitoring. This PR adds the code for the  _propagation_ and storage of the pathway context, as well as the basic initialization of the `DataStreamsManager`.

## Implementation details

- Config is fairly self explanatory. 
- `PropagationContext` is calculated based on the spec (and reference implementations in java and [go](https://github.com/DataDog/data-streams-go))
- Currently context can only be injected into binary headers (i.e. kafka) but can extend this later to string headers when required.

The actual _usage_ of this will appear in a subsequent PR (I'm keeping the PRs small for easier reviewing), but will look something like this for consumers:

```csharp
if (dataStreamsManager.IsEnabled)
{
    pathwayContext = dataStreamsManager.ExtractPathwayContext(headers);
    span.Context.MergePathwayContext(pathwayContext);
    span.Context.SetCheckpoint(dataStreamsManager, new []{"some-tags"});
}
```

And like this for producers:

```csharp
if (dataStreamsManager.IsEnabled)
{
    context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
    dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
}
```

## Test coverage

Unit tests for the basics in this PR, but will have full integration tests in subsequent PRs.

## Other details
This PR is dependent on https://github.com/DataDog/dd-trace-dotnet/pull/3131 being merged first.

Subsequent PRs to follow:
- Enable storing, aggregation, and sending of pathway context stats: https://github.com/DataDog/dd-trace-dotnet/pull/3191
- Implementation and integration tests for kafka: https://github.com/DataDog/dd-trace-dotnet/pull/3192
- Enable/Disable via discovery service https://github.com/DataDog/dd-trace-dotnet/pull/3197
- Public API/adaptation of existing to handle manual context creation (e.g. when automatic consumer scopes are disabled)

