### PR TITLE
Add Kafka data streams monitoring implementation

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -490,6 +490,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependency-libs", "dependen
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes.External", "tracer\test\test-applications\debugger\dependency-libs\Samples.Probes.External\Samples.Probes.External.csproj", "{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.DataStreams.Kafka", "tracer\test\test-applications\integrations\Samples.DataStreams.Kafka\Samples.DataStreams.Kafka.csproj", "{7415B0FB-A446-41D6-A0CD-D64B703F15AD}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{3c6dd42e-9214-4747-92ba-78de29aace59}*SharedItemsImports = 4
@@ -2448,6 +2450,18 @@ Global
 		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Release|x64.Build.0 = Release|x64
 		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Release|x86.ActiveCfg = Release|x86
 		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Release|x86.Build.0 = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x64.ActiveCfg = Debug|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x64.Build.0 = Debug|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x86.ActiveCfg = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x86.Build.0 = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x64.ActiveCfg = Release|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x64.Build.0 = Release|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x86.ActiveCfg = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x86.Build.0 = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.Build.0 = Debug|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2633,6 +2647,7 @@ Global
 		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{0884B566-D22E-498C-BAA9-26D50ABCAE3A} = {16427BFB-B4C6-46A9-A290-8EA51FF73FEA}
 		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6} = {0884B566-D22E-498C-BAA9-26D50ABCAE3A}
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
@@ -64,8 +64,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             {
                 // This sets the span as active and either disposes it immediately
                 // or disposes it on the next call to Consumer.Consume()
+                var tracer = Tracer.Instance;
                 Scope scope = KafkaHelper.CreateConsumerScope(
-                    Tracer.Instance,
+                    tracer,
+                    tracer.TracerManager.DataStreamsManager,
                     instance,
                     consumeResult.Topic,
                     consumeResult.Partition,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
@@ -12,7 +12,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
-    internal readonly struct KafkaHeadersCollectionAdapter : IHeadersCollection
+    internal readonly struct KafkaHeadersCollectionAdapter : IHeadersCollection, IBinaryHeadersCollection
     {
         private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<KafkaHeadersCollectionAdapter>();
         private readonly IHeaders _headers;
@@ -54,6 +54,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         public void Remove(string name)
         {
             _headers.Remove(name);
+        }
+
+        public byte[] TryGetBytes(string name)
+        {
+            return _headers.TryGetLastBytes(name, out var bytes) ? bytes : null;
+        }
+
+        public void Add(string name, byte[] value)
+        {
+            _headers.Add(name, value);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
@@ -76,6 +78,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
         internal static Scope CreateConsumerScope(
             Tracer tracer,
+            DataStreamsManager dataStreamsManager,
             object consumer,
             string topic,
             Partition? partition,
@@ -101,6 +104,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
 
                 SpanContext propagatedContext = null;
+                PathwayContext? pathwayContext = null;
+
                 // Try to extract propagated context from headers
                 if (message is not null && message.Headers is not null)
                 {
@@ -113,6 +118,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     catch (Exception ex)
                     {
                         Log.Error(ex, "Error extracting propagated headers from Kafka message");
+                    }
+
+                    if (dataStreamsManager.IsEnabled)
+                    {
+                        try
+                        {
+                            pathwayContext = dataStreamsManager.ExtractPathwayContext(headers);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Error extracting PathwayContext from Kafka message");
+                        }
                     }
                 }
 
@@ -159,6 +176,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 span.SetTag(Tags.Measured, "1");
 
                 tags.SetAnalyticsSampleRate(KafkaConstants.IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
+
+                if (dataStreamsManager.IsEnabled)
+                {
+                    span.Context.MergePathwayContext(pathwayContext);
+
+                    // TODO: we could cache this list in a thread local similar to StringBuilderCache to reduce allocations
+                    var edgeTags = string.IsNullOrEmpty(topic)
+                                       ? new[] { $"group:{groupId}", "type:kafka", }
+                                       : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };
+
+                    span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
+                }
             }
             catch (Exception ex)
             {
@@ -200,10 +229,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// Try to inject the prop
         /// </summary>
         /// <param name="context">The Span context to propagate</param>
+        /// <param name="dataStreamsManager">The global data streams manager</param>
         /// <param name="message">The duck-typed Kafka Message object</param>
         /// <typeparam name="TTopicPartitionMarker">The TopicPartition type (used  optimisation purposes)</typeparam>
         /// <typeparam name="TMessage">The type of the duck-type proxy</typeparam>
-        internal static void TryInjectHeaders<TTopicPartitionMarker, TMessage>(SpanContext context, TMessage message)
+        internal static void TryInjectHeaders<TTopicPartitionMarker, TMessage>(
+            SpanContext context,
+            DataStreamsManager dataStreamsManager,
+            TMessage message)
             where TMessage : IMessage
         {
             if (!_headersInjectionEnabled)
@@ -221,6 +254,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 var adapter = new KafkaHeadersCollectionAdapter(message.Headers);
 
                 SpanContextPropagator.Instance.Inject(context, adapter);
+
+                if (dataStreamsManager.IsEnabled)
+                {
+                    // TODO: optimise the edge tags here, no need to use a list, or at least cache it/make it a singleton
+                    context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
+                    dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
+                }
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -257,8 +257,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 if (dataStreamsManager.IsEnabled)
                 {
-                    // TODO: optimise the edge tags here, no need to use a list, or at least cache it/make it a singleton
-                    context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
+                    context.SetCheckpoint(dataStreamsManager, DataStreamsManager.InternalEdgeTags);
                     dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -50,7 +50,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (scope is not null)
             {
-                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(scope.Span.Context, message);
+                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
+                    scope.Span.Context,
+                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    message);
                 return new CallTargetState(scope);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -51,7 +51,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (scope is not null)
             {
-                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(scope.Span.Context, message);
+                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
+                    scope.Span.Context,
+                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    message);
                 return new CallTargetState(scope);
             }
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Datadog.Sketches;
 using Datadog.Trace.Vendors.MessagePack;
 
@@ -16,6 +17,8 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
 {
     internal class DataStreamsMessagePackFormatter
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsWriter>();
+
         private readonly byte[] _environmentBytes = StringEncoding.UTF8.GetBytes("Env");
         private readonly byte[] _environmentValueBytes;
         private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("Service");
@@ -60,6 +63,8 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
         public int Serialize(ref byte[] bytes, int offset, long bucketDurationNs, List<SerializableStatsBucket> statsBuckets)
         {
             var originalOffset = offset;
+            var hashCount = 0;
+            double pointCount = 0;
 
             // 6 entries in StatsPayload:
             // -1 because we don't have a primary tag
@@ -87,6 +92,7 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
 
             foreach (var statsBucket in statsBuckets)
             {
+                hashCount += statsBucket.Bucket.Count;
                 // 3 entries per StatsBucket:
                 // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L27
                 offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 3);
@@ -107,6 +113,7 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 foreach (var point in statsBucket.Bucket.Values)
                 {
                     var hasEdges = point.EdgeTags.Length > 0;
+                    pointCount += point.EdgeLatency.GetCount();
 
                     // 6 entries per StatsPoint:
                     // 5 if no edge tags
@@ -141,6 +148,8 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                     }
                 }
             }
+
+            Log.Debug<int, int, double>("Serialized data stream data: {BucketCount} buckets, {StatsCount} hashes. {PointsCount} points", statsBuckets.Count, hashCount, pointCount);
 
             return offset - originalOffset;
         }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -44,6 +44,13 @@ internal class DataStreamsManager
                       : null;
     }
 
+    /// <summary>
+    /// Gets the tags to use when setting a checkpoint on a "producer",
+    /// which requires setting the <c>type:internal</c> edge tags.
+    /// Rather than creating a new array each time, this provides a cache.
+    /// </summary>
+    public static string[] InternalEdgeTags { get; } = { "type:internal" };
+
     public bool IsEnabled => Volatile.Read(ref _isEnabled);
 
     public static DataStreamsManager Create(

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -74,7 +74,7 @@ public class DataStreamsMonitoringTests : TestHelper
         using var processResult = RunSampleAndWaitForExit(agent);
 
         using var assertionScope = new AssertionScope();
-        var dataStreams = agent.DataStreams;
+        var dataStreams = agent.WaitForDataStreams(2);
 
         // This is nasty and hacky, but it's the only way I could get any semblence
         // of snapshots. We could have more than one payload due to the way flushing works,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -1,0 +1,207 @@
+﻿// <copyright file="DataStreamsMonitoringTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using VerifyTests;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+[UsesVerify]
+[Collection(nameof(KafkaTests.KafkaTestsCollection))]
+[Trait("RequiresDockerDependency", "true")]
+public class DataStreamsMonitoringTests : TestHelper
+{
+    public DataStreamsMonitoringTests(ITestOutputHelper output)
+        : base("DataStreams.Kafka", output)
+    {
+        SetServiceVersion("1.0.0");
+        EnableDebugMode();
+    }
+
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <summary>
+    /// This sample does a series of produces and consumes to create two pipelines:
+    ///  - service -> topic 1 -> Consumer 1 -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
+    ///  - service -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
+    /// Each node (apart from 'service') in the pipelines above have a unique hash
+    ///
+    /// In mermaid (view at https://mermaid.live/), this looks like:
+    /// sequenceDiagram
+    ///    participant A as Root Service<br>(12926600137239154356)
+    ///    participant T1 as Topic 1<br>(2704081292861755358)
+    ///    participant C1 as Consumer 1<br>(5289074475783863123)
+    ///    participant T2a as Topic 2<br>(2821413369272395429)
+    ///    participant C2a as Consumer 2<br>(9753735904472423641)
+    ///    participant T3a as Topic 3<br>(5363062531028060751)
+    ///    participant T2 as Topic 2<br>(246622801349204431)
+    ///    participant C2 as Consumer 2<br>(3398817358352474903)
+    ///    participant T3 as Topic 3<br>(16689539899325095461 )
+    ///
+    ///    A->>+T1: Produce
+    ///    T1-->>-C1: Consume
+    ///    C1->>+T2a: Produce
+    ///    T2a-->>-C2a: Consume
+    ///    C2a->>+T3a: Produce
+    ///
+    ///    A->>+T2: Produce
+    ///    T2-->>-C2: Consume
+    ///    C2->>+T3: Produce
+    /// </summary>
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    public async Task SubmitsDataStreams()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
+
+        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        using var assertionScope = new AssertionScope();
+        var dataStreams = agent.DataStreams;
+
+        // This is nasty and hacky, but it's the only way I could get any semblence
+        // of snapshots. We could have more than one payload due to the way flushing works,
+        // but if we ignore the start times of the buckets, we can group them in a consistent way
+        dataStreams.Should().NotBeEmpty();
+
+        agent.AssertConfiguration(ConfigTelemetryData.DataStreamsMonitoringEnabled, true);
+
+        // make sure they all have the same top level properties
+        var payload = dataStreams.First();
+        dataStreams.Should()
+                   .OnlyContain(x => x.Env == payload.Env)
+                   .And.OnlyContain(x => x.Lang == payload.Lang)
+                   .And.OnlyContain(x => x.Service == payload.Service)
+                   .And.OnlyContain(x => x.PrimaryTag == payload.PrimaryTag)
+                   .And.OnlyContain(x => x.TracerVersion == payload.TracerVersion);
+
+        var currentBucket = new MockDataStreamsBucket { Duration = 10_000_000_000, Start = 1661520120000000000UL };
+        var originBucket = new MockDataStreamsBucket { Duration = 10_000_000_000, Start = 1661520120000000000UL };
+
+        var currentBucketStats = new List<MockDataStreamsStatsPoint>();
+        var originBucketStats = new List<MockDataStreamsStatsPoint>();
+        foreach (var mockPayload in dataStreams)
+        {
+            foreach (var bucket in mockPayload.Stats)
+            {
+                bucket.Duration.Should().Be(10_000_000_000); // 10s in ns
+                bucket.Start.Should().BePositive();
+
+                var buckets = bucket.Stats.First().TimestampType == "current" ? currentBucketStats : originBucketStats;
+                foreach (var bucketStat in bucket.Stats)
+                {
+                    if (!buckets.Any(x => x.Hash == bucketStat.Hash && x.ParentHash == bucketStat.ParentHash))
+                    {
+                        buckets.Add(bucketStat);
+                    }
+                }
+            }
+        }
+
+        currentBucket.Stats = StableSort(currentBucketStats);
+        originBucket.Stats = StableSort(originBucketStats);
+        payload.Stats = new[] { currentBucket, originBucket };
+
+        // using span verifier to add all the default scrubbers
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddSimpleScrubber(TracerConstants.AssemblyVersion, "2.x.x.x");
+        settings.ModifySerialization(
+            _ =>
+            {
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.EdgeLatency, ScrubByteArray);
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PathwayLatency, ScrubByteArray);
+            });
+
+        await Verifier.Verify(payload, settings);
+
+        static MockDataStreamsStatsPoint[] StableSort(IReadOnlyCollection<MockDataStreamsStatsPoint> points)
+        {
+            // sort each bucket by "depth", then by consumer name
+            // Ensure a static ordering for the spans
+            return points
+                  .OrderBy(x => GetRootHashName(x, points))
+                  .ThenBy(x => GetHashDepth(x, points))
+                  .ThenBy(x => x.Hash)
+                  .ToArray();
+        }
+
+        static ulong GetRootHashName(MockDataStreamsStatsPoint point, IReadOnlyCollection<MockDataStreamsStatsPoint> allPoints)
+        {
+            while (point.ParentHash != 0)
+            {
+                var parent = allPoints.FirstOrDefault(x => x.Hash == point.ParentHash);
+                if (parent is null)
+                {
+                    // no span with the given Parent Id, so treat this one as the root instead
+                    break;
+                }
+
+                point = parent;
+            }
+
+            return point.Hash;
+        }
+
+        static int GetHashDepth(MockDataStreamsStatsPoint point, IReadOnlyCollection<MockDataStreamsStatsPoint> allPoints)
+        {
+            var depth = 0;
+            while (point.ParentHash != 0)
+            {
+                var parent = allPoints.FirstOrDefault(x => x.Hash == point.ParentHash);
+                if (parent is null)
+                {
+                    // no span with the given Parent Id, so treat this one as the root instead
+                    break;
+                }
+
+                point = parent;
+                depth++;
+            }
+
+            return depth;
+        }
+    }
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    public void WhenDisabled_DoesNotSubmitDataStreams()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "0");
+
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        using var assertionScope = new AssertionScope();
+        var dataStreams = agent.DataStreams;
+        dataStreams.Should().BeEmpty();
+    }
+
+    private byte[] ScrubByteArray(MockDataStreamsStatsPoint target, byte[] value)
+    {
+        if (value is null || value.Length == 0)
+        {
+            return value;
+        }
+
+        // return a different value so we can identify that we have some data
+        return new byte[] { 0xFF };
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -64,15 +64,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static TelemetryData AssertConfiguration(this MockTracerAgent mockAgent, string key)
+        public static TelemetryData AssertConfiguration(this MockTracerAgent mockAgent, string key, object value = null)
         {
             mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).RequestType == TelemetryRequestTypes.AppStarted);
 
             var allData = mockAgent.Telemetry.Cast<TelemetryData>().ToArray();
-            return AssertConfiguration(allData, key);
+            return AssertConfiguration(allData, key, value);
         }
 
