### PR TITLE
Schedule CI to run 10 times on a Saturday morning

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -111,6 +111,7 @@ variables:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
   # For scheduled builds, only run benchmarks and throughput (and deps). Always do a full build on master.
+  isScheduledBuildOnMain: ${{ and(eq(variables['Build.Reason'], 'Schedule'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')) }}
   isBenchmarksOnlyBuild: ${{ and(eq(variables['Build.Reason'], 'Schedule'), not(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'))) }} # only works if you have a main branch
   dotnetToolTag: build-dotnet-tool
   Verify_DisableClipboard: true
@@ -1467,6 +1468,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
+        eq(variables['isScheduledBuildOnMain'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'],'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
@@ -1524,6 +1526,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
+        eq(variables['isScheduledBuildOnMain'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'],'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -83,7 +83,13 @@ schedules:
         - /benchmarks/*
       exclude:
         - release/1.x
+    always: true
 
+  - cron: "*/6 1 * * Sat"
+    displayName: Saturday CI, every 6 minutes from 1am
+    branches:
+      include:
+        - master
     always: true
 
 # Global variables


### PR DESCRIPTION
## Summary of changes

- Add an AzDo schedule that runs CI 10 times on a Saturday morning
- Always run the exploration tests on these builds

## Reason for change

We're struggling with flaky tests at the moment, so we want more data about what's failing.

## Implementation details

Setup a schedule to start a CI run on master, every 6mins, starting at 1am on Saturday. That gives us 10 runs.

## Test coverage

We can find out if it worked in a week!

## Other details
[Crontab expression reference](https://github.com/atifaziz/NCrontab/wiki/Crontab-Expression), [AzDo schedule docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml)