### PR TITLE
Fix WindowsContainer tracing sample

### DIFF
--- a/tracer/samples/WindowsContainer/Pages/Shared/_Layout.cshtml
+++ b/tracer/samples/WindowsContainer/Pages/Shared/_Layout.cshtml
@@ -8,14 +8,6 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
 </head>
 <body>
-    <div>
-        @RenderBody()
-    </div>
-</body>
-</html>
-
-</head>
-<body>
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">

--- a/tracer/samples/WindowsContainer/docker-compose.yml
+++ b/tracer/samples/WindowsContainer/docker-compose.yml
@@ -13,8 +13,9 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
 
   datadog-agent:
-    image: "gcr.io/datadoghq/agent:7"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
+      DD_HOSTNAME: "windowscontainer-datadog-agent"
       DD_API_KEY: ${DD_API_KEY}
       DD_APM_ENABLED: "true"
       DD_APM_NON_LOCAL_TRAFFIC: "true"


### PR DESCRIPTION
## Summary of changes
Fix the C# build error and make required changes for datadog-agent to start properly on the latest Windows 11. After the changes, I am able to see traces in Datadog after following the steps in the sample's `README.md`

## Reason for change

## Implementation details

## Test coverage

## Other details
