### PR TITLE
Added integration tests to verify that the tracer still sends traces if the agent doesn't work properly.

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -1,0 +1,81 @@
+// <copyright file="AgentMalfunctionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [UsesVerify]
+    public class AgentMalfunctionTests : TestHelper
+    {
+        private static readonly Regex StackRegex = new(@"      error.stack:(\n|\r){1,2}.*(\n|\r){1,2}.*,(\r|\n){1,2}");
+        private static readonly Regex ErrorMsgRegex = new(@"      error.msg:.*,(\r|\n){1,2}");
+
+        public AgentMalfunctionTests(ITestOutputHelper output)
+            : base("ProcessStart", output)
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTracesWhenAgentDoesNotAnswer()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent();
+            agent.SetBehaviour(AgentBehaviour.NO_ANSWER);
+            TestInstrumentation(agent);
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTracesWhenAgentAnswersSlowly()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent();
+            agent.SetBehaviour(AgentBehaviour.SLOW_ANSWER);
+            TestInstrumentation(agent);
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTracesWhenAgentSendsWrongMessages()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent();
+            agent.SetBehaviour(AgentBehaviour.WRONG_ANSWER);
+            TestInstrumentation(agent);
+        }
+
+        private async void TestInstrumentation(MockTracerAgent agent)
+        {
+            const int expectedSpanCount = 5;
+            const string expectedOperationName = "command_execution";
+
+            using var process = RunSampleAndWaitForExit(agent);
+            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+            settings.AddRegexScrubber(StackRegex, string.Empty);
+            settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
+            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+            await VerifyHelper.VerifySpans(spans, settings)
+                              .UseFileName(filename)
+                              .DisableRequireUniquePrefix();
+
+            VerifyInstrumentation(process.Process);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -33,16 +33,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Tcp)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return404, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return500, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.WindowsNamedPipe)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.WindowsNamedPipe)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.WindowsNamedPipe)]
 #if NETCOREAPP3_1_OR_GREATER
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Uds)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Uds)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Uds)]
 #endif
         public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transport)
@@ -60,9 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var process = RunSampleAndWaitForExit(agent);
 
-            var timeout = behaviour == AgentBehaviour.SlowAnswer ? MockTracerAgent.SlowAnswerModeMiliseconds * 2 : 20000;
-
-            var spans = agent.WaitForSpans(expectedSpanCount, timeout, operationName: expectedOperationName);
+            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -59,6 +59,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             TestInstrumentation(agent);
         }
 
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTracesWhenAgentReturns404()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent();
+            agent.SetBehaviour(AgentBehaviour.RETURN_404);
+            TestInstrumentation(agent);
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTracesWhenAgentReturns500()
+        {
+            using var agent = EnvironmentHelper.GetMockAgent();
+            agent.SetBehaviour(AgentBehaviour.RETURN_500);
+            TestInstrumentation(agent);
+        }
+
         private async void TestInstrumentation(MockTracerAgent agent)
         {
             const int expectedSpanCount = 5;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -32,15 +32,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [InlineData(AgentBehaviour.Normal, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return404, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return500, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.Normal, TestTransports.WindowsNamedPipe)]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.WindowsNamedPipe)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.Return404, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.Return500, TestTransports.WindowsNamedPipe)]
 #if NETCOREAPP3_1_OR_GREATER
+        [InlineData(AgentBehaviour.Normal, TestTransports.Uds)]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Uds)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.Return404, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.Return500, TestTransports.Uds)]
 #endif
         public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transportType)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -32,13 +32,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(AgentBehaviour.NoAnswer)]
