### PR TITLE
[Profiler] Fix sanitizer jobs

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -260,7 +260,11 @@ jobs:
           tests_output_dir="$(realpath .)/test_output"
           echo "DD_TESTING_OUPUT_DIR=$tests_output_dir" >> $GITHUB_ENV
           echo "DD_PROFILING_LOG_DIR=$tests_output_dir/logs" >> $GITHUB_ENV
-          echo "DD_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
+          echo "DD_INTERNAL_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
+          echo "DD_PROFILING_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_EXCEPTION_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_ALLOCATION_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_CONTENTION_ENABLED=1" >> $GITHUB_ENV
           echo "DD_TRACE_DEBUG=1" >> $GITHUB_ENV
 
       - name: Run Computer01 for 2min
@@ -320,7 +324,11 @@ jobs:
           tests_output_dir="$(realpath .)/test_output"
           echo "DD_TESTING_OUPUT_DIR=$tests_output_dir" >> $GITHUB_ENV
           echo "DD_PROFILING_LOG_DIR=$tests_output_dir/logs" >> $GITHUB_ENV
-          echo "DD_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
+          echo "DD_INTERNAL_PROFILING_OUTPUT_DIR=$tests_output_dir/pprofs" >> $GITHUB_ENV
+          echo "DD_PROFILING_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_EXCEPTION_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_ALLOCATION_ENABLED=1" >> $GITHUB_ENV
+          echo "DD_PROFILING_CONTENTION_ENABLED=1" >> $GITHUB_ENV
           echo "DD_TRACE_DEBUG=1" >> $GITHUB_ENV
 
       - name: Run Computer01 for 2min
@@ -760,8 +768,12 @@ jobs:
           echo "DD_TESTING_OUPUT_DIR=$tests_output" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "DD_TRACE_DEBUG=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "DD_PROFILING_LOG_DIR=$(Join-Path -Path $tests_output -ChildPath logs)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          echo "DD_PROFILING_OUTPUT_DIR=$(Join-Path -Path $tests_output -ChildPath pprofs)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DD_INTERNAL_PROFILING_OUTPUT_DIR=$(Join-Path -Path $tests_output -ChildPath pprofs)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "DD_TRACE_ENABLED=0" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DD_PROFILING_ENABLED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DD_PROFILING_EXCEPTION_ENABLED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DD_PROFILING_ALLOCATION_ENABLED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DD_PROFILING_CONTENTION_ENABLED=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "COR_ENABLE_PROFILING=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "COR_PROFILER_PATH=$(Join-Path -Path $(Resolve-Path .) -ChildPath shared/bin/monitoring-home/win-${{ matrix.platform }}/Datadog.Trace.ClrProfiler.Native.dll)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append

--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -51,6 +51,9 @@ namespace Samples.Computer01
                     StartFibonacciComputation(nbThreads);
                     StartSleep(nbThreads);
                     StartAsyncComputation(nbThreads);
+                    StartIteratorComputation(nbThreads);
+                    StartGenericsAllocation(nbThreads);
+                    StartContentionGenerator(nbThreads, parameter);
                     break;
 
                 case Scenario.Computer:
@@ -122,6 +125,10 @@ namespace Samples.Computer01
                     StopPiComputation();
                     StopFibonacciComputation();
                     StopSleep();
+                    StopAsyncComputation();
+                    StopIteratorComputation();
+                    StopGenericsAllocation();
+                    StopContentionGenerator();
                     break;
 
                 case Scenario.Computer:
@@ -196,6 +203,11 @@ namespace Samples.Computer01
                         RunSimpleWallTime();
                         RunPiComputation();
                         RunFibonacciComputation(nbThreads);
+                        RunSleep(nbThreads);
+                        RunAsyncComputation(nbThreads);
+                        RunIteratorComputation(nbThreads);
+                        RunGenericsAllocation(nbThreads);
+                        RunContentionGenerator(nbThreads, parameter);
                         break;
 
                     case Scenario.Computer:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -24,11 +24,11 @@ if (IS_ALPINE)
 endif()
 
 if (RUN_ASAN)
-    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
+    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer -DDD_SANITIZERS)
 endif()
 
 if (RUN_UBSAN)
-    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
+    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all -DDD_SANITIZERS)
 endif()
 
 if(ISLINUX)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -335,8 +335,9 @@ std::string OpSysTools::GetProcessName()
 
 bool OpSysTools::IsSafeToStartProfiler(double coresThreshold)
 {
-#ifdef _WINDOWS
+#if defined(_WINDOWS) || defined(DD_SANITIZERS)
     // Today we do not have any specific check before starting the profiler on Windows.
+    // And also when we compile for sanitizers tests (Address and Undefined behavior sanitizers)
     return true;
 #else
     // For linux, we check that the wrapper library is loaded and the default `dl_iterate_phdr` is


### PR DESCRIPTION
## Summary of changes

Fix Address sanitizer and Undefined behavior jobs.

## Reason for change

Changes in the profiler silently broke the sanitizers jobs.

## Implementation details

- Add a `DD_SANITIZERS` compilation flag to enable the profiler even if the LD_PRELOAD does not contain the `anti-deadlock` library.
- deactivate the alignment check for `ParseGcEvent` function
- Run other scenarios in the sanitizers tests.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