-        public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key, string value)
+        public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key, object value)
         {
             telemetry.WaitForLatestTelemetry(x => x.RequestType == TelemetryRequestTypes.AppStarted);
 
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key) => telemetry.AssertConfiguration(key, value: null);
 
-        private static TelemetryData AssertConfiguration(TelemetryData[] allData, string key, string value = null)
+        private static TelemetryData AssertConfiguration(TelemetryData[] allData, string key, object value = null)
         {
             var (latestConfigurationData, configurationPayload) =
                 allData

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -20,6 +20,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using Datadog.Trace.TestHelpers.Stats;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -69,6 +70,8 @@ namespace Datadog.Trace.TestHelpers
         public IImmutableList<MockSpan> Spans { get; private set; } = ImmutableList<MockSpan>.Empty;
 
         public IImmutableList<MockClientStatsPayload> Stats { get; private set; } = ImmutableList<MockClientStatsPayload>.Empty;
+
+        public IImmutableList<MockDataStreamsPayload> DataStreams { get; private set; } = ImmutableList<MockDataStreamsPayload>.Empty;
 
         public IImmutableList<NameValueCollection> TraceRequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
 
@@ -237,6 +240,29 @@ namespace Datadog.Trace.TestHelpers
             return stats;
         }
 
+        public IImmutableList<MockDataStreamsPayload> WaitForDataStreams(
+            int count,
+            int timeoutInMilliseconds = 20000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
+
+            IImmutableList<MockDataStreamsPayload> stats = ImmutableList<MockDataStreamsPayload>.Empty;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                stats = DataStreams;
+
+                if (stats.Count >= count)
+                {
+                    break;
+                }
+
+                Thread.Sleep(500);
+            }
+
+            return stats;
+        }
+
         /// <summary>
         /// Wait for the given number of probe snapshots to appear.
         /// </summary>
