### PR TITLE
[CIVisibility] - Move the CI Visibility check to native

### DIFF
--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -15,6 +15,7 @@
 
 #if MACOS
 #include <libproc.h>
+#include <crt_externs.h>
 #endif
 
 #include "dd_filesystem.hpp"

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -88,6 +88,47 @@ inline WSTRING GetCurrentProcessName()
 #endif
 }
 
+inline WSTRING GetCurrentProcessCommandLine()
+{
+#ifdef _WIN32
+    return WSTRING(GetCommandLine());
+#elif MACOS
+    std::string name;
+    int argCount = *_NSGetArgc();
+    char ** arguments = *_NSGetArgv();
+    for (int i = 0; i < argCount; i++) {
+        char* currentArg = arguments[i];
+        name = name + " " + std::string(currentArg);
+    }
+    return Trim(ToWSTRING(name));
+#else
+    std::string cmdline;
+    char buf[1024];
+    size_t len;
+    FILE* fp = fopen("/proc/self/cmdline", "rb");
+    if (fp)
+    {
+        while ((len = fread(buf, 1, sizeof(buf), fp)) > 0)
+        {
+            cmdline.append(buf, len);
+        }
+    }
+
+    std::string name;
+    std::stringstream tokens(cmdline);
+    std::string tmp;
+    while (getline(tokens, tmp, '\0'))
+    {
+        name = name + " " + tmp;
+    }
+    fclose(fp);
+    
+    return Trim(ToWSTRING(name));
+#endif
+
+    return EmptyWStr;
+}
+
 inline int GetPID()
 {
 #ifdef _WIN32

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -76,24 +76,6 @@ namespace Datadog.Trace.ClrProfiler
                 return;
             }
 
-            if (CIVisibility.Settings.Enabled && !CIVisibility.Enabled)
-            {
-                // If CI Visibility is enabled by configuration
-                // we check if is the testhost.dll process
-                // we avoid instrumenting other process started from dotnet test.
-                try
-                {
-                    Log.Information("Disabling tracer clr profiler.");
-                    NativeMethods.DisableTracerCLRProfiler();
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "DisableTracerCLRProfiler returned an error: ");
-                }
-
-                return;
-            }
-
             Log.Debug("Initialization started.");
 
             try

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -62,10 +62,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         }
     }
 
-    const auto& process_name = shared::GetCurrentProcessName();
+    const auto process_name = shared::GetCurrentProcessName();
     Logger::Info("ProcessName: ", process_name);
 
-    const auto& process_command_line = shared::GetCurrentProcessCommandLine();
+    const auto process_command_line = shared::GetCurrentProcessCommandLine();
     Logger::Info("Process CommandLine: ", process_command_line);
 
     // CI visibility checks

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -26,6 +26,7 @@ const shared::WSTRING env_vars_to_display[]{environment::tracing_enabled,
                                     environment::clr_enable_inlining,
                                     environment::clr_enable_ngen,
                                     environment::dump_il_rewrite_enabled,
+                                    environment::ci_visibility_enabled,
                                     environment::azure_app_services,
                                     environment::azure_app_services_app_pool_id,
                                     environment::azure_app_services_cli_telemetry_profile_value};

--- a/tracer/src/Datadog.Tracer.Native/environment_variables.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables.h
@@ -112,6 +112,9 @@ namespace environment
     // Sets whether to enable NGEN images.
     const shared::WSTRING clr_enable_ngen = WStr("DD_CLR_ENABLE_NGEN");
 
+    // Sets whether the current process must run in CI Visibility mode or not.
+    const shared::WSTRING ci_visibility_enabled = WStr("DD_CIVISIBILITY_ENABLED");
+
 } // namespace environment
 } // namespace trace
 


### PR DESCRIPTION
## Summary of changes

This PR moves the CI Visibility check to native and avoid loading the profiler on process we don't want to instrument.

## Reason for change

The current managed implementation requires the CLR profiler to be loaded, the loader to be injected and then disabled by the PInvoke call. 

In this implementation we avoid to load the CLR profiler at all.

## Implementation details

Same as managed implementation but in native.