### PR TITLE
Use `LifeTimeManager` for LiveDebugger shutdown events

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ILineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ILineProbeResolver.cs
@@ -14,8 +14,6 @@ namespace Datadog.Trace.Debugger
     /// </summary>
     internal interface ILineProbeResolver
     {
-        void OnDomainUnloaded();
-
         LineProbeResolveResult TryResolveLineProbe(ProbeDefinition probe, out BoundLineProbeLocation location);
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -11,7 +11,6 @@ using System.Reflection;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Models;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
 using Datadog.Trace.Vendors.dnlib.DotNet.Pdb.Symbols;
@@ -160,17 +159,6 @@ namespace Datadog.Trace.Debugger
             {
                 Log.Error(e, "Failed to resolve line probe for ProbeID {ProbeId}", probe.Id);
                 return new LineProbeResolveResult(LiveProbeResolveStatus.Error, "An error occurred while trying to resolve probe location");
-            }
-        }
-
-        public void OnDomainUnloaded()
-        {
-            lock (_locker)
-            {
-                foreach (var unloadedAssembly in AppDomain.CurrentDomain.GetAssemblies())
-                {
-                    _loadedAssemblies.Remove(unloadedAssembly);
-                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -149,7 +149,6 @@ namespace Datadog.Trace.Debugger
                 LifetimeManager.Instance.AddShutdownTask(() => _discoveryService.RemoveSubscription(DiscoveryCallback));
                 LifetimeManager.Instance.AddShutdownTask(_debuggerSink.Dispose);
                 LifetimeManager.Instance.AddShutdownTask(_probeStatusPoller.Dispose);
-                LifetimeManager.Instance.AddShutdownTask(_lineProbeResolver.OnDomainUnloaded);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -120,11 +120,6 @@ public class LiveDebuggerTests
     {
         internal bool Called { get; private set; }
 
-        public void OnDomainUnloaded()
-        {
-            Called = true;
-        }
-
         public LineProbeResolveResult TryResolveLineProbe(ProbeDefinition probe, out BoundLineProbeLocation location)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
## Summary of changes
Use `LifeTimeManager.AddShutdownTask()` method, instead of custom subscritpion to `AppDomain.CurrentDomain.DomainUnload` event.
Run each dispose method as separate task.

## Reason for change
Use standard way for register shutdown events.