@@ -390,6 +416,11 @@ namespace Datadog.Trace.TestHelpers
             {
                 HandlePotentialRemoteConfig(request);
                 response = RcmResponse ?? "{}";
+            }
+            else if (request.PathAndQuery.StartsWith("/v0.1/pipeline_stats"))
+            {
+                HandlePotentialDataStreams(request);
+                response = "{}";
             }
             else
             {
@@ -572,6 +603,37 @@ namespace Datadog.Trace.TestHelpers
                     var body = ReadStreamBody(request);
                     var rc = Encoding.UTF8.GetString(body);
                     RemoteConfigRequests.Enqueue(rc);
+                }
+                catch (Exception ex)
+                {
+                    var message = ex.Message.ToLowerInvariant();
+
+                    if (message.Contains("beyond the end of the stream"))
+                    {
+                        // Accept call is likely interrupted by a dispose
+                        // Swallow the exception and let the test finish
+                        return;
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        private void HandlePotentialDataStreams(MockHttpParser.MockHttpRequest request)
+        {
+            if (ShouldDeserializeTraces && request.ContentLength >= 1)
+            {
+                try
+                {
+                    var body = ReadStreamBody(request);
+
+                    var dataStreamsPayload = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(body);
+
+                    lock (this)
+                    {
+                        DataStreams = DataStreams.Add(dataStreamsPayload);
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
@@ -1,0 +1,218 @@
+﻿{
+  Env: integration_tests,
+  Service: Samples.DataStreams.Kafka,
+  TracerVersion: 2.x.x.x,
+  Lang: dotnet,
+  Stats: [
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-1,
+            topic:data-streams-1,
+            type:kafka
+          ],
+          Hash: 3184837087859198448,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 9146411116191305908,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 428893431238664991,
+          ParentHash: 3184837087859198448,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 9288243326407318747,
+          ParentHash: 9146411116191305908,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 4701874528067105417,
+          ParentHash: 428893431238664991,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 17029362228578737937,
+          ParentHash: 9288243326407318747,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5603712524956936337,
+          ParentHash: 4701874528067105417,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 713412453862704155,
+          ParentHash: 5603712524956936337,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        }
+      ]
+    },
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-1,
+            topic:data-streams-1,
+            type:kafka
+          ],
+          Hash: 3184837087859198448,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 9146411116191305908,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 428893431238664991,
+          ParentHash: 3184837087859198448,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 9288243326407318747,
+          ParentHash: 9146411116191305908,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 4701874528067105417,
+          ParentHash: 428893431238664991,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 17029362228578737937,
+          ParentHash: 9288243326407318747,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5603712524956936337,
+          ParentHash: 4701874528067105417,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 713412453862704155,
+          ParentHash: 5603712524956936337,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Consumer.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Consumer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Confluent.Kafka;
+using Samples.Kafka;
+
+namespace Samples.DataStreams.Kafka;
+
+internal class Consumer : ConsumerBase
+{
+    private readonly Action<ConsumeResult<string, string>> _handler;
+    private Consumer(ConsumerConfig config, string topic, string consumerName, Action<ConsumeResult<string, string>> handler)
+        : base(config, topic, consumerName)
+    {
+        _handler = handler;
+    }
+
+    protected override void HandleMessage(ConsumeResult<string, string> consumeResult) => _handler(consumeResult);
+
+    public static Consumer Create(string topic, string consumerName, Action<ConsumeResult<string, string>> handler)
+    {
+        Console.WriteLine($"Creating consumer '{consumerName}' and subscribing to topic {topic}");
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = Samples.Kafka.Config.KafkaBrokerHost,
+            GroupId = "Samples.DataStreams.Kafka." + consumerName,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true,
+        };
+        return new Consumer(config, topic, consumerName, handler);
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Newtonsoft.Json;
+using Samples.DataStreams.Kafka;
+using Samples.Kafka;
+using Config = Samples.Kafka.Config;
+
+// Create Topics
+var sw = new Stopwatch();
+var topicPrefix = "data-streams";
+
+var topic1 = $"{topicPrefix}-1";
+var topic2 = $"{topicPrefix}-2";
+var topic3 = $"{topicPrefix}-3";
+var allTopics = new[] { topic1, topic2, topic3 };
+var topic3ConsumeCount = 0;
+
+var config = Config.Create();
+Console.WriteLine("Creating topics...");
+foreach (var topic in allTopics)
+{
+    await TopicHelpers.TryDeleteTopic(topic, config);
+    await TopicHelpers.TryCreateTopic(topic, numPartitions: 3, replicationFactor: 1, config);
+}
+
+LogWithTime("Finished creating topics");
+Console.WriteLine($"Creating consumers...");
+var consumer1 = Consumer.Create(topic1, "consumer-1", HandleAndProduceToTopic2);
+var consumer2 = Consumer.Create(topic2, "consumer-2", HandleAndProduceToTopic3);
+var consumer3 = Consumer.Create(topic3, "consumer-3", HandleTopic3);
+
+Console.WriteLine("Starting consumers...");
+var cts = new CancellationTokenSource();
+var consumeTasks = new Task[3];
+consumeTasks[0] = Task.Run(() => consumer1.Consume(cts.Token));
+consumeTasks[1] = Task.Run(() => consumer2.Consume(cts.Token));
+consumeTasks[2] = Task.Run(() => consumer3.Consume(cts.Token));
+
+
+LogWithTime("Finished starting consumers");
+Console.WriteLine($"Producing messages");
+Producer.Produce(topic1, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+Producer.Produce(topic2, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+
+LogWithTime("Finished producing messages");
+Console.WriteLine($"Waiting for final consumption...");
+
+// Wait for all messages to be consumed
+// This assumes that the topics all start empty, and ultimately 6 messages end up consumed from topic 3
+var deadline = DateTime.UtcNow.AddSeconds(30);
+while (true)
+{
+    var consumed = Volatile.Read(ref topic3ConsumeCount);
+    if (consumed >= 6)
+    {
+        Console.WriteLine($"All messages produced and consumed");
+        break;
+    }
+
+    if (DateTime.UtcNow > deadline)
+    {
+        Console.WriteLine($"Exiting consumer: did not consume all messages: {consumed}");
+        break;
+    }
+
+    await Task.Delay(1000);
+}
+
+LogWithTime("Finished waiting for messages");
+
+Console.WriteLine($"Waiting for graceful exit...");
+cts.Cancel();
+
+await Task.WhenAny(Task.WhenAll(consumeTasks),
+                   Task.Delay(TimeSpan.FromSeconds(5)));
+
+LogWithTime("Shut down complete");
+
+void HandleTopic3(ConsumeResult<string,string> consumeResult)
+{
+    Handle(consumeResult);
+
+    var consumeCount = Interlocked.Increment(ref topic3ConsumeCount);
+    Console.WriteLine($"Consumed message {consumeCount} in Topic({topic3})");
+}
+
+void HandleAndProduceToTopic2(ConsumeResult<string, string> consumeResult)
+    => HandleAndProduce(consumeResult, topic2);
+
+void HandleAndProduceToTopic3(ConsumeResult<string, string> consumeResult)
+    => HandleAndProduce(consumeResult, topic3);
+
+void HandleAndProduce(ConsumeResult<string,string> consumeResult, string produceToTopic)
+{
+    Handle(consumeResult);
+    
+    Console.WriteLine($"Producing to {produceToTopic}");
+    Producer.Produce(produceToTopic, numMessages: 1, config, handleDelivery: true, isTombstone: false);
+}
+
+void Handle(ConsumeResult<string, string> consumeResult)
+{
+    var kafkaMessage = consumeResult.Message;
+    Console.WriteLine($"Consuming Key({kafkaMessage.Key}), Topic({consumeResult.TopicPartitionOffset})");
+
+    var sampleMessage = JsonConvert.DeserializeObject<SampleMessage>(kafkaMessage.Value);
+    Console.WriteLine($"Received {(sampleMessage.IsProducedAsync ? "async" : "sync")} message for Key({kafkaMessage.Key})");
+}
+
+void LogWithTime(string message)
+{
+    Console.WriteLine($"{message}: {sw.Elapsed:g}");
+    sw.Restart();
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "Samples.Kafka": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "COR_ENABLE_PROFILING": "1",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Samples.Kafka": {
+    "Samples.DataStreams.Kafka": {
       "commandName": "Project",
       "environmentVariables": {
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Samples.DataStreams.Kafka.csproj
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Samples.DataStreams.Kafka.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RequiresDockerDependency>true</RequiresDockerDependency>
+
+    <!-- Required to build multiple projects with the same Configuration|Platform -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <Platforms>x64;x86;AnyCPU</Platforms>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Samples.Kafka\Config.cs">
+      <Link>Config.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\ConsumerBase.cs">
+      <Link>ConsumerBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\Producer.cs">
+      <Link>Producer.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\TopicHelpers.cs">
+      <Link>TopicHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
@@ -9,142 +9,17 @@ using Newtonsoft.Json;
 
 namespace Samples.Kafka
 {
-    internal class Consumer: IDisposable
+    internal class Consumer: ConsumerBase
     {
-        private readonly string _consumerName;
-        private readonly IConsumer<string, string> _consumer;
-
-        public static int TotalAsyncMessages = 0;
-        public static int TotalSyncMessages = 0;
-        public static int TotalTombstones = 0;
-
         private Consumer(ConsumerConfig config, string topic, string consumerName)
+            : base(config, topic, consumerName)
         {
-            _consumerName = consumerName;
-            _consumer = new ConsumerBuilder<string, string>(config).Build();
-            _consumer.Subscribe(topic);
         }
 
-
-        public bool Consume(int retries, int timeoutMilliSeconds)
-        {
-            try
-            {
-                for (int i = 0; i < retries; i++)
-                {
-                    try
-                    {
-                        // will block until a message is available
-                        // on 1.5.3 this will throw if the topic doesn't exist
-                        var consumeResult = _consumer.Consume(timeoutMilliSeconds);
-                        if (consumeResult is null)
-                        {
-                            Console.WriteLine($"{_consumerName}: Null consume result");
-                            return true;
-                        }
-
-                        if (consumeResult.IsPartitionEOF)
-                        {
-                            Console.WriteLine($"{_consumerName}: Reached EOF");
-                            return true;
-                        }
-                        else
-                        {
-                            HandleMessage(consumeResult);
-                            return true;
-                        }
-                    }
-                    catch (ConsumeException ex)
-                    {
-                        Console.WriteLine($"Consume Exception in manual consume: {ex}");
-                    }
-
-                    Task.Delay(500);
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-
-            return false;
-        }
-
-        public void Consume(CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    // will block until a message is available
-                    var consumeResult = _consumer.Consume(cancellationToken);
-
-                    if (consumeResult.IsPartitionEOF)
-                    {
-                        Console.WriteLine($"{_consumerName}: Reached EOF");
-                    }
-                    else
-                    {
-                        HandleMessage(consumeResult);
-                    }
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-        }
-
-        public void ConsumeWithExplicitCommit(int commitEveryXMessages, CancellationToken cancellationToken = default)
-        {
-            ConsumeResult<string, string> consumeResult = null;
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    // will block until a message is available
-                    consumeResult = _consumer.Consume(cancellationToken);
-
-                    if (consumeResult.IsPartitionEOF)
-                    {
-                        Console.WriteLine($"{_consumerName}: Reached EOF");
-                    }
-                    else
-                    {
-                        HandleMessage(consumeResult);
-                    }
-
-                    if (consumeResult.Offset % commitEveryXMessages == 0)
-                    {
-                        try
-                        {
-                            Console.WriteLine($"{_consumerName}: committing...");
-                            _consumer.Commit(consumeResult);
-                        }
-                        catch (KafkaException e)
-                        {
-                            Console.WriteLine($"{_consumerName}: commit error: {e.Error.Reason}");
-                        }
-                    }
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-
-            // As we're doing manual commit, make sure we force a commit now
-            if (consumeResult is not null)
-            {
-                Console.WriteLine($"{_consumerName}: committing...");
-                _consumer.Commit(consumeResult);
-            }
-        }
-
-        private void HandleMessage(ConsumeResult<string, string> consumeResult)
+        protected override void HandleMessage(ConsumeResult<string, string> consumeResult)
         {
             var kafkaMessage = consumeResult.Message;
-            Console.WriteLine($"{_consumerName}: Consuming {kafkaMessage.Key}, {consumeResult.TopicPartitionOffset}");
+            Console.WriteLine($"{ConsumerName}: Consuming {kafkaMessage.Key}, {consumeResult.TopicPartitionOffset}");
 
             var messageHeaders = kafkaMessage.Headers;
             SampleHelpers.ExtractScope(messageHeaders, GetValues, out var traceId, out var spanId);
@@ -196,13 +71,6 @@ namespace Samples.Kafka
                     Interlocked.Increment(ref TotalSyncMessages);
                 }
             }
-        }
-
-        public void Dispose()
-        {
-            Console.WriteLine($"{_consumerName}: Closing consumer");
-            _consumer?.Close();
-            _consumer?.Dispose();
         }
 
         public static Consumer Create(bool enableAutoCommit, string topic, string consumerName)

--- a/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Samples.Kafka;
+
+internal abstract class ConsumerBase : IDisposable
+{
+    private readonly IConsumer<string, string> _consumer;
+    public static int TotalAsyncMessages = 0;
+    public static int TotalSyncMessages = 0;
+    public static int TotalTombstones = 0;
+
+    protected ConsumerBase(ConsumerConfig config, string topic, string consumerName)
+    {
+        ConsumerName = consumerName;
+        _consumer = new ConsumerBuilder<string, string>(config).Build();
+        _consumer.Subscribe(topic);
+    }
+
+    protected string ConsumerName { get; }
+
+    public bool Consume(int retries, int timeoutMilliSeconds)
+    {
+        try
+        {
+            for (int i = 0; i < retries; i++)
+            {
+                try
+                {
+                    // will block until a message is available
+                    // on 1.5.3 this will throw if the topic doesn't exist
+                    var consumeResult = _consumer.Consume(timeoutMilliSeconds);
+                    if (consumeResult is null)
+                    {
+                        Console.WriteLine($"{ConsumerName}: Null consume result");
+                        return true;
+                    }
+
+                    if (consumeResult.IsPartitionEOF)
+                    {
+                        Console.WriteLine($"{ConsumerName}: Reached EOF");
+                        return true;
+                    }
+                    else
+                    {
+                        HandleMessage(consumeResult);
+                        return true;
+                    }
+                }
+                catch (ConsumeException ex)
+                {
+                    Console.WriteLine($"Consume Exception in manual consume: {ex}");
+                }
+
+                Task.Delay(500);
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+
+        return false;
+    }
+
+    public void Consume(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // will block until a message is available
+                var consumeResult = _consumer.Consume(cancellationToken);
+
+                if (consumeResult.IsPartitionEOF)
+                {
+                    Console.WriteLine($"{ConsumerName}: Reached EOF");
+                }
+                else
+                {
+                    HandleMessage(consumeResult);
+                }
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+    }
+
+    public void ConsumeWithExplicitCommit(int commitEveryXMessages, CancellationToken cancellationToken = default)
+    {
+        ConsumeResult<string, string> consumeResult = null;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // will block until a message is available
+                consumeResult = _consumer.Consume(cancellationToken);
+
+                if (consumeResult.IsPartitionEOF)
+                {
+                    Console.WriteLine($"{ConsumerName}: Reached EOF");
+                }
+                else
+                {
+                    HandleMessage(consumeResult);
+                }
+
+                if (consumeResult.Offset % commitEveryXMessages == 0)
+                {
+                    try
+                    {
+                        Console.WriteLine($"{ConsumerName}: committing...");
+                        _consumer.Commit(consumeResult);
+                    }
+                    catch (KafkaException e)
+                    {
+                        Console.WriteLine($"{ConsumerName}: commit error: {e.Error.Reason}");
+                    }
+                }
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+
+        // As we're doing manual commit, make sure we force a commit now
+        if (consumeResult is not null)
+        {
+            Console.WriteLine($"{ConsumerName}: committing...");
+            _consumer.Commit(consumeResult);
+        }
+    }
+
+    protected abstract void HandleMessage(ConsumeResult<string, string> consumeResult);
+
+    public void Dispose()
+    {
+        Console.WriteLine($"{ConsumerName}: Closing consumer");
+        _consumer?.Close();
+        _consumer?.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Adds data streams monitoring to the Kafka integration
- Add data streams Kafka sample app (based on existing Kafka sample for reuse)
- Integration tests for DSM

## Reason for change

Enables data streams monitoring for Kafka and adds integration tests for it

## Implementation details

When _producing_ to a Kafka topic, when DSM is enabled, we call 

```csharp
context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
```

This records the state, and injects the pathway into the outgoing message headers

When _consuming_ from a Kafka topic, when DSM is enabled we try to extract the pathway context, merge it with an existing context (there won't be one in our current implementation), and create the checkpoint (depending if we have managed to extract the `topic`; we likely will have it)
```csharp
var pathwayContext = dataStreamsManager.ExtractPathwayContext(headers);
span.Context.MergePathwayContext(pathwayContext);

var edgeTags = string.IsNullOrEmpty(topic)
           ? new[] { $"group:{groupId}", "type:kafka", }
           : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };

span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
```

In this PR we _don't_ support when customers have set `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=0` and are extracting the headers manually (extracting context manually currently does _not_ propagate pathway context). This will be addressed in a follow up PR

## Test coverage

Integration tests. Specifically it tests two pipelines:

```bash
service -> topic 1 -> Consumer 1 -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
service -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
```

It's not an ideal representation, but this creates data stream pipelines that look something like this:

```mermaid
sequenceDiagram
    participant A as Root Service<br>(12926600137239154356)
    participant T1 as Topic 1<br>(3184837087859198448)
    participant C1 as Consumer 1<br>(428893431238664991)
    participant T2a as Topic 2<br>(4701874528067105417)
    participant C2a as Consumer 2<br>(5603712524956936337)
    participant T3a as Topic 3<br>(713412453862704155)
    participant T2 as Topic 2<br>(9146411116191305908)
    participant C2 as Consumer 2<br>(9288243326407318747)
    participant T3 as Topic 3<br>(17029362228578737937 )

    A->>+T1: Produce
    T1-->>-C1: Consume
    C1->>+T2a: Produce
    T2a-->>-C2a: Consume
    C2a->>+T3a: Produce

    A->>+T2: Produce
    T2-->>-C2: Consume
    C2->>+T3: Produce
```

## Other details

Dependent on: 
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3099
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3174
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3191

Subsequent PRs to follow:

- Enable/Disable via discovery service: https://github.com/DataDog/dd-trace-dotnet/pull/3197
- Public API/adaptation of existing to handle manual context creation (e.g. when automatic consumer scopes are disabled)