### PR TITLE
Don't overwrite the origin

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -393,7 +393,12 @@ namespace Datadog.Trace.AppSec
                 span.SetTag(Tags.ActorIp, clientIp);
             }
 
-            span.SetTag(Tags.Origin, "appsec");
+            var origin = span.GetTag(Tags.Origin);
+            if (origin == null)
+            {
+                span.SetTag(Tags.Origin, "appsec");
+            }
+
             span.SetTag(Tags.AppSecRuleFileVersion, _waf.InitializationResult.RuleFileVersion);
             span.SetMetric(Metrics.AppSecWafDuration, result.AggregatedTotalRuntime);
             span.SetMetric(Metrics.AppSecWafAndBindingsDuration, result.AggregatedTotalRuntimeWithBindings);


### PR DESCRIPTION
## Summary of changes

Don't overwrite the origin if it's already set.

## Reason for change

The origin could be set to 'RUM' or 'Synthetics', we should not overwrite this value.  
