### PR TITLE
[Tracer] Add PID to log file name

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Logging
                 var domainMetadata = DomainMetadata.Instance;
 
                 // Ends in a dash because of the date postfix
-                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-.log");
+                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-{domainMetadata.ProcessId}-.log");
 
                 var loggerConfiguration =
                     new LoggerConfiguration()


### PR DESCRIPTION
## Summary of changes
Ad PID to managed log file name

## Reason for change
Wan realized that 2 iis websites on different app pools would write to the same file. In her case, only one site was logging data.

## Implementation details
Just added the PID. I've checked that our strings to check logs didn't contain a whole string so this should still work
