### PR TITLE
Use `Moq` mocking library for live debugger unit tests.

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -4,25 +4,50 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
-using Datadog.Trace.Debugger.Configurations.Models;
-using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
-using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.RemoteConfigurationManagement;
-using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Debugger;
 
 public class LiveDebuggerTests
 {
+    private readonly Mock<IDiscoveryService> _discoveryService;
+    private readonly Mock<IRemoteConfigurationManager> _remoteConfigurationManager;
+    private readonly Mock<ILineProbeResolver> _lineProbeResolver;
+    private readonly Mock<IDebuggerSink> _debuggerSink;
+    private readonly Mock<IProbeStatusPoller> _probeStatusPoller;
+    private readonly ConfigurationUpdater _configurationUpdater;
+
+    public LiveDebuggerTests()
+    {
+        _discoveryService = new Mock<IDiscoveryService>();
+        _discoveryService
+           .Setup(service => service.SubscribeToChanges(It.IsAny<Action<AgentConfiguration>>()))
+           .Callback(
+                (Action<AgentConfiguration> callback) => callback(
+                    new AgentConfiguration(
+                        configurationEndpoint: "configurationEndpoint",
+                        debuggerEndpoint: "debuggerEndpoint",
+                        agentVersion: "agentVersion",
+                        statsEndpoint: "traceStatsEndpoint",
+                        dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
+                        clientDropP0: false)));
+
+        _remoteConfigurationManager = new Mock<IRemoteConfigurationManager>();
+        _lineProbeResolver = new Mock<ILineProbeResolver>();
+        _debuggerSink = new Mock<IDebuggerSink>();
+        _probeStatusPoller = new Mock<IProbeStatusPoller>();
+        _configurationUpdater = ConfigurationUpdater.Create("env", "version");
+    }
+
     [Fact]
     public async Task DebuggerEnabled_ServicesCalled()
     {
@@ -31,19 +56,13 @@ public class LiveDebuggerTests
             { ConfigurationKeys.Debugger.Enabled, "1" },
         }));
 
-        var discoveryService = new DiscoveryServiceMock();
-        var managerMock = new RemoteConfigurationManagerMock();
-        var lineProbeResolver = new LineProbeResolverMock();
-        var debuggerSink = new DebuggerSinkMock();
-        var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create("env", "version");
-
-        var debugger = LiveDebugger.Create(settings, string.Empty, discoveryService, managerMock, lineProbeResolver, debuggerSink, probeStatusPoller, updater);
+        var debugger = LiveDebugger.Create(settings, string.Empty, _discoveryService.Object, _remoteConfigurationManager.Object, _lineProbeResolver.Object, _debuggerSink.Object, _probeStatusPoller.Object, _configurationUpdater);
         await debugger.InitializeAsync();
 
-        probeStatusPoller.Called.Should().BeTrue();
-        debuggerSink.Called.Should().BeTrue();
-        managerMock.Products.ContainsKey(LiveDebugger.Instance.Product.Name).Should().BeTrue();
+        _discoveryService.Verify(service => service.SubscribeToChanges(It.IsAny<Action<AgentConfiguration>>()), Times.Once());
+        _remoteConfigurationManager.Verify(rcm => rcm.RegisterProduct(It.IsAny<LiveDebuggerProduct>()), Times.Once());
+        _debuggerSink.Verify(debuggerSink => debuggerSink.StartFlushingAsync(), Times.Once());
+        _probeStatusPoller.Verify(poller => poller.StartPolling(), Times.Once());
     }
 
     [Fact]
@@ -54,129 +73,12 @@ public class LiveDebuggerTests
             { ConfigurationKeys.Debugger.Enabled, "0" },
         }));
 
