### PR TITLE
Fix flakey test Http_Headers_Contain_ContainerId 

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -46,15 +46,17 @@ namespace Datadog.Trace.IntegrationTests
 
                 var headers = agent.TraceRequestHeaders.Should().ContainSingle().Subject;
 
-                if (EnvironmentTools.IsWindows())
-                {
-                    // we don't extract the containerId on Windows (yet?)
-                    headers.AllKeys.Should().NotContain(AgentHttpHeaderNames.ContainerId);
-                    return;
-                }
-
                 var expectedContainedId = ContainerMetadata.GetContainerId();
-                headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.ContainerId, expectedContainedId);
+                if (expectedContainedId == null)
+                {
+                    // we don't extract the containerId in some cases, such as when running on Windows.
+                    // In these cases, it should not appear in the headers at all.
+                    headers.AllKeys.Should().NotContain(AgentHttpHeaderNames.ContainerId);
+                }
+                else
+                {
+                    headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.ContainerId, expectedContainedId);
+                }
             }
         }
     }

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -44,10 +44,16 @@ namespace Datadog.Trace.IntegrationTests
                 var spans = agent.WaitForSpans(count: 1);
                 Assert.Equal(expected: 1, spans.Count);
 
-                // we don't extract the containerId on Windows (yet?)
-                var expectedContainedId = EnvironmentTools.IsWindows() ? null : ContainerMetadata.GetContainerId();
-
                 var headers = agent.TraceRequestHeaders.Should().ContainSingle().Subject;
+
+                if (EnvironmentTools.IsWindows())
+                {
+                    // we don't extract the containerId on Windows (yet?)
+                    headers.AllKeys.Should().NotContain(AgentHttpHeaderNames.ContainerId);
+                    return;
+                }
+
+                var expectedContainedId = ContainerMetadata.GetContainerId();
                 headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.ContainerId, expectedContainedId);
             }
         }

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -4,10 +4,12 @@
 // </copyright>
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -43,9 +45,10 @@ namespace Datadog.Trace.IntegrationTests
                 Assert.Equal(expected: 1, spans.Count);
 
                 // we don't extract the containerId on Windows (yet?)
-                Assert.Equal(expected: 1, agent.TraceRequestHeaders.Count);
                 var expectedContainedId = EnvironmentTools.IsWindows() ? null : ContainerMetadata.GetContainerId();
-                Assert.All(agent.TraceRequestHeaders, headers => Assert.Equal(expectedContainedId, headers[AgentHttpHeaderNames.ContainerId]));
+
+                var headers = agent.TraceRequestHeaders.Should().ContainSingle().Subject;
+                headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.ContainerId, expectedContainedId);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.TestHelpers
 
         public IImmutableList<MockClientStatsPayload> Stats { get; private set; } = ImmutableList<MockClientStatsPayload>.Empty;
 
-        public IImmutableList<NameValueCollection> RequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
+        public IImmutableList<NameValueCollection> TraceRequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
 
         public List<string> Snapshots { get; private set; } = new();
 
@@ -139,7 +139,7 @@ namespace Datadog.Trace.TestHelpers
                 Thread.Sleep(500);
             }
 
-            foreach (var headers in RequestHeaders)
+            foreach (var headers in TraceRequestHeaders)
             {
                 // This is the place to check against headers we expect
                 AssertHeader(
@@ -412,7 +412,7 @@ namespace Datadog.Trace.TestHelpers
                             headerCollection.Add(header.Name, header.Value);
                         }
 
-                        RequestHeaders = RequestHeaders.Add(headerCollection);
+                        TraceRequestHeaders = TraceRequestHeaders.Add(headerCollection);
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
## Reason for change
Following #3154 getting merged into `master`, we noticed this test is failing fairly consistently (on around 80%-90% of CI builds). 
The likely culprit is an issue that may have already existed prior to that PR, but is now much more prevalent: certain requests that happen during startup (such as the request for `/info` for `DiscoveryService`) do not contain the `ContainerId` in the header. This created a race condition where depending on the order of requests, the test might flake out.

## Summary of changes
Ensure that the `ContainerTaggingTests.Http_Headers_Contain_ContainerId` test will only inspect requests that report **spans** to the `MockAgent`, but not any other requests. 