-        [InlineData(AgentBehaviour.SlowAnswer)]
-        [InlineData(AgentBehaviour.WrongAnswer)]
-        [InlineData(AgentBehaviour.Return404)]
-        [InlineData(AgentBehaviour.Return500)]
-        public void SubmitsTraces(AgentBehaviour behaviour)
+        [InlineData(AgentBehaviour.NoAnswer, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.Return404, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.Return500, TestTransports.Tcp)]
+        [InlineData(AgentBehaviour.NoAnswer, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.WrongAnswer, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.Return404, TestTransports.WindowsNamedPipe)]
+        [InlineData(AgentBehaviour.Return500, TestTransports.WindowsNamedPipe)]
+#if NETCOREAPP3_1_OR_GREATER
+        [InlineData(AgentBehaviour.NoAnswer, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.Return404, TestTransports.Uds)]
+        [InlineData(AgentBehaviour.Return500, TestTransports.Uds)]
+#endif
+        public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transport)
         {
+            EnvironmentHelper.EnableTransport(transport);
             using var agent = EnvironmentHelper.GetMockAgent();
             agent.SetBehaviour(behaviour);
             TestInstrumentation(agent);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -32,16 +32,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(AgentBehaviour.NO_ANSWER)
-        [InlineData(AgentBehaviour.SLOW_ANSWER)
-        [InlineData(AgentBehaviour.WRONG_ANSWER)
-        [InlineData(AgentBehaviour.RETURN_404)
-        [InlineData(AgentBehaviour.RETURN_500)
+        [InlineData(AgentBehaviour.NoAnswer)]
+        [InlineData(AgentBehaviour.SlowAnswer)]
+        [InlineData(AgentBehaviour.WrongAnswer)]
+        [InlineData(AgentBehaviour.Return404)]
+        [InlineData(AgentBehaviour.Return500)]
         public void SubmitsTraces(AgentBehaviour behaviour)
         {
             using var agent = EnvironmentHelper.GetMockAgent();
             agent.SetBehaviour(behaviour);
             TestInstrumentation(agent);
+        }
+
+        private async void TestInstrumentation(MockTracerAgent agent)
         {
             const int expectedSpanCount = 5;
             const string expectedOperationName = "command_execution";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -42,15 +42,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Uds)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Uds)]
 #endif
-        public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transport)
+        public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transportType)
         {
-            EnvironmentHelper.EnableTransport(transport);
+            if (transportType == TestTransports.WindowsNamedPipe && !EnvironmentTools.IsWindows())
+            {
+                throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
+            }
+
+            EnvironmentHelper.EnableTransport(transportType);
             using var agent = EnvironmentHelper.GetMockAgent();
             agent.SetBehaviour(behaviour);
-            TestInstrumentation(agent, behaviour);
+            TestInstrumentation(agent);
         }
 
-        private async void TestInstrumentation(MockTracerAgent agent, AgentBehaviour behaviour)
+        private async void TestInstrumentation(MockTracerAgent agent)
         {
             const int expectedSpanCount = 5;
             const string expectedOperationName = "command_execution";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -29,57 +29,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        [SkippableFact]
+        [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWhenAgentDoesNotAnswer()
+        [InlineData(AgentBehaviour.NO_ANSWER)
+        [InlineData(AgentBehaviour.SLOW_ANSWER)
+        [InlineData(AgentBehaviour.WRONG_ANSWER)
+        [InlineData(AgentBehaviour.RETURN_404)
+        [InlineData(AgentBehaviour.RETURN_500)
+        public void SubmitsTraces(AgentBehaviour behaviour)
         {
             using var agent = EnvironmentHelper.GetMockAgent();
-            agent.SetBehaviour(AgentBehaviour.NO_ANSWER);
+            agent.SetBehaviour(behaviour);
             TestInstrumentation(agent);
-        }
-
-        [SkippableFact]
-        [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWhenAgentAnswersSlowly()
-        {
-            using var agent = EnvironmentHelper.GetMockAgent();
-            agent.SetBehaviour(AgentBehaviour.SLOW_ANSWER);
-            TestInstrumentation(agent);
-        }
-
-        [SkippableFact]
-        [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWhenAgentSendsWrongMessages()
-        {
-            using var agent = EnvironmentHelper.GetMockAgent();
-            agent.SetBehaviour(AgentBehaviour.WRONG_ANSWER);
-            TestInstrumentation(agent);
-        }
-
-        [SkippableFact]
-        [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWhenAgentReturns404()
-        {
-            using var agent = EnvironmentHelper.GetMockAgent();
-            agent.SetBehaviour(AgentBehaviour.RETURN_404);
-            TestInstrumentation(agent);
-        }
-
-        [SkippableFact]
-        [Trait("Category", "EndToEnd")]
-        [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWhenAgentReturns500()
-        {
-            using var agent = EnvironmentHelper.GetMockAgent();
-            agent.SetBehaviour(AgentBehaviour.RETURN_500);
-            TestInstrumentation(agent);
-        }
-
-        private async void TestInstrumentation(MockTracerAgent agent)
         {
             const int expectedSpanCount = 5;
             const string expectedOperationName = "command_execution";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/AgentMalfunctionTests/AgentMalfunctionTests.cs
@@ -33,21 +33,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Tcp)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return404, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.Return500, TestTransports.Tcp)]
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.WindowsNamedPipe)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.WindowsNamedPipe)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.WindowsNamedPipe)]
-        [InlineData(AgentBehaviour.Return404, TestTransports.WindowsNamedPipe)]
-        [InlineData(AgentBehaviour.Return500, TestTransports.WindowsNamedPipe)]
 #if NETCOREAPP3_1_OR_GREATER
         [InlineData(AgentBehaviour.NoAnswer, TestTransports.Uds)]
-        [InlineData(AgentBehaviour.SlowAnswer, TestTransports.Uds)]
         [InlineData(AgentBehaviour.WrongAnswer, TestTransports.Uds)]
-        [InlineData(AgentBehaviour.Return404, TestTransports.Uds)]
-        [InlineData(AgentBehaviour.Return500, TestTransports.Uds)]
 #endif
         public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transport)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
@@ -10,31 +10,31 @@ namespace Datadog.Trace.TestHelpers
         /// <summary>
         /// Normal agent behaviour
         /// </summary>
-        NORMAL = 0,
+        Normal = 0,
 
         /// <summary>
         /// The agent doesn't answer
         /// </summary>
-        NO_ANSWER = 1,
+        NoAnswer = 1,
 
         /// <summary>
         /// The agent answers after a long time
         /// </summary>
-        SLOW_ANSWER = 2,
+        SlowAnswer = 2,
 
         /// <summary>
         /// The agent answers with wrong data
         /// </summary>
-        WRONG_ANSWER = 3,
+        WrongAnswer = 3,
 
         /// <summary>
         /// The agent answers with 404 code
         /// </summary>
-        RETURN_404 = 4,
+        Return404 = 4,
 
         /// <summary>
         /// The agent answers with 500 code
         /// </summary>
-        RETURN_500 = 5,
+        Return500 = 5,
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.TestHelpers
         RETURN_404 = 4,
 
         /// <summary>
-        /// The agent answers with 404 code
+        /// The agent answers with 500 code
         /// </summary>
         RETURN_500 = 5,
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
@@ -18,13 +18,23 @@ namespace Datadog.Trace.TestHelpers
         NO_ANSWER = 1,
 
         /// <summary>
-        /// The agent answer after a long time
+        /// The agent answers after a long time
         /// </summary>
         SLOW_ANSWER = 2,
 
         /// <summary>
-        /// The agent answer with wrong data
+        /// The agent answers with wrong data
         /// </summary>
         WRONG_ANSWER = 3,
+
+        /// <summary>
+        /// The agent answers with 404 code
+        /// </summary>
+        RETURN_404 = 4,
+
+        /// <summary>
+        /// The agent answers with 404 code
+        /// </summary>
+        RETURN_500 = 5,
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
@@ -13,28 +13,23 @@ namespace Datadog.Trace.TestHelpers
         Normal = 0,
 
         /// <summary>
-        /// The agent doesn't answer
+        /// The agent doesn't answer, causing timeout
         /// </summary>
         NoAnswer = 1,
 
         /// <summary>
-        /// The agent answers after a long time
-        /// </summary>
-        SlowAnswer = 2,
-
-        /// <summary>
         /// The agent answers with wrong data
         /// </summary>
-        WrongAnswer = 3,
+        WrongAnswer = 2,
 
         /// <summary>
         /// The agent answers with 404 code
         /// </summary>
-        Return404 = 4,
+        Return404 = 3,
 
         /// <summary>
         /// The agent answers with 500 code
         /// </summary>
-        Return500 = 5,
+        Return500 = 4,
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AgentBehaviour.cs
@@ -1,0 +1,30 @@
+// <copyright file="AgentBehaviour.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.TestHelpers
+{
+    public enum AgentBehaviour
+    {
+        /// <summary>
+        /// Normal agent behaviour
+        /// </summary>
+        NORMAL = 0,
+
+        /// <summary>
+        /// The agent doesn't answer
+        /// </summary>
+        NO_ANSWER = 1,
+
+        /// <summary>
+        /// The agent answer after a long time
+        /// </summary>
+        SLOW_ANSWER = 2,
+
+        /// <summary>
+        /// The agent answer with wrong data
+        /// </summary>
+        WRONG_ANSWER = 3,
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -826,14 +826,20 @@ namespace Datadog.Trace.TestHelpers
                                 ctx.Response.AddHeader("Datadog-Agent-Version", Version);
                             }
 
-                            byte[] buffer;
-                            if (behaviour == AgentBehaviour.WRONG_ANSWER)
+                            var response = HandleHttpRequest(MockHttpParser.MockHttpRequest.Create(ctx.Request));
+                            var buffer = behaviour == AgentBehaviour.WRONG_ANSWER ? Encoding.UTF8.GetBytes("WRONG DATA") : Encoding.UTF8.GetBytes(response);
+
+                            if (!ctx.Request.RawUrl.ToLower().Contains("/traces"))
                             {
-                                buffer = Encoding.UTF8.GetBytes("WRONG DATA");
-                            }
-                            else
-                            {
-                                buffer = Encoding.UTF8.GetBytes(HandleHttpRequest(MockHttpParser.MockHttpRequest.Create(ctx.Request)));
+                                if (behaviour == AgentBehaviour.RETURN_404)
+                                {
+                                    ctx.Response.StatusCode = 404;
+                                }
+
+                                if (behaviour == AgentBehaviour.RETURN_500)
+                                {
+                                    ctx.Response.StatusCode = 500;
+                                }
                             }
 
                             ctx.Response.ContentType = "application/json";

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -31,6 +31,8 @@ namespace Datadog.Trace.TestHelpers
 {
     public abstract class MockTracerAgent : IDisposable
     {
+        public const int SlowAnswerModeMiliseconds = 80000;
+
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         private AgentBehaviour behaviour = AgentBehaviour.Normal;
@@ -415,7 +417,7 @@ namespace Datadog.Trace.TestHelpers
 
                 if (behaviour == AgentBehaviour.SlowAnswer)
                 {
-                    System.Threading.Thread.Sleep(120000);
+                    System.Threading.Thread.Sleep(SlowAnswerModeMiliseconds);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -613,7 +613,7 @@ namespace Datadog.Trace.TestHelpers
             404 => "404 Not Found",
             500 => "500 Internal Server Error",
             _ => status.ToString(),
-        }
+        };
 
         private byte[] GetResponseBytes(string body, int status)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -869,11 +869,7 @@ namespace Datadog.Trace.TestHelpers
                                 ctx.Response.ContentType = "application/json";
                                 ctx.Response.ContentLength64 = buffer.LongLength;
                                 ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
-
-                                if (mockTracerResponse.SendResponse)
-                                {
-                                    ctx.Response.Close();
-                                }
+                                ctx.Response.Close();
                             }
                         }
                         catch (Exception ex)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -607,19 +607,12 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-        private string GetStatusString(int status)
+        private string GetStatusString(int status) => status switch
         {
-            switch (status)
-            {
-                case 200:
-                    return "200 OK";
-                case 404:
-                    return "404 Not Found";
-                case 500:
-                    return "500 Internal Server Error";
-                default:
-                    return status.ToString();
-            }
+            200 => "200 OK",
+            404 => "404 Not Found",
+            500 => "500 Internal Server Error",
+            _ => status.ToString(),
         }
 
         private byte[] GetResponseBytes(string body, int status)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -847,7 +847,7 @@ namespace Datadog.Trace.TestHelpers
 
                             if (behaviour == AgentBehaviour.SlowAnswer)
                             {
-                                System.Threading.Thread.Sleep(10000);
+                                System.Threading.Thread.Sleep(120000);
                             }
 
                             if (behaviour != AgentBehaviour.NoAnswer)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -412,11 +412,11 @@ namespace Datadog.Trace.TestHelpers
 
                 sendResponse = behaviour != AgentBehaviour.NoAnswer;
                 statusCode = behaviour == AgentBehaviour.Return500 ? 500 : (behaviour == AgentBehaviour.Return404 ? 404 : 200);
-            }
 
-            if (behaviour == AgentBehaviour.SlowAnswer)
-            {
-                System.Threading.Thread.Sleep(10000);
+                if (behaviour == AgentBehaviour.SlowAnswer)
+                {
+                    System.Threading.Thread.Sleep(120000);
+                }
             }
 
             return new MockTracerResponse()
@@ -865,7 +865,12 @@ namespace Datadog.Trace.TestHelpers
                             if (mockTracerResponse.SendResponse)
                             {
                                 var buffer = Encoding.UTF8.GetBytes(mockTracerResponse.Response);
-                                ctx.Response.StatusCode = mockTracerResponse.StatusCode;
+
+                                if (ctx.Response.StatusCode == 200)
+                                {
+                                    ctx.Response.StatusCode = mockTracerResponse.StatusCode;
+                                }
+
                                 ctx.Response.ContentType = "application/json";
                                 ctx.Response.ContentLength64 = buffer.LongLength;
                                 ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.TestHelpers
     {
         private readonly CancellationTokenSource _cancellationTokenSource = new();
 
-        private AgentBehaviour behaviour = AgentBehaviour.NORMAL;
+        private AgentBehaviour behaviour = AgentBehaviour.Normal;
 
         protected MockTracerAgent(bool telemetryEnabled, TestTransports transport)
         {
@@ -827,16 +827,16 @@ namespace Datadog.Trace.TestHelpers
                             }
 
                             var response = HandleHttpRequest(MockHttpParser.MockHttpRequest.Create(ctx.Request));
-                            var buffer = behaviour == AgentBehaviour.WRONG_ANSWER ? Encoding.UTF8.GetBytes("WRONG DATA") : Encoding.UTF8.GetBytes(response);
+                            var buffer = behaviour == AgentBehaviour.WrongAnswer ? Encoding.UTF8.GetBytes("WRONG DATA") : Encoding.UTF8.GetBytes(response);
 
                             if (!ctx.Request.RawUrl.ToLower().Contains("/traces"))
                             {
-                                if (behaviour == AgentBehaviour.RETURN_404)
+                                if (behaviour == AgentBehaviour.Return404)
                                 {
                                     ctx.Response.StatusCode = 404;
                                 }
 
-                                if (behaviour == AgentBehaviour.RETURN_500)
+                                if (behaviour == AgentBehaviour.Return500)
                                 {
                                     ctx.Response.StatusCode = 500;
                                 }
@@ -845,12 +845,12 @@ namespace Datadog.Trace.TestHelpers
                             ctx.Response.ContentType = "application/json";
                             ctx.Response.ContentLength64 = buffer.LongLength;
 
-                            if (behaviour == AgentBehaviour.SLOW_ANSWER)
+                            if (behaviour == AgentBehaviour.SlowAnswer)
                             {
                                 System.Threading.Thread.Sleep(10000);
                             }
 
-                            if (behaviour != AgentBehaviour.NO_ANSWER)
+                            if (behaviour != AgentBehaviour.NoAnswer)
                             {
                                 ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
                             }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerResponse.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerResponse.cs
@@ -1,0 +1,16 @@
+// <copyright file="MockTracerResponse.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class MockTracerResponse
+    {
+        public int StatusCode { get; set; } = 200;
+
+        public string Response { get; set; }
+
+        public bool SendResponse { get; set; } = true;
+    }
+}


### PR DESCRIPTION
## Summary of changes

Some new integration tests have been added to verify that the tracer still sends traces even if the agent doesn't answer, answers with a significative delay, sends 404 or 500 codes in the response or sends wrong data.

## Reason for change

Being able to make sure that the tracer can handle these agent malfunctions.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
