### PR TITLE
Add support for `IDiscoveryService` to `DataStreamsManager`

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -481,6 +481,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ProcessStart", "tra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.HotChocolate", "tracer\test\test-applications\integrations\Samples.HotChocolate\Samples.HotChocolate.csproj", "{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.DataStreams.Kafka", "tracer\test\test-applications\integrations\Samples.DataStreams.Kafka\Samples.DataStreams.Kafka.csproj", "{7415B0FB-A446-41D6-A0CD-D64B703F15AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -2405,6 +2407,18 @@ Global
 		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Release|x64.Build.0 = Release|x64
 		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Release|x86.ActiveCfg = Release|x86
 		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Release|x86.Build.0 = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x64.ActiveCfg = Debug|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x64.Build.0 = Debug|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x86.ActiveCfg = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|x86.Build.0 = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x64.ActiveCfg = Release|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x64.Build.0 = Release|x64
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x86.ActiveCfg = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|x86.Build.0 = Release|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.Build.0 = Debug|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2587,6 +2601,7 @@ Global
 		{2BED2D88-0B51-468B-A559-DA7B4BACA00B} = {16427BFB-B4C6-46A9-A290-8EA51FF73FEA}
 		{B1F9F419-87E1-4B59-A954-9895FCD7949E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.EventModel;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
@@ -23,8 +24,8 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, string defaultServiceName)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, defaultServiceName, new Trace.Processors.ITraceProcessor[]
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, new Trace.Processors.ITraceProcessor[]
             {
                 new Trace.Processors.NormalizerTraceProcessor(),
                 new Trace.Processors.TruncatorTraceProcessor(),

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
@@ -41,9 +42,10 @@ namespace Datadog.Trace.Ci
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager,
             string defaultServiceName)
         {
-            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
         }
 
         protected override ISampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
@@ -64,8 +64,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             {
                 // This sets the span as active and either disposes it immediately
                 // or disposes it on the next call to Consumer.Consume()
+                var tracer = Tracer.Instance;
                 Scope scope = KafkaHelper.CreateConsumerScope(
-                    Tracer.Instance,
+                    tracer,
+                    tracer.TracerManager.DataStreamsManager,
                     instance,
                     consumeResult.Topic,
                     consumeResult.Partition,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
@@ -12,7 +12,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
-    internal readonly struct KafkaHeadersCollectionAdapter : IHeadersCollection
+    internal readonly struct KafkaHeadersCollectionAdapter : IHeadersCollection, IBinaryHeadersCollection
     {
         private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<KafkaHeadersCollectionAdapter>();
         private readonly IHeaders _headers;
@@ -54,6 +54,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         public void Remove(string name)
         {
             _headers.Remove(name);
+        }
+
+        public byte[] TryGetBytes(string name)
+        {
+            return _headers.TryGetLastBytes(name, out var bytes) ? bytes : null;
+        }
+
+        public void Add(string name, byte[] value)
+        {
+            _headers.Add(name, value);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
@@ -76,6 +78,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
         internal static Scope CreateConsumerScope(
             Tracer tracer,
+            DataStreamsManager dataStreamsManager,
             object consumer,
             string topic,
             Partition? partition,
@@ -101,6 +104,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
 
                 SpanContext propagatedContext = null;
+                PathwayContext? pathwayContext = null;
+
                 // Try to extract propagated context from headers
                 if (message is not null && message.Headers is not null)
                 {
@@ -113,6 +118,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     catch (Exception ex)
                     {
                         Log.Error(ex, "Error extracting propagated headers from Kafka message");
+                    }
+
+                    if (dataStreamsManager.IsEnabled)
+                    {
+                        try
+                        {
+                            pathwayContext = dataStreamsManager.ExtractPathwayContext(headers);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Error extracting PathwayContext from Kafka message");
+                        }
                     }
                 }
 
@@ -159,6 +176,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 span.SetTag(Tags.Measured, "1");
 
                 tags.SetAnalyticsSampleRate(KafkaConstants.IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
+
+                if (dataStreamsManager.IsEnabled)
+                {
+                    span.Context.MergePathwayContext(pathwayContext);
+
+                    // TODO: we could cache this list in a thread local similar to StringBuilderCache to reduce allocations
+                    var edgeTags = string.IsNullOrEmpty(topic)
+                                       ? new[] { $"group:{groupId}", "type:kafka", }
+                                       : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };
+
+                    span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
+                }
             }
             catch (Exception ex)
             {
@@ -200,10 +229,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// Try to inject the prop
         /// </summary>
         /// <param name="context">The Span context to propagate</param>
+        /// <param name="dataStreamsManager">The global data streams manager</param>
         /// <param name="message">The duck-typed Kafka Message object</param>
         /// <typeparam name="TTopicPartitionMarker">The TopicPartition type (used  optimisation purposes)</typeparam>
         /// <typeparam name="TMessage">The type of the duck-type proxy</typeparam>
-        internal static void TryInjectHeaders<TTopicPartitionMarker, TMessage>(SpanContext context, TMessage message)
+        internal static void TryInjectHeaders<TTopicPartitionMarker, TMessage>(
+            SpanContext context,
+            DataStreamsManager dataStreamsManager,
+            TMessage message)
             where TMessage : IMessage
         {
             if (!_headersInjectionEnabled)
@@ -221,6 +254,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 var adapter = new KafkaHeadersCollectionAdapter(message.Headers);
 
                 SpanContextPropagator.Instance.Inject(context, adapter);
+
+                if (dataStreamsManager.IsEnabled)
+                {
+                    // TODO: optimise the edge tags here, no need to use a list, or at least cache it/make it a singleton
+                    context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
+                    dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
+                }
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -257,8 +257,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 if (dataStreamsManager.IsEnabled)
                 {
-                    // TODO: optimise the edge tags here, no need to use a list, or at least cache it/make it a singleton
-                    context.SetCheckpoint(dataStreamsManager, new[] { "type:internal" });
+                    context.SetCheckpoint(dataStreamsManager, DataStreamsManager.InternalEdgeTags);
                     dataStreamsManager.InjectPathwayContext(context.PathwayContext, adapter);
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -50,7 +50,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (scope is not null)
             {
-                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(scope.Span.Context, message);
+                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
+                    scope.Span.Context,
+                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    message);
                 return new CallTargetState(scope);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -51,7 +51,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (scope is not null)
             {
-                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(scope.Span.Context, message);
+                KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
+                    scope.Span.Context,
+                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    message);
                 return new CallTargetState(scope);
             }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -516,5 +516,14 @@ namespace Datadog.Trace.Configuration
             /// </remarks>
             public const string HeaderMaxLength = "DD_TRACE_X_DATADOG_TAGS_MAX_LENGTH";
         }
+
+        internal static class DataStreamsMonitoring
+        {
+            /// <summary>
+            /// Enables data streams monitoring support
+            /// </summary>
+            /// <see cref="TracerSettings.IsDataStreamsMonitoringEnabled"/>
+            public const string Enabled = "DD_DATA_STREAMS_ENABLED";
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -71,6 +71,7 @@ namespace Datadog.Trace.Configuration
             PropagationStyleExtract = settings.PropagationStyleExtract;
             TraceMethods = settings.TraceMethods;
             IsActivityListenerEnabled = settings.IsActivityListenerEnabled;
+            IsDataStreamsMonitoringEnabled = settings.IsDataStreamsMonitoringEnabled;
 
             LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
             // Logs injection is enabled by default if direct log submission is enabled, otherwise disabled by default
@@ -321,6 +322,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the activity listener is enabled or not.
         /// </summary>
         internal bool IsActivityListenerEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether data streams monitoring is enabled or not.
+        /// </summary>
+        internal bool IsDataStreamsMonitoringEnabled { get; }
 
         /// <summary>
         /// Gets the maximum length of an outgoing propagation header's value ("x-datadog-tags")

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -8,7 +8,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Datadog.Trace.Debugger;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
@@ -226,6 +225,10 @@ namespace Datadog.Trace.Configuration
                     PropagationStyleInject = PropagationStyleInject.Concat(nameof(Propagators.ContextPropagators.Names.W3C));
                 }
             }
+
+            IsDataStreamsMonitoringEnabled = source?.GetBool(ConfigurationKeys.DataStreamsMonitoring.Enabled) ??
+                                        // default value
+                                        false;
         }
 
         /// <summary>
@@ -496,6 +499,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the activity listener is enabled or not.
         /// </summary>
         internal bool IsActivityListenerEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether data streams monitoring is enabled or not.
+        /// </summary>
+        internal bool IsDataStreamsMonitoringEnabled { get; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
@@ -1,0 +1,172 @@
+﻿// <copyright file="DataStreamsAggregator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+/// <summary>
+/// Aggregates multiple <see cref="StatsPoint"/>s into their correct buckets
+/// Note that this class is not thread safe
+/// </summary>
+internal class DataStreamsAggregator
+{
+    // The inner dictionary is constrained in size by the number of unique hashes seen by the app
+    // Unique hashes are unique paths from origin to here, which could be unbounded if there are loops
+    // The outer dictionary is constrained by FlushInterval/BucketDuration + 1
+    private readonly Dictionary<long, Dictionary<ulong, StatsBucket>> _currentBuckets = new();
+
+    // The inner dictionary is similarly constrained
+    // but the outer dictionary is unconstrained, which could be problematic...
+    private readonly Dictionary<long, Dictionary<ulong, StatsBucket>> _originBuckets = new();
+
+    private readonly DataStreamsMessagePackFormatter _formatter;
+    private readonly DDSketchPool _sketchPool = new();
+    private readonly long _bucketDurationInNs;
+    private List<SerializableStatsBucket>? _statsToWrite;
+
+    public DataStreamsAggregator(DataStreamsMessagePackFormatter formatter, int bucketDurationMs)
+    {
+        _formatter = formatter;
+        _bucketDurationInNs = ((long)bucketDurationMs) * 1_000_000;
+    }
+
+    /// <summary>
+    /// Add the stats point to the aggregated stats
+    /// </summary>
+    public void Add(in StatsPoint point)
+    {
+        var currentBucketStartTime = BucketStartTimeForTimestamp(point.TimestampNs);
+        AddToBuckets(point, currentBucketStartTime, _currentBuckets);
+
+        var originTimestamp = point.TimestampNs - point.PathwayLatencyNs;
+        var originBucketStartTime = BucketStartTimeForTimestamp(originTimestamp);
+        AddToBuckets(point, originBucketStartTime, _originBuckets);
+    }
+
+    /// <summary>
+    /// Serialize the aggregated results using message pack
+    /// </summary>
+    /// <param name="buffer">The buffer to write the stats into. This may be replaced with a larger buffer
+    /// if it needs to grow</param>
+    /// <param name="offset">The offset into the buffer which to start writing</param>
+    /// <param name="maxBucketFlushTimeNs">Don't flush buckets that start (or include) this time (in Ns)</param>
+    /// <returns>The number of bytes written into the buffer</returns>
+    public int Serialize(ref byte[] buffer, int offset, long maxBucketFlushTimeNs)
+    {
+        var statsToAdd = Export(maxBucketFlushTimeNs);
+        if (statsToAdd?.Count > 0)
+        {
+            var bytesWritten = _formatter.Serialize(ref buffer, offset, _bucketDurationInNs, statsToAdd);
+
+            Clear(statsToAdd);
+
+            return bytesWritten;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Exports the currently aggregated stats
+    /// Internal for testing
+    /// </summary>
+    internal List<SerializableStatsBucket>? Export(long maxBucketFlushTimeNs)
+    {
+        // we don't have overlapping buckets so any buckets with a start time greater than
+        // this must be "current"
+        var currentBucketStart = maxBucketFlushTimeNs - _bucketDurationInNs;
+        _statsToWrite ??= new List<SerializableStatsBucket>(_currentBuckets.Count + _originBuckets.Count);
+        _statsToWrite.Clear();
+        foreach (var kvp in _currentBuckets)
+        {
+            if (kvp.Key > currentBucketStart)
+            {
+                // don't flush the current bucket
+                continue;
+            }
+
+            _statsToWrite.Add(new SerializableStatsBucket(TimestampType.Current, kvp.Key, kvp.Value));
+        }
+
+        foreach (var kvp in _originBuckets)
+        {
+            if (kvp.Key > currentBucketStart)
+            {
+                // don't flush the current bucket
+                continue;
+            }
+
+            _statsToWrite.Add(new SerializableStatsBucket(TimestampType.Origin, kvp.Key, kvp.Value));
+        }
+
+        return _statsToWrite;
+    }
+
+    internal void Clear(List<SerializableStatsBucket> statsToRemove)
+    {
+        // remove the old buckets
+        foreach (var statsBucket in statsToRemove)
+        {
+            if (statsBucket.TimestampType == TimestampType.Current)
+            {
+                _currentBuckets.Remove(statsBucket.BucketStartTimeNs);
+            }
+            else
+            {
+                _originBuckets.Remove(statsBucket.BucketStartTimeNs);
+            }
+
+            // add the sketches back to the pool
+            foreach (var bucket in statsBucket.Bucket)
+            {
+                _sketchPool.Release(bucket.Value.EdgeLatency);
+                _sketchPool.Release(bucket.Value.PathwayLatency);
+            }
+        }
+    }
+
+    private void AddToBuckets(
+        StatsPoint point,
+        long currentBucketStartTime,
+        Dictionary<long, Dictionary<ulong, StatsBucket>> buckets)
+    {
+        if (!buckets.TryGetValue(currentBucketStartTime, out var bucket))
+        {
+            bucket = new Dictionary<ulong, StatsBucket>();
+            buckets[currentBucketStartTime] = bucket;
+        }
+
+        if (!bucket.TryGetValue(point.Hash.Value, out var group))
+        {
+            group = new StatsBucket(
+                edgeTags: point.EdgeTags,
+                hash: point.Hash,
+                parentHash: point.ParentHash,
+                pathwayLatency: _sketchPool.Get(),
+                edgeLatency: _sketchPool.Get());
+            bucket[point.Hash.Value] = group;
+        }
+
+        var pathwayLatencySeconds = Convert.ToDouble(point.PathwayLatencyNs) / 1_000_000_000;
+        group.PathwayLatency.Add(Math.Max(pathwayLatencySeconds, 0));
+
+        var edgeLatencySeconds = Convert.ToDouble(point.EdgeLatencyNs) / 1_000_000_000;
+        group.EdgeLatency.Add(Math.Max(edgeLatencySeconds, 0));
+    }
+
+    /// <summary>
+    /// Gets the provided timestamp truncated to the bucket size.
+    /// It gives us the start time of the time bucket in which such timestamp falls.
+    /// </summary>
+    private long BucketStartTimeForTimestamp(long timestampNs)
+    {
+        return timestampNs - (timestampNs % _bucketDurationInNs);
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
@@ -1,0 +1,165 @@
+﻿// <copyright file="DataStreamsMessagePackFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
+{
+    internal class DataStreamsMessagePackFormatter
+    {
+        private readonly byte[] _environmentBytes = StringEncoding.UTF8.GetBytes("Env");
+        private readonly byte[] _environmentValueBytes;
+        private readonly byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("Service");
+
+        private readonly byte[] _serviceValueBytes;
+
+        // private readonly byte[] _primaryTagBytes = StringEncoding.UTF8.GetBytes("PrimaryTag");
+        // private readonly byte[] _primaryTagValueBytes;
+        private readonly byte[] _statsBytes = StringEncoding.UTF8.GetBytes("Stats");
+        private readonly byte[] _tracerVersionBytes = StringEncoding.UTF8.GetBytes("TracerVersion");
+        private readonly byte[] _tracerVersionValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.AssemblyVersion);
+        private readonly byte[] _langBytes = StringEncoding.UTF8.GetBytes("Lang");
+        private readonly byte[] _langValueBytes = StringEncoding.UTF8.GetBytes("dotnet");
+
+        private readonly byte[] _startBytes = StringEncoding.UTF8.GetBytes("Start");
+        private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("Duration");
+
+        private readonly byte[] _edgeTagsBytes = StringEncoding.UTF8.GetBytes("EdgeTags");
+        private readonly byte[] _hashBytes = StringEncoding.UTF8.GetBytes("Hash");
+        private readonly byte[] _parentHashBytes = StringEncoding.UTF8.GetBytes("ParentHash");
+        private readonly byte[] _pathwayLatencyBytes = StringEncoding.UTF8.GetBytes("PathwayLatency");
+        private readonly byte[] _edgeLatencyBytes = StringEncoding.UTF8.GetBytes("EdgeLatency");
+        private readonly byte[] _timestampTypeBytes = StringEncoding.UTF8.GetBytes("TimestampType");
+        private readonly byte[] _currentTimestampTypeBytes = StringEncoding.UTF8.GetBytes("current");
+        private readonly byte[] _originTimestampTypeBytes = StringEncoding.UTF8.GetBytes("origin");
+
+        public DataStreamsMessagePackFormatter(ImmutableTracerSettings tracerSettings, string defaultServiceName)
+            : this(tracerSettings.Environment, defaultServiceName)
+        {
+        }
+
+        public DataStreamsMessagePackFormatter(string? environment, string defaultServiceName)
+        {
+            // .NET tracer doesn't yet support primary tag
+            // _primaryTagValueBytes = Array.Empty<byte>();
+            _environmentValueBytes = string.IsNullOrEmpty(environment)
+                                         ? Array.Empty<byte>()
+                                         : StringEncoding.UTF8.GetBytes(environment);
+            _serviceValueBytes = StringEncoding.UTF8.GetBytes(defaultServiceName);
+        }
+
+        public int Serialize(ref byte[] bytes, int offset, long bucketDurationNs, List<SerializableStatsBucket> statsBuckets)
+        {
+            var originalOffset = offset;
+
+            // 6 entries in StatsPayload:
+            // -1 because we don't have a primary tag
+            // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L11
+            offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 5);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _environmentValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceValueBytes);
+
+            // We never have a primary tag currently, make sure to increase header size if/when we add it
+            // offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _primaryTagBytes);
+            // offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _primaryTagValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _langBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _langValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _tracerVersionBytes);
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _tracerVersionValueBytes);
+
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _statsBytes);
+            offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, statsBuckets.Count);
+
+            foreach (var statsBucket in statsBuckets)
+            {
+                // 3 entries per StatsBucket:
+                // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L27
+                offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, 3);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _startBytes);
+                offset += MessagePackBinary.WriteInt64(ref bytes, offset, statsBucket.BucketStartTimeNs);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
+                offset += MessagePackBinary.WriteInt64(ref bytes, offset, bucketDurationNs);
+
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _statsBytes);
+                offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, statsBucket.Bucket.Values.Count);
+
+                var timestampBytes = statsBucket.TimestampType == TimestampType.Current
+                                         ? _currentTimestampTypeBytes
+                                         : _originTimestampTypeBytes;
+
+                foreach (var point in statsBucket.Bucket.Values)
+                {
+                    var hasEdges = point.EdgeTags.Length > 0;
+
+                    // 6 entries per StatsPoint:
+                    // 5 if no edge tags
+                    // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L44
+                    var itemCount = hasEdges ? 6 : 5;
+                    offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, itemCount);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _hashBytes);
+                    offset += MessagePackBinary.WriteUInt64(ref bytes, offset, point.Hash.Value);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentHashBytes);
+                    offset += MessagePackBinary.WriteUInt64(ref bytes, offset, point.ParentHash.Value);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _timestampTypeBytes);
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, timestampBytes);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _pathwayLatencyBytes);
+                    offset += SerializeSketch(ref bytes, offset, point.PathwayLatency);
+
+                    offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _edgeLatencyBytes);
+                    offset += SerializeSketch(ref bytes, offset, point.EdgeLatency);
+
+                    if (hasEdges)
+                    {
+                        offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _edgeTagsBytes);
+                        offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, point.EdgeTags.Length);
+
+                        foreach (var edgeTag in point.EdgeTags)
+                        {
+                            offset += MessagePackBinary.WriteString(ref bytes, offset, edgeTag);
+                        }
+                    }
+                }
+            }
+
+            return offset - originalOffset;
+        }
+
+        private static int SerializeSketch(ref byte[] bytes, int offset, DDSketch sketch)
+        {
+            var size = sketch.ComputeSerializedSize();
+            var totalBytes = size + 5; // 5 header bytes
+
+            MessagePackBinary.EnsureCapacity(ref bytes, offset, totalBytes);
+            bytes[offset] = MessagePackCode.Bin32;
+            bytes[offset + 1] = (byte)(size >> 24);
+            bytes[offset + 2] = (byte)(size >> 16);
+            bytes[offset + 3] = (byte)(size >> 8);
+            bytes[offset + 4] = (byte)size;
+
+            using var stream = new MemoryStream(bytes, index: offset + 5, count: size);
+            sketch.Serialize(stream);
+            return totalBytes;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/SerializableStatsBucket.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/SerializableStatsBucket.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="SerializableStatsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct SerializableStatsBucket
+{
+    /// <summary>
+    /// The type of bucket this is
+    /// </summary>
+    public readonly TimestampType TimestampType;
+
+    /// <summary>
+    /// The start time of this bucket
+    /// </summary>
+    public readonly long BucketStartTimeNs;
+
+    /// <summary>
+    /// The stats bucket, keyed on <see cref="StatsBucket.Hash"/>
+    /// </summary>
+    public readonly Dictionary<ulong, StatsBucket> Bucket;
+
+    public SerializableStatsBucket(
+        TimestampType timestampType,
+        long bucketStartTimeNs,
+        Dictionary<ulong, StatsBucket> bucket)
+    {
+        TimestampType = timestampType;
+        BucketStartTimeNs = bucketStartTimeNs;
+        Bucket = bucket;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="StatsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct StatsBucket
+{
+    public readonly string[] EdgeTags;
+    public readonly PathwayHash Hash;
+    public readonly PathwayHash ParentHash;
+    public readonly DDSketch PathwayLatency;
+    public readonly DDSketch EdgeLatency;
+
+    public StatsBucket(string[] edgeTags, PathwayHash hash, PathwayHash parentHash, DDSketch pathwayLatency, DDSketch edgeLatency)
+    {
+        EdgeTags = edgeTags;
+        Hash = hash;
+        ParentHash = parentHash;
+        PathwayLatency = pathwayLatency;
+        EdgeLatency = edgeLatency;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="StatsPoint.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal readonly struct StatsPoint
+{
+    public readonly string[] EdgeTags;
+    public readonly PathwayHash Hash;
+    public readonly PathwayHash ParentHash;
+    public readonly long TimestampNs;
+    public readonly long PathwayLatencyNs;
+    public readonly long EdgeLatencyNs;
+
+    public StatsPoint(
+        string[] edgeTags,
+        PathwayHash hash,
+        PathwayHash parentHash,
+        long timestampNs,
+        long pathwayLatencyNs,
+        long edgeLatencyNs)
+    {
+        EdgeTags = edgeTags;
+        Hash = hash;
+        ParentHash = parentHash;
+        TimestampNs = timestampNs;
+        PathwayLatencyNs = pathwayLatencyNs;
+        EdgeLatencyNs = edgeLatencyNs;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/TimestampType.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/TimestampType.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="TimestampType.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
+
+internal enum TimestampType
+{
+    /// <summary>
+    /// The timestamp is relative to the current bucket
+    /// </summary>
+    Current = 0,
+
+    /// <summary>
+    /// The timestamp is relative to the start of the pathway
+    /// </summary>
+    Origin = 1,
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="DataStreamsConstants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class DataStreamsConstants
+{
+    public const int DefaultBucketDurationMs = 10_000;
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsConstants.cs
@@ -9,4 +9,5 @@ namespace Datadog.Trace.DataStreamsMonitoring;
 internal static class DataStreamsConstants
 {
     public const int DefaultBucketDurationMs = 10_000;
+    public const string IntakePath = "v0.1/pipeline_stats";
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -1,0 +1,52 @@
+// <copyright file="DataStreamsContextPropagator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.Headers;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// Used for injecting the data streams pipeline context into headers
+/// </summary>
+internal class DataStreamsContextPropagator
+{
+    private const string PropagationKey = "dd-pathway-ctx";
+
+    public static DataStreamsContextPropagator Instance { get; } = new();
+
+    /// <summary>
+    /// Propagates the specified context by adding new headers to a <see cref="IHeadersCollection"/>.
+    /// This locks the sampling priority for <paramref name="context"/>.
+    /// </summary>
+    /// <param name="context">A <see cref="PathwayContext"/> value that will be propagated into <paramref name="headers"/>.</param>
+    /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
+    /// <typeparam name="TCarrier">Type of header collection</typeparam>
+    public void Inject<TCarrier>(PathwayContext context, TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
+
+        headers.Add(PropagationKey, PathwayContextEncoder.Encode(context));
+    }
+
+    /// <summary>
+    /// Extracts a <see cref="PathwayContext"/> from the values found in the specified headers.
+    /// </summary>
+    /// <param name="headers">The headers that contain the values to be extracted.</param>
+    /// <typeparam name="TCarrier">Type of header collection</typeparam>
+    /// <returns>A new <see cref="PathwayContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
+    public PathwayContext? Extract<TCarrier>(TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
+
+        var bytes = headers.TryGetBytes(PropagationKey);
+
+        return bytes is { } ? PathwayContextEncoder.Decode(bytes) : null;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="DataStreamsManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// Manages all the data streams monitoring behaviour
+/// </summary>
+internal class DataStreamsManager
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsManager>();
+    private readonly NodeHashBase _nodeHashBase;
+    private bool _isEnabled;
+
+    public DataStreamsManager(
+        bool enabled,
+        string env,
+        string defaultServiceName)
+    {
+        _isEnabled = enabled;
+        // We don't yet support primary tag in .NET yet
+        _nodeHashBase = HashHelper.CalculateNodeHashBase(defaultServiceName, env, primaryTag: null);
+    }
+
+    public bool IsEnabled => Volatile.Read(ref _isEnabled);
+
+    public static DataStreamsManager Create(
+        ImmutableTracerSettings settings,
+        string defaultServiceName)
+        => new(settings.IsDataStreamsMonitoringEnabled, settings.Environment, defaultServiceName);
+
+    public Task DisposeAsync()
+    {
+        Volatile.Write(ref _isEnabled, false);
+        return Task.CompletedTask;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -4,11 +4,15 @@
 // </copyright>
 
 #nullable enable
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.DataStreamsMonitoring;
 
@@ -42,5 +46,90 @@ internal class DataStreamsManager
     {
         Volatile.Write(ref _isEnabled, false);
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Trys to extract a <see cref="PathwayContext"/>, from the provided <paramref name="headers"/>
+    /// If data streams is disabled, or no pathway is present, returns null.
+    /// </summary>
+    public PathwayContext? ExtractPathwayContext<TCarrier>(TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+        => IsEnabled ? DataStreamsContextPropagator.Instance.Extract(headers) : null;
+
+    /// <summary>
+    /// Injects a <see cref="PathwayContext"/> into headers
+    /// </summary>
+    /// <param name="context">The pathway context to inject</param>
+    /// <param name="headers">The header collection to inject the headers into</param>
+    public void InjectPathwayContext<TCarrier>(PathwayContext? context, TCarrier headers)
+        where TCarrier : IBinaryHeadersCollection
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        if (context is not null)
+        {
+            DataStreamsContextPropagator.Instance.Inject(context.Value, headers);
+            return;
+        }
+
+        // This shouldn't happen normally, as you should call SetCheckpoint before calling InjectPathwayContext
+        // But if data streams was disabled, you call SetCheckpoint, and then data streams is enabled
+        // you will hit this code path
+        System.Diagnostics.Debug.Fail("Attempted to inject null pathway context");
+        Log.Debug("Attempted to inject null pathway context");
+    }
+
+    /// <summary>
+    /// Sets a checkpoint using the provided <see cref="PathwayContext"/>
+    /// NOTE: <paramref name="edgeTags"/> must be in correct sort order
+    /// </summary>
+    /// <param name="parentPathway">The current pathway</param>
+    /// <param name="edgeTags">Edge tags to set for the new pathway. MUST be sorted in alphabetical order</param>
+    /// <returns>If disabled, returns <c>null</c>. Otherwise returns a new <see cref="PathwayContext"/></returns>
+    public PathwayContext? SetCheckpoint(in PathwayContext? parentPathway, string[] edgeTags)
+    {
+        if (!IsEnabled)
+        {
+            return null;
+        }
+
+        try
+        {
+            var edgeStartNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            var pathwayStartNs = parentPathway?.PathwayStart ?? edgeStartNs;
+
+            var nodeHash = HashHelper.CalculateNodeHash(_nodeHashBase, edgeTags);
+            var parentHash = parentPathway?.Hash ?? default;
+            var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
+
+            // TODO: send to aggregator
+            var pathway = new PathwayContext(
+                hash: pathwayHash,
+                pathwayStartNs: pathwayStartNs,
+                edgeStartNs: edgeStartNs);
+
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug(
+                    "SetCheckpoint with {PathwayHash}, {PathwayStart}, {EdgeStart}",
+                    pathway.Hash,
+                    pathway.PathwayStart,
+                    pathway.EdgeStart);
+            }
+
+            return pathway;
+        }
+        catch (Exception ex)
+        {
+            Log.Error("Error setting a data streams checkpoint. Disabling data streams monitoring", ex);
+            // Set this to false out of an abundance of caution.
+            // We will look at being less conservative in the future
+            // if we see intermittent errors for some reason.
+            Volatile.Write(ref _isEnabled, false);
+            return null;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -7,8 +7,11 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
@@ -24,15 +27,21 @@ internal class DataStreamsManager
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsManager>();
     private readonly NodeHashBase _nodeHashBase;
     private bool _isEnabled;
+    private DataStreamsWriter? _writer;
 
     public DataStreamsManager(
         bool enabled,
         string env,
-        string defaultServiceName)
+        string defaultServiceName,
+        IApiRequestFactory apiRequestFactory)
     {
-        _isEnabled = enabled;
         // We don't yet support primary tag in .NET yet
         _nodeHashBase = HashHelper.CalculateNodeHashBase(defaultServiceName, env, primaryTag: null);
+        // TODO: dynamically enable/disable based on discovery service
+        _isEnabled = enabled;
+        _writer = enabled
+                      ? _writer = CreateWriter(env, defaultServiceName, apiRequestFactory)
+                      : null;
     }
 
     public bool IsEnabled => Volatile.Read(ref _isEnabled);
@@ -40,12 +49,23 @@ internal class DataStreamsManager
     public static DataStreamsManager Create(
         ImmutableTracerSettings settings,
         string defaultServiceName)
-        => new(settings.IsDataStreamsMonitoringEnabled, settings.Environment, defaultServiceName);
+        => new(
+            settings.IsDataStreamsMonitoringEnabled,
+            settings.Environment,
+            defaultServiceName,
+            DataStreamsTransportStrategy.GetAgentIntakeFactory(settings.Exporter));
 
-    public Task DisposeAsync()
+    public async Task DisposeAsync()
     {
         Volatile.Write(ref _isEnabled, false);
-        return Task.CompletedTask;
+        var writer = Interlocked.Exchange(ref _writer, null);
+
+        if (writer is null)
+        {
+            return;
+        }
+
+        await writer.DisposeAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -105,7 +125,16 @@ internal class DataStreamsManager
             var parentHash = parentPathway?.Hash ?? default;
             var pathwayHash = HashHelper.CalculatePathwayHash(nodeHash, parentHash);
 
-            // TODO: send to aggregator
+            var writer = Volatile.Read(ref _writer);
+            writer?.Add(
+                new StatsPoint(
+                    edgeTags: edgeTags,
+                    hash: pathwayHash,
+                    parentHash: parentHash,
+                    timestampNs: edgeStartNs,
+                    pathwayLatencyNs: edgeStartNs - pathwayStartNs,
+                    edgeLatencyNs: edgeStartNs - (parentPathway?.EdgeStart ?? edgeStartNs)));
+
             var pathway = new PathwayContext(
                 hash: pathwayHash,
                 pathwayStartNs: pathwayStartNs,
@@ -132,4 +161,15 @@ internal class DataStreamsManager
             return null;
         }
     }
+
+    private static DataStreamsWriter CreateWriter(
+        string env,
+        string defaultServiceName,
+        IApiRequestFactory requestFactory) =>
+        new DataStreamsWriter(
+            new DataStreamsAggregator(
+                new DataStreamsMessagePackFormatter(env, defaultServiceName),
+                bucketDurationMs: DataStreamsConstants.DefaultBucketDurationMs),
+            new DataStreamsApi(requestFactory),
+            bucketDurationMs: DataStreamsConstants.DefaultBucketDurationMs);
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -44,6 +44,13 @@ internal class DataStreamsManager
                       : null;
     }
 
+    /// <summary>
+    /// Gets the tags to use when setting a checkpoint on a "producer",
+    /// which requires setting the <c>type:internal</c> edge tags.
+    /// Rather than creating a new array each time, this provides a cache.
+    /// </summary>
+    public static string[] InternalEdgeTags { get; } = { "type:internal" };
+
     public bool IsEnabled => Volatile.Read(ref _isEnabled);
 
     public static DataStreamsManager Create(

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -1,0 +1,174 @@
+﻿// <copyright file="DataStreamsWriter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal class DataStreamsWriter
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsWriter>();
+
+    private readonly BoundedConcurrentQueue<StatsPoint> _buffer = new(queueLimit: 10_000);
+    private readonly Task _processTask;
+    private readonly ManualResetEventSlim _processingMutex = new(initialState: false, spinCount: 0);
+    private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly DataStreamsAggregator _aggregator;
+    private readonly IDataStreamsApi _api;
+    private readonly Timer _flushTimer;
+    private byte[]? _serializationBuffer;
+    private long _pointsDropped;
+    private int _flushRequested;
+
+    public DataStreamsWriter(
+        DataStreamsAggregator aggregator,
+        IDataStreamsApi api,
+        long bucketDurationMs)
+    {
+        _aggregator = aggregator;
+        _api = api;
+
+        _processTask = Task.Run(ProcessQueueLoopAsync);
+        _processTask.ContinueWith(t => Log.Error(t.Exception, "Error in processing task"), TaskContinuationOptions.OnlyOnFaulted);
+
+        _flushTimer = new Timer(
+            x => ((DataStreamsWriter)x!).RequestFlush(),
+            this,
+            dueTime: bucketDurationMs,
+            period: bucketDurationMs);
+    }
+
+    public void Add(in StatsPoint point)
+    {
+        if (_buffer.TryEnqueue(point))
+        {
+            if (!_processingMutex.IsSet)
+            {
+                _processingMutex.Set();
+            }
+        }
+        else
+        {
+            Interlocked.Increment(ref _pointsDropped);
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        await _flushTimer.DisposeAsync().ConfigureAwait(false);
+#else
+        _flushTimer.Dispose();
+#endif
+        await FlushAndCloseAsync().ConfigureAwait(false);
+    }
+
+    private async Task FlushAndCloseAsync()
+    {
+        if (!_processExit.TrySetResult(true))
+        {
+            return;
+        }
+
+        // request a final flush - as the _processExit flag is now set
+        // this ensures we will definitely flush all the stats
+        // (and sets the mutex if it isn't already set)
+        RequestFlush();
+
+        // wait for the processing loop to complete
+        var completedTask = await Task.WhenAny(
+                                           _processTask,
+                                           Task.Delay(TimeSpan.FromSeconds(20)))
+                                      .ConfigureAwait(false);
+
+        if (completedTask != _processTask)
+        {
+            Log.Error("Could not flush all data streams stats before process exit");
+        }
+    }
+
+    private void RequestFlush()
+    {
+        Interlocked.Exchange(ref _flushRequested, 1);
+        if (!_processingMutex.IsSet)
+        {
+            _processingMutex.Set();
+        }
+    }
+
+    private async Task WriteToApiAsync()
+    {
+        // This method blocks ingestion of new stats points into the aggregator
+        // but they will continue to be added to the queue, and will be processed later
+        // Default buffer capacity matches Java implementation:
+        // https://cs.github.com/DataDog/dd-trace-java/blob/3386bd137e58ed7450d1704e269d3567aeadf4c0/dd-trace-core/src/main/java/datadog/trace/core/datastreams/MsgPackDatastreamsPayloadWriter.java?q=MsgPackDatastreamsPayloadWriter#L28
+        _serializationBuffer ??= new byte[512 * 1024];
+
+        var flushTimeNs = _processExit.Task.IsCompleted
+                          ? long.MaxValue // flush all buckets
+                          : DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(); // don't flush current bucket
+
+        const int offset = 0;
+        var bytesWritten = _aggregator.Serialize(ref _serializationBuffer, offset: offset, flushTimeNs);
+
+        if (bytesWritten > 0)
+        {
+            // This flushes on the same thread as the processing loop
+            var data = new ArraySegment<byte>(_serializationBuffer, offset, bytesWritten);
+
+            var success = await _api.SendAsync(data).ConfigureAwait(false);
+
+            var dropCount = Interlocked.Exchange(ref _pointsDropped, 0);
+            if (success)
+            {
+                Log.Debug("Flushed {Count}bytes to data streams intake. {Dropped} points were dropped since last flush", bytesWritten, dropCount);
+            }
+            else
+            {
+                Log.Warning("Error flushing {Count}bytes to data streams intake. {Dropped} points were dropped since last flush", bytesWritten, dropCount);
+            }
+        }
+    }
+
+    private async Task ProcessQueueLoopAsync()
+    {
+        while (true)
+        {
+            try
+            {
+                while (_buffer.TryDequeue(out var statsPoint))
+                {
+                    _aggregator.Add(in statsPoint);
+                }
+
+                var flushRequested = Interlocked.CompareExchange(ref _flushRequested, 0, 1);
+                if (flushRequested == 1)
+                {
+                    await WriteToApiAsync().ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occured in the processing thread");
+            }
+
+            if (_processExit.Task.IsCompleted)
+            {
+                return;
+            }
+
+            _processingMutex.Wait();
+            _processingMutex.Reset();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContext.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContext.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="PathwayContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+/// <summary>
+/// PathwayContext is used to monitor how payloads are sent across different services.
+/// An example Pathway would be:
+/// service A -- edge 1 --> service B -- edge 2 --> service C
+/// So it's a branch of services (we also call them "nodes") connected via edges.
+/// As the payload is sent around, we save the start time (start of service A),
+/// and the start time of the previous service.
+/// This allows us to measure the latency of each edge, as well as the latency from origin of any service.
+/// </summary>
+internal readonly struct PathwayContext
+{
+    /// <summary>
+    /// The hash of the current node, of the parent node,
+    /// and of the edge that connects the parent node to this node
+    /// </summary>
+    public readonly PathwayHash Hash;
+
+    /// <summary>
+    /// Start time of the first node in the pathway as a unix epoch in nanoseconds
+    /// </summary>
+    public readonly long PathwayStart;
+
+    /// <summary>
+    /// Start time of the previous node as a unix epoch in nanoseconds
+    /// </summary>
+    public readonly long EdgeStart;
+
+    public PathwayContext(PathwayHash hash, long pathwayStartNs, long edgeStartNs)
+    {
+        Hash = hash;
+        PathwayStart = pathwayStartNs;
+        EdgeStart = edgeStartNs;
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/PathwayContextEncoder.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="PathwayContextEncoder.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class PathwayContextEncoder
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(PathwayContextEncoder));
+
+    /// <summary>
+    /// Encodes a <see cref="PathwayContext"/> as a series of bytes
+    /// NOTE: the encoding is lossy, in that we convert <see cref="PathwayContext.PathwayStart"/>
+    /// and <see cref="PathwayContext.EdgeStart"/> from ns to ms
+    /// </summary>
+    /// <param name="pathway">The pathway to encode</param>
+    /// <returns>The encoded pathway</returns>
+    public static byte[] Encode(PathwayContext pathway)
+    {
+        var pathwayStartMs = pathway.PathwayStart / 1000;
+        var edgeStartMs = pathway.EdgeStart / 1000;
+
+        var pathwayBytes = VarEncodingHelper.VarLongZigZagLength(pathwayStartMs);
+        var edgeBytes = VarEncodingHelper.VarLongZigZagLength(edgeStartMs);
+
+        // maximum size = 8 + edge + pathway
+        var bytes = new byte[8 + pathwayBytes + edgeBytes];
+        BinaryPrimitivesHelper.WriteUInt64LittleEndian(bytes, pathway.Hash.Value);
+        VarEncodingHelper.WriteVarLongZigZag(bytes, offset: 8, pathwayStartMs);
+        VarEncodingHelper.WriteVarLongZigZag(bytes, offset: 8 + pathwayBytes, edgeStartMs);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Tries to decode a <see cref="PathwayContext"/> from a <c>byte[]</c>.
+    /// NOTE: the encoding process is lossy, so the decoded <see cref="PathwayContext"/>
+    /// contains truncated values for <see cref="PathwayContext.PathwayStart"/>
+    /// and <see cref="PathwayContext.EdgeStart"/> (conversion from ns to ms)
+    /// </summary>
+    /// <param name="bytes">The pathway to decode</param>
+    /// <returns>The decoded <see cref="PathwayContext"/>, or <c>null</c> if decoding fails </returns>
+    public static PathwayContext? Decode(byte[] bytes)
+    {
+        if (bytes.Length < 10)
+        {
+            Log.Warning<string, int>("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: insufficient bytes ({ByteCount})", Convert.ToBase64String(bytes), bytes.Length);
+            return null;
+        }
+
+        // first 8 bytes
+        var hash = BinaryPrimitivesHelper.ReadUInt64LittleEndian(bytes);
+
+        var pathwayStartMs = VarEncodingHelper.ReadVarLongZigZag(bytes, offset: 8, out var bytesRead);
+        if (pathwayStartMs is null)
+        {
+            Log.Warning("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: invalid pathway start", Convert.ToBase64String(bytes));
+            return null;
+        }
+
+        var edgeBytesMs = VarEncodingHelper.ReadVarLongZigZag(bytes, offset: 8 + bytesRead, out _);
+        if (edgeBytesMs is null)
+        {
+            Log.Warning("Error decoding Data Stream PathwayContext from bytes {Base64EncodedBytes}: invalid edge start", Convert.ToBase64String(bytes));
+            return null;
+        }
+
+        // Pathway context values are in ns
+        return new PathwayContext(new PathwayHash(hash), pathwayStartMs.Value * 1000, edgeBytesMs.Value * 1000);
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="DataStreamsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal class DataStreamsApi : IDataStreamsApi
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DataStreamsApi>();
+    private readonly IApiRequestFactory _requestFactory;
+    private readonly Uri _endpoint;
+
+    public DataStreamsApi(IApiRequestFactory apiRequestFactory)
+    {
+        _requestFactory = apiRequestFactory;
+        _endpoint = _requestFactory.GetEndpoint(DataStreamsConstants.IntakePath);
+        Log.Debug("Using data streams intake endpoint {DataStreamsIntakeEndpoint}", _endpoint.ToString());
+    }
+
+    public async Task<bool> SendAsync(ArraySegment<byte> bytes)
+    {
+        try
+        {
+            Log.Debug<int>("Sending {Count}bytes to the data streams intake", bytes.Count);
+            var request = _requestFactory.Create(_endpoint);
+
+            using var response = await request.PostAsync(bytes, MimeTypes.MsgPack).ConfigureAwait(false);
+            if (response.StatusCode is >= 200 and < 300)
+            {
+                Log.Debug("Data streams monitoring data sent successfully");
+                return true;
+            }
+
+            Log.Warning<string, int>("Error sending data streams monitoring data to '{Endpoint}' {StatusCode} ", _requestFactory.Info(_endpoint), response.StatusCode);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error sending data streams monitoring data to '{Endpoint}'", _requestFactory.Info(_endpoint));
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderHelper.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="DataStreamsHttpHeaderHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Linq;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.HttpOverStreams;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal class DataStreamsHttpHeaderHelper : HttpHeaderHelperBase
+{
+    private static string? _metadataHeaders = null;
+
+    protected override string MetadataHeaders
+    {
+        get
+        {
+            if (_metadataHeaders is null)
+            {
+                var headers = DataStreamsHttpHeaderNames.GetDefaultAgentHeaders().Select(kvp => $"{kvp.Key}: {kvp.Value}{DatadogHttpValues.CrLf}");
+                _metadataHeaders = string.Concat(headers);
+            }
+
+            return _metadataHeaders;
+        }
+    }
+
+    protected override string ContentType => MimeTypes.MsgPack;
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsHttpHeaderNames.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="DataStreamsHttpHeaderNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport
+{
+    internal static class DataStreamsHttpHeaderNames
+    {
+        /// <summary>
+        /// Gets the default constant headers that should be added to any request to the agent
+        /// Similar to the defaults in <see cref="AgentHttpHeaderNames"/> (but not the same!)
+        /// </summary>
+        internal static KeyValuePair<string, string>[] GetDefaultAgentHeaders()
+            => new KeyValuePair<string, string>[]
+            {
+                new(AgentHttpHeaderNames.Language, ".NET"),
+                new(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion),
+                new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
+                new(AgentHttpHeaderNames.LanguageInterpreter, FrameworkDescription.Instance.Name),
+                new(AgentHttpHeaderNames.LanguageVersion, FrameworkDescription.Instance.ProductVersion),
+            };
+    }
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsTransportStrategy.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="DataStreamsTransportStrategy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal static class DataStreamsTransportStrategy
+{
+    public static IApiRequestFactory GetAgentIntakeFactory(ImmutableExporterSettings settings)
+        => AgentTransportStrategy.Get(
+            settings,
+            productName: "data streams monitoring",
+            tcpTimeout: TimeSpan.FromSeconds(5), // Short timeout, because we don't want to get "overlapping" flushes if the agent is being slow
+            DataStreamsHttpHeaderNames.GetDefaultAgentHeaders(),
+            () => new DataStreamsHttpHeaderHelper(),
+            uri => uri);
+}

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/IDataStreamsApi.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/IDataStreamsApi.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="IDataStreamsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.DataStreamsMonitoring.Transport;
+
+internal interface IDataStreamsApi
+{
+    Task<bool> SendAsync(ArraySegment<byte> bytes);
+}

--- a/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="IBinaryHeadersCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Headers;
+
+/// <summary>
+/// Specified a common interface that can be used to manipulate collections of binary headers.
+/// </summary>
+internal interface IBinaryHeadersCollection
+{
+    /// <summary>
+    /// Returns the first header value for a specified header stored in the collection.
+    /// </summary>
+    /// <param name="name">The specified header to return values for.</param>
+    /// <returns>Zero or more header strings.</returns>
+    byte[]? TryGetBytes(string name);
+
+    /// <summary>
+    /// Adds the specified header and its value into the collection.
+    /// </summary>
+    /// <param name="name">The header to add to the collection.</param>
+    /// <param name="value">The content of the header.</param>
+    void Add(string name, byte[] value);
+}

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -144,6 +144,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.CodeHotspotsEnabled, value: _profiler?.ContextTracker.IsEnabled),
                 new(ConfigTelemetryData.StatsComputationEnabled, value: settings.StatsComputationEnabled),
                 new(ConfigTelemetryData.WcfObfuscationEnabled, value: settings.WcfObfuscationEnabled),
+                new(ConfigTelemetryData.DataStreamsMonitoringEnabled, value: settings.IsDataStreamsMonitoringEnabled),
             };
 
             if (_azureApServicesMetadata.IsRelevant)

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.Telemetry
         public const string TraceMethods = "trace_methods";
         public const string StatsComputationEnabled = "stats_computation_enabled";
         public const string WcfObfuscationEnabled = "wcf_obfuscation_enabled";
+        public const string DataStreamsMonitoringEnabled = "data_streams_enabled";
 
         public const string CloudHosting = "cloud_hosting";
         public const string AasSiteExtensionVersion = "aas_siteextensions_version";

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService, dataStreamsManager: null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -451,6 +451,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("wcf_obfuscation_enabled");
                     writer.WriteValue(instanceSettings.WcfObfuscationEnabled);
 
+                    writer.WritePropertyName("data_streams_enabled");
+                    writer.WriteValue(instanceSettings.IsDataStreamsMonitoringEnabled);
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace
 
             SpanContextPropagator.Instance = ContextPropagators.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 
-            dataStreamsManager ??= DataStreamsManager.Create(settings, defaultServiceName);
+            dataStreamsManager ??= DataStreamsManager.Create(settings, discoveryService, defaultServiceName);
 
             var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
             return tracerManager;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -52,7 +53,8 @@ namespace Datadog.Trace
                 runtimeMetrics: null,
                 logSubmissionManager: previous?.DirectLogSubmission,
                 telemetry: null,
-                discoveryService: null);
+                discoveryService: null,
+                dataStreamsManager: null);
 
             try
             {
@@ -85,7 +87,8 @@ namespace Datadog.Trace
             RuntimeMetricsWriter runtimeMetrics,
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
-            IDiscoveryService discoveryService)
+            IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager)
         {
             settings ??= ImmutableTracerSettings.FromDefaultSources();
 
@@ -121,7 +124,9 @@ namespace Datadog.Trace
 
             SpanContextPropagator.Instance = ContextPropagators.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 
-            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            dataStreamsManager ??= DataStreamsManager.Create(settings, defaultServiceName);
+
+            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
             return tracerManager;
         }
 
@@ -138,8 +143,9 @@ namespace Datadog.Trace
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
+            DataStreamsManager dataStreamsManager,
             string defaultServiceName)
-            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, defaultServiceName);
+            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
 
         protected virtual ISampler GetSampler(ImmutableTracerSettings settings)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -194,6 +194,22 @@ public class DataStreamsMonitoringTests : TestHelper
         dataStreams.Should().BeEmpty();
     }
 
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    public void WhenNotSupported_DoesNotSubmitDataStreams()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
+
+        using var agent = EnvironmentHelper.GetMockAgent();
+        agent.Configuration = new MockTracerAgent.AgentConfiguration { Endpoints = Array.Empty<string>() };
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        using var assertionScope = new AssertionScope();
+        var dataStreams = agent.DataStreams;
+        dataStreams.Should().BeEmpty();
+    }
+
     private byte[] ScrubByteArray(MockDataStreamsStatsPoint target, byte[] value)
     {
         if (value is null || value.Length == 0)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -1,0 +1,207 @@
+﻿// <copyright file="DataStreamsMonitoringTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using VerifyTests;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+[UsesVerify]
+[Collection(nameof(KafkaTests.KafkaTestsCollection))]
+[Trait("RequiresDockerDependency", "true")]
+public class DataStreamsMonitoringTests : TestHelper
+{
+    public DataStreamsMonitoringTests(ITestOutputHelper output)
+        : base("DataStreams.Kafka", output)
+    {
+        SetServiceVersion("1.0.0");
+        EnableDebugMode();
+    }
+
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <summary>
+    /// This sample does a series of produces and consumes to create two pipelines:
+    ///  - service -> topic 1 -> Consumer 1 -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
+    ///  - service -> topic 2 -> Consumer 2 -> topic 3 -> consumer 3
+    /// Each node (apart from 'service') in the pipelines above have a unique hash
+    ///
+    /// In mermaid (view at https://mermaid.live/), this looks like:
+    /// sequenceDiagram
+    ///    participant A as Root Service<br>(12926600137239154356)
+    ///    participant T1 as Topic 1<br>(2704081292861755358)
+    ///    participant C1 as Consumer 1<br>(5289074475783863123)
+    ///    participant T2a as Topic 2<br>(2821413369272395429)
+    ///    participant C2a as Consumer 2<br>(9753735904472423641)
+    ///    participant T3a as Topic 3<br>(5363062531028060751)
+    ///    participant T2 as Topic 2<br>(246622801349204431)
+    ///    participant C2 as Consumer 2<br>(3398817358352474903)
+    ///    participant T3 as Topic 3<br>(16689539899325095461 )
+    ///
+    ///    A->>+T1: Produce
+    ///    T1-->>-C1: Consume
+    ///    C1->>+T2a: Produce
+    ///    T2a-->>-C2a: Consume
+    ///    C2a->>+T3a: Produce
+    ///
+    ///    A->>+T2: Produce
+    ///    T2-->>-C2: Consume
+    ///    C2->>+T3: Produce
+    /// </summary>
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    public async Task SubmitsDataStreams()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
+
+        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        using var assertionScope = new AssertionScope();
+        var dataStreams = agent.DataStreams;
+
+        // This is nasty and hacky, but it's the only way I could get any semblence
+        // of snapshots. We could have more than one payload due to the way flushing works,
+        // but if we ignore the start times of the buckets, we can group them in a consistent way
+        dataStreams.Should().NotBeEmpty();
+
+        agent.AssertConfiguration(ConfigTelemetryData.DataStreamsMonitoringEnabled, true);
+
+        // make sure they all have the same top level properties
+        var payload = dataStreams.First();
+        dataStreams.Should()
+                   .OnlyContain(x => x.Env == payload.Env)
+                   .And.OnlyContain(x => x.Lang == payload.Lang)
+                   .And.OnlyContain(x => x.Service == payload.Service)
+                   .And.OnlyContain(x => x.PrimaryTag == payload.PrimaryTag)
+                   .And.OnlyContain(x => x.TracerVersion == payload.TracerVersion);
+
+        var currentBucket = new MockDataStreamsBucket { Duration = 10_000_000_000, Start = 1661520120000000000UL };
+        var originBucket = new MockDataStreamsBucket { Duration = 10_000_000_000, Start = 1661520120000000000UL };
+
+        var currentBucketStats = new List<MockDataStreamsStatsPoint>();
+        var originBucketStats = new List<MockDataStreamsStatsPoint>();
+        foreach (var mockPayload in dataStreams)
+        {
+            foreach (var bucket in mockPayload.Stats)
+            {
+                bucket.Duration.Should().Be(10_000_000_000); // 10s in ns
+                bucket.Start.Should().BePositive();
+
+                var buckets = bucket.Stats.First().TimestampType == "current" ? currentBucketStats : originBucketStats;
+                foreach (var bucketStat in bucket.Stats)
+                {
+                    if (!buckets.Any(x => x.Hash == bucketStat.Hash && x.ParentHash == bucketStat.ParentHash))
+                    {
+                        buckets.Add(bucketStat);
+                    }
+                }
+            }
+        }
+
+        currentBucket.Stats = StableSort(currentBucketStats);
+        originBucket.Stats = StableSort(originBucketStats);
+        payload.Stats = new[] { currentBucket, originBucket };
+
+        // using span verifier to add all the default scrubbers
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddSimpleScrubber(TracerConstants.AssemblyVersion, "2.x.x.x");
+        settings.ModifySerialization(
+            _ =>
+            {
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.EdgeLatency, ScrubByteArray);
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PathwayLatency, ScrubByteArray);
+            });
+
+        await Verifier.Verify(payload, settings);
+
+        static MockDataStreamsStatsPoint[] StableSort(IReadOnlyCollection<MockDataStreamsStatsPoint> points)
+        {
+            // sort each bucket by "depth", then by consumer name
+            // Ensure a static ordering for the spans
+            return points
+                  .OrderBy(x => GetRootHashName(x, points))
+                  .ThenBy(x => GetHashDepth(x, points))
+                  .ThenBy(x => x.Hash)
+                  .ToArray();
+        }
+
+        static ulong GetRootHashName(MockDataStreamsStatsPoint point, IReadOnlyCollection<MockDataStreamsStatsPoint> allPoints)
+        {
+            while (point.ParentHash != 0)
+            {
+                var parent = allPoints.FirstOrDefault(x => x.Hash == point.ParentHash);
+                if (parent is null)
+                {
+                    // no span with the given Parent Id, so treat this one as the root instead
+                    break;
+                }
+
+                point = parent;
+            }
+
+            return point.Hash;
+        }
+
+        static int GetHashDepth(MockDataStreamsStatsPoint point, IReadOnlyCollection<MockDataStreamsStatsPoint> allPoints)
+        {
+            var depth = 0;
+            while (point.ParentHash != 0)
+            {
+                var parent = allPoints.FirstOrDefault(x => x.Hash == point.ParentHash);
+                if (parent is null)
+                {
+                    // no span with the given Parent Id, so treat this one as the root instead
+                    break;
+                }
+
+                point = parent;
+                depth++;
+            }
+
+            return depth;
+        }
+    }
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("Category", "ArmUnsupported")]
+    public void WhenDisabled_DoesNotSubmitDataStreams()
+    {
+        SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "0");
+
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        using var assertionScope = new AssertionScope();
+        var dataStreams = agent.DataStreams;
+        dataStreams.Should().BeEmpty();
+    }
+
+    private byte[] ScrubByteArray(MockDataStreamsStatsPoint target, byte[] value)
+    {
+        if (value is null || value.Length == 0)
+        {
+            return value;
+        }
+
+        // return a different value so we can identify that we have some data
+        return new byte[] { 0xFF };
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -64,15 +64,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return AssertIntegration(allData, integrationId, enabled, autoEnabled);
         }
 
-        public static TelemetryData AssertConfiguration(this MockTracerAgent mockAgent, string key)
+        public static TelemetryData AssertConfiguration(this MockTracerAgent mockAgent, string key, object value = null)
         {
             mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).RequestType == TelemetryRequestTypes.AppStarted);
 
             var allData = mockAgent.Telemetry.Cast<TelemetryData>().ToArray();
-            return AssertConfiguration(allData, key);
+            return AssertConfiguration(allData, key, value);
         }
 
-        public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key, string value)
+        public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key, object value)
         {
             telemetry.WaitForLatestTelemetry(x => x.RequestType == TelemetryRequestTypes.AppStarted);
 
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static TelemetryData AssertConfiguration(this MockTelemetryAgent<TelemetryData> telemetry, string key) => telemetry.AssertConfiguration(key, value: null);
 
-        private static TelemetryData AssertConfiguration(TelemetryData[] allData, string key, string value = null)
+        private static TelemetryData AssertConfiguration(TelemetryData[] allData, string key, object value = null)
         {
             var (latestConfigurationData, configurationPayload) =
                 allData

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsBucket.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsBucket.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="MockDataStreamsBucket.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsBucket
+{
+    [Key(nameof(Start))]
+    public ulong Start { get; set; }
+
+    [Key(nameof(Duration))]
+    public ulong Duration { get; set; }
+
+    [Key(nameof(Stats))]
+    public MockDataStreamsStatsPoint[] Stats { get; set; }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsPayload.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsPayload.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="MockDataStreamsPayload.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsPayload
+{
+    [Key(nameof(Env))]
+    public string Env { get; set; }
+
+    // Service is the service of the application
+    [Key(nameof(Service))]
+    public string Service { get; set; }
+
+    [Key(nameof(PrimaryTag))]
+    public string PrimaryTag { get; set; }
+
+    [Key(nameof(TracerVersion))]
+    public string TracerVersion { get; set; }
+
+    [Key(nameof(Lang))]
+    public string Lang { get; set; }
+
+    [Key(nameof(Stats))]
+    public MockDataStreamsBucket[] Stats { get; set; }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="MockDataStreamsStatsPoint.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using MessagePack;
+
+namespace Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+
+[MessagePackObject]
+public class MockDataStreamsStatsPoint
+{
+    [Key(nameof(EdgeTags))]
+    public string[] EdgeTags { get; set; }
+
+    [Key(nameof(Hash))]
+    public ulong Hash { get; set; }
+
+    [Key(nameof(ParentHash))]
+    public ulong ParentHash { get; set; }
+
+    [Key(nameof(PathwayLatency))]
+    public byte[] PathwayLatency { get; set; }
+
+    [Key(nameof(EdgeLatency))]
+    public byte[] EdgeLatency { get; set; }
+
+    [Key(nameof(TimestampType))]
+    public string TimestampType { get; set; }
+}

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="DiscoveryServiceMock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent.DiscoveryService;
+
+namespace Datadog.Trace.Tests.Agent;
+
+internal class DiscoveryServiceMock : IDiscoveryService
+{
+    public List<Action<AgentConfiguration>> Callbacks { get; } = new();
+
+    public void TriggerChange(
+        string configurationEndpoint = "configurationEndpoint",
+        string debuggerEndpoint = "debuggerEndpoint",
+        string agentVersion = "agentVersion",
+        string statsEndpoint = "traceStatsEndpoint",
+        string dataStreamsMonitoringEndpoint = "dataStreamsMonitoringEndpoint",
+        bool clientDropP0 = true)
+        => TriggerChange(
+            new AgentConfiguration(
+                configurationEndpoint: configurationEndpoint,
+                debuggerEndpoint: debuggerEndpoint,
+                agentVersion: agentVersion,
+                statsEndpoint: statsEndpoint,
+                dataStreamsMonitoringEndpoint: dataStreamsMonitoringEndpoint,
+                clientDropP0: clientDropP0));
+
+    public void TriggerChange(AgentConfiguration config)
+    {
+        foreach (var callback in Callbacks)
+        {
+            callback(config);
+        }
+    }
+
+    public void SubscribeToChanges(Action<AgentConfiguration> callback)
+    {
+        Callbacks.Add(callback);
+    }
+
+    public void RemoveSubscription(Action<AgentConfiguration> callback)
+    {
+        Callbacks.Remove(callback);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
@@ -1,0 +1,180 @@
+﻿// <copyright file="DataStreamsAggregatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsAggregatorTests
+{
+    private const long OneSecondNs = 1_000_000_000;
+    private const int BucketDurationMs = DataStreamsConstants.DefaultBucketDurationMs; // 10s
+    private const long BucketDurationNs = ((long)BucketDurationMs) * 1_000_000;
+
+    private static readonly long T1 = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+
+    // Set tp2 to be some 40 seconds after the tp1, but also account for bucket alignments,
+    // otherwise the possible StatsPayload would change depending on when the test is run.
+    private static readonly long T2 = BucketStartTimeForTimestamp(T1 + (40 * OneSecondNs)) + (6 * OneSecondNs);
+
+    // Based on the go aggregator_tests
+    // https://cs.github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/aggregator_test.go#L28
+
+    [Fact]
+    public void Aggregator_DoesNotFlushCurrentStats()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        // flush at t2 doesn't flush points at t2 (current bucket)
+        // so only the last point is included
+        var statsToWrite = aggregator.Export(T2);
+
+        // compare expected, bit messy, but works
+        var stats = statsToWrite[0];
+        AssertStats(stats, TimestampType.Current, BucketStartTimeForTimestamp(T1));
+        AssertBucket(stats, hash: 2, CreateSketch(5), CreateSketch(2));
+
+        stats = statsToWrite[1];
+        // // origin timestamp subtracts the pathway latency
+        AssertStats(stats, TimestampType.Origin, BucketStartTimeForTimestamp(T1 - (5 * OneSecondNs)));
+        AssertBucket(stats, hash: 2, CreateSketch(5), CreateSketch(2));
+    }
+
+    [Fact]
+    public void Aggregator_SecondSerializationClearsBuckets()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        var buffer = Array.Empty<byte>();
+        var bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().BePositive();
+
+        // serializing clears the stats, so shouldn't write anything on the second attempt;
+        bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().Be(0);
+    }
+
+    [Fact]
+    public void Aggregator_FlushesStats()
+    {
+        var aggregator = CreateAggregatorWithData(T1, T2);
+
+        // flush at t2 doesn't flush points at t2 (current bucket)
+        // so only the last point is included
+        var statsToWrite = aggregator.Export(T2);
+
+        // we always clear after calling Export
+        aggregator.Clear(statsToWrite);
+
+        // Now advance for bucket duration + 1 and flush again
+        statsToWrite = aggregator.Export(T2 + BucketDurationNs + OneSecondNs);
+
+        // compare expected
+        var stats = statsToWrite[0];
+        AssertStats(stats, TimestampType.Current, BucketStartTimeForTimestamp(T2));
+        AssertBucket(stats, hash: 2, CreateSketch(1, 5), CreateSketch(1, 2));
+        AssertBucket(stats, hash: 3, CreateSketch(5), CreateSketch(2));
+
+        stats = statsToWrite[1];
+        // // origin timestamp subtracts the pathway latency
+        AssertStats(stats, TimestampType.Origin, BucketStartTimeForTimestamp(T2 - (5 * OneSecondNs)));
+        AssertBucket(stats, hash: 2, CreateSketch(1, 5), CreateSketch(1, 2));
+        AssertBucket(stats, hash: 3, CreateSketch(5), CreateSketch(2));
+    }
+
+    private static DataStreamsAggregator CreateAggregatorWithData(long t1, long t2)
+    {
+        var aggregator = new DataStreamsAggregator(
+            new DataStreamsMessagePackFormatter("env", "service"),
+            BucketDurationMs);
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: OneSecondNs,
+                edgeLatencyNs: OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(3), // different hash
+                parentHash: new PathwayHash(1),
+                timestampNs: t2,
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+
+        aggregator.Add(
+            new StatsPoint(
+                edgeTags: new[] { "edge-1" },
+                hash: new PathwayHash(2),
+                parentHash: new PathwayHash(1),
+                timestampNs: t1, // different start time
+                pathwayLatencyNs: 5 * OneSecondNs,
+                edgeLatencyNs: 2 * OneSecondNs));
+        return aggregator;
+    }
+
+    private static void AssertStats(SerializableStatsBucket stats, TimestampType timestampType, long startTime)
+    {
+        stats.TimestampType.Should().Be(timestampType);
+        stats.BucketStartTimeNs.Should().Be(startTime);
+    }
+
+    private static void AssertBucket(SerializableStatsBucket stats, ulong hash, byte[] pathway, byte[] edge)
+    {
+        stats.Bucket.Should().ContainKey(hash);
+
+        var bucket = stats.Bucket[hash];
+        bucket.EdgeTags.Should().ContainSingle("edge-1");
+        bucket.Hash.Value.Should().Be(hash);
+        bucket.ParentHash.Value.Should().Be(1);
+        Serialize(bucket.PathwayLatency).Should().BeEquivalentTo(pathway);
+        Serialize(bucket.EdgeLatency).Should().BeEquivalentTo(edge);
+    }
+
+    private static long BucketStartTimeForTimestamp(long timestampNs)
+        => timestampNs - (timestampNs % BucketDurationNs);
+
+    private static byte[] CreateSketch(params int[] values)
+    {
+        // don't actually need to pool them for these tests
+        var sketch = new DDSketchPool().Get();
+        foreach (var value in values)
+        {
+            sketch.Add(value);
+        }
+
+        return Serialize(sketch);
+    }
+
+    private static byte[] Serialize(DDSketch sketch)
+    {
+        var bytes = new byte[sketch.ComputeSerializedSize()];
+        using var ms = new MemoryStream(bytes);
+        sketch.Serialize(ms);
+        return bytes;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsApiTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="DataStreamsApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsApiTests
+{
+    [Fact]
+    public async Task SendAsync_When200_ReturnsTrue()
+    {
+        var factory = new TestRequestFactory(x => new TestApiRequest(x));
+        var api = new DataStreamsApi(factory);
+
+        var result = await api.SendAsync(new ArraySegment<byte>(new byte[64]));
+        factory.RequestsSent.Should().HaveCount(1);
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task SendAsync_WhenError_ReturnsFalse_AndDoesntRetry(int statusCode)
+    {
+        var factory = new TestRequestFactory(x => new TestApiRequest(x, statusCode));
+        var api = new DataStreamsApi(factory);
+
+        var result = await api.SendAsync(new ArraySegment<byte>(new byte[64]));
+        factory.RequestsSent.Should().HaveCount(1);
+        result.Should().BeFalse();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsContextPropagatorTests.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="DataStreamsContextPropagatorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsContextPropagatorTests
+{
+    [Fact]
+    public void CanRoundTripPathwayContext()
+    {
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(
+            new PathwayHash(1234),
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000, // leaky abstraction, the encoder truncates
+            DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1000);
+
+        DataStreamsContextPropagator.Instance.Inject(context, headers);
+
+        var extracted = DataStreamsContextPropagator.Instance.Extract(headers);
+
+        extracted.Should().NotBeNull();
+        extracted.Value.Hash.Value.Should().Be(context.Hash.Value);
+        extracted.Value.PathwayStart.Should().Be(context.PathwayStart);
+        extracted.Value.EdgeStart.Should().Be(context.EdgeStart);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -1,0 +1,141 @@
+﻿// <copyright file="DataStreamsManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsManagerTests
+{
+    [Fact]
+    public void WhenDisabled_DoesNotInjectContext()
+    {
+        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        dsm.InjectPathwayContext(context, headers);
+
+        headers.Values.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WhenEnabled_InjectsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        dsm.InjectPathwayContext(context, headers);
+
+        headers.Values.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WhenDisabled_DoesNotExtractContext()
+    {
+        var enabledDsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var disabledDsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
+
+        enabledDsm.InjectPathwayContext(context, headers);
+        headers.Values.Should().NotBeEmpty();
+
+        disabledDsm.ExtractPathwayContext(headers).Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenEnabled_ExtractsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var headers = new TestHeadersCollection();
+        var context = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        dsm.InjectPathwayContext(context, headers);
+        headers.Values.Should().NotBeEmpty();
+
+        var extracted = dsm.ExtractPathwayContext(headers);
+        extracted.Should().NotBeNull();
+        extracted.Value.Hash.Value.Should().Be(context.Hash.Value);
+        extracted.Value.PathwayStart.Should().Be(context.PathwayStart);
+        extracted.Value.EdgeStart.Should().Be(context.EdgeStart);
+    }
+
+    [Fact]
+    public void WhenEnabled_AndNoContext_ReturnsNewContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+
+        var context = dsm.SetCheckpoint(parentPathway: null, new[] { "some-tags" });
+        context.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void WhenEnabled_AndNoContext_HashShouldUseParentHashOfZero()
+    {
+        var env = "foo";
+        var service = "bar";
+        var edgeTags = new[] { "some-tags" };
+        var dsm = new DataStreamsManager(enabled: true, env, service);
+
+        var context = dsm.SetCheckpoint(parentPathway: null, edgeTags);
+        context.Should().NotBeNull();
+
+        var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
+        var nodeHash = HashHelper.CalculateNodeHash(baseHash, edgeTags);
+        var hash = HashHelper.CalculatePathwayHash(nodeHash, parentHash: new PathwayHash(0));
+
+        context.Value.Hash.Value.Should().Be(hash.Value);
+    }
+
+    [Fact]
+    public void WhenEnabled_AndHashContext_HashShouldUseParentHash()
+    {
+        var env = "foo";
+        var service = "bar";
+        var edgeTags = new[] { "some-tags" };
+        var dsm = new DataStreamsManager(enabled: true, env, service);
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        var context = dsm.SetCheckpoint(parent, edgeTags);
+        context.Should().NotBeNull();
+
+        var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
+        var nodeHash = HashHelper.CalculateNodeHash(baseHash, edgeTags);
+        var hash = HashHelper.CalculatePathwayHash(nodeHash, parentHash: parent.Hash);
+
+        context.Value.Hash.Value.Should().Be(hash.Value);
+    }
+
+    [Fact]
+    public void WhenDisabled_SetCheckpoint_ReturnsNull()
+    {
+        var dsm = new DataStreamsManager(enabled: false, "foo", "bar");
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
+        context.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DisablesDsm()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "foo", "bar");
+        var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
+
+        dsm.IsEnabled.Should().BeTrue();
+
+        await dsm.DisposeAsync();
+        dsm.IsEnabled.Should().BeFalse();
+
+        var context = dsm.SetCheckpoint(parent, new[] { "some-tags" });
+        context.Should().BeNull();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
@@ -1,0 +1,148 @@
+﻿// <copyright file="DataStreamsMessagePackFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Utils;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
+using Datadog.Trace.Vendors.Datadog.Sketches;
+using FluentAssertions;
+using MessagePack;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsMessagePackFormatterTests
+{
+    [Fact]
+    public void CanRoundTripMessagePackFormat()
+    {
+        var env = "my-env";
+        var service = "service=name";
+        var bucketDuration = 10_000_000_000;
+        var edgeTags = new[] { "edge-1" };
+        var formatter = new DataStreamsMessagePackFormatter(env, service);
+
+        var bytes = new byte[100];
+        var timeNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+
+        var bucketStartTimeNs1 = timeNs - (timeNs % bucketDuration);
+        var bucketStartTimeNs2 = bucketStartTimeNs1 - 5_000_000_000;
+
+        var pathwaySketch = CreateSketch(5);
+        var edgeSketch = CreateSketch(2);
+
+        var hash1 = new PathwayHash(2);
+        var hash2 = new PathwayHash(3);
+        var parentHash = new PathwayHash(1);
+        List<SerializableStatsBucket> buckets = new()
+        {
+            new SerializableStatsBucket(
+                TimestampType.Current,
+                bucketStartTimeNs: bucketStartTimeNs1,
+                bucket: new()
+                {
+                    {
+                        hash1.Value, new StatsBucket(
+                            edgeTags,
+                            hash: hash1,
+                            parentHash: parentHash,
+                            pathwayLatency: pathwaySketch,
+                            edgeLatency: edgeSketch)
+                    },
+                }),
+            new SerializableStatsBucket(
+                TimestampType.Origin,
+                bucketStartTimeNs: bucketStartTimeNs2,
+                bucket: new()
+                {
+                    {
+                        hash2.Value, new StatsBucket(
+                            Array.Empty<string>(),
+                            hash: hash2,
+                            parentHash: parentHash,
+                            pathwayLatency: pathwaySketch,
+                            edgeLatency: edgeSketch)
+                    },
+                }),
+        };
+
+        var bytesWritten = formatter.Serialize(ref bytes, offset: 0, bucketDurationNs: bucketDuration, statsBuckets: buckets);
+
+        var data = new ArraySegment<byte>(bytes, offset: 0, count: bytesWritten);
+
+        var result = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(data);
+
+        var pathwayBytes = new byte[pathwaySketch.ComputeSerializedSize()];
+        using var ms1 = new MemoryStream(pathwayBytes);
+        pathwaySketch.Serialize(ms1);
+        var edgeBytes = new byte[edgeSketch.ComputeSerializedSize()];
+        using var ms2 = new MemoryStream(edgeBytes);
+        edgeSketch.Serialize(ms2);
+
+        var expected = new MockDataStreamsPayload
+        {
+            Env = env,
+            Service = service,
+            Lang = "dotnet",
+            TracerVersion = TracerConstants.AssemblyVersion,
+            Stats = new MockDataStreamsBucket[]
+            {
+                new()
+                {
+                    Duration = (ulong)bucketDuration,
+                    Start = (ulong)bucketStartTimeNs1,
+                    Stats = new MockDataStreamsStatsPoint[]
+                    {
+                        new()
+                        {
+                            EdgeTags = edgeTags,
+                            Hash = hash1.Value,
+                            ParentHash = parentHash.Value,
+                            EdgeLatency = edgeBytes,
+                            PathwayLatency = pathwayBytes,
+                            TimestampType = "current",
+                        }
+                    }
+                },
+                new()
+                {
+                    Duration = (ulong)bucketDuration,
+                    Start = (ulong)bucketStartTimeNs2,
+                    Stats = new MockDataStreamsStatsPoint[]
+                    {
+                        new()
+                        {
+                            EdgeTags = null,
+                            Hash = hash2.Value,
+                            ParentHash = parentHash.Value,
+                            EdgeLatency = edgeBytes,
+                            PathwayLatency = pathwayBytes,
+                            TimestampType = "origin",
+                        }
+                    }
+                }
+            }
+        };
+
+        result.Should().BeEquivalentTo(expected);
+    }
+
+    private static DDSketch CreateSketch(params int[] values)
+    {
+        // don't actually need to pool them for these tests
+        var sketch = new DDSketchPool().Get();
+        foreach (var value in values)
+        {
+            sketch.Add(value);
+        }
+
+        return sketch;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -1,0 +1,144 @@
+﻿// <copyright file="DataStreamsWriterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsWriterTests
+{
+    private const int BucketDurationMs = 1_000; // 1 second
+
+    [Fact]
+    public async Task DoesNotWriteIfNoStats_Periodic()
+    {
+        var bucketDurationMs = 100; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDurationMs * 1_000_000);
+
+        await Task.Delay(bucketDurationMs * 10);
+
+        api.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DoesNotWriteIfNoStats_OnClose()
+    {
+        var bucketDuration = 100_000_000; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task WritesAStatsPointAfterDelay()
+    {
+        var bucketDurationMs = 100; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDurationMs * 1_000_000);
+
+        writer.Add(CreateStatsPoint());
+
+        await Task.Delay(bucketDurationMs * 10);
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task WritesAStatsPoint_OnClose()
+    {
+        var bucketDuration = 100_000_000; // 100 ms
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        writer.Add(CreateStatsPoint());
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AllBucketsAreReportedOnClose()
+    {
+        // using a very long duration here so that we're guaranteed to still
+        // be in the "current" bucket when we call flush and close
+        var bucketDuration = int.MaxValue; // 100 s
+        var api = new StubApi();
+        var writer = CreateWriter(api, bucketDuration);
+
+        writer.Add(CreateStatsPoint());
+
+        await writer.DisposeAsync();
+
+        api.Sent.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task CanCreateWriterWithDefaultBucket()
+    {
+        var writer = CreateWriter(new StubApi(), DataStreamsConstants.DefaultBucketDurationMs);
+        await writer.DisposeAsync();
+    }
+
+    private static DataStreamsWriter CreateWriter(IDataStreamsApi stubApi, int bucketDurationMs = BucketDurationMs)
+    {
+        return new DataStreamsWriter(
+            new DataStreamsAggregator(new DataStreamsMessagePackFormatter("env", "service"), bucketDurationMs),
+            stubApi,
+            bucketDurationMs: bucketDurationMs);
+    }
+
+    private static StatsPoint CreateStatsPoint()
+        => new StatsPoint(
+            edgeTags: new[] { "type:internal" },
+            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
+            pathwayLatencyNs: 5_000_000_000,
+            edgeLatencyNs: 2_000_000_000);
+
+    private class StubApi : IDataStreamsApi
+    {
+        private readonly List<ArraySegment<byte>> _sent = new();
+
+        public List<ArraySegment<byte>> Sent
+        {
+            get
+            {
+                lock (_sent)
+                {
+                    return _sent.ToList();
+                }
+            }
+        }
+
+        public Task<bool> SendAsync(ArraySegment<byte> bytes)
+        {
+            lock (_sent)
+            {
+                _sent.Add(bytes);
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/PathwayContextEncoderTests.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="PathwayContextEncoderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class PathwayContextEncoderTests
+{
+    private static readonly Random Random = new();
+
+    [Fact]
+    public void TestRandomValues()
+    {
+        for (var i = 0; i < 1000; i++)
+        {
+            EncodeTest(unchecked((ulong)GetLong()), Math.Abs(GetLong()), Math.Abs(GetLong()));
+        }
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(ulong.MaxValue, long.MaxValue, long.MaxValue)]
+    [InlineData(ulong.MinValue, long.MinValue, long.MinValue)]
+    public void TestEdgeCases(ulong hash, long pathwayStartNs, long edgeStartNs)
+        => EncodeTest(hash, pathwayStartNs, edgeStartNs);
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(8)]
+    [InlineData(9)]
+    public void DecoderFailure_InsufficientBytes(int byteCount)
+    {
+        // Minimum byte count is 10 bytes:
+        // first 8 bytes are the hash (0), 1 byte min for pathway, 1 byte min for edge
+        var bytes = new byte[byteCount];
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecoderFailure_InvalidEdgeBytes()
+    {
+        // first 8 bytes are the hash (0)
+        // 9th byte is valid pathway  (0)
+        // 10th byte is invalid edge bytes (Pattern 1xxx_xxxx is invalid except in 9th byte)
+        var bytes = new byte[10];
+        bytes[9] = 0b1000_0000;
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    [Fact]
+    public void DecoderFailure_InvalidPathwayBytes()
+    {
+        // first 8 bytes are the hash (0)
+        // 9th byte is invalid pathway (0)
+        var bytes = new byte[9];
+        bytes[8] = 0b1000_0000;
+
+        var decoded = PathwayContextEncoder.Decode(bytes);
+        decoded.Should().BeNull();
+    }
+
+    private static void EncodeTest(ulong hash, long pathwayStartNs, long edgeStartNs)
+    {
+        var pathway = new PathwayContext(
+            new PathwayHash(hash),
+            pathwayStartNs: pathwayStartNs,
+            edgeStartNs: edgeStartNs);
+
+        var encoded = PathwayContextEncoder.Encode(pathway);
+
+        encoded.Should().NotBeNullOrEmpty();
+
+        var decoded = PathwayContextEncoder.Decode(encoded);
+
+        decoded.Should().NotBeNull();
+        // can't compare directly, because encoding and decoding truncates the ns values to be ms
+        decoded.Value.Hash.Should().Be(pathway.Hash);
+        decoded.Value.EdgeStart.Should().Be((pathway.EdgeStart / 1000) * 1000);
+        decoded.Value.PathwayStart.Should().Be((pathway.PathwayStart / 1000) * 1000);
+    }
+
+    private static long GetLong()
+    {
+        var bytes = new byte[8];
+        Random.NextBytes(bytes);
+        return BitConverter.ToInt64(bytes, 0);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -6,6 +6,7 @@
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
 using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
 using FluentAssertions;
 using Xunit;
 
@@ -16,7 +17,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void SetCheckpoint_SetsTheSpanPathwayContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
+        var dsm = GetEnabledDataStreamManager();
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.PathwayContext.Should().BeNull();
 
@@ -40,7 +41,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void MergePathwayContext_WhenOtherContextIsNull_KeepsContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
+        var dsm = GetEnabledDataStreamManager();
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
         spanContext.PathwayContext.Should().NotBeNull();
@@ -55,7 +56,7 @@ public class SpanContextDataStreamsManagerTests
     {
         int iterations = 1000_000;
         // When we have a context and there's a new context we pick one randomly
-        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
+        var dsm = GetEnabledDataStreamManager();
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
 
@@ -82,5 +83,17 @@ public class SpanContextDataStreamsManagerTests
         }
 
         sameCount.Should().BeCloseTo(otherCount, (uint)(iterations / 100)); // roughly 1%
+    }
+
+    private static DataStreamsManager GetEnabledDataStreamManager()
+    {
+        var discoveryServiceMock = new DiscoveryServiceMock();
+        var dsm = new DataStreamsManager(
+            env: "env",
+            defaultServiceName: "service",
+            DataStreamsWriter.Create("foo", "bar", new TestRequestFactory()),
+            discoveryServiceMock);
+        discoveryServiceMock.TriggerChange();
+        return dsm;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -5,6 +5,7 @@
 
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.TestHelpers.TransportHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -15,7 +16,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void SetCheckpoint_SetsTheSpanPathwayContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.PathwayContext.Should().BeNull();
 
@@ -39,7 +40,7 @@ public class SpanContextDataStreamsManagerTests
     [Fact]
     public void MergePathwayContext_WhenOtherContextIsNull_KeepsContext()
     {
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
         spanContext.PathwayContext.Should().NotBeNull();
@@ -54,7 +55,7 @@ public class SpanContextDataStreamsManagerTests
     {
         int iterations = 1000_000;
         // When we have a context and there's a new context we pick one randomly
-        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var dsm = new DataStreamsManager(enabled: true, "env", "service", new TestRequestFactory());
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -1,0 +1,85 @@
+﻿// <copyright file="SpanContextDataStreamsManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class SpanContextDataStreamsManagerTests
+{
+    [Fact]
+    public void SetCheckpoint_SetsTheSpanPathwayContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.PathwayContext.Should().BeNull();
+
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+
+        spanContext.PathwayContext.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenNull_UsesOtherContext()
+    {
+        var ctx = new PathwayContext();
+
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.PathwayContext.Should().BeNull();
+
+        spanContext.MergePathwayContext(ctx);
+        spanContext.PathwayContext.Value.Should().Be(ctx);
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenOtherContextIsNull_KeepsContext()
+    {
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+        spanContext.PathwayContext.Should().NotBeNull();
+        var previous = spanContext.PathwayContext;
+
+        spanContext.MergePathwayContext(null);
+        spanContext.PathwayContext.Should().Be(previous);
+    }
+
+    [Fact]
+    public void MergePathwayContext_WhenOtherContextIsNotNull_KeepsEach50Percent()
+    {
+        int iterations = 1000_000;
+        // When we have a context and there's a new context we pick one randomly
+        var dsm = new DataStreamsManager(enabled: true, "env", "service");
+        var spanContext = new SpanContext(traceId: 123, spanId: 1234);
+        spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+
+        // Make sure we have a different hash for comparison purposes
+        while (spanContext.PathwayContext.Value.Hash.Value < (ulong)iterations)
+        {
+            spanContext.SetCheckpoint(dsm, new[] { "some-edge" });
+        }
+
+        var sameCount = 0;
+        var otherCount = 0;
+        for (int i = 0; i < iterations; i++)
+        {
+            var other = new PathwayContext(new PathwayHash((ulong)i), 1234, 5678);
+            spanContext.MergePathwayContext(other);
+            if (spanContext.PathwayContext.Value.Hash.Value == (ulong)i)
+            {
+                otherCount++;
+            }
+            else
+            {
+                sameCount++;
+            }
+        }
+
+        sameCount.Should().BeCloseTo(otherCount, (uint)(iterations / 100)); // roughly 1%
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="TestHeadersCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Headers;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class TestHeadersCollection : IBinaryHeadersCollection
+{
+    public Dictionary<string, byte[]> Values { get; } = new();
+
+    public byte[] TryGetBytes(string name)
+        => Values.TryGetValue(name, out var value) ? value : null;
+
+    public void Add(string name, byte[] value)
+        => Values[name] = value;
+}

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(null, null, null, null, null, null, null, null, null, null)
+                : base(null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }

--- a/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
@@ -1,0 +1,218 @@
+﻿{
+  Env: integration_tests,
+  Service: Samples.DataStreams.Kafka,
+  TracerVersion: 2.x.x.x,
+  Lang: dotnet,
+  Stats: [
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-1,
+            topic:data-streams-1,
+            type:kafka
+          ],
+          Hash: 3184837087859198448,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 9146411116191305908,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 428893431238664991,
+          ParentHash: 3184837087859198448,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 9288243326407318747,
+          ParentHash: 9146411116191305908,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 4701874528067105417,
+          ParentHash: 428893431238664991,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 17029362228578737937,
+          ParentHash: 9288243326407318747,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5603712524956936337,
+          ParentHash: 4701874528067105417,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 713412453862704155,
+          ParentHash: 5603712524956936337,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        }
+      ]
+    },
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-1,
+            topic:data-streams-1,
+            type:kafka
+          ],
+          Hash: 3184837087859198448,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 9146411116191305908,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 428893431238664991,
+          ParentHash: 3184837087859198448,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 9288243326407318747,
+          ParentHash: 9146411116191305908,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-2,
+            topic:data-streams-2,
+            type:kafka
+          ],
+          Hash: 4701874528067105417,
+          ParentHash: 428893431238664991,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 17029362228578737937,
+          ParentHash: 9288243326407318747,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5603712524956936337,
+          ParentHash: 4701874528067105417,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.consumer-3,
+            topic:data-streams-3,
+            type:kafka
+          ],
+          Hash: 713412453862704155,
+          ParentHash: 5603712524956936337,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Consumer.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Consumer.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Confluent.Kafka;
+using Samples.Kafka;
+
+namespace Samples.DataStreams.Kafka;
+
+internal class Consumer : ConsumerBase
+{
+    private readonly Action<ConsumeResult<string, string>> _handler;
+    private Consumer(ConsumerConfig config, string topic, string consumerName, Action<ConsumeResult<string, string>> handler)
+        : base(config, topic, consumerName)
+    {
+        _handler = handler;
+    }
+
+    protected override void HandleMessage(ConsumeResult<string, string> consumeResult) => _handler(consumeResult);
+
+    public static Consumer Create(string topic, string consumerName, Action<ConsumeResult<string, string>> handler)
+    {
+        Console.WriteLine($"Creating consumer '{consumerName}' and subscribing to topic {topic}");
+
+        var config = new ConsumerConfig
+        {
+            BootstrapServers = Samples.Kafka.Config.KafkaBrokerHost,
+            GroupId = "Samples.DataStreams.Kafka." + consumerName,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            EnableAutoCommit = true,
+        };
+        return new Consumer(config, topic, consumerName, handler);
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Newtonsoft.Json;
+using Samples.DataStreams.Kafka;
+using Samples.Kafka;
+using Config = Samples.Kafka.Config;
+
+// Create Topics
+var sw = new Stopwatch();
+var topicPrefix = "data-streams";
+
+var topic1 = $"{topicPrefix}-1";
+var topic2 = $"{topicPrefix}-2";
+var topic3 = $"{topicPrefix}-3";
+var allTopics = new[] { topic1, topic2, topic3 };
+var topic3ConsumeCount = 0;
+
+var config = Config.Create();
+Console.WriteLine("Creating topics...");
+foreach (var topic in allTopics)
+{
+    await TopicHelpers.TryDeleteTopic(topic, config);
+    await TopicHelpers.TryCreateTopic(topic, numPartitions: 3, replicationFactor: 1, config);
+}
+
+LogWithTime("Finished creating topics");
+Console.WriteLine($"Creating consumers...");
+var consumer1 = Consumer.Create(topic1, "consumer-1", HandleAndProduceToTopic2);
+var consumer2 = Consumer.Create(topic2, "consumer-2", HandleAndProduceToTopic3);
+var consumer3 = Consumer.Create(topic3, "consumer-3", HandleTopic3);
+
+Console.WriteLine("Starting consumers...");
+var cts = new CancellationTokenSource();
+var consumeTasks = new Task[3];
+consumeTasks[0] = Task.Run(() => consumer1.Consume(cts.Token));
+consumeTasks[1] = Task.Run(() => consumer2.Consume(cts.Token));
+consumeTasks[2] = Task.Run(() => consumer3.Consume(cts.Token));
+
+
+LogWithTime("Finished starting consumers");
+Console.WriteLine($"Producing messages");
+Producer.Produce(topic1, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+Producer.Produce(topic2, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+
+LogWithTime("Finished producing messages");
+Console.WriteLine($"Waiting for final consumption...");
+
+// Wait for all messages to be consumed
+// This assumes that the topics all start empty, and ultimately 6 messages end up consumed from topic 3
+var deadline = DateTime.UtcNow.AddSeconds(30);
+while (true)
+{
+    var consumed = Volatile.Read(ref topic3ConsumeCount);
+    if (consumed >= 6)
+    {
+        Console.WriteLine($"All messages produced and consumed");
+        break;
+    }
+
+    if (DateTime.UtcNow > deadline)
+    {
+        Console.WriteLine($"Exiting consumer: did not consume all messages: {consumed}");
+        break;
+    }
+
+    await Task.Delay(1000);
+}
+
+LogWithTime("Finished waiting for messages");
+
+Console.WriteLine($"Waiting for graceful exit...");
+cts.Cancel();
+
+await Task.WhenAny(Task.WhenAll(consumeTasks),
+                   Task.Delay(TimeSpan.FromSeconds(5)));
+
+LogWithTime("Shut down complete");
+
+void HandleTopic3(ConsumeResult<string,string> consumeResult)
+{
+    Handle(consumeResult);
+
+    var consumeCount = Interlocked.Increment(ref topic3ConsumeCount);
+    Console.WriteLine($"Consumed message {consumeCount} in Topic({topic3})");
+}
+
+void HandleAndProduceToTopic2(ConsumeResult<string, string> consumeResult)
+    => HandleAndProduce(consumeResult, topic2);
+
+void HandleAndProduceToTopic3(ConsumeResult<string, string> consumeResult)
+    => HandleAndProduce(consumeResult, topic3);
+
+void HandleAndProduce(ConsumeResult<string,string> consumeResult, string produceToTopic)
+{
+    Handle(consumeResult);
+    
+    Console.WriteLine($"Producing to {produceToTopic}");
+    Producer.Produce(produceToTopic, numMessages: 1, config, handleDelivery: true, isTombstone: false);
+}
+
+void Handle(ConsumeResult<string, string> consumeResult)
+{
+    var kafkaMessage = consumeResult.Message;
+    Console.WriteLine($"Consuming Key({kafkaMessage.Key}), Topic({consumeResult.TopicPartitionOffset})");
+
+    var sampleMessage = JsonConvert.DeserializeObject<SampleMessage>(kafkaMessage.Value);
+    Console.WriteLine($"Received {(sampleMessage.IsProducedAsync ? "async" : "sync")} message for Key({kafkaMessage.Key})");
+}
+
+void LogWithTime(string message)
+{
+    Console.WriteLine($"{message}: {sw.Elapsed:g}");
+    sw.Restart();
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "Samples.Kafka": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer",
+        "COR_ENABLE_PROFILING": "1",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\tracer\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Samples.DataStreams.Kafka.csproj
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Samples.DataStreams.Kafka.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RequiresDockerDependency>true</RequiresDockerDependency>
+
+    <!-- Required to build multiple projects with the same Configuration|Platform -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <Platforms>x64;x86;AnyCPU</Platforms>
+
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Samples.Kafka\Config.cs">
+      <Link>Config.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\ConsumerBase.cs">
+      <Link>ConsumerBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\Producer.cs">
+      <Link>Producer.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.Kafka\TopicHelpers.cs">
+      <Link>TopicHelpers.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
@@ -9,142 +9,17 @@ using Newtonsoft.Json;
 
 namespace Samples.Kafka
 {
-    internal class Consumer: IDisposable
+    internal class Consumer: ConsumerBase
     {
-        private readonly string _consumerName;
-        private readonly IConsumer<string, string> _consumer;
-
-        public static int TotalAsyncMessages = 0;
-        public static int TotalSyncMessages = 0;
-        public static int TotalTombstones = 0;
-
         private Consumer(ConsumerConfig config, string topic, string consumerName)
+            : base(config, topic, consumerName)
         {
-            _consumerName = consumerName;
-            _consumer = new ConsumerBuilder<string, string>(config).Build();
-            _consumer.Subscribe(topic);
         }
 
-
-        public bool Consume(int retries, int timeoutMilliSeconds)
-        {
-            try
-            {
-                for (int i = 0; i < retries; i++)
-                {
-                    try
-                    {
-                        // will block until a message is available
-                        // on 1.5.3 this will throw if the topic doesn't exist
-                        var consumeResult = _consumer.Consume(timeoutMilliSeconds);
-                        if (consumeResult is null)
-                        {
-                            Console.WriteLine($"{_consumerName}: Null consume result");
-                            return true;
-                        }
-
-                        if (consumeResult.IsPartitionEOF)
-                        {
-                            Console.WriteLine($"{_consumerName}: Reached EOF");
-                            return true;
-                        }
-                        else
-                        {
-                            HandleMessage(consumeResult);
-                            return true;
-                        }
-                    }
-                    catch (ConsumeException ex)
-                    {
-                        Console.WriteLine($"Consume Exception in manual consume: {ex}");
-                    }
-
-                    Task.Delay(500);
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-
-            return false;
-        }
-
-        public void Consume(CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    // will block until a message is available
-                    var consumeResult = _consumer.Consume(cancellationToken);
-
-                    if (consumeResult.IsPartitionEOF)
-                    {
-                        Console.WriteLine($"{_consumerName}: Reached EOF");
-                    }
-                    else
-                    {
-                        HandleMessage(consumeResult);
-                    }
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-        }
-
-        public void ConsumeWithExplicitCommit(int commitEveryXMessages, CancellationToken cancellationToken = default)
-        {
-            ConsumeResult<string, string> consumeResult = null;
-            try
-            {
-                while (!cancellationToken.IsCancellationRequested)
-                {
-                    // will block until a message is available
-                    consumeResult = _consumer.Consume(cancellationToken);
-
-                    if (consumeResult.IsPartitionEOF)
-                    {
-                        Console.WriteLine($"{_consumerName}: Reached EOF");
-                    }
-                    else
-                    {
-                        HandleMessage(consumeResult);
-                    }
-
-                    if (consumeResult.Offset % commitEveryXMessages == 0)
-                    {
-                        try
-                        {
-                            Console.WriteLine($"{_consumerName}: committing...");
-                            _consumer.Commit(consumeResult);
-                        }
-                        catch (KafkaException e)
-                        {
-                            Console.WriteLine($"{_consumerName}: commit error: {e.Error.Reason}");
-                        }
-                    }
-                }
-            }
-            catch (TaskCanceledException)
-            {
-                Console.WriteLine($"{_consumerName}: Cancellation requested, exiting.");
-            }
-
-            // As we're doing manual commit, make sure we force a commit now
-            if (consumeResult is not null)
-            {
-                Console.WriteLine($"{_consumerName}: committing...");
-                _consumer.Commit(consumeResult);
-            }
-        }
-
-        private void HandleMessage(ConsumeResult<string, string> consumeResult)
+        protected override void HandleMessage(ConsumeResult<string, string> consumeResult)
         {
             var kafkaMessage = consumeResult.Message;
-            Console.WriteLine($"{_consumerName}: Consuming {kafkaMessage.Key}, {consumeResult.TopicPartitionOffset}");
+            Console.WriteLine($"{ConsumerName}: Consuming {kafkaMessage.Key}, {consumeResult.TopicPartitionOffset}");
 
             var messageHeaders = kafkaMessage.Headers;
             SampleHelpers.ExtractScope(messageHeaders, GetValues, out var traceId, out var spanId);
@@ -196,13 +71,6 @@ namespace Samples.Kafka
                     Interlocked.Increment(ref TotalSyncMessages);
                 }
             }
-        }
-
-        public void Dispose()
-        {
-            Console.WriteLine($"{_consumerName}: Closing consumer");
-            _consumer?.Close();
-            _consumer?.Dispose();
         }
 
         public static Consumer Create(bool enableAutoCommit, string topic, string consumerName)

--- a/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Samples.Kafka;
+
+internal abstract class ConsumerBase : IDisposable
+{
+    private readonly IConsumer<string, string> _consumer;
+    public static int TotalAsyncMessages = 0;
+    public static int TotalSyncMessages = 0;
+    public static int TotalTombstones = 0;
+
+    protected ConsumerBase(ConsumerConfig config, string topic, string consumerName)
+    {
+        ConsumerName = consumerName;
+        _consumer = new ConsumerBuilder<string, string>(config).Build();
+        _consumer.Subscribe(topic);
+    }
+
+    protected string ConsumerName { get; }
+
+    public bool Consume(int retries, int timeoutMilliSeconds)
+    {
+        try
+        {
+            for (int i = 0; i < retries; i++)
+            {
+                try
+                {
+                    // will block until a message is available
+                    // on 1.5.3 this will throw if the topic doesn't exist
+                    var consumeResult = _consumer.Consume(timeoutMilliSeconds);
+                    if (consumeResult is null)
+                    {
+                        Console.WriteLine($"{ConsumerName}: Null consume result");
+                        return true;
+                    }
+
+                    if (consumeResult.IsPartitionEOF)
+                    {
+                        Console.WriteLine($"{ConsumerName}: Reached EOF");
+                        return true;
+                    }
+                    else
+                    {
+                        HandleMessage(consumeResult);
+                        return true;
+                    }
+                }
+                catch (ConsumeException ex)
+                {
+                    Console.WriteLine($"Consume Exception in manual consume: {ex}");
+                }
+
+                Task.Delay(500);
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+
+        return false;
+    }
+
+    public void Consume(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // will block until a message is available
+                var consumeResult = _consumer.Consume(cancellationToken);
+
+                if (consumeResult.IsPartitionEOF)
+                {
+                    Console.WriteLine($"{ConsumerName}: Reached EOF");
+                }
+                else
+                {
+                    HandleMessage(consumeResult);
+                }
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+    }
+
+    public void ConsumeWithExplicitCommit(int commitEveryXMessages, CancellationToken cancellationToken = default)
+    {
+        ConsumeResult<string, string> consumeResult = null;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // will block until a message is available
+                consumeResult = _consumer.Consume(cancellationToken);
+
+                if (consumeResult.IsPartitionEOF)
+                {
+                    Console.WriteLine($"{ConsumerName}: Reached EOF");
+                }
+                else
+                {
+                    HandleMessage(consumeResult);
+                }
+
+                if (consumeResult.Offset % commitEveryXMessages == 0)
+                {
+                    try
+                    {
+                        Console.WriteLine($"{ConsumerName}: committing...");
+                        _consumer.Commit(consumeResult);
+                    }
+                    catch (KafkaException e)
+                    {
+                        Console.WriteLine($"{ConsumerName}: commit error: {e.Error.Reason}");
+                    }
+                }
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            Console.WriteLine($"{ConsumerName}: Cancellation requested, exiting.");
+        }
+
+        // As we're doing manual commit, make sure we force a commit now
+        if (consumeResult is not null)
+        {
+            Console.WriteLine($"{ConsumerName}: committing...");
+            _consumer.Commit(consumeResult);
+        }
+    }
+
+    protected abstract void HandleMessage(ConsumeResult<string, string> consumeResult);
+
+    public void Dispose()
+    {
+        Console.WriteLine($"{ConsumerName}: Closing consumer");
+        _consumer?.Close();
+        _consumer?.Dispose();
+    }
+}


### PR DESCRIPTION
- DSM should be enabled or disabled depending if the agent supports it
- Currently _checkpointing_ (stats collection) remains disabled until support has been indicated. This is to handle the case where the agent is not available for a long period, as we would otherwise have unbounded growth in the stats buckets. Pathway injection is always enabled regardless of support, as long as DSM is enabled.
- Added some unit tests for the upgrade/downgrade
- Added integration tests to test for unsupported scenario
- Added a DiscoveryServiceMock for helping with testing

## Summary of changes

Added support for `IDiscoveryService` to `DataStreamsManager`

## Reason for change

DSM needs to be enabled or disabled depending on whether the agent supports it or not.

## Implementation details

Checkpointing (stats collection) remains _disabled_ until support has been indicated by the discovery service. This is to handle the case where the agent is not available for a long period, as we would otherwise have unbounded growth in the stats buckets. Note that there is a risk of missed data if messages are consumed or produced _before_ the discovery service indicates support.

The `DataStreamsManager` has two levels of enablement: 
- `_isEnabled`, indicated by the setting set in `TracerSettings` via an env var. If disabled, `_writer` is `null`, and all functionality in `DataStreamsManager` is a noop. When enabled, pathway context extraction and injection is _always_ enabled, regardless of support.
- `_supportState`, which is updated based on `IDiscoveryService` events. Until this is `Supported`, stats are _not_ collected for checkpoints. 

> The `SupportState` enum + casting to `int` is a big gnarly, but I wanted to use `Volatile.Read()` to be belt-and-braces about it, and you can't do that with `bool?`, so this seemed most declarative 🙄 

## Test coverage

Added unit tests for `DataStreamsManager` to test upgrade/downgrade scenarios etc. Added "not supported" scenario to integration tests.

## Other details

Dependent on: 
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3099
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3154
- [ ] https://github.com/DataDog/dd-trace-dotnet/pull/3174
- [ ] https://github.com/DataDog/dd-trace-dotnet/pull/3191
- [ ] https://github.com/DataDog/dd-trace-dotnet/pull/3192

Subsequent PRs to follow:

- Public API/adaptation of existing to handle manual context creation (e.g. when automatic consumer scopes are disabled)