-        var discoveryService = new DiscoveryServiceMock();
-        var managerMock = new RemoteConfigurationManagerMock();
-        var lineProbeResolver = new LineProbeResolverMock();
-        var debuggerSink = new DebuggerSinkMock();
-        var probeStatusPoller = new ProbeStatusPollerMock();
-        var updater = ConfigurationUpdater.Create(string.Empty, string.Empty);
-
-        var debugger = LiveDebugger.Create(settings, string.Empty, discoveryService, managerMock, lineProbeResolver, debuggerSink, probeStatusPoller, updater);
+        var debugger = LiveDebugger.Create(settings, string.Empty, _discoveryService.Object, _remoteConfigurationManager.Object, _lineProbeResolver.Object, _debuggerSink.Object, _probeStatusPoller.Object, _configurationUpdater);
         await debugger.InitializeAsync();
 
-        lineProbeResolver.Called.Should().BeFalse();
-        debuggerSink.Called.Should().BeFalse();
-        probeStatusPoller.Called.Should().BeFalse();
-        managerMock.Products.ContainsKey(LiveDebugger.Instance.Product.Name).Should().BeFalse();
-    }
-
-    private class DiscoveryServiceMock : IDiscoveryService
-    {
-        internal bool Called { get; private set; }
-
-        public void SubscribeToChanges(Action<AgentConfiguration> callback)
-        {
-            Called = true;
-            callback(new AgentConfiguration(
-                         configurationEndpoint: "configurationEndpoint",
-                         debuggerEndpoint: "debuggerEndpoint",
-                         agentVersion: "agentVersion",
-                         statsEndpoint: "traceStatsEndpoint",
-                         dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
-                         clientDropP0: false));
-        }
-
-        public void RemoveSubscription(Action<AgentConfiguration> callback)
-        {
-        }
-
-        public Task DisposeAsync() => Task.CompletedTask;
-    }
-
-    private class RemoteConfigurationManagerMock : IRemoteConfigurationManager
-    {
-        internal bool Called { get; private set; }
-
-        internal Dictionary<string, Product> Products { get; private set; } = new();
-
-        public Task StartPollingAsync()
-        {
-            Called = true;
-            return Task.CompletedTask;
-        }
-
-        public void RegisterProduct(Product product)
-        {
-            Products.Add(product.Name, product);
-        }
-
-        public void UnregisterProduct(string productName)
-        {
-            Products.Remove(productName);
-        }
-    }
-
-    private class LineProbeResolverMock : ILineProbeResolver
-    {
-        internal bool Called { get; private set; }
-
-        public void OnDomainUnloaded()
-        {
-            Called = true;
-        }
-
-        public LineProbeResolveResult TryResolveLineProbe(ProbeDefinition probe, out BoundLineProbeLocation location)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    private class DebuggerSinkMock : IDebuggerSink
-    {
-        internal bool Called { get; private set; }
-
-        public Task StartFlushingAsync()
-        {
-            Called = true;
-            return Task.CompletedTask;
-        }
-
-        public void AddSnapshot(string snapshot)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AddProbeStatus(string probeId, Status status, Exception exception = null, string errorMessage = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void Dispose()
-        {
-        }
-    }
-
-    private class ProbeStatusPollerMock : IProbeStatusPoller
-    {
-        internal bool Called { get; private set; }
-
-        public void StartPolling()
-        {
-            Called = true;
-        }
-
-        public void AddProbes(string[] newProbes)
-        {
-            Called = true;
-        }
-
-        public void RemoveProbes(string[] newProbes)
-        {
-            Called = true;
-        }
-
-        public void Dispose()
-        {
-        }
+        _discoveryService.Verify(service => service.SubscribeToChanges(It.IsAny<Action<AgentConfiguration>>()), Times.Never());
+        _remoteConfigurationManager.Verify(rcm => rcm.RegisterProduct(It.IsAny<LiveDebuggerProduct>()), Times.Never());
+        _debuggerSink.Verify(debuggerSink => debuggerSink.StartFlushingAsync(), Times.Never());
+        _probeStatusPoller.Verify(poller => poller.StartPolling(), Times.Never());
     }
 }


### PR DESCRIPTION
## Summary of changes
Remove custom mock implementations and use `Moq` mocking library.

## Reason for change
Use standard way for unit tests.