### PR TITLE
Add checkpointing and aggregation for data streams monitoring

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
@@ -1,0 +1,172 @@
+﻿// <copyright file="DataStreamsAggregator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+/// <summary>
+/// Aggregates multiple <see cref="StatsPoint"/>s into their correct buckets
+/// Note that this class is not thread safe
+/// </summary>
+internal class DataStreamsAggregator
+{
+    // The inner dictionary is constrained in size by the number of unique hashes seen by the app
+    // Unique hashes are unique paths from origin to here, which could be unbounded if there are loops
+    // The outer dictionary is constrained by FlushInterval/BucketDuration + 1
+    private readonly Dictionary<long, Dictionary<ulong, StatsBucket>> _currentBuckets = new();
+
+    // The inner dictionary is similarly constrained
+    // but the outer dictionary is unconstrained, which could be problematic...
+    private readonly Dictionary<long, Dictionary<ulong, StatsBucket>> _originBuckets = new();
+
+    private readonly DataStreamsMessagePackFormatter _formatter;
+    private readonly DDSketchPool _sketchPool = new();
+    private readonly long _bucketDurationInNs;
+    private List<SerializableStatsBucket>? _statsToWrite;
+
+    public DataStreamsAggregator(DataStreamsMessagePackFormatter formatter, int bucketDurationMs)
+    {
+        _formatter = formatter;
+        _bucketDurationInNs = ((long)bucketDurationMs) * 1_000_000;
+    }
+
+    /// <summary>
+    /// Add the stats point to the aggregated stats
+    /// </summary>
+    public void Add(in StatsPoint point)
+    {
+        var currentBucketStartTime = BucketStartTimeForTimestamp(point.TimestampNs);
+        AddToBuckets(point, currentBucketStartTime, _currentBuckets);
+
+        var originTimestamp = point.TimestampNs - point.PathwayLatencyNs;
+        var originBucketStartTime = BucketStartTimeForTimestamp(originTimestamp);
+        AddToBuckets(point, originBucketStartTime, _originBuckets);
+    }
+
+    /// <summary>
+    /// Serialize the aggregated results using message pack
+    /// </summary>
+    /// <param name="buffer">The buffer to write the stats into. This may be replaced with a larger buffer
+    /// if it needs to grow</param>
+    /// <param name="offset">The offset into the buffer which to start writing</param>
+    /// <param name="maxBucketFlushTimeNs">Don't flush buckets that start (or include) this time (in Ns)</param>
+    /// <returns>The number of bytes written into the buffer</returns>
+    public int Serialize(ref byte[] buffer, int offset, long maxBucketFlushTimeNs)
+    {
+        var statsToAdd = Export(maxBucketFlushTimeNs);
+        if (statsToAdd?.Count > 0)
+        {
+            var bytesWritten = _formatter.Serialize(ref buffer, offset, _bucketDurationInNs, statsToAdd);
+
+            Clear(statsToAdd);
+
+            return bytesWritten;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Exports the currently aggregated stats
+    /// Internal for testing
+    /// </summary>
+    internal List<SerializableStatsBucket>? Export(long maxBucketFlushTimeNs)
+    {
+        // we don't have overlapping buckets so any buckets with a start time greater than
+        // this must be "current"
+        var currentBucketStart = maxBucketFlushTimeNs - _bucketDurationInNs;
+        _statsToWrite ??= new List<SerializableStatsBucket>(_currentBuckets.Count + _originBuckets.Count);
+        _statsToWrite.Clear();
+        foreach (var kvp in _currentBuckets)
+        {
+            if (kvp.Key > currentBucketStart)
+            {
+                // don't flush the current bucket
+                continue;
+            }
+
+            _statsToWrite.Add(new SerializableStatsBucket(TimestampType.Current, kvp.Key, kvp.Value));
+        }
+
+        foreach (var kvp in _originBuckets)
+        {
+            if (kvp.Key > currentBucketStart)
+            {
+                // don't flush the current bucket
+                continue;
+            }
+
+            _statsToWrite.Add(new SerializableStatsBucket(TimestampType.Origin, kvp.Key, kvp.Value));
+        }
+
+        return _statsToWrite;
+    }
+
+    internal void Clear(List<SerializableStatsBucket> statsToRemove)
+    {
+        // remove the old buckets
+        foreach (var statsBucket in statsToRemove)
+        {
+            if (statsBucket.TimestampType == TimestampType.Current)
+            {
+                _currentBuckets.Remove(statsBucket.BucketStartTimeNs);
+            }
+            else
+            {
+                _originBuckets.Remove(statsBucket.BucketStartTimeNs);
+            }
+
+            // add the sketches back to the pool
+            foreach (var bucket in statsBucket.Bucket)
+            {
+                _sketchPool.Release(bucket.Value.EdgeLatency);
+                _sketchPool.Release(bucket.Value.PathwayLatency);
+            }
+        }
+    }
+
+    private void AddToBuckets(
+        StatsPoint point,
+        long currentBucketStartTime,
+        Dictionary<long, Dictionary<ulong, StatsBucket>> buckets)
+    {
+        if (!buckets.TryGetValue(currentBucketStartTime, out var bucket))
+        {
+            bucket = new Dictionary<ulong, StatsBucket>();
+            buckets[currentBucketStartTime] = bucket;
+        }
+
+        if (!bucket.TryGetValue(point.Hash.Value, out var group))
+        {
+            group = new StatsBucket(
+                edgeTags: point.EdgeTags,
+                hash: point.Hash,
+                parentHash: point.ParentHash,
+                pathwayLatency: _sketchPool.Get(),
+                edgeLatency: _sketchPool.Get());
+            bucket[point.Hash.Value] = group;
+        }
+
+        var pathwayLatencySeconds = Convert.ToDouble(point.PathwayLatencyNs) / 1_000_000_000;
+        group.PathwayLatency.Add(Math.Max(pathwayLatencySeconds, 0));
+
+        var edgeLatencySeconds = Convert.ToDouble(point.EdgeLatencyNs) / 1_000_000_000;
+        group.EdgeLatency.Add(Math.Max(edgeLatencySeconds, 0));
+    }
+
+    /// <summary>
+    /// Gets the provided timestamp truncated to the bucket size.
+    /// It gives us the start time of the time bucket in which such timestamp falls.
+    /// </summary>
+    private long BucketStartTimeForTimestamp(long timestampNs)
+    {
+        return timestampNs - (timestampNs % _bucketDurationInNs);
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
@@ -1,0 +1,165 @@
+﻿// <copyright file="DataStreamsMessagePackFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
+{
+    internal class DataStreamsMessagePackFormatter
+    {
+        private readonly byte[] _environmentBytes = StringEncoding.UTF8.GetBytes("Env");
+        private readonly byte[] _environmentValueBytes;
+        private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("Service");
+
+        private readonly byte[] _serviceValueBytes;
+
+        // private readonly byte[] _primaryTagBytes = StringEncoding.UTF8.GetBytes("PrimaryTag");
+        // private readonly byte[] _primaryTagValueBytes;
+        private readonly byte[] _statsBytes = StringEncoding.UTF8.GetBytes("Stats");
+        private readonly byte[] _tracerVersionBytes = StringEncoding.UTF8.GetBytes("TracerVersion");
+        private readonly byte[] _tracerVersionValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.AssemblyVersion);
+        private readonly byte[] _langBytes = StringEncoding.UTF8.GetBytes("Lang");
+        private readonly byte[] _langValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.Language);
+
+        private readonly byte[] _startBytes = StringEncoding.UTF8.GetBytes("Start");
+        private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("Duration");
+
+        private readonly byte[] _edgeTagsBytes = StringEncoding.UTF8.GetBytes("EdgeTags");
+        private readonly byte[] _hashBytes = StringEncoding.UTF8.GetBytes("Hash");
+        private readonly byte[] _parentHashBytes = StringEncoding.UTF8.GetBytes("ParentHash");
+        private readonly byte[] _pathwayLatencyBytes = StringEncoding.UTF8.GetBytes("PathwayLatency");
+        private readonly byte[] _edgeLatencyBytes = StringEncoding.UTF8.GetBytes("EdgeLatency");
+        private readonly byte[] _timestampTypeBytes = StringEncoding.UTF8.GetBytes("TimestampType");
+        private readonly byte[] _currentTimestampTypeBytes = StringEncoding.UTF8.GetBytes("current");
+        private readonly byte[] _originTimestampTypeBytes = StringEncoding.UTF8.GetBytes("origin");
+
+        public DataStreamsMessagePackFormatter(ImmutableTracerSettings tracerSettings, string defaultServiceName)
+            : this(tracerSettings.Environment, defaultServiceName)
+        {
+        }
+
+        public DataStreamsMessagePackFormatter(string? environment, string defaultServiceName)
+        {
+            // .NET tracer doesn't yet support primary tag
+            // _primaryTagValueBytes = Array.Empty<byte>();
+            _environmentValueBytes = string.IsNullOrEmpty(environment)
+                                         ? Array.Empty<byte>()
+                                         : StringEncoding.UTF8.GetBytes(environment);
+            _serviceValueBytes = StringEncoding.UTF8.GetBytes(defaultServiceName);
+        }
+
+        public int Serialize(ref byte[] bytes, int offset, long bucketDurationNs, List<SerializableStatsBucket> statsBuckets)
+        {
+            var originalOffset = offset;
+
+            // 6 entries in StatsPayload:
+            // -1 because we don't have a primary tag
+            // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L11
+            offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 5);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceValueBytes);
+
+            // We never have a primary tag currently, make sure to increase header size if/when we add it
+            // offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _primaryTagBytes);
+            // offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _primaryTagValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _langBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _langValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _tracerVersionBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _tracerVersionValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _statsBytes);
+            offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, statsBuckets.Count);
+
+            foreach (var statsBucket in statsBuckets)
+            {
+                // 3 entries per StatsBucket:
+                // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L27
+                offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 3);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _startBytes);
+                offset += MessagePackBinary.WriteInt64(ref bytes, offset, statsBucket.BucketStartTimeNs);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
+                offset += MessagePackBinary.WriteInt64(ref bytes, offset, bucketDurationNs);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _statsBytes);
+                offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, statsBucket.Bucket.Values.Count);
+
+                var timestampTypeBytes = statsBucket.TimestampType == TimestampType.Current
+                                         ? _currentTimestampTypeBytes
+                                         : _originTimestampTypeBytes;
+
+                foreach (var point in statsBucket.Bucket.Values)
+                {
+                    var hasEdges = point.EdgeTags.Length > 0;
+
+                    // 6 entries per StatsPoint:
+                    // 5 if no edge tags
+                    // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L44
+                    var itemCount = hasEdges ? 6 : 5;
+                    offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, itemCount);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _hashBytes);
+                    offset += MessagePackBinary.WriteUInt64(ref bytes, offset, point.Hash.Value);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentHashBytes);
+                    offset += MessagePackBinary.WriteUInt64(ref bytes, offset, point.ParentHash.Value);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _timestampTypeBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, timestampTypeBytes);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _pathwayLatencyBytes);
+                    offset += SerializeSketch(ref bytes, offset, point.PathwayLatency);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _edgeLatencyBytes);
+                    offset += SerializeSketch(ref bytes, offset, point.EdgeLatency);
+
+                    if (hasEdges)
+                    {
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _edgeTagsBytes);
+                        offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, point.EdgeTags.Length);
+
+                        foreach (var edgeTag in point.EdgeTags)
+                        {
+                            offset += MessagePackBinary.WriteString(ref bytes, offset, edgeTag);
+                        }
+                    }
+                }
+            }
+
+            return offset - originalOffset;
+        }
+
+        private static int SerializeSketch(ref byte[] bytes, int offset, DDSketch sketch)
+        {
+            var size = sketch.ComputeSerializedSize();
+            var totalBytes = size + 5; // 5 header bytes
+
+            MessagePackBinary.EnsureCapacity(ref bytes, offset, totalBytes);
+            bytes[offset] = MessagePackCode.Bin32;
+            bytes[offset + 1] = (byte)(size >> 24);
+            bytes[offset + 2] = (byte)(size >> 16);
+            bytes[offset + 3] = (byte)(size >> 8);
+            bytes[offset + 4] = (byte)size;
+
+            using var stream = new MemoryStream(bytes, index: offset + 5, count: size);
+            sketch.Serialize(stream);
+            return totalBytes;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/SerializableStatsBucket.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/SerializableStatsBucket.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="SerializableStatsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct SerializableStatsBucket
+{
+    /// <summary>
+    /// The type of bucket this is
+    /// </summary>
+    public readonly TimestampType TimestampType;
+
+    /// <summary>
+    /// The start time of this bucket
+    /// </summary>
+    public readonly long BucketStartTimeNs;
+
+    /// <summary>
+    /// The stats bucket, keyed on <see cref="StatsBucket.Hash"/>
+    /// </summary>
+    public readonly Dictionary<ulong, StatsBucket> Bucket;
+
+    public SerializableStatsBucket(
+        TimestampType timestampType,
+        long bucketStartTimeNs,
+        Dictionary<ulong, StatsBucket> bucket)
+    {
+        TimestampType = timestampType;
+        BucketStartTimeNs = bucketStartTimeNs;
+        Bucket = bucket;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="StatsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct StatsBucket
+{
+    public readonly string[] EdgeTags;
+    public readonly PathwayHash Hash;
+    public readonly PathwayHash ParentHash;
+    public readonly DDSketch PathwayLatency;
+    public readonly DDSketch EdgeLatency;
+
+    public StatsBucket(string[] edgeTags, PathwayHash hash, PathwayHash parentHash, DDSketch pathwayLatency, DDSketch edgeLatency)
+    {
+        EdgeTags = edgeTags;
+        Hash = hash;
+        ParentHash = parentHash;
+        PathwayLatency = pathwayLatency;
+        EdgeLatency = edgeLatency;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="StatsPoint.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct StatsPoint
+{
+    public readonly string[] EdgeTags;
+    public readonly PathwayHash Hash;
+    public readonly PathwayHash ParentHash;
+    public readonly long TimestampNs;
+    public readonly long PathwayLatencyNs;
+    public readonly long EdgeLatencyNs;
+
+    public StatsPoint(
+        string[] edgeTags,
+        PathwayHash hash,
+        PathwayHash parentHash,
+        long timestampNs,
+        long pathwayLatencyNs,
+        long edgeLatencyNs)
+    {
+        EdgeTags = edgeTags;
+        Hash = hash;
+        ParentHash = parentHash;
+        TimestampNs = timestampNs;
+        PathwayLatencyNs = pathwayLatencyNs;
+        EdgeLatencyNs = edgeLatencyNs;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/TimestampType.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/TimestampType.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="TimestampType.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal enum TimestampType
+{
+    /// <summary>
+    /// The timestamp is relative to the current bucket
+    /// </summary>
+    Current = 0,
+
+    /// <summary>
+    /// The timestamp is relative to the start of the pathway
+    /// </summary>
+    Origin = 1,
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="DataStreamsConstants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class DataStreamsConstants
+{
+    public const int DefaultBucketDurationMs = 10_000;
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
@@ -9,4 +9,5 @@ namespace Datadog.Trace.DataStreamsMonitoring;
 internal static class DataStreamsConstants
 {
     public const int DefaultBucketDurationMs = 10_000;
+    public const string IntakePath = "v0.1/pipeline_stats";
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -1,0 +1,175 @@
+﻿// <copyright file="DataStreamsWriter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal class DataStreamsWriter
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsWriter>();
+
+    private readonly BoundedConcurrentQueue<StatsPoint> _buffer = new(queueLimit: 10_000);
+    private readonly Task _processTask;
+    private readonly ManualResetEventSlim _processingMutex = new(initialState: false, spinCount: 0);
+    private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly DataStreamsAggregator _aggregator;
+    private readonly IDataStreamsApi _api;
+    private readonly Timer _flushTimer;
+    private byte[]? _serializationBuffer;
+    private long _pointsDropped;
+    private int _flushRequested;
+
+    public DataStreamsWriter(
+        DataStreamsAggregator aggregator,
+        IDataStreamsApi api,
+        long bucketDurationMs)
+    {
+        _aggregator = aggregator;
+        _api = api;
+
+        _processTask = Task.Run(ProcessQueueLoopAsync);
+        _processTask.ContinueWith(t => Log.Error(t.Exception, "Error in processing task"), TaskContinuationOptions.OnlyOnFaulted);
+
+        _flushTimer = new Timer(
+            x => ((DataStreamsWriter)x!).RequestFlush(),
+            this,
+            dueTime: bucketDurationMs,
+            period: bucketDurationMs);
+    }
+
+    public void Add(in StatsPoint point)
+    {
+        if (_buffer.TryEnqueue(point))
+        {
+            if (!_processingMutex.IsSet)
+            {
+                _processingMutex.Set();
+            }
+        }
+        else
+        {
+            // TODO: Monitor with telemetry
+            Interlocked.Increment(ref _pointsDropped);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        await _flushTimer.DisposeAsync().ConfigureAwait(false);
+#else
+        _flushTimer.Dispose();
+#endif
+        await FlushAndCloseAsync().ConfigureAwait(false);
+    }
+
+    private async Task FlushAndCloseAsync()
+    {
+        if (!_processExit.TrySetResult(true))
+        {
+            return;
+        }
+
+        // request a final flush - as the _processExit flag is now set
+        // this ensures we will definitely flush all the stats
+        // (and sets the mutex if it isn't already set)
+        RequestFlush();
+
+        // wait for the processing loop to complete
+        var completedTask = await Task.WhenAny(
+                                           _processTask,
+                                           Task.Delay(TimeSpan.FromSeconds(20)))
+                                      .ConfigureAwait(false);
+
+        if (completedTask != _processTask)
+        {
+            Log.Error("Could not flush all data streams stats before process exit");
+        }
+    }
+
+    private void RequestFlush()
+    {
+        Interlocked.Exchange(ref _flushRequested, 1);
+        if (!_processingMutex.IsSet)
+        {
+            _processingMutex.Set();
+        }
+    }
+
+    private async Task WriteToApiAsync()
+    {
+        // This method blocks ingestion of new stats points into the aggregator
+        // but they will continue to be added to the queue, and will be processed later
+        // Default buffer capacity matches Java implementation:
+        // https://cs.github.com/DataDog/dd-trace-java/blob/3386bd137e58ed7450d1704e269d3567aeadf4c0/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java?q=MsgPackDatastreamsPayloadWriter#L28
+        _serializationBuffer ??= new byte[512 * 1024];
+
+        var flushTimeNs = _processExit.Task.IsCompleted
+                          ? long.MaxValue // flush all buckets
+                          : DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(); // don't flush current bucket
+
+        const int offset = 0;
+        var bytesWritten = _aggregator.Serialize(ref _serializationBuffer, offset: offset, flushTimeNs);
+
+        if (bytesWritten > 0)
+        {
+            // This flushes on the same thread as the processing loop
+            var data = new ArraySegment<byte>(_serializationBuffer, offset, bytesWritten);
+
+            var success = await _api.SendAsync(data).ConfigureAwait(false);
+
+            var dropCount = Interlocked.Exchange(ref _pointsDropped, 0);
+            if (success)
+            {
+                Log.Debug("Flushed {Count}bytes to data streams intake. {Dropped} points were dropped since last flush", bytesWritten, dropCount);
+            }
+            else
+            {
+                Log.Warning("Error flushing {Count}bytes to data streams intake. {Dropped} points were dropped since last flush", bytesWritten, dropCount);
+            }
+        }
+    }
+
+    private async Task ProcessQueueLoopAsync()
+    {
+        while (true)
+        {
+            try
+            {
+                while (_buffer.TryDequeue(out var statsPoint))
+                {
+                    _aggregator.Add(in statsPoint);
+                }
+
+                var flushRequested = Interlocked.CompareExchange(ref _flushRequested, 0, 1);
+                if (flushRequested == 1)
+                {
+                    await WriteToApiAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occured in the processing thread");
+            }
+
+            if (_processExit.Task.IsCompleted)
+            {
+                return;
+            }
+
+            _processingMutex.Wait();
+            _processingMutex.Reset();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="DataStreamsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal class DataStreamsApi : IDataStreamsApi
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsApi>();
+    private readonly IApiRequestFactory _requestFactory;
+    private readonly Uri _endpoint;
+
+    public DataStreamsApi(IApiRequestFactory apiRequestFactory)
+    {
+        _requestFactory = apiRequestFactory;
+        _endpoint = _requestFactory.GetEndpoint(DataStreamsConstants.IntakePath);
+        Log.Debug("Using data streams intake endpoint {DataStreamsIntakeEndpoint}", _endpoint.ToString());
+    }
+
+    public async Task<bool> SendAsync(ArraySegment<byte> bytes)
+    {
+        try
+        {
+            Log.Debug<int>("Sending {Count} bytes to the data streams intake", bytes.Count);
+            var request = _requestFactory.Create(_endpoint);
+
+            using var response = await request.PostAsync(bytes, MimeTypes.MsgPack).ConfigureAwait(false);
+            if (response.StatusCode is >= 200 and < 300)
+            {
+                Log.Debug("Data streams monitoring data sent successfully");
+                return true;
+            }
+
+            Log.Warning<string, int>("Error sending data streams monitoring data to '{Endpoint}' {StatusCode} ", _requestFactory.Info(_endpoint), response.StatusCode);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error sending data streams monitoring data to '{Endpoint}'", _requestFactory.Info(_endpoint));
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderHelper.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="DataStreamsHttpHeaderHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Linq;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.HttpOverStreams;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal class DataStreamsHttpHeaderHelper : HttpHeaderHelperBase
+{
+    private static string? _metadataHeaders = null;
+
+    protected override string MetadataHeaders
+    {
+        get
+        {
+            if (_metadataHeaders is null)
+            {
+                var headers = DataStreamsHttpHeaderNames.GetDefaultAgentHeaders().Select(kvp => $"{kvp.Key}: {kvp.Value}{DatadogHttpValues.CrLf}");
+                _metadataHeaders = string.Concat(headers);
+            }
+
+            return _metadataHeaders;
+        }
+    }
+
+    protected override string ContentType => MimeTypes.MsgPack;
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderNames.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="DataStreamsHttpHeaderNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport
+{
+    internal static class DataStreamsHttpHeaderNames
+    {
+        /// <summary>
+        /// Gets the default constant headers that should be added to any request to the agent
+        /// Similar to the defaults in <see cref="AgentHttpHeaderNames"/> (but not the same!)
+        /// </summary>
+        internal static KeyValuePair<string, string>[] GetDefaultAgentHeaders()
+            => new KeyValuePair<string, string>[]
+            {
+                new(AgentHttpHeaderNames.Language, ".NET"),
+                new(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion),
+                new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
+                new(AgentHttpHeaderNames.LanguageInterpreter, FrameworkDescription.Instance.Name),
+                new(AgentHttpHeaderNames.LanguageVersion, FrameworkDescription.Instance.ProductVersion),
+            };
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsTransportStrategy.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="DataStreamsTransportStrategy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal static class DataStreamsTransportStrategy
+{
+    public static IApiRequestFactory GetAgentIntakeFactory(ImmutableExporterSettings settings)
+        => AgentTransportStrategy.Get(
+            settings,
+            productName: "data streams monitoring",
+            tcpTimeout: TimeSpan.FromSeconds(5), // Short timeout, because we don't want to get "overlapping" flushes if the agent is being slow
+            DataStreamsHttpHeaderNames.GetDefaultAgentHeaders(),
+            () => new DataStreamsHttpHeaderHelper(),
+            uri => uri);
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/IDataStreamsApi.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/IDataStreamsApi.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="IDataStreamsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal interface IDataStreamsApi
+{
+    Task<bool> SendAsync(ArraySegment<byte> bytes);
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsBucket.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsBucket.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="MockDataStreamsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsBucket
+{
+    [Key(nameof(Start))]
+    public ulong Start { get; set; }
+
+    [Key(nameof(Duration))]
+    public ulong Duration { get; set; }
+
+    [Key(nameof(Stats))]
+    public MockDataStreamsStatsPoint[] Stats { get; set; }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsPayload.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsPayload.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="MockDataStreamsPayload.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsPayload
+{
+    [Key(nameof(Env))]
+    public string Env { get; set; }
+
+    // Service is the service of the application
+    [Key(nameof(Service))]
+    public string Service { get; set; }
+
+    [Key(nameof(PrimaryTag))]
+    public string PrimaryTag { get; set; }
+
+    [Key(nameof(TracerVersion))]
+    public string TracerVersion { get; set; }
+
+    [Key(nameof(Lang))]
+    public string Lang { get; set; }
+
+    [Key(nameof(Stats))]
+    public MockDataStreamsBucket[] Stats { get; set; }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="MockDataStreamsStatsPoint.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsStatsPoint
+{
+    [Key(nameof(EdgeTags))]
+    public string[] EdgeTags { get; set; }
+
+    [Key(nameof(Hash))]
+    public ulong Hash { get; set; }
+
+    [Key(nameof(ParentHash))]
+    public ulong ParentHash { get; set; }
+
+    [Key(nameof(PathwayLatency))]
+    public byte[] PathwayLatency { get; set; }
+
+    [Key(nameof(EdgeLatency))]
+    public byte[] EdgeLatency { get; set; }
+
+    [Key(nameof(TimestampType))]
+    public string TimestampType { get; set; }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
@@ -1,0 +1,180 @@
+﻿// <copyright file="DataStreamsAggregatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsAggregatorTests
+{
+    private const long OneSecondNs = 1_000_000_000;
+    private const int BucketDurationMs = DataStreamsConstants.DefaultBucketDurationMs; // 10s
+    private const long BucketDurationNs = ((long)BucketDurationMs) * 1_000_000;
+
+    private static readonly long T1 = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+
+    // Set tp2 to be some 40 seconds after the tp1, but also account for bucket alignments,
+    // otherwise the possible StatsPayload would change depending on when the test is run.
+    private static readonly long T2 = BucketStartTimeForTimestamp(T1 + (40 * OneSecondNs)) + (6 * OneSecondNs);
+
+    // Based on the go aggregator_tests
+    // https://cs.github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/aggregator_test.go#L28
+
+    [Fact]
+    public void Aggregator_DoesNotFlushCurrentStats()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        // flush at t2 doesn't flush points at t2 (current bucket)
+        // so only the last point is included
+        var statsToWrite = aggregator.Export(T2);
+
+        // compare expected, bit messy, but works
+        var stats = statsToWrite[0];
+        AssertStats(stats, TimestampType.Current, BucketStartTimeForTimestamp(T1));
+        AssertBucket(stats, hash: 2, CreateSketch(5), CreateSketch(2));
+
+        stats = statsToWrite[1];
+        // // origin timestamp subtracts the pathway latency
+        AssertStats(stats, TimestampType.Origin, BucketStartTimeForTimestamp(T1 - (5 * OneSecondNs)));
+        AssertBucket(stats, hash: 2, CreateSketch(5), CreateSketch(2));
+    }
+
+    [Fact]
+    public void Aggregator_SecondSerializationClearsBuckets()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        var buffer = Array.Empty<byte>();
+        var bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().BePositive();
+
+        // serializing clears the stats, so shouldn't write anything on the second attempt;
+        bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().Be(0);
+    }
+
+    [Fact]
+    public void Aggregator_FlushesStats()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        // flush at t2 doesn't flush points at t2 (current bucket)
+        // so only the last point is included
+        var statsToWrite = aggregator.Export(T2);
+
+        // we always clear after calling Export
+        aggregator.Clear(statsToWrite);
+
+        // Now advance for bucket duration + 1 and flush again
+        statsToWrite = aggregator.Export(T2 + BucketDurationNs + OneSecondNs);
+
+        // compare expected
+        var stats = statsToWrite[0];
+        AssertStats(stats, TimestampType.Current, BucketStartTimeForTimestamp(T2));
+        AssertBucket(stats, hash: 2, CreateSketch(1, 5), CreateSketch(1, 2));
+        AssertBucket(stats, hash: 3, CreateSketch(5), CreateSketch(2));
+
+        stats = statsToWrite[1];
+        // // origin timestamp subtracts the pathway latency
+        AssertStats(stats, TimestampType.Origin, BucketStartTimeForTimestamp(T2 - (5 * OneSecondNs)));
+        AssertBucket(stats, hash: 2, CreateSketch(1, 5), CreateSketch(1, 2));
+        AssertBucket(stats, hash: 3, CreateSketch(5), CreateSketch(2));
+    }
+
+    private static DataStreamsAggregator CreateAggregatorWithData(long t1, long t2)
+    {
+        var aggregator = new DataStreamsAggregator(
+            new DataStreamsMessagePackFormatter("env", "service"),
+            BucketDurationMs);
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: OneSecondNs,
+                edgeLatencyNs: OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(3), // different hash
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t1, // different start time
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+        return aggregator;
+    }
+
+    private static void AssertStats(SerializableStatsBucket stats, TimestampType timestampType, long startTime)
+    {
+        stats.TimestampType.Should().Be(timestampType);
+        stats.BucketStartTimeNs.Should().Be(startTime);
+    }
+
+    private static void AssertBucket(SerializableStatsBucket stats, ulong hash, byte[] pathway, byte[] edge)
+    {
+        stats.Bucket.Should().ContainKey(hash);
+
+        var bucket = stats.Bucket[hash];
+        bucket.EdgeTags.Should().ContainSingle("edge-1");
+        bucket.Hash.Value.Should().Be(hash);
+        bucket.ParentHash.Value.Should().Be(1);
+        Serialize(bucket.PathwayLatency).Should().BeEquivalentTo(pathway);
+        Serialize(bucket.EdgeLatency).Should().BeEquivalentTo(edge);
+    }
+
+    private static long BucketStartTimeForTimestamp(long timestampNs)
+        => timestampNs - (timestampNs % BucketDurationNs);
+
+    private static byte[] CreateSketch(params int[] values)
+    {
+        // don't actually need to pool them for these tests
+        var sketch = new DDSketchPool().Get();
+        foreach (var value in values)
+        {
+            sketch.Add(value);
+        }
+
+        return Serialize(sketch);
+    }
+
+    private static byte[] Serialize(DDSketch sketch)
+    {
+        var bytes = new byte[sketch.ComputeSerializedSize()];
+        using var ms = new MemoryStream(bytes);
+        sketch.Serialize(ms);
+        return bytes;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsApiTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="DataStreamsApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsApiTests
+{
+    [Fact]
+    public async Task SendAsync_When200_ReturnsTrue()
+    {
+        var factory = new TestRequestFactory(x => new TestApiRequest(x));
+        var api = new DataStreamsApi(factory);
+
+        var result = await api.SendAsync(new ArraySegment<byte>(new byte[64]));
+        factory.RequestsSent.Should().HaveCount(1);
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task SendAsync_WhenError_ReturnsFalse_AndDoesntRetry(int statusCode)
+    {
+        var factory = new TestRequestFactory(x => new TestApiRequest(x, statusCode));
+        var api = new DataStreamsApi(factory);
+
+        var result = await api.SendAsync(new ArraySegment<byte>(new byte[64]));
+        factory.RequestsSent.Should().HaveCount(1);
+        result.Should().BeFalse();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -6,6 +6,7 @@
 using System.Threading.Tasks;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.TestHelpers.TransportHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -16,7 +17,7 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenDisabled_DoesNotInjectContext()
     {
-        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var dsm = GetDataStreamManager(false);
         var headers = new TestHeadersCollection();
         var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
 
@@ -28,7 +29,7 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenEnabled_InjectsContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var dsm = GetDataStreamManager(true);
         var headers = new TestHeadersCollection();
         var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
 
@@ -40,8 +41,8 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenDisabled_DoesNotExtractContext()
     {
-        var enabledDsm = new DataStreamsManager(enabled: true, "foo", "bar");
-        var disabledDsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var enabledDsm = GetDataStreamManager(true);
+        var disabledDsm = GetDataStreamManager(false);
         var headers = new TestHeadersCollection();
         var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
 
@@ -54,7 +55,7 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenEnabled_ExtractsContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var dsm = GetDataStreamManager(true);
         var headers = new TestHeadersCollection();
         var context = new PathwayContext(new PathwayHash(123), 1_234_000_000, 5_678_000_000);
 
@@ -71,7 +72,7 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenEnabled_AndNoContext_ReturnsNewContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var dsm = GetDataStreamManager(true);
 
         var context = dsm.SetCheckpoint(parentPathway: null, new[] { "some-tags" });
         context.Should().NotBeNull();
@@ -83,7 +84,7 @@ public class DataStreamsManagerTests
         var env = "foo";
         var service = "bar";
         var edgeTags = new[] { "some-tags" };
-        var dsm = new DataStreamsManager(enabled: true, env, service);
+        var dsm = GetDataStreamManager(true);
 
         var context = dsm.SetCheckpoint(parentPathway: null, edgeTags);
         context.Should().NotBeNull();
@@ -101,7 +102,7 @@ public class DataStreamsManagerTests
         var env = "foo";
         var service = "bar";
         var edgeTags = new[] { "some-tags" };
-        var dsm = new DataStreamsManager(enabled: true, env, service);
+        var dsm = GetDataStreamManager(true);
         var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
 
         var context = dsm.SetCheckpoint(parent, edgeTags);
@@ -117,7 +118,7 @@ public class DataStreamsManagerTests
     [Fact]
     public void WhenDisabled_SetCheckpoint_ReturnsNull()
     {
-        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var dsm = GetDataStreamManager(false);
         var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
 
         var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
@@ -127,7 +128,7 @@ public class DataStreamsManagerTests
     [Fact]
     public async Task DisposeAsync_DisablesDsm()
     {
-        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var dsm = GetDataStreamManager(true);
         var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
 
         dsm.IsEnabled.Should().BeTrue();
@@ -138,4 +139,11 @@ public class DataStreamsManagerTests
         var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
         context.Should().BeNull();
     }
+
+    private static DataStreamsManager GetDataStreamManager(bool enabled)
+        => new DataStreamsManager(
+            enabled,
+            env: "foo",
+            defaultServiceName: "bar",
+            new TestRequestFactory());
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
@@ -1,0 +1,148 @@
+﻿// <copyright file="DataStreamsMessagePackFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using FluentAssertions;
+using MessagePack;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsMessagePackFormatterTests
+{
+    [Fact]
+    public void CanRoundTripMessagePackFormat()
+    {
+        var env = "my-env";
+        var service = "service=name";
+        var bucketDuration = 10_000_000_000;
+        var edgeTags = new[] { "edge-1" };
+        var formatter = new DataStreamsMessagePackFormatter(env, service);
+
+        var bytes = new byte[100];
+        var timeNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+
+        var bucketStartTimeNs1 = timeNs - (timeNs % bucketDuration);
+        var bucketStartTimeNs2 = bucketStartTimeNs1 - 5_000_000_000;
+
+        var pathwaySketch = CreateSketch(5);
+        var edgeSketch = CreateSketch(2);
+
+        var hash1 = new PathwayHash(2);
+        var hash2 = new PathwayHash(3);
+        var parentHash = new PathwayHash(1);
+        List<SerializableStatsBucket> buckets = new()
+        {
+            new SerializableStatsBucket(
+                TimestampType.Current,
+                bucketStartTimeNs: bucketStartTimeNs1,
+                bucket: new()
+                {
+                    {
+                        hash1.Value, new StatsBucket(
+                            edgeTags,
+                            hash: hash1,
+                            parentHash: parentHash,
+                            pathwayLatency: pathwaySketch,
+                            edgeLatency: edgeSketch)
+                    },
+                }),
+            new SerializableStatsBucket(
+                TimestampType.Origin,
+                bucketStartTimeNs: bucketStartTimeNs2,
+                bucket: new()
+                {
+                    {
+                        hash2.Value, new StatsBucket(
+                            Array.Empty<string>(),
+                            hash: hash2,
+                            parentHash: parentHash,
+                            pathwayLatency: pathwaySketch,
+                            edgeLatency: edgeSketch)
+                    },
+                }),
+        };
+
+        var bytesWritten = formatter.Serialize(ref bytes, offset: 0, bucketDurationNs: bucketDuration, statsBuckets: buckets);
+
+        var data = new ArraySegment<byte>(bytes, offset: 0, count: bytesWritten);
+
+        var result = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(data);
+
+        var pathwayBytes = new byte[pathwaySketch.ComputeSerializedSize()];
+        using var ms1 = new MemoryStream(pathwayBytes);
+        pathwaySketch.Serialize(ms1);
+        var edgeBytes = new byte[edgeSketch.ComputeSerializedSize()];
+        using var ms2 = new MemoryStream(edgeBytes);
+        edgeSketch.Serialize(ms2);
+
+        var expected = new MockDataStreamsPayload
+        {
+            Env = env,
+            Service = service,
+            Lang = "dotnet",
+            TracerVersion = TracerConstants.AssemblyVersion,
+            Stats = new MockDataStreamsBucket[]
+            {
+                new()
+                {
+                    Duration = (ulong)bucketDuration,
+                    Start = (ulong)bucketStartTimeNs1,
+                    Stats = new MockDataStreamsStatsPoint[]
+                    {
+                        new()
+                        {
+                            EdgeTags = edgeTags,
+                            Hash = hash1.Value,
+                            ParentHash = parentHash.Value,
+                            EdgeLatency = edgeBytes,
+                            PathwayLatency = pathwayBytes,
+                            TimestampType = "current",
+                        }
+                    }
+                },
+                new()
+                {
+                    Duration = (ulong)bucketDuration,
+                    Start = (ulong)bucketStartTimeNs2,
+                    Stats = new MockDataStreamsStatsPoint[]
+                    {
+                        new()
+                        {
+                            EdgeTags = null,
+                            Hash = hash2.Value,
+                            ParentHash = parentHash.Value,
+                            EdgeLatency = edgeBytes,
+                            PathwayLatency = pathwayBytes,
+                            TimestampType = "origin",
+                        }
+                    }
+                }
+            }
+        };
+
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    private static DDSketch CreateSketch(params int[] values)
+    {
+        // don't actually need to pool them for these tests
+        var sketch = new DDSketchPool().Get();
+        foreach (var value in values)
+        {
+            sketch.Add(value);
+        }
+
+        return sketch;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -81,7 +81,7 @@ public class DataStreamsWriterTests
     {
         // using a very long duration here so that we're guaranteed to still
         // be in the "current" bucket when we call flush and close
-        var bucketDuration = int.MaxValue; // 100 s
+        var bucketDuration = int.MaxValue;
         var api = new StubApi();
         var writer = CreateWriter(api, bucketDuration);
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -1,0 +1,144 @@
+﻿// <copyright file="DataStreamsWriterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsWriterTests
+{
+    private const int BucketDurationMs = 1_000; // 1 second
+
+    [Fact]
+    public async Task DoesNotWriteIfNoStats_Periodic()
+    {
+        var bucketDurationMs = 100; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDurationMs * 1_000_000);
+
+        await Task.Delay(bucketDurationMs * 10);
+
+        api.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DoesNotWriteIfNoStats_OnClose()
+    {
+        var bucketDuration = 100_000_000; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WritesAStatsPointAfterDelay()
+    {
+        var bucketDurationMs = 100; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDurationMs * 1_000_000);
+
+        writer.Add(CreateStatsPoint());
+
+        await Task.Delay(bucketDurationMs * 10);
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task WritesAStatsPoint_OnClose()
+    {
+        var bucketDuration = 100_000_000; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        writer.Add(CreateStatsPoint());
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AllBucketsAreReportedOnClose()
+    {
+        // using a very long duration here so that we're guaranteed to still
+        // be in the "current" bucket when we call flush and close
+        var bucketDuration = int.MaxValue; // 100 s
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        writer.Add(CreateStatsPoint());
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task CanCreateWriterWithDefaultBucket()
+    {
+        var writer = CreateWriter(new StubApi(), DataStreamsConstants.DefaultBucketDurationMs);
+        await writer.DisposeAsync();
+    }
+
+    private static DataStreamsWriter CreateWriter(IDataStreamsApi stubApi, int bucketDurationMs = BucketDurationMs)
+    {
+        return new DataStreamsWriter(
+            new DataStreamsAggregator(new DataStreamsMessagePackFormatter("env", "service"), bucketDurationMs),
+            stubApi,
+            bucketDurationMs: bucketDurationMs);
+    }
+
+    private static StatsPoint CreateStatsPoint()
+        => new StatsPoint(
+            edgeTags: new[] { "type:internal" },
+            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
+            pathwayLatencyNs: 5_000_000_000,
+            edgeLatencyNs: 2_000_000_000);
+
+    private class StubApi : IDataStreamsApi
+    {
+        private readonly List<ArraySegment<byte>> _sent = new();
+
+        public List<ArraySegment<byte>> Sent
+        {
+            get
+            {
+                lock (_sent)
+                {
+                    return _sent.ToList();
+                }
+            }
+        }
+
+        public Task<bool> SendAsync(ArraySegment<byte> bytes)
+        {
+            lock (_sent)
+            {
+                _sent.Add(bytes);
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -5,6 +5,7 @@
 
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.TestHelpers.TransportHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -15,7 +16,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void SetCheckpoint_SetsTheSpanPathwayContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.PathwayContext.Should().BeNull();
 
@@ -39,7 +40,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void MergePathwayContext_WhenOtherContextIsNull_KeepsContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
         spanContext.PathwayContext.Should().NotBeNull();
@@ -54,7 +55,7 @@ public class SpanContextDataStreamsManagerTests
     {
         int iterations = 1000_000;
         // When we have a context and there's a new context we pick one randomly
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
 


### PR DESCRIPTION
## Summary of changes

- Adds aggregation of pathway contexts for data streams monitoring
- Adds sending of aggregate data to backend

## Reason for change

This is the bulk of the implementation for the actual data streams monitoring work. Note that this also includes the implementation for the experimental "origin" latency stats. There are potential issues with that around unbounded growth (see similar concerns in the java implementation PR: https://github.com/DataDog/dd-trace-java/pull/3730)

## Implementation details

Based on the [go](https://github.com/DataDog/data-streams-go) and [java](https://cs.github.com/DataDog/dd-trace-java/blob/643d4f536b4edc2f772b6713fee5a344f2d529bf/dd-trace-core/src/main/java/datadog/trace/core/datastreams/DefaultPathwayContext.java#L23) implementations, as well as the [RFC](https://docs.google.com/document/d/1z4vdxQFg6hVHmdMchAvL_b87XdvWVJ7NJBPF12XE8zo/edit#heading=h.1vfctcgxwa5s) and [guide](https://docs.google.com/document/d/1LTO2z_0_GBLRNW9gwy-JqbhZAuTbtLbK0xfHtDRVjdw/edit#).

The summary of the implementation is:
- When you call `SetCheckpoint` on the `DataStreamsManager`, this generates a new `PathwayContext` (which is propagated using the mechanism in https://github.com/DataDog/dd-trace-dotnet/pull/3174).
- This writes a `StatsPoint` to the `DataStreamsWriter`, which keeps a queue of points for processing, and flushes them to the `DataStreamsAggregator`.
- The `Aggregator` accumulates the latencies for "similar" stats points (same path, within a 10s bucket size), generating a DD-sketch for each.
- Every 10s, the `DataStreamsWriter` grabs all the buckets from the `DataStreamsAggregator` (except for the current "open" bucket), serializes, and flushes to the agent

Note that nothing actually calls `SetCheckpoint()` yet - the implementation for kafka will follow in a subsequent PR.

## Test coverage

Unit tests should cover everything here, integration tests to follow

## Other details
Dependent on: 
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3174 which needs merging first.

Subsequent PRs to follow:

- Implementation and integration tests for kafka: https://github.com/DataDog/dd-trace-dotnet/pull/3192
- Enable/Disable via discovery service https://github.com/DataDog/dd-trace-dotnet/pull/3197
- Public API/adaptation of existing to handle manual context creation (e.g. when automatic consumer scopes are disabled)
