### PR TITLE
[tests] show only diff in test failures when comparing long multi-line strings

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -20,6 +21,7 @@ namespace Datadog.Trace.TestHelpers
         public CustomTestFramework(IMessageSink messageSink)
             : base(messageSink)
         {
+            FluentAssertions.Formatting.Formatter.AddFormatter(new DiffPaneModelFormatter());
         }
 
         public CustomTestFramework(IMessageSink messageSink, Type typeTestedAssembly)

--- a/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -5,6 +5,7 @@
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
+    <PackageReference Include="DiffPlex" Version="1.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/DiffPaneModelFormatter.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/DiffPaneModelFormatter.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="DiffPaneModelFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Text;
+using DiffPlex.DiffBuilder.Model;
+using FluentAssertions.Formatting;
+
+namespace Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
+
+public class DiffPaneModelFormatter : IValueFormatter
+{
+    public bool CanHandle(object value)
+    {
+        return value is DiffPaneModel;
+    }
+
+    public void Format(object value, FormattedObjectGraph formattedGraph, FormattingContext context, FormatChild formatChild)
+    {
+        if (value is DiffPaneModel { HasDifferences: true } diffModel)
+        {
+            var sb = new StringBuilder(Environment.NewLine);
+
+            // used to right-align line numbers
+            int highestLinePositionDigitCount = diffModel.Lines
+                                                         .Where(line => line.Position is not null && line.Type is ChangeType.Deleted or ChangeType.Inserted or ChangeType.Modified)
+                                                         .Max(line => (int)line.Position!)
+                                                         .ToString()
+                                                         .Length;
+
+            for (var i = 0; i < diffModel.Lines.Count; i++)
+            {
+                var line = diffModel.Lines[i];
+
+                if (line.Position is not null && line.Type is ChangeType.Deleted or ChangeType.Inserted or ChangeType.Modified)
+                {
+                    var changeTypeIndicator = line.Type switch
+                                              {
+                                                  ChangeType.Deleted => "-",
+                                                  ChangeType.Inserted => "+",
+                                                  ChangeType.Modified => "~",
+                                                  _ => null
+                                              };
+
+                    sb.AppendFormat("{0}{1," + highestLinePositionDigitCount + "}:{2}", changeTypeIndicator, (int)line.Position!, line.Text);
+                }
+            }
+
+            var result = sb.ToString();
+
+            if (context.UseLineBreaks)
+            {
+                // Forces the result to be added as a separate line in the final output
+                formattedGraph.AddLine(result);
+            }
+            else
+            {
+                // Appends the result to any existing fragments on the current line
+                formattedGraph.AddFragment(result);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/StringExtensions.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/StringExtensions.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="StringExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using DiffPlex.DiffBuilder;
+using DiffPlex.DiffBuilder.Model;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
+
+public static class StringExtensions
+{
+    public static StringAssertions HaveEmptyDiffWhenComparedTo(this StringAssertions value, string expected, string because = "", params object[] becauseArgs)
+    {
+        Execute.Assertion
+               .BecauseOf(because, becauseArgs)
+               .Given(() => Diff(expected, value.Subject))
+               .ForCondition(diffLines => diffLines?.Count > 0)
+               .FailWith(
+                    "{context:string} has differences from expected value {reason}:{0}",
+                    diffLines => diffLines);
+
+        return value;
+    }
+
+    private static List<string> Diff(string expected, string actual)
+    {
+        var diff = InlineDiffBuilder.Diff(expected, actual);
+
+        if (diff.HasDifferences)
+        {
+            var diffs = new List<string>();
+
+            for (var i = 0; i < diff.Lines.Count; i++)
+            {
+                var line = diff.Lines[i];
+
+                switch (line.Type)
+                {
+                    case ChangeType.Inserted:
+                        diffs.Add($"{line.Position} + {line.Text}");
+                        break;
+                    case ChangeType.Deleted:
+                        diffs.Add($"{line.Position} - {line.Text}");
+                        break;
+                    case ChangeType.Modified:
+                        diffs.Add($"{line.Position} ~ {line.Text}");
+                        break;
+                }
+            }
+
+            return diffs;
+        }
+
+        return null;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/StringExtensions.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/FluentAssertionsExtensions/StringExtensions.cs
@@ -14,8 +14,14 @@ namespace Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
 public static class StringExtensions
 {
     [CustomAssertion]
-    public static StringAssertions HaveEmptyDiffWhenComparedTo(this StringAssertions value, string expected, string because = "", params object[] becauseArgs)
+    public static AndConstraint<StringAssertions> Be(this StringAssertions value, string expected, bool outputDiffOnly, string because = "", params object[] becauseArgs)
     {
+        if (!outputDiffOnly)
+        {
+            // fallback to Be()'s default behavior (show full strings instead of diffs)
+            return value.Be(expected, because, becauseArgs);
+        }
+
         Execute.Assertion
                .BecauseOf(because, becauseArgs)
                .Given(() => InlineDiffBuilder.Diff(expected, value.Subject))
@@ -24,6 +30,6 @@ public static class StringExtensions
                     "{context:string} has differences from expected value{reason}. Diff:{0}",
                     diffModel => diffModel);
 
-        return value;
+        return new AndConstraint<StringAssertions>(value);
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
@@ -13,6 +13,7 @@ using System.Runtime.Versioning;
 using System.Text;
 using Datadog.Trace.Ci.Coverage.Attributes;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
 using FluentAssertions;
 using PublicApiGenerator;
 using Xunit;
@@ -60,7 +61,7 @@ namespace Datadog.Trace.Tests
 
             var expected = GetExpected(publicApi);
 
-            publicApi.Should().Be(expected, "Public API should match the verified API. Update verified snapshot when the public API changes as appropriate");
+            publicApi.Should().HaveEmptyDiffWhenComparedTo(expected, "Public API should match the verified API. Update verified snapshot when the public API changes as appropriate");
         }
 
         [Fact]
@@ -84,7 +85,7 @@ namespace Datadog.Trace.Tests
             string frameworkName = EnvironmentTools.GetTracerTargetFrameworkDirectory();
             var expected = GetExpected(referencedAssemblyOutput, frameworkName);
 
-            referencedAssemblyOutput.Should().Be(expected, "Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change");
+            referencedAssemblyOutput.Should().HaveEmptyDiffWhenComparedTo(expected, "Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change");
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/PublicApiTestsBase.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Tests
 
             var expected = GetExpected(publicApi);
 
-            publicApi.Should().HaveEmptyDiffWhenComparedTo(expected, "Public API should match the verified API. Update verified snapshot when the public API changes as appropriate");
+            publicApi.Should().Be(expected, outputDiffOnly: true, "Public API should match the verified API. Update verified snapshot when the public API changes as appropriate");
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tests
             string frameworkName = EnvironmentTools.GetTracerTargetFrameworkDirectory();
             var expected = GetExpected(referencedAssemblyOutput, frameworkName);
 
-            referencedAssemblyOutput.Should().HaveEmptyDiffWhenComparedTo(expected, "Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change");
+            referencedAssemblyOutput.Should().Be(expected, outputDiffOnly: true, "Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change");
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes

Add an extension for Fluent Assertions that compares strings for equality but only outputs a diff between the strings. Useful when working with very long multi-line strings.

For example, adding one assembly references causes the test `AssemblyReferencesHaveNotChanged` to fail with the following message:

```
Expected referencedAssemblyOutput to be "Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Http.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Http.Features, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Mvc.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Routing.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
[...57 lines total...]
" with a length of 5452 because Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change, but "Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Http.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Http.Features, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Mvc.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
Microsoft.AspNetCore.Routing.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
[...58 lines total...]
" has a length of 5545, differs near "ool" (index 1896).
```

The message above includes the full text of both strings, but does not indicate what the differences are between the strings. After this PR, the message shows only the differences between the two strings, including their line number. In the example below it is clear that a single line was added at line 20 and the new assembly is `System.Diagnostics.Tools`:
```
ReferencedAssemblyOutput has differences from expected value because Assembly references should match the verified list of assembly references. Update the verified snapshot when the assembly references change. Diff:
+20:System.Diagnostics.Tools, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
```

## Reason for change

This change should make it easier to diagnose failing test that compare long multi-line strings.

## Implementation details

- added `DiffPlex` library to perform the actual diff between strings
- added `StringAssertions.Be()` extension method overload with additional `bool outputDiffOnly` parameter
- added `DiffPaneModelFormatter : IValueFormatter` to convert the `DiffPaneModel` to output string used by Fluent Assertions
- use new extension method to compare strings in `PublicApiHasNotChanged` and `AssemblyReferencesHaveNotChanged`

Usage:
```csharp
// to output only the diff between both strings
actualString.Should().Be(expectedString, outputDiffOnly: true);

// to output both strings fully
actualString.Should().Be(expectedString, outputDiffOnly: false);

// internally, `showDiffOnly: false` simply calls the original `Be()`
actualString.Should().Be(expectedString);
```

Currently this only performs a line-by-line diff, but it would be trivial to add a parameter to the extension method to use different `DiffPlex` "chunkers" (e.g. word-by-word, char-by-char).

## Test coverage

`:inception:`
