### PR TITLE
Add debug log in `Api` when sending to agent fails

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
@@ -152,6 +153,10 @@ namespace Datadog.Trace.Agent
                         // stop retrying
                         _log.Error(exception, "An error occurred while sending data to the agent at {AgentEndpoint}", _apiRequestFactory.Info(endpoint));
                         return false;
+                    }
+                    else if (_log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        _log.Debug(exception, "An error occurred while sending data to the agent at {AgentEndpoint}. Retrying.", _apiRequestFactory.Info(endpoint));
                     }
 
                     // Before retry delay

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             _inProcess = inProcess;
             _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
+            EnableDebugMode();
 
             SetServiceVersion("1.0.0");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1UpperWithMapping}:{HeaderTagName1WithMapping},{HeaderName2},{HeaderName3}");
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
+            EnableDebugMode();
 
             SetServiceVersion("1.0.0");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             this.fixture = fixture;
             _testName = testName;
+            EnableDebugMode();
         }
 
         public async Task TestIncorrectMethod(string path)


### PR DESCRIPTION
## Summary of changes

- Add a debug log when we fail to send to the agent, but we will retry.
- Enable debug logs for aspnetcore tests

## Reason for change

We have some flakiness in the aspnetcore tests, which we _think_ may be related to the `MockTracerAgent`, but can't figure out why. This is just to try to help with debugging

## Implementation details

Add a debug log if _not_ final try (previously we were _only_ logging if it's final try).

## Test coverage

N/A

## Other details
Trying to understand failures [like this one](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=111297&view=logs&j=4d2bd072-69d2-52f9-9ef7-1ebf54e62e75&t=932c758b-5f44-5d34-a86c-84ce5d520f99&s=81ae2f89-c25e-5081-04b4-ddbf80377ce9) where we receive the same span twice.
