### PR TITLE
Fix ICorProfilerInfo11 framework support message

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -952,7 +952,7 @@ namespace datadog::shared::nativeloader
         IUnknown* tstVerProfilerInfo;
         if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo11), (void**) &tstVerProfilerInfo))
         {
-            Log::Info("ICorProfilerInfo11 available. Profiling API compatibility: .NET Core 5.0 or later.");
+            Log::Info("ICorProfilerInfo11 available. Profiling API compatibility: .NET Core 3.1 or later.");
             tstVerProfilerInfo->Release();
         }
         else if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo10), (void**) &tstVerProfilerInfo))

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -950,7 +950,12 @@ namespace datadog::shared::nativeloader
         }
 
         IUnknown* tstVerProfilerInfo;
-        if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo11), (void**) &tstVerProfilerInfo))
+        if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo12), (void**) &tstVerProfilerInfo))
+        {
+            Log::Info("ICorProfilerInfo12 available. Profiling API compatibility: .NET Core 5.0 or later.");
+            tstVerProfilerInfo->Release();
+        }
+        else if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo11), (void**) &tstVerProfilerInfo))
         {
             Log::Info("ICorProfilerInfo11 available. Profiling API compatibility: .NET Core 3.1 or later.");
             tstVerProfilerInfo->Release();


### PR DESCRIPTION
## Summary of changes

- Fix the log message in the native loader 
- Record when ICorProfilerInfo12 is available

## Reason for change

`ICorProfilerInfo11` is supported in .NET Core 3.1, not .NET 5.0.

## Implementation details

Update the log and check for `ICorProfilerInfo12`

## Test coverage

N/A

## Other details
N/A
