### PR TITLE
Avoid multiple configuration source enumeration

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -23,8 +23,7 @@ namespace Datadog.Trace.Coverage.Collector
             _logger = logger;
             _collectionContext = collectionContext;
 
-            var settings = GlobalSettings.FromDefaultSources();
-            _isDebugEnabled = settings.DebugEnabled;
+            _isDebugEnabled = GlobalSettings.Instance.DebugEnabled;
         }
 
         public void Error(string? text)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessInfo.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessInfo.cs
@@ -204,7 +204,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
             }
 
-            if (GlobalSettings.TryLoadJsonConfigurationFile(configurationSource, baseDirectory, out var jsonConfigurationSource))
+            if (GlobalConfigurationSource.TryLoadJsonConfigurationFile(configurationSource, baseDirectory, out var jsonConfigurationSource))
             {
                 configurationSource.Add(jsonConfigurationSource);
             }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -245,7 +245,7 @@ namespace Datadog.Trace.Tools.Runner
 
             var configurationSource = new CompositeConfigurationSource()
             {
-                GlobalSettings.ConfigurationSource,
+                GlobalConfigurationSource.Instance,
                 new NameValueConfigurationSource(env)
             };
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -243,9 +243,13 @@ namespace Datadog.Trace.Tools.Runner
                 env["DD_TRACE_AGENT_URL"] = agentUrl;
             }
 
-            var globalSettings = GlobalSettings.CreateDefaultConfigurationSource();
-            globalSettings.Add(new NameValueConfigurationSource(env));
-            var tracerSettings = new TracerSettings(globalSettings);
+            var configurationSource = new CompositeConfigurationSource()
+            {
+                GlobalSettings.ConfigurationSource,
+                new NameValueConfigurationSource(env)
+            };
+
+            var tracerSettings = new TracerSettings(configurationSource);
             var settings = tracerSettings.Build();
             var discoveryService = DiscoveryService.Create(settings.Exporter);
 

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -122,8 +122,7 @@ namespace Datadog.Trace.AppSec
 
         public static SecuritySettings FromDefaultSources()
         {
-            var source = GlobalSettings.CreateDefaultConfigurationSource();
-            return new SecuritySettings(source);
+            return new SecuritySettings(GlobalSettings.ConfigurationSource);
         }
 
         private static int ParseWafTimeout(string wafTimeoutString)

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.AppSec
 
         public static SecuritySettings FromDefaultSources()
         {
-            return new SecuritySettings(GlobalSettings.ConfigurationSource);
+            return new SecuritySettings(GlobalConfigurationSource.Instance);
         }
 
         private static int ParseWafTimeout(string wafTimeoutString)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             // convert to a delegate and attempt to pin it by assigning it to  field
             _setupLogCallbackField = new SetupLogCallbackDelegate(LoggingCallback);
             // set the log level and setup the logger
-            var level = GlobalSettings.Source.DebugEnabled ? DDWAF_LOG_LEVEL.DDWAF_DEBUG : DDWAF_LOG_LEVEL.DDWAF_INFO;
+            var level = GlobalSettings.Instance.DebugEnabled ? DDWAF_LOG_LEVEL.DDWAF_DEBUG : DDWAF_LOG_LEVEL.DDWAF_INFO;
             setupLogging(_setupLogCallbackField, level);
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -23,12 +23,12 @@ namespace Datadog.Trace.Ci.Agent
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CIWriterHttpSender>();
 
         private readonly IApiRequestFactory _apiRequestFactory;
-        private readonly GlobalSettings _globalSettings;
+        private readonly bool _isDebugEnabled;
 
         public CIWriterHttpSender(IApiRequestFactory apiRequestFactory)
         {
             _apiRequestFactory = apiRequestFactory;
-            _globalSettings = GlobalSettings.FromDefaultSources();
+            _isDebugEnabled = GlobalSettings.Instance.DebugEnabled;
             Log.Information("CIWriterHttpSender Initialized.");
         }
 
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Ci.Agent
                 {
                     exception = ex;
 
-                    if (_globalSettings.DebugEnabled)
+                    if (_isDebugEnabled)
                     {
                         if (ex.InnerException is InvalidOperationException ioe)
                         {

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -105,12 +105,12 @@ namespace Datadog.Trace.Ci.Configuration
 
         public static CIVisibilitySettings FromDefaultSources()
         {
-            return new CIVisibilitySettings(GlobalSettings.ConfigurationSource);
+            return new CIVisibilitySettings(GlobalConfigurationSource.Instance);
         }
 
         private TracerSettings InitializeTracerSettings()
         {
-            var tracerSettings = new TracerSettings(GlobalSettings.ConfigurationSource);
+            var tracerSettings = new TracerSettings(GlobalConfigurationSource.Instance);
 
             if (Logs)
             {

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -105,13 +105,12 @@ namespace Datadog.Trace.Ci.Configuration
 
         public static CIVisibilitySettings FromDefaultSources()
         {
-            var source = GlobalSettings.CreateDefaultConfigurationSource();
-            return new CIVisibilitySettings(source);
+            return new CIVisibilitySettings(GlobalSettings.ConfigurationSource);
         }
 
         private TracerSettings InitializeTracerSettings()
         {
-            var tracerSettings = new TracerSettings(GlobalSettings.CreateDefaultConfigurationSource());
+            var tracerSettings = new TracerSettings(GlobalSettings.ConfigurationSource);
 
             if (Logs)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -244,7 +244,7 @@ namespace Datadog.Trace.ClrProfiler
 #if !NETFRAMEWORK
             try
             {
-                if (GlobalSettings.Source.DiagnosticSourceEnabled)
+                if (GlobalSettings.Instance.DiagnosticSourceEnabled)
                 {
                     // check if DiagnosticSource is available before trying to use it
                     var type = Type.GetType("System.Diagnostics.DiagnosticSource, System.Diagnostics.DiagnosticSource", throwOnError: false);
@@ -328,7 +328,6 @@ namespace Datadog.Trace.ClrProfiler
         private static void InitRemoteConfigurationManagement(Tracer tracer)
         {
             var serviceName = tracer.Settings.ServiceName ?? tracer.DefaultServiceName;
-            var exporterSettings = tracer.Settings.Exporter;
             var discoveryService = tracer.TracerManager.DiscoveryService;
 
             Task.Run(
@@ -340,9 +339,9 @@ namespace Datadog.Trace.ClrProfiler
                     if (isDiscoverySuccessful)
                     {
                         var rcmSettings = RemoteConfigurationSettings.FromDefaultSource();
-                        var rcmApi = RemoteConfigurationApiFactory.Create(exporterSettings, rcmSettings, discoveryService);
+                        var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
 
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName);
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion);
                         configurationManager.RegisterProduct(SharedRemoteConfiguration.FeaturesProduct);
 
                         var liveDebugger = LiveDebuggerFactory.Create(discoveryService, configurationManager, tracer.Settings, serviceName);

--- a/tracer/src/Datadog.Trace/Configuration/GlobalConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalConfigurationSource.cs
@@ -1,0 +1,86 @@
+// <copyright file="GlobalConfigurationSource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace Datadog.Trace.Configuration;
+
+/// <summary>
+/// Contains global datadog configuration.
+/// </summary>
+internal class GlobalConfigurationSource
+{
+    /// <summary>
+    /// Gets the configuration source instance.
+    /// </summary>
+    internal static IConfigurationSource Instance { get; private set;  } = CreateDefaultConfigurationSource();
+
+    /// <summary>
+    /// Creates a <see cref="IConfigurationSource"/> by combining environment variables,
+    /// AppSettings where available, and a local datadog.json file, if present.
+    /// </summary>
+    /// <returns>A new <see cref="IConfigurationSource"/> instance.</returns>
+    internal static CompositeConfigurationSource CreateDefaultConfigurationSource()
+    {
+        // env > AppSettings > datadog.json
+        var configurationSource = new CompositeConfigurationSource
+        {
+            new EnvironmentConfigurationSource(),
+
+#if NETFRAMEWORK
+            // on .NET Framework only, also read from app.config/web.config
+            new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings)
+#endif
+        };
+
+        if (TryLoadJsonConfigurationFile(configurationSource, null, out var jsonConfigurationSource))
+        {
+            configurationSource.Add(jsonConfigurationSource);
+        }
+
+        return configurationSource;
+    }
+
+    internal static bool TryLoadJsonConfigurationFile(IConfigurationSource configurationSource, string baseDirectory, out IConfigurationSource jsonConfigurationSource)
+    {
+        try
+        {
+            // if environment variable is not set, look for default file name in the current directory
+            var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
+                                        configurationSource.GetString("DD_DOTNET_TRACER_CONFIG_FILE") ??
+                                        Path.Combine(baseDirectory ?? GetCurrentDirectory(), "datadog.json");
+
+            if (string.Equals(Path.GetExtension(configurationFileName), ".JSON", StringComparison.OrdinalIgnoreCase) &&
+                File.Exists(configurationFileName))
+            {
+                jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName);
+                return true;
+            }
+        }
+        catch (Exception)
+        {
+            // Unable to load the JSON file from disk
+            // The configuration manager should not depend on a logger being bootstrapped yet
+            // so do not do anything
+        }
+
+        jsonConfigurationSource = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Used to refresh configuration source.
+    /// </summary>
+    internal static void Reload()
+    {
+        Instance = CreateDefaultConfigurationSource();
+    }
+
+    private static string GetCurrentDirectory()
+    {
+        return AppDomain.CurrentDomain.BaseDirectory;
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.IO;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -48,11 +46,6 @@ namespace Datadog.Trace.Configuration
         public bool DebugEnabled { get; private set; }
 
         /// <summary>
-        /// Gets the configuration source instance.
-        /// </summary>
-        internal static IConfigurationSource ConfigurationSource { get; private set; } = CreateDefaultConfigurationSource();
-
-        /// <summary>
         /// Gets the global settings instance.
         /// </summary>
         internal static GlobalSettings Instance { get; private set; } = FromDefaultSources();
@@ -91,76 +84,18 @@ namespace Datadog.Trace.Configuration
         public static void Reload()
         {
             DatadogLogging.Reset();
+            GlobalConfigurationSource.Reload();
             Instance = FromDefaultSources();
-            ConfigurationSource = CreateDefaultConfigurationSource();
         }
 
         /// <summary>
         /// Create a <see cref="GlobalSettings"/> populated from the default sources
-        /// returned by <see cref="ConfigurationSource"/>.
+        /// returned by <see cref="GlobalConfigurationSource.Instance"/>.
         /// </summary>
         /// <returns>A <see cref="TracerSettings"/> populated from the default sources.</returns>
         public static GlobalSettings FromDefaultSources()
         {
-            return new GlobalSettings(ConfigurationSource);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="IConfigurationSource"/> by combining environment variables,
-        /// AppSettings where available, and a local datadog.json file, if present.
-        /// </summary>
-        /// <returns>A new <see cref="IConfigurationSource"/> instance.</returns>
-        internal static CompositeConfigurationSource CreateDefaultConfigurationSource()
-        {
-            // env > AppSettings > datadog.json
-            var configurationSource = new CompositeConfigurationSource
-            {
-                new EnvironmentConfigurationSource(),
-
-#if NETFRAMEWORK
-                // on .NET Framework only, also read from app.config/web.config
-                new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings)
-#endif
-            };
-
-            if (TryLoadJsonConfigurationFile(configurationSource, null, out var jsonConfigurationSource))
-            {
-                configurationSource.Add(jsonConfigurationSource);
-            }
-
-            return configurationSource;
-        }
-
-        internal static bool TryLoadJsonConfigurationFile(IConfigurationSource configurationSource, string baseDirectory, out IConfigurationSource jsonConfigurationSource)
-        {
-            try
-            {
-                // if environment variable is not set, look for default file name in the current directory
-                var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
-                                            configurationSource.GetString("DD_DOTNET_TRACER_CONFIG_FILE") ??
-                                            Path.Combine(baseDirectory ?? GetCurrentDirectory(), "datadog.json");
-
-                if (string.Equals(Path.GetExtension(configurationFileName), ".JSON", StringComparison.OrdinalIgnoreCase) &&
-                    File.Exists(configurationFileName))
-                {
-                    jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName);
-                    return true;
-                }
-            }
-            catch (Exception)
-            {
-                // Unable to load the JSON file from disk
-                // The configuration manager should not depend on a logger being bootstrapped yet
-                // so do not do anything
-            }
-
-            jsonConfigurationSource = default;
-            return false;
-        }
-
-        private static string GetCurrentDirectory()
-        {
-            return System.AppDomain.CurrentDomain.BaseDirectory;
+            return new GlobalSettings(GlobalConfigurationSource.Instance);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -48,9 +48,14 @@ namespace Datadog.Trace.Configuration
         public bool DebugEnabled { get; private set; }
 
         /// <summary>
-        /// Gets or sets the global settings instance.
+        /// Gets the configuration source instance.
         /// </summary>
-        internal static GlobalSettings Source { get; set; } = FromDefaultSources();
+        internal static IConfigurationSource ConfigurationSource { get; private set; } = CreateDefaultConfigurationSource();
+
+        /// <summary>
+        /// Gets the global settings instance.
+        /// </summary>
+        internal static GlobalSettings Instance { get; private set; } = FromDefaultSources();
 
         /// <summary>
         /// Gets a value indicating whether the use
@@ -67,7 +72,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="enabled">Whether debug is enabled.</param>
         public static void SetDebugEnabled(bool enabled)
         {
-            Source.DebugEnabled = enabled;
+            Instance.DebugEnabled = enabled;
 
             if (enabled)
             {
@@ -86,18 +91,18 @@ namespace Datadog.Trace.Configuration
         public static void Reload()
         {
             DatadogLogging.Reset();
-            Source = FromDefaultSources();
+            Instance = FromDefaultSources();
+            ConfigurationSource = CreateDefaultConfigurationSource();
         }
 
         /// <summary>
         /// Create a <see cref="GlobalSettings"/> populated from the default sources
-        /// returned by <see cref="CreateDefaultConfigurationSource"/>.
+        /// returned by <see cref="ConfigurationSource"/>.
         /// </summary>
         /// <returns>A <see cref="TracerSettings"/> populated from the default sources.</returns>
         public static GlobalSettings FromDefaultSources()
         {
-            var source = CreateDefaultConfigurationSource();
-            return new GlobalSettings(source);
+            return new GlobalSettings(ConfigurationSource);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -334,12 +334,12 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources
-        /// returned by <see cref="GlobalSettings.ConfigurationSource"/>.
+        /// returned by <see cref="GlobalConfigurationSource.Instance"/>.
         /// </summary>
         /// <returns>A <see cref="ImmutableTracerSettings"/> populated from the default sources.</returns>
         public static ImmutableTracerSettings FromDefaultSources()
         {
-            return new ImmutableTracerSettings(GlobalSettings.ConfigurationSource);
+            return new ImmutableTracerSettings(GlobalConfigurationSource.Instance);
         }
 
         internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -334,13 +334,12 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources
-        /// returned by <see cref="GlobalSettings.CreateDefaultConfigurationSource()"/>.
+        /// returned by <see cref="GlobalSettings.ConfigurationSource"/>.
         /// </summary>
         /// <returns>A <see cref="ImmutableTracerSettings"/> populated from the default sources.</returns>
         public static ImmutableTracerSettings FromDefaultSources()
         {
-            var source = GlobalSettings.CreateDefaultConfigurationSource();
-            return new ImmutableTracerSettings(source);
+            return new ImmutableTracerSettings(GlobalSettings.ConfigurationSource);
         }
 
         internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="useDefaultSources">If <c>true</c>, creates a <see cref="TracerSettings"/> populated from
         /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
         public TracerSettings(bool useDefaultSources)
-            : this(useDefaultSources ? GlobalSettings.ConfigurationSource : null)
+            : this(useDefaultSources ? GlobalConfigurationSource.Instance : null)
         {
         }
 
@@ -499,12 +499,12 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources
-        /// returned by <see cref="GlobalSettings.ConfigurationSource"/>.
+        /// returned by <see cref="GlobalConfigurationSource.Instance"/>.
         /// </summary>
         /// <returns>A <see cref="TracerSettings"/> populated from the default sources.</returns>
         public static TracerSettings FromDefaultSources()
         {
-            return new TracerSettings(GlobalSettings.ConfigurationSource);
+            return new TracerSettings(GlobalConfigurationSource.Instance);
         }
 
         /// <summary>
@@ -514,7 +514,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>A new <see cref="IConfigurationSource"/> instance.</returns>
         public static CompositeConfigurationSource CreateDefaultConfigurationSource()
         {
-            return GlobalSettings.CreateDefaultConfigurationSource();
+            return GlobalConfigurationSource.CreateDefaultConfigurationSource();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="useDefaultSources">If <c>true</c>, creates a <see cref="TracerSettings"/> populated from
         /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
         public TracerSettings(bool useDefaultSources)
-            : this(useDefaultSources ? CreateDefaultConfigurationSource() : null)
+            : this(useDefaultSources ? GlobalSettings.ConfigurationSource : null)
         {
         }
 
@@ -361,7 +361,7 @@ namespace Datadog.Trace.Configuration
         /// </remark>
         public bool DiagnosticSourceEnabled
         {
-            get => GlobalSettings.Source.DiagnosticSourceEnabled;
+            get => GlobalSettings.Instance.DiagnosticSourceEnabled;
             set { }
         }
 
@@ -499,13 +499,12 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources
-        /// returned by <see cref="CreateDefaultConfigurationSource"/>.
+        /// returned by <see cref="GlobalSettings.ConfigurationSource"/>.
         /// </summary>
         /// <returns>A <see cref="TracerSettings"/> populated from the default sources.</returns>
         public static TracerSettings FromDefaultSources()
         {
-            var source = CreateDefaultConfigurationSource();
-            return new TracerSettings(source);
+            return new TracerSettings(GlobalSettings.ConfigurationSource);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Debugger
 
         public static DebuggerSettings FromDefaultSource()
         {
-            return FromSource(GlobalSettings.CreateDefaultConfigurationSource());
+            return FromSource(GlobalSettings.ConfigurationSource);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Debugger
 
         public static DebuggerSettings FromDefaultSource()
         {
-            return FromSource(GlobalSettings.ConfigurationSource);
+            return FromSource(GlobalConfigurationSource.Instance);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -23,7 +23,7 @@ internal class LiveDebuggerFactory
 
     public static LiveDebugger Create(IDiscoveryService discoveryService, IRemoteConfigurationManager remoteConfigurationManager, ImmutableTracerSettings tracerSettings, string serviceName)
     {
-        var settings = DebuggerSettings.FromSource(GlobalSettings.ConfigurationSource);
+        var settings = DebuggerSettings.FromDefaultSource();
         if (!settings.Enabled)
         {
             Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -23,8 +23,7 @@ internal class LiveDebuggerFactory
 
     public static LiveDebugger Create(IDiscoveryService discoveryService, IRemoteConfigurationManager remoteConfigurationManager, ImmutableTracerSettings tracerSettings, string serviceName)
     {
-        var source = GlobalSettings.CreateDefaultConfigurationSource();
-        var settings = DebuggerSettings.FromSource(source);
+        var settings = DebuggerSettings.FromSource(GlobalSettings.ConfigurationSource);
         if (!settings.Enabled)
         {
             Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Logging
 
             try
             {
-                if (GlobalSettings.Source.DebugEnabled)
+                if (GlobalSettings.Instance.DebugEnabled)
                 {
                     LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -33,7 +35,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         private int _rootVersion;
         private int _targetsVersion;
-        private string _lastPollError;
+        private string? _lastPollError;
         private bool _isPollingStarted;
         private bool _isRcmEnabled;
 
@@ -58,13 +60,15 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             discoveryService.SubscribeToChanges(SetRcmEnabled);
         }
 
-        public static RemoteConfigurationManager Instance { get; private set; }
+        public static RemoteConfigurationManager? Instance { get; private set; }
 
         public static RemoteConfigurationManager Create(
             IDiscoveryService discoveryService,
             IRemoteConfigurationApi remoteConfigurationApi,
             RemoteConfigurationSettings settings,
-            string serviceName)
+            string serviceName,
+            string? environment,
+            string? serviceVersion)
         {
             lock (LockObject)
             {
@@ -72,7 +76,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                     discoveryService,
                     remoteConfigurationApi,
                     id: settings.Id,
-                    rcmTracer: new RcmClientTracer(settings.RuntimeId, settings.TracerVersion, serviceName, settings.Environment, settings.AppVersion),
+                    rcmTracer: new RcmClientTracer(settings.RuntimeId, settings.TracerVersion, serviceName, environment, serviceVersion),
                     pollInterval: settings.PollInterval);
             }
         }
@@ -247,7 +251,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
             void UnapplyRemovedConfigurations()
             {
-                List<string> remove = null;
+                List<string>? remove = null;
 
                 foreach (var product in products.Values)
                 {

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using Datadog.Trace.Configuration;
 
@@ -17,13 +19,11 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         {
         }
 
-        public RemoteConfigurationSettings(IConfigurationSource configurationSource)
+        public RemoteConfigurationSettings(IConfigurationSource? configurationSource)
         {
             Id = Guid.NewGuid().ToString();
             RuntimeId = Util.RuntimeId.Get();
             TracerVersion = TracerConstants.AssemblyVersion;
-            Environment = configurationSource?.GetString(ConfigurationKeys.Environment);
-            AppVersion = configurationSource?.GetString(ConfigurationKeys.ServiceVersion);
 
             var pollInterval = configurationSource?.GetInt32(ConfigurationKeys.Rcm.PollInterval);
             pollInterval =
@@ -40,10 +40,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public string TracerVersion { get; }
 
-        public string Environment { get; }
-
-        public string AppVersion { get; }
-
         public TimeSpan PollInterval { get; }
 
         public static RemoteConfigurationSettings FromSource(IConfigurationSource source)
@@ -53,7 +49,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static RemoteConfigurationSettings FromDefaultSource()
         {
-            return FromSource(GlobalSettings.CreateDefaultConfigurationSource());
+            return FromSource(GlobalSettings.ConfigurationSource);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static RemoteConfigurationSettings FromDefaultSource()
         {
-            return FromSource(GlobalSettings.ConfigurationSource);
+            return FromSource(GlobalConfigurationSource.Instance);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.Enabled, value: settings.TraceEnabled),
                 new(ConfigTelemetryData.AgentUrl, value: settings.Exporter.AgentUri.ToString()),
                 new(ConfigTelemetryData.AgentTraceTransport, value: settings.Exporter.TracesTransport.ToString()),
-                new(ConfigTelemetryData.Debug, value: GlobalSettings.Source.DebugEnabled),
+                new(ConfigTelemetryData.Debug, value: GlobalSettings.Instance.DebugEnabled),
 #pragma warning disable CS0618
                 new(ConfigTelemetryData.AnalyticsEnabled, value: settings.AnalyticsEnabled),
 #pragma warning restore CS0618

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetrySettings.cs" company="Datadog">
+// <copyright file="TelemetrySettings.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Telemetry
 
         public AgentlessSettings? Agentless { get; }
 
-        public static TelemetrySettings FromDefaultSources() => FromSource(GlobalSettings.CreateDefaultConfigurationSource());
+        public static TelemetrySettings FromDefaultSources() => FromSource(GlobalSettings.ConfigurationSource);
 
         public static TelemetrySettings FromSource(IConfigurationSource? source)
         {

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Telemetry
 
         public AgentlessSettings? Agentless { get; }
 
-        public static TelemetrySettings FromDefaultSources() => FromSource(GlobalSettings.ConfigurationSource);
+        public static TelemetrySettings FromDefaultSources() => FromSource(GlobalConfigurationSource.Instance);
 
         public static TelemetrySettings FromSource(IConfigurationSource? source)
         {

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -315,7 +315,7 @@ namespace Datadog.Trace
                     writer.WriteValue(instanceSettings.Exporter.TracesTransport.ToString());
 
                     writer.WritePropertyName("debug");
-                    writer.WriteValue(GlobalSettings.Source.DebugEnabled);
+                    writer.WriteValue(GlobalSettings.Instance.DebugEnabled);
 
                     writer.WritePropertyName("health_checks_enabled");
                     writer.WriteValue(instanceSettings.TracerMetricsEnabled);


### PR DESCRIPTION
## Summary of changes
Change `GlobalSettings`:

- Add `IConfigurationSource ConfigurationSource` static property, and initialize it with `CreateDefaultConfigurationSource` method.
- Remove all usages of `CreateDefaultConfigurationSource` to avoid multiple enumeration of configuration sources, and use `ConfigurationSource` property instead.
- Rename `DebuggerSource Source` to `Instance` to match naming conventions of other single tones.

## Reason for change
Avoid multiple enumeration of configuration sources
