### PR TITLE
[Testing] Improve span metadata rules

### DIFF
--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -22,7 +22,7 @@ jobs:
       - name: "Regenerate docs/span_metadata.md"
         run: .\tracer\build.ps1 GenerateSpanDocumentation
 
-      - name: "Verify no changes in generated files"
+      - name: "Verify no changes in docs/span_metadata.md"
         run: |
           git diff --quiet -- .\docs\span_metadata.md
           if ($LASTEXITCODE -eq 1) {

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify_source_generators:
+  verify_span_metadata:
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -1,0 +1,34 @@
+name: Verify docs/span_metadata.md is updated
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  verify_source_generators:
+    runs-on: windows-latest
+
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.100'
+
+      - name: "Regenerate docs/span_metadata.md"
+        run: .\tracer\build.ps1 GenerateSpanDocumentation
+
+      - name: "Verify no changes in generated files"
+        run: |
+          git diff --quiet -- .\docs\span_metadata.md
+          if ($LASTEXITCODE -eq 1) {
+            git diff -- .\docs\span_metadata.md
+            Write-Error "Found changes in docs/span_metadata.md file. Run build task GenerateSpanDocumentation to regenerate the file with the latest C# rules."
+            Exit 1
+          } else {
+            echo "No changes found to docs/span_metadata.md file"
+          }

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -13,10 +13,11 @@ Creating a new instrumentation implementation typically uses the following proce
 5. (Optional) Create duck-typing unit tests in _Datadog.Trace.Tests_ to confirm any duck types are valid. This can make the feedback cycle much faster than relying on integration tests
 6. Create integration tests for your instrumentation 
    1. Create (or reuse) a sample application that uses the target library, which ideally exercises all the code paths in your new instrumentation. Use an `$(ApiVersion)` MSBuild variables to allow testing against multiple package versions in CI. 
-   2. Add an entry in [tracer/build/PackageVersionsGeneratorDefinitions.json](../../tracer/build/PackageVersionsGeneratorDefinitions.json) defining the range of all supported versions. See the existing definitions for examples. You may need to add an entry in the [tracer/build/Honeypot/IntegrationGroups.cs](../../tracer/build//Honeypot/IntegrationGroups.cs) to specify the Nuget Package instrumented by the integration. 
-   3. Run `./tracer/build.ps1 GeneratePackageVersions`. This generates the xunit test data for package versions in the `TestData` that you can use as `[MemberData]` for your `[Theory]` tests. 
-   4. If needed, add a docker image in the docker-compose.yml to allow the CI to test against it. Locally, you can use docker-compose as well and start only the dependencies you need.
-   5. Use the `MockTracerAgent` to confirm your instrumentation is working as expected.
+   2. Add a new entry in the [SpanMetadataRules file](../../tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs) that defines the expected Name, Type, and Tags for the new integration spans, and run build target `GenerateSpanDocumentation` to generate the updated Markdown file.
+   3. Add an entry in [tracer/build/PackageVersionsGeneratorDefinitions.json](../../tracer/build/PackageVersionsGeneratorDefinitions.json) defining the range of all supported versions. See the existing definitions for examples. You may need to add an entry in the [tracer/build/Honeypot/IntegrationGroups.cs](../../tracer/build//Honeypot/IntegrationGroups.cs) to specify the Nuget Package instrumented by the integration. 
+   4. Run `./tracer/build.ps1 GeneratePackageVersions`. This generates the xunit test data for package versions in the `TestData` that you can use as `[MemberData]` for your `[Theory]` tests. 
+   5. If needed, add a docker image in the docker-compose.yml to allow the CI to test against it. Locally, you can use docker-compose as well and start only the dependencies you need.
+   6. Use the `MockTracerAgent` and the newly defined `SpanMetadataRules` method in your integration test to confirm your instrumentation is working as expected.
 7. After testing locally, push to GitHub, and do a manual run in Azure Devops for your branch
    1. Navigate to the [consolidated-pipeline](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build?definitionId=54)
    2. Click `Run Pipeline`

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -509,6 +509,7 @@ Type | `http`
 Name | Required |
 ---------|----------------|
 component | `HttpMessageHandler`; `WebRequest`
+http-client-handler-type | No
 http.method | Yes
 http.status_code | Yes
 http.url | Yes

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -160,10 +160,10 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-b.type | `cosmosdb`
 component | `CosmosDb`
 cosmosdb.container | No
 db.name | No
+db.type | `cosmosdb`
 out.host | Yes
 span.kind | `client`
 

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -38,10 +38,14 @@ Type | `web`
 ### Tags
 Name | Required |
 ---------|----------------|
+http.client_ip | Yes
 http.method | Yes
 http.request.headers.host | Yes
+http.route | No
 http.status_code | Yes
 http.url | Yes
+http.useragent | Yes
+network.client.ip | Yes
 span.kind | `server`
 
 ## AspNetMvc
@@ -61,6 +65,7 @@ http.method | Yes
 http.request.headers.host | Yes
 http.status_code | Yes
 http.url | Yes
+http.useragent | Yes
 span.kind | `server`
 
 ## AspNetWebApi2
@@ -75,9 +80,14 @@ Name | Required |
 aspnet.action | No
 aspnet.controller | No
 aspnet.route | Yes
+http.client_ip | No
 http.method | Yes
 http.request.headers.host | Yes
+http.route | No
+http.status_code | No
 http.url | Yes
+http.useragent | Yes
+network.client.ip | No
 span.kind | `server`
 
 ## AspNetCore
@@ -92,10 +102,14 @@ Name | Required |
 aspnet_core.endpoint | No
 aspnet_core.route | No
 component | `aspnet_core`
+http.client_ip | Yes
 http.method | Yes
 http.request.headers.host | Yes
+http.route | No
 http.status_code | Yes
 http.url | Yes
+http.useragent | Yes
+network.client.ip | Yes
 span.kind | `server`
 
 ## AspNetCoreMvc
@@ -111,6 +125,7 @@ aspnet_core.action | Yes
 aspnet_core.area | No
 aspnet_core.controller | Yes
 aspnet_core.page | No
+aspnet_core.route | Yes
 component | `aspnet_core`
 span.kind | `server`
 
@@ -217,6 +232,21 @@ grpc.method.service | Yes
 grpc.status.code | Yes
 span.kind | `client`; `server`
 
+## HotChocolate
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `graphql.execute`; `graphql.validate`
+Type | `graphql`
+### Tags
+Name | Required |
+---------|----------------|
+component | `HotChocolate`
+graphql.operation.name | No
+graphql.operation.type | No
+graphql.source | Yes
+span.kind | `server`
+
 ## HttpMessageHandler
 ### Span properties
 Name | Required |
@@ -243,6 +273,7 @@ Type | `queue`
 Name | Required |
 ---------|----------------|
 component | `kafka`
+kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
@@ -294,6 +325,8 @@ Name | Required |
 component | `MySql`
 db.name | Yes
 db.type | `mysql`
+db.user | Yes
+out.host | Yes
 span.kind | `client`
 
 ## Npgsql
@@ -308,6 +341,7 @@ Name | Required |
 component | `Npgsql`
 db.name | Yes
 db.type | `postgres`
+out.host | Yes
 span.kind | `client`
 
 ## Oracle
@@ -323,6 +357,18 @@ component | `Oracle`
 db.name | Yes
 db.type | `oracle`
 span.kind | `client`
+
+## Process
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `command_execution`
+Type | `system`
+### Tags
+Name | Required |
+---------|----------------|
+cmd.environment_variables | No
+span.kind | `internal`
 
 ## RabbitMQ
 ### Span properties
@@ -420,6 +466,7 @@ Name | Required |
 component | `Sqlite`
 db.name | No
 db.type | `sqlite`
+out.host | Yes
 span.kind | `client`
 
 ## SqlClient
@@ -434,6 +481,7 @@ Name | Required |
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`
+out.host | Yes
 span.kind | `client`
 
 ## Wcf
@@ -446,6 +494,8 @@ Type | `web`
 Name | Required |
 ---------|----------------|
 component | `Wcf`
+http.method | No
+http.request.headers.host | No
 http.url | Yes
 span.kind | `server`
 

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -38,14 +38,10 @@ Type | `web`
 ### Tags
 Name | Required |
 ---------|----------------|
-http.client_ip | Yes
 http.method | Yes
 http.request.headers.host | Yes
-http.route | No
 http.status_code | Yes
 http.url | Yes
-http.useragent | Yes
-network.client.ip | Yes
 span.kind | `server`
 
 ## AspNetMvc
@@ -65,7 +61,6 @@ http.method | Yes
 http.request.headers.host | Yes
 http.status_code | Yes
 http.url | Yes
-http.useragent | Yes
 span.kind | `server`
 
 ## AspNetWebApi2
@@ -80,14 +75,9 @@ Name | Required |
 aspnet.action | No
 aspnet.controller | No
 aspnet.route | Yes
-http.client_ip | No
 http.method | Yes
 http.request.headers.host | Yes
-http.route | No
-http.status_code | No
 http.url | Yes
-http.useragent | Yes
-network.client.ip | No
 span.kind | `server`
 
 ## AspNetCore
@@ -102,14 +92,10 @@ Name | Required |
 aspnet_core.endpoint | No
 aspnet_core.route | No
 component | `aspnet_core`
-http.client_ip | Yes
 http.method | Yes
 http.request.headers.host | Yes
-http.route | No
 http.status_code | Yes
 http.url | Yes
-http.useragent | Yes
-network.client.ip | Yes
 span.kind | `server`
 
 ## AspNetCoreMvc
@@ -125,7 +111,6 @@ aspnet_core.action | Yes
 aspnet_core.area | No
 aspnet_core.controller | Yes
 aspnet_core.page | No
-aspnet_core.route | Yes
 component | `aspnet_core`
 span.kind | `server`
 
@@ -232,21 +217,6 @@ grpc.method.service | Yes
 grpc.status.code | Yes
 span.kind | `client`; `server`
 
-## HotChocolate
-### Span properties
-Name | Required |
----------|----------------|
-Name | `graphql.execute`; `graphql.validate`
-Type | `graphql`
-### Tags
-Name | Required |
----------|----------------|
-component | `HotChocolate`
-graphql.operation.name | No
-graphql.operation.type | No
-graphql.source | Yes
-span.kind | `server`
-
 ## HttpMessageHandler
 ### Span properties
 Name | Required |
@@ -273,7 +243,6 @@ Type | `queue`
 Name | Required |
 ---------|----------------|
 component | `kafka`
-kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
@@ -325,8 +294,6 @@ Name | Required |
 component | `MySql`
 db.name | Yes
 db.type | `mysql`
-db.user | Yes
-out.host | Yes
 span.kind | `client`
 
 ## Npgsql
@@ -341,7 +308,6 @@ Name | Required |
 component | `Npgsql`
 db.name | Yes
 db.type | `postgres`
-out.host | Yes
 span.kind | `client`
 
 ## Oracle
@@ -357,18 +323,6 @@ component | `Oracle`
 db.name | Yes
 db.type | `oracle`
 span.kind | `client`
-
-## Process
-### Span properties
-Name | Required |
----------|----------------|
-Name | `command_execution`
-Type | `system`
-### Tags
-Name | Required |
----------|----------------|
-cmd.environment_variables | No
-span.kind | `internal`
 
 ## RabbitMQ
 ### Span properties
@@ -466,7 +420,6 @@ Name | Required |
 component | `Sqlite`
 db.name | No
 db.type | `sqlite`
-out.host | Yes
 span.kind | `client`
 
 ## SqlClient
@@ -481,7 +434,6 @@ Name | Required |
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`
-out.host | Yes
 span.kind | `client`
 
 ## Wcf
@@ -494,8 +446,6 @@ Type | `web`
 Name | Required |
 ---------|----------------|
 component | `Wcf`
-http.method | No
-http.request.headers.host | No
 http.url | Yes
 span.kind | `server`
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -50,11 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var frameworkName = "NetCore";
 #endif
                 var spans = agent.WaitForSpans(expectedCount);
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AWS.SQS-sqs");
 
                 var host = Environment.GetEnvironmentVariable("AWS_SQS_HOST");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -50,7 +50,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var frameworkName = "NetCore";
 #endif
                 var spans = agent.WaitForSpans(expectedCount);
-                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AWS.SQS-sqs");
+                foreach (var span in spans)
+                {
+                    // TODO: Refactor to use ValidateIntegrationSpans later once we figure out how to best handle the combination of "http-client" and "sqs" service names produced by the integration
+                    var result = ValidateIntegrationSpan(span);
+                    Assert.True(result.Success, result.ToString());
+                }
 
                 var host = Environment.GetEnvironmentVariable("AWS_SQS_HOST");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             SetServiceVersion("1.0.0");
         }
 
+        // Assert Npgsql because the Dapper application uses Postgres for the actual client
         public override Result ValidateIntegrationSpan(MockSpan span) => span.IsNpgsql();
 
         [SkippableFact]
@@ -34,17 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
-
-                foreach (var span in spans)
-                {
-                    // Assert Npgsql because the Dapper application uses Postgres for the actual client
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal(expectedOperationName, span.Name);
-                    Assert.Equal(expectedServiceName, span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             }
         }
 
@@ -62,17 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
-
-                foreach (var span in spans)
-                {
-                    // Assert Npgsql because the Dapper application uses Postgres for the actual client
-                    var result = span.IsNpgsql();
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal(expectedOperationName, span.Name);
-                    Assert.Equal(expectedServiceName, span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -10,13 +10,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class DapperTests : TestHelper
+    public class DapperTests : TracingIntegrationTest
     {
         public DapperTests(ITestOutputHelper output)
             : base("Dapper", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsNpgsql();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -36,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 foreach (var span in spans)
                 {
                     // Assert Npgsql because the Dapper application uses Postgres for the actual client
-                    var result = span.IsNpgsql();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal(expectedOperationName, span.Name);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -11,13 +11,15 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
-    public class FakeCommandTests : TestHelper
+    public class FakeCommandTests : TracingIntegrationTest
     {
         public FakeCommandTests(ITestOutputHelper output)
             : base("FakeDbCommand", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsAdoNet();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -47,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsAdoNet();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedOperationName, span.Name);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -46,15 +46,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
 
             foreach (var span in spans)
             {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
                 Assert.Equal(expectedOperationName, span.Name);
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
             }
 
             telemetry.AssertIntegrationEnabled(IntegrationId.AdoNet);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -69,16 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -13,13 +13,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class MicrosoftDataSqlClientTests : TestHelper
+    public class MicrosoftDataSqlClientTests : TracingIntegrationTest
     {
         public MicrosoftDataSqlClientTests(ITestOutputHelper output)
             : base("Microsoft.Data.SqlClient", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsSqlClient();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MicrosoftDataSqlClient), MemberType = typeof(PackageVersions))]
@@ -70,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsSqlClient();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -49,15 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
 
             telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -12,13 +12,15 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
-    public class MicrosoftDataSqliteTests : TestHelper
+    public class MicrosoftDataSqliteTests : TracingIntegrationTest
     {
         public MicrosoftDataSqliteTests(ITestOutputHelper output)
             : base("Microsoft.Data.Sqlite", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsSqlite();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MicrosoftDataSqlite), MemberType = typeof(PackageVersions))]
@@ -50,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsSqlite();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -120,16 +120,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class MySqlCommandTests : TestHelper
+    public class MySqlCommandTests : TracingIntegrationTest
     {
         public MySqlCommandTests(ITestOutputHelper output)
             : base("MySql", output)
@@ -47,6 +47,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 yield return item;
             }
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMySql();
 
         [SkippableTheory]
         [MemberData(nameof(GetMySql8Data))]
@@ -121,7 +123,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsMySql();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -13,13 +13,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class MySqlConnectorTests : TestHelper
+    public class MySqlConnectorTests : TracingIntegrationTest
     {
         public MySqlConnectorTests(ITestOutputHelper output)
             : base("MySqlConnector", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMySql();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MySqlConnector), MemberType = typeof(PackageVersions))]
@@ -56,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsMySql();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -55,16 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)); // Remove unexpected DB spans from the calculation
 
             Assert.Equal(expectedSpanCount, actualSpanCount);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -54,16 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             // Assert.Equal(expectedSpanCount, spans.Count); // Assert an exact match once we can correctly instrument the generic constraint case
             Assert.Equal(expectedSpanCount, actualSpanCount);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.Npgsql);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -12,13 +12,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class NpgsqlCommandTests : TestHelper
+    public class NpgsqlCommandTests : TracingIntegrationTest
     {
         public NpgsqlCommandTests(ITestOutputHelper output)
             : base("Npgsql", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsNpgsql();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.Npgsql), MemberType = typeof(PackageVersions))]
@@ -55,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsNpgsql();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -38,16 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -12,13 +12,15 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
-    public class SqlCommand20Tests : TestHelper
+    public class SqlCommand20Tests : TracingIntegrationTest
     {
         public SqlCommand20Tests(ITestOutputHelper output)
         : base("SqlServer.NetFramework20", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsSqlClient();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -39,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsSqlClient();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -60,16 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -14,13 +14,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class SystemDataSqlClientTests : TestHelper
+    public class SystemDataSqlClientTests : TracingIntegrationTest
     {
         public SystemDataSqlClientTests(ITestOutputHelper output)
             : base("SqlServer", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsSqlClient();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.SystemDataSqlClient), MemberType = typeof(PackageVersions))]
@@ -61,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsSqlClient();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -11,13 +11,15 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 {
-    public class SystemDataSqliteTests : TestHelper
+    public class SystemDataSqliteTests : TracingIntegrationTest
     {
         public SystemDataSqliteTests(ITestOutputHelper output)
             : base("SQLite.Core", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsSqlite();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -39,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             foreach (var span in spans)
             {
-                var result = span.IsSqlite();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -38,16 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                Assert.Equal(expectedServiceName, span.Service);
-                Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-            }
-
+            ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
             telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -17,13 +17,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class AerospikeTests : TestHelper
+    public class AerospikeTests : TracingIntegrationTest
     {
         public AerospikeTests(ITestOutputHelper output)
             : base("Aerospike", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsAerospike();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.Aerospike), MemberType = typeof(PackageVersions))]
@@ -42,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 spans.Count.Should().Be(expectedSpanCount);
                 foreach (var span in spans)
                 {
-                    var result = span.IsAerospike();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -42,11 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Aerospike-aerospike");
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetAsyncHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetAsyncHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNet
         }
     }
 
-    public abstract class AspNetAsyncHandlerTests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetAsyncHandlerTests : TracingIntegrationTest, IClassFixture<IisFixture>
     {
         private readonly IisFixture _iisFixture;
 
@@ -40,6 +40,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNet
             _iisFixture.ShutdownPath = "/shutdown";
             _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "aspnet.request" => span.IsAspNet(),
+                "aspnet-mvc.request" => span.IsAspNetMvc(),
+                _ => Result.DefaultSuccess,
+            };
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [UsesVerify]
-    public abstract class AspNetMvc4Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc4Tests : TracingIntegrationTest, IClassFixture<IisFixture>
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -107,6 +107,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
               { "/graphql/GetAllFoo", 200 }, // Slug in route template
         };
 
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "aspnet.request" => span.IsAspNet(),
+                "aspnet-mvc.request" => span.IsAspNetMvc(),
+                _ => Result.DefaultSuccess,
+            };
+
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
@@ -122,18 +130,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode);
-
-            var aspnetSpans = spans.Where(s => s.Name == "aspnet.request");
-            foreach (var aspnetSpan in aspnetSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetSpan.IsAspNet();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetMvcSpans = spans.Where(s => s.Name == "aspnet-mvc.request");
-            foreach (var aspnetMvcSpan in aspnetMvcSpans)
-            {
-                var result = aspnetMvcSpan.IsAspNetMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -130,11 +130,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "sample", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [UsesVerify]
-    public abstract class AspNetMvc5QueryStringTests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5QueryStringTests : TracingIntegrationTest, IClassFixture<IisFixture>
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -58,6 +58,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         public static TheoryData<string, int> Data => new() { { "/?authentic1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2", 200 }, };
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "aspnet.request" => span.IsAspNet(),
+                "aspnet-mvc.request" => span.IsAspNetMvc(),
+                _ => Result.DefaultSuccess,
+            };
 
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -71,6 +71,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: true)
         {
         }
+
+        protected override string ExpectedServiceName => "sample/my-app";
     }
 
     [Collection("IisTests")]
@@ -160,6 +162,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/graphql/GetAllFoo", 200 }, // Slug in route template
         };
 
+        protected virtual string ExpectedServiceName => "sample";
+
         public override Result ValidateIntegrationSpan(MockSpan span) =>
             span.Name switch
             {
@@ -184,11 +188,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             // Append virtual directory to the actual request
             var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: ExpectedServiceName, isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -70,6 +70,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 : base(iisFixture, output, virtualApp: true, classicMode: false, enableRouteTemplateResourceNames: true)
             {
             }
+
+            protected override string ExpectedServiceName => "sample/my-app";
         }
 
         [Collection("IisTests")]
@@ -137,6 +139,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         (enableRouteTemplateResourceNames ?  ".WithFF" : ".NoFF"));
         }
 
+        protected virtual string ExpectedServiceName => "sample";
+
         public static TheoryData<string, int, int> Data() => new()
         {
             { "/api/environment", 200, 2 },
@@ -202,11 +206,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             // Append virtual directory to the actual request
             var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: ExpectedServiceName, isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -87,11 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                    .ToList();
 
             Assert.True(allSpans.Count > 0, "Expected there to be spans.");
-            foreach (var span in allSpans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(allSpans, expectedServiceName: "sample", isExternalSpan: false);
 
             var elasticSpans = allSpans
                              .Where(s => s.Type == "elasticsearch")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -125,11 +125,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             await _fixture.TryStartApp(this, _output);
 
             var spans = await _fixture.WaitForSpans(Output, path, expectedSpanCount);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Owin.WebApi2", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
@@ -74,18 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
@@ -58,18 +58,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
@@ -74,18 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
@@ -74,18 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             // We actually sometimes expect 2, but waiting for 1 is good enough
             var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
     [UsesVerify]
-    public abstract class AspNetCoreIisMvcTestBase : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetCoreIisMvcTestBase : TracingIntegrationTest, IClassFixture<IisFixture>
     {
         private readonly bool _inProcess;
         private readonly bool _enableRouteTemplateResourceNames;
@@ -51,6 +51,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             { "/branch/not-found", 404 },
             { "/handled-exception", 500 },
         };
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Type switch
+            {
+                "aspnet_core.request" => span.IsAspNetCore(),
+                "aspnet_core_mvc.request" => span.IsAspNetCoreMvc(),
+                _ => Result.DefaultSuccess,
+            };
 
         protected string GetTestName(string testName)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -51,18 +51,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -51,11 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AspNetCoreMinimalApis", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -6,6 +6,7 @@
 #if NETCOREAPP2_1
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -55,7 +56,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
             foreach (var aspnetCoreSpan in aspnetCoreSpans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
+                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
+                    {
+                        "datadog-header-tag",
+                        "http.request.headers.sample_correlation_identifier",
+                        "http.response.headers.sample_correlation_identifier",
+                        "http.response.headers.server",
+                    });
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -52,24 +52,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
-                    {
-                        "datadog-header-tag",
-                        "http.request.headers.sample_correlation_identifier",
-                        "http.response.headers.sample_correlation_identifier",
-                        "http.response.headers.server",
-                    });
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -52,11 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AspNetCoreMvc21", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -52,11 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AspNetCoreMvc30", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -52,24 +52,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
-                    {
-                        "datadog-header-tag",
-                        "http.request.headers.sample_correlation_identifier",
-                        "http.response.headers.sample_correlation_identifier",
-                        "http.response.headers.server",
-                    });
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -6,6 +6,7 @@
 #if NETCOREAPP3_0
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -55,7 +56,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
             foreach (var aspnetCoreSpan in aspnetCoreSpans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
+                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
+                    {
+                        "datadog-header-tag",
+                        "http.request.headers.sample_correlation_identifier",
+                        "http.response.headers.sample_correlation_identifier",
+                        "http.response.headers.server",
+                    });
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -52,24 +52,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-
-            var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
-            foreach (var aspnetCoreSpan in aspnetCoreSpans)
+            foreach (var span in spans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
-                    {
-                        "datadog-header-tag",
-                        "http.request.headers.sample_correlation_identifier",
-                        "http.response.headers.sample_correlation_identifier",
-                        "http.response.headers.server",
-                    });
-                Assert.True(result.Success, result.ToString());
-            }
-
-            var aspnetCoreMvcSpans = spans.Where(s => s.Name == "aspnet_core_mvc.request");
-            foreach (var aspnetCoreMvcSpan in aspnetCoreMvcSpans)
-            {
-                var result = aspnetCoreMvcSpan.IsAspNetCoreMvc();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -52,11 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.AspNetCoreMvc31", isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -6,6 +6,7 @@
 #if NETCOREAPP3_1
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -55,7 +56,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             var aspnetCoreSpans = spans.Where(s => s.Name == "aspnet_core.request");
             foreach (var aspnetCoreSpan in aspnetCoreSpans)
             {
-                var result = aspnetCoreSpan.IsAspNetCore();
+                var result = aspnetCoreSpan.IsAspNetCore(excludeTags: new HashSet<string>
+                    {
+                        "datadog-header-tag",
+                        "http.request.headers.sample_correlation_identifier",
+                        "http.response.headers.sample_correlation_identifier",
+                        "http.response.headers.server",
+                    });
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
@@ -43,11 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await fixture.TryStartApp(this);
 
             var spans = await fixture.WaitForSpans(path, true);
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(spans, expectedServiceName: EnvironmentHelper.FullSampleName, isExternalSpan: false);
 
             var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -60,15 +60,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 var dbTags = 0;
                 var containerTags = 0;
+                ValidateIntegrationSpans(spans, expectedServiceName: ExpectedServiceName);
 
                 foreach (var span in spans)
                 {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    span.Service.Should().Be(ExpectedServiceName);
                     span.Resource.Should().StartWith("SELECT * FROM");
-                    span.Tags.Should().NotContain(Tags.Version, "External service span should not have service version tag.");
 
                     if (span.Tags.ContainsKey(Tags.CosmosDbContainer))
                     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class CosmosTests : TestHelper
+    public class CosmosTests : TracingIntegrationTest
     {
         private const string ExpectedOperationName = "cosmosdb.query";
         private const string ExpectedServiceName = "Samples.CosmosDb-cosmosdb";
@@ -31,6 +31,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var processResult = RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}");
             }
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsCosmosDb();
 
         [SkippableTheory(Skip = "Cosmos emulator is too flaky at the moment")]
         [MemberData(nameof(PackageVersions.CosmosDb), MemberType = typeof(PackageVersions))]
@@ -61,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsCosmosDb();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     span.Service.Should().Be(ExpectedServiceName);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class Couchbase3Tests : TestHelper
+    public class Couchbase3Tests : TracingIntegrationTest
     {
         public Couchbase3Tests(ITestOutputHelper output)
             : base("Couchbase3", output)
@@ -28,6 +28,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 yield return item.ToArray();
             }
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsCouchbase();
 
         [SkippableTheory]
         [MemberData(nameof(GetCouchbase))]
@@ -47,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsCouchbase();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal("Samples.Couchbase3-couchbase", span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -46,15 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .ToList();
 
                 Assert.True(spans.Count >= 9, $"Expecting at least 9 spans, only received {spans.Count}");
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal("Samples.Couchbase3-couchbase", span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Couchbase3-couchbase");
 
                 var expected = new List<string>
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class CouchbaseTests : TestHelper
+    public class CouchbaseTests : TracingIntegrationTest
     {
         public CouchbaseTests(ITestOutputHelper output)
             : base("Couchbase", output)
@@ -29,6 +29,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 yield return item.ToArray();
             }
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsCouchbase();
 
         [SkippableTheory]
         [MemberData(nameof(GetCouchbase))]
@@ -45,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsCouchbase();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal("Samples.Couchbase-couchbase", span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -44,15 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var spans = agent.WaitForSpans(13, 500);
                 Assert.True(spans.Count >= 13, $"Expecting at least 13 spans, only received {spans.Count}");
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal("Samples.Couchbase-couchbase", span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Couchbase-couchbase");
 
                 var expected = new List<string>
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -14,13 +14,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class Elasticsearch5Tests : TestHelper
+    public class Elasticsearch5Tests : TracingIntegrationTest
     {
         public Elasticsearch5Tests(ITestOutputHelper output)
             : base("Elasticsearch.V5", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsElasticsearchNet();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.ElasticSearch5), MemberType = typeof(PackageVersions))]
@@ -133,7 +135,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsElasticsearchNet();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal("Samples.Elasticsearch.V5-elasticsearch", span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -133,15 +133,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .OrderBy(s => s.Start)
                                  .ToList();
 
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal("Samples.Elasticsearch.V5-elasticsearch", span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
-
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Elasticsearch.V5-elasticsearch");
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -15,13 +15,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class Elasticsearch6Tests : TestHelper
+    public class Elasticsearch6Tests : TracingIntegrationTest
     {
         public Elasticsearch6Tests(ITestOutputHelper output)
             : base("Elasticsearch", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsElasticsearchNet();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.ElasticSearch6), MemberType = typeof(PackageVersions))]
@@ -141,7 +143,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsElasticsearchNet();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal("Samples.Elasticsearch-elasticsearch", span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -140,16 +140,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .Where(s => s.Type == "elasticsearch")
                                  .OrderBy(s => s.Start)
                                  .ToList();
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal("Samples.Elasticsearch-elasticsearch", span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
-
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Elasticsearch-elasticsearch");
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -14,13 +14,15 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class Elasticsearch7Tests : TestHelper
+    public class Elasticsearch7Tests : TracingIntegrationTest
     {
         public Elasticsearch7Tests(ITestOutputHelper output)
             : base("Elasticsearch.V7", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsElasticsearchNet();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.ElasticSearch7), MemberType = typeof(PackageVersions))]
@@ -139,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsElasticsearchNet();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal("Samples.Elasticsearch.V7-elasticsearch", span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -138,16 +138,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .Where(s => s.Type == "elasticsearch")
                                  .OrderBy(s => s.Start)
                                  .ToList();
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal("Samples.Elasticsearch.V7-elasticsearch", span.Service);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
-
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Elasticsearch.V7-elasticsearch");
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -174,6 +174,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedSpans);
                 foreach (var span in spans)
                 {
+                    // TODO: Refactor to use ValidateIntegrationSpans when the graphql server integratoin is fixed. It currently produces a service name of {service]-graphql
                     var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -174,7 +174,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedSpans);
                 foreach (var span in spans)
                 {
-                    // TODO: Refactor to use ValidateIntegrationSpans when the graphql server integratoin is fixed. It currently produces a service name of {service]-graphql
+                    // TODO: Refactor to use ValidateIntegrationSpans when the graphql server integration is fixed. It currently produces a service name of {service]-graphql
                     var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [UsesVerify]
-    public abstract class GraphQLTests : TestHelper
+    public abstract class GraphQLTests : TracingIntegrationTest
     {
         private const string ServiceVersion = "1.0.0";
 
@@ -89,6 +89,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _testName = testName;
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Type switch
+            {
+                "graphql" => span.IsGraphQL(),
+                _ => Result.DefaultSuccess,
+            };
 
         protected async Task RunSubmitsTraces(string packageVersion = "")
         {
@@ -165,12 +172,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);
-                var graphQLSpans = spans.Where(s => s.Type == "graphql")
-                                        .ToList();
-
-                foreach (var graphQLSpan in graphQLSpans)
+                foreach (var span in spans)
                 {
-                    var result = graphQLSpan.IsGraphQL();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -320,7 +320,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var grpcSpan in grpcSpans)
                 {
-                    var result = grpcSpan.IsGrpc();
+                    var result = grpcSpan.IsGrpc(excludeTags: new HashSet<string>
+                    {
+                        "clientmeta",
+                        "grpc.request.metadata.client-value1",
+                        "servermeta",
+                        "grpc.response.metadata.server-value1"
+                    });
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -174,7 +174,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #endif
 
     [UsesVerify]
-    public abstract class GrpcTestsBase : TestHelper
+    public abstract class GrpcTestsBase : TracingIntegrationTest
     {
         private const string MetadataHeaders = "server-value1,server-value2:servermeta,client-value1,client-value2:clientmeta";
         private static readonly Regex GrpcCoreCreatedRegex = new(@"\@\d{10}\.\d{9}", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -213,6 +213,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             => from packageVersionArray in PackageVersions.Grpc
                from httpClientType in Enum.GetValues(typeof(HttpClientIntegrationType)).Cast<HttpClientIntegrationType>()
                select new[] { packageVersionArray[0], httpClientType };
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "grpc.request" => span.IsGrpc(excludeTags: new HashSet<string>
+                    {
+                        "clientmeta",
+                        "grpc.request.metadata.client-value1",
+                        "servermeta",
+                        "grpc.response.metadata.server-value1"
+                    }),
+                _ => Result.DefaultSuccess
+            };
 
         protected async Task RunSubmitTraces(
             string packageVersion,
@@ -315,18 +328,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     FixVerySlowClientSpans(spans);
                 }
 
-                var grpcSpans = spans.Where(s => s.Name == "grpc.request")
-                                     .ToList();
-
-                foreach (var grpcSpan in grpcSpans)
+                foreach (var span in spans)
                 {
-                    var result = grpcSpan.IsGrpc(excludeTags: new HashSet<string>
-                    {
-                        "clientmeta",
-                        "grpc.request.metadata.client-value1",
-                        "servermeta",
-                        "grpc.response.metadata.server-value1"
-                    });
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -330,6 +330,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
+                    // TODO: Refactor to use ValidateIntegrationSpans, but this sample produces both server and client spans so the immediate implementation is not suitable for this test
                     var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -138,6 +138,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedSpans);
                 foreach (var span in spans)
                 {
+                    // TODO: Refactor to use ValidateIntegrationSpans when the HotChocolate server integration is fixed. It currently produces a service name of {service]-graphql
                     var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -129,6 +129,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);
+                var graphQLSpans = spans.Where(s => s.Type == "graphql")
+                                        .ToList();
+
+                foreach (var graphQLSpan in graphQLSpans)
+                {
+                    var result = graphQLSpan.IsHotChocolate();
+                    Assert.True(result.Success, result.ToString());
+                }
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -17,7 +18,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [CollectionDefinition(nameof(HttpMessageHandlerTests), DisableParallelization = true)]
-    public class HttpMessageHandlerTests : TestHelper
+    public class HttpMessageHandlerTests : TracingIntegrationTest
     {
         public HttpMessageHandlerTests(ITestOutputHelper output)
             : base("HttpMessageHandler", output)
@@ -39,6 +40,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             from instrumentationOptions in InstrumentationOptionsValues
             from socketHandlerEnabled in new[] { true, false }
             select new object[] { instrumentationOptions, socketHandlerEnabled };
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsHttpMessageHandler();
 
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
@@ -70,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsHttpMessageHandler();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -70,16 +70,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
+                ValidateIntegrationSpans(spans, expectedServiceName: expectedServiceName);
 
                 foreach (var span in spans)
                 {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal(expectedServiceName, span.Service);
-                    Assert.Equal("HttpMessageHandler", span.Tags[Tags.InstrumentationName]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-
                     if (span.Tags[Tags.HttpStatusCode] == "502")
                     {
                         Assert.Equal(1, span.Error);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -61,12 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // We use HaveCountGreaterOrEqualTo because _both_ consumers may handle the message
             // Due to manual/autocommit behaviour
             allSpans.Should().HaveCountGreaterOrEqualTo(TotalExpectedSpanCount);
-
-            foreach (var span in allSpans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
+            ValidateIntegrationSpans(allSpans, expectedServiceName: "Samples.Kafka-kafka");
 
             var allProducerSpans = allSpans.Where(x => x.Name == "kafka.produce").ToList();
             var successfulProducerSpans = allProducerSpans.Where(x => x.Error == 0).ToList();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Collection(nameof(KafkaTestsCollection))]
     [Trait("RequiresDockerDependency", "true")]
-    public class KafkaTests : TestHelper
+    public class KafkaTests : TracingIntegrationTest
     {
         private const int ExpectedSuccessProducerWithHandlerSpans = 20;
         private const int ExpectedSuccessProducerWithoutHandlerSpans = 10;
@@ -42,6 +42,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             EnableDebugMode();
         }
 
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsKafka();
+
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.Kafka), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
@@ -62,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             foreach (var span in allSpans)
             {
-                var result = span.IsKafka();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -31,12 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public override Result ValidateIntegrationSpan(MockSpan span) =>
-            span.Name switch
-            {
-                "mongodb.query" => span.IsMongoDB(),
-                _ => Result.DefaultSuccess
-            };
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMongoDB();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MongoDB), MemberType = typeof(PackageVersions))]
@@ -86,11 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseTextForParameters($"packageVersion={snapshotSuffix}")
                                   .DisableRequireUniquePrefix();
 
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
+                ValidateIntegrationSpans(allMongoSpans, expectedServiceName: "Samples.MongoDB-mongodb");
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.MongoDb);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class MongoDbTests : TestHelper
+    public class MongoDbTests : TracingIntegrationTest
     {
         private static readonly Regex OsRegex = new(@"""os"" : \{.*?\} ");
         private static readonly Regex ObjectIdRegex = new(@"ObjectId\("".*?""\)");
@@ -30,6 +30,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "mongodb.query" => span.IsMongoDB(),
+                _ => Result.DefaultSuccess
+            };
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MongoDB), MemberType = typeof(PackageVersions))]
@@ -79,9 +86,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseTextForParameters($"packageVersion={snapshotSuffix}")
                                   .DisableRequireUniquePrefix();
 
-                foreach (var span in allMongoSpans)
+                foreach (var span in spans)
                 {
-                    var result = span.IsMongoDB();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -14,7 +14,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class MsmqTests : TestHelper
+    public class MsmqTests : TracingIntegrationTest
     {
         private const string ExpectedServiceName = "Samples.Msmq-msmq";
 
@@ -23,6 +23,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMsmq();
 
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
@@ -53,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var msmqSpans = spans.Where(span => string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
             foreach (var span in msmqSpans)
             {
-                var result = span.IsMsmq();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
 
                 span.Service.Should().Be(ExpectedServiceName);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -53,13 +53,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var spans = agent.WaitForSpans(totalTransactions);
             Assert.True(spans.Count >= totalTransactions, $"Expecting at least {totalTransactions} spans, only received {spans.Count}");
             var msmqSpans = spans.Where(span => string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
+            ValidateIntegrationSpans(msmqSpans, expectedServiceName: ExpectedServiceName);
+
             foreach (var span in msmqSpans)
             {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-
-                span.Service.Should().Be(ExpectedServiceName);
-                span.Tags.Should().Contain(new System.Collections.Generic.KeyValuePair<string, string>(Tags.InstrumentationName, "msmq"));
                 if (span.Tags[Tags.MsmqIsTransactionalQueue] == "True")
                 {
                     span.Tags[Tags.MsmqQueuePath].Should().Be(".\\Private$\\private-transactional-queue");
@@ -70,8 +67,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     span.Tags[Tags.MsmqQueuePath].Should().Be(".\\Private$\\private-nontransactional-queue");
                     nonTransactionalTraces++;
                 }
-
-                span.Tags?.ContainsKey(Tags.Version).Should().BeFalse("External service span should not have service version tag.");
 
                 var command = span.Tags[Tags.MsmqCommand];
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -46,6 +46,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
             var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+
+            foreach (var span in spans)
+            {
+                var result = span.IsProcess();
+                Assert.True(result.Success, result.ToString());
+            }
+
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)
                               .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [UsesVerify]
-    public class ProcessStartTests : TestHelper
+    public class ProcessStartTests : TracingIntegrationTest
     {
         private static readonly Regex StackRegex = new(@"      error.stack:(\n|\r){1,2}.*(\n|\r){1,2}.*,(\r|\n){1,2}");
         private static readonly Regex ErrorMsgRegex = new(@"      error.msg:.*,(\r|\n){1,2}");
@@ -28,6 +28,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsProcess();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -49,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             foreach (var span in spans)
             {
-                var result = span.IsProcess();
+                var result = ValidateIntegrationSpan(span);
                 Assert.True(result.Success, result.ToString());
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -43,17 +43,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            ValidateIntegrationSpans(spans, expectedServiceName: "Samples.ProcessStart-command");
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
             var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
-
-            foreach (var span in spans)
-            {
-                var result = ValidateIntegrationSpan(span);
-                Assert.True(result.Success, result.ToString());
-            }
 
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -16,7 +16,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
-    public class RabbitMQTests : TestHelper
+    public class RabbitMQTests : TracingIntegrationTest
     {
         private const string ExpectedServiceName = "Samples.RabbitMQ-rabbitmq";
 
@@ -25,6 +25,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsRabbitMQ();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.RabbitMQ), MemberType = typeof(PackageVersions))]
@@ -64,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in rabbitmqSpans)
                 {
-                    var result = span.IsRabbitMQ();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -64,13 +64,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var rabbitmqSpans = spans.Where(span => string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
                 var manualSpans = spans.Where(span => !string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
 
+                ValidateIntegrationSpans(rabbitmqSpans, expectedServiceName: "Samples.RabbitMQ-rabbitmq");
+
                 foreach (var span in rabbitmqSpans)
                 {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-
                     var command = span.Tags[Tags.AmqpCommand];
 
                     if (command.StartsWith("basic.", StringComparison.OrdinalIgnoreCase))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -19,13 +19,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class ServiceStackRedisTests : TestHelper
+    public class ServiceStackRedisTests : TracingIntegrationTest
     {
         public ServiceStackRedisTests(ITestOutputHelper output)
             : base("ServiceStack.Redis", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsServiceStackRedis();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.ServiceStackRedis), MemberType = typeof(PackageVersions))]
@@ -49,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 spans.Count.Should().Be(numberOfRuns * expectedSpansPerRun);
                 foreach (var span in spans)
                 {
-                    var result = span.IsServiceStackRedis();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -49,11 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                  .OrderBy(s => s.Start)
                                  .ToList();
                 spans.Count.Should().Be(numberOfRuns * expectedSpansPerRun);
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.ServiceStack.Redis-redis");
 
                 var host = Environment.GetEnvironmentVariable("SERVICESTACK_REDIS_HOST") ?? "localhost:6379";
                 var port = host.Substring(host.IndexOf(':') + 1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     [Collection(nameof(StackExchangeRedisTestCollection))]
     [Trait("RequiresDockerDependency", "true")]
     [UsesVerify]
-    public class StackExchangeRedisTests : TestHelper
+    public class StackExchangeRedisTests : TracingIntegrationTest
     {
         public StackExchangeRedisTests(ITestOutputHelper output)
             : base("StackExchange.Redis", output)
@@ -41,6 +41,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Latest, // Uses different call stacks
             // ReSharper restore InconsistentNaming
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsStackExchangeRedis();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.StackExchangeRedis), MemberType = typeof(PackageVersions))]
@@ -64,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedCount);
                 foreach (var span in spans)
                 {
-                    var result = span.IsStackExchangeRedis();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -64,11 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 };
 
                 var spans = agent.WaitForSpans(expectedCount);
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.StackExchange.Redis-redis");
 
                 var host = Environment.GetEnvironmentVariable("STACKEXCHANGE_REDIS_HOST") ?? "localhost:6389";
                 var port = host.Substring(host.IndexOf(':') + 1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Datadog.Trace.TestHelpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
@@ -21,5 +23,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         public abstract Result ValidateIntegrationSpan(MockSpan span);
+
+        public void ValidateIntegrationSpans(IEnumerable<MockSpan> spans, string expectedServiceName, bool isExternalSpan = true)
+        {
+            foreach (var span in spans)
+            {
+                var result = ValidateIntegrationSpan(span);
+                Assert.True(result.Success, result.ToString());
+
+                Assert.Equal(expectedServiceName, span.Service);
+                if (isExternalSpan == true)
+                {
+                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                }
+            }
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
@@ -1,0 +1,20 @@
+// <copyright file="TracingIntegrationTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.TestHelpers;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public abstract class TracingIntegrationTest : TestHelper
+    {
+        public TracingIntegrationTest(string sampleAppName, ITestOutputHelper output)
+            : base(sampleAppName, output)
+        {
+        }
+
+        public abstract Result ValidateIntegrationSpan(MockSpan span);
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs
@@ -15,6 +15,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
         }
 
+        public TracingIntegrationTest(string sampleAppName, string samplePathOverrides, ITestOutputHelper output)
+            : base(sampleAppName, samplePathOverrides, output)
+        {
+        }
+
         public abstract Result ValidateIntegrationSpan(MockSpan span);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -92,17 +92,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // so we can wait on the exact number of spans we expect.
                 agent.SpanFilters.Add(s => !s.Resource.Contains("schemas.xmlsoap.org") && !s.Resource.Contains("www.w3.org"));
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.Wcf", isExternalSpan: false);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings(binding, enableNewWcfInstrumentation, enableWcfObfuscation);
 
                 await VerifyHelper.VerifySpans(spans, settings)
                               .UseMethodName("_");
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-                }
 
                 // The custom binding doesn't trigger the integration
                 telemetry.AssertIntegration(IntegrationId.Wcf, enabled: binding != "Custom", autoEnabled: true);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -18,7 +18,7 @@ using Xunit.Sdk;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [UsesVerify]
-    public class WcfTests : TestHelper
+    public class WcfTests : TracingIntegrationTest
     {
         private const string ServiceVersion = "1.0.0";
 
@@ -54,6 +54,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 yield return new object[] { binding, true,  false };
             }
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsWcf();
 
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
@@ -98,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsWcf();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -32,7 +32,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             int expectedSpanCount = 45;
             const string expectedOperationName = "http.request";
-            const string expectedServiceName = "Samples.WebRequest.NetFramework20-http-client";
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
@@ -43,16 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal(expectedServiceName, span.Service);
-                    Assert.Equal("WebRequest", span.Tags[Tags.InstrumentationName]);
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.WebRequest.NetFramework20-http-client");
 
                 var firstSpan = spans.First();
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -14,13 +14,15 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class WebRequest20Tests : TestHelper
+    public class WebRequest20Tests : TracingIntegrationTest
     {
         public WebRequest20Tests(ITestOutputHelper output)
             : base("WebRequest.NetFramework20", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsWebRequest();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -44,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsWebRequest();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -16,13 +16,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [CollectionDefinition(nameof(WebRequestTests), DisableParallelization = true)]
     [Collection(nameof(WebRequestTests))]
-    public class WebRequestTests : TestHelper
+    public class WebRequestTests : TracingIntegrationTest
     {
         public WebRequestTests(ITestOutputHelper output)
             : base("WebRequest", output)
         {
             SetServiceVersion("1.0.0");
         }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsWebRequest();
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
@@ -48,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    var result = span.IsWebRequest();
+                    var result = ValidateIntegrationSpan(span);
                     Assert.True(result.Success, result.ToString());
 
                     Assert.Equal(expectedServiceName, span.Service);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -36,7 +36,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedSpanCount = 76;
 
             const string expectedOperationName = "http.request";
-            const string expectedServiceName = "Samples.WebRequest-http-client";
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
@@ -47,16 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName).OrderBy(s => s.Start);
                 spans.Should().HaveCount(expectedSpanCount);
-
-                foreach (var span in spans)
-                {
-                    var result = ValidateIntegrationSpan(span);
-                    Assert.True(result.Success, result.ToString());
-
-                    Assert.Equal(expectedServiceName, span.Service);
-                    Assert.True(string.Equals(span.Tags[Tags.InstrumentationName], "WebRequest") || string.Equals(span.Tags[Tags.InstrumentationName], "HttpMessageHandler"));
-                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
-                }
+                ValidateIntegrationSpans(spans, expectedServiceName: "Samples.WebRequest-http-client");
 
                 var firstSpan = spans.First();
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/Datadog.Trace.TestHelpers/Result.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Result.cs
@@ -1,0 +1,71 @@
+// <copyright file="Result.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class Result
+    {
+        public static readonly Result DefaultSuccess = FromSpan(null);
+
+        private Result(MockSpan span, ISet<string> excludeTags)
+        {
+            Span = span;
+            ExcludeTags = excludeTags;
+            Errors = new List<string>();
+        }
+
+        public MockSpan Span { get; }
+
+        public ISet<string> ExcludeTags { get; }
+
+        public List<string> Errors { get; }
+
+        public bool Success
+        {
+            get => Errors.Count == 0;
+        }
+
+        public static Result FromSpan(MockSpan span, ISet<string> excludeTags = null)
+        {
+            return new Result(span, excludeTags ?? new HashSet<string>());
+        }
+
+        public Result WithFailure(string failureMessage)
+        {
+            Errors.Add(failureMessage);
+            return this;
+        }
+
+        public Result Properties(Action<SpanPropertyAssertion> propertyAssertions)
+        {
+            var p = new SpanPropertyAssertion(this);
+            propertyAssertions(p);
+            return this;
+        }
+
+        public Result Tags(Action<SpanTagAssertion> tagAssertions)
+        {
+            var t = new SpanTagAssertion(this, this.Span.Tags);
+            tagAssertions(t);
+
+            SpanTagAssertion.DefaultTagAssertions(t);
+            SpanTagAssertion.AssertNoRemainingTags(t);
+            return this;
+        }
+
+        public override string ToString()
+        {
+            string errorMessage = string.Concat(Errors.Select(s => $"{Environment.NewLine}- {s}"));
+
+            return $"Result: {Success}{Environment.NewLine}"
+                 + $"Span: {Span}{Environment.NewLine}"
+                 + $"Errors:{errorMessage}";
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanAssertion.cs
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Datadog.Trace.TestHelpers
 {
     public class SpanAssertion
@@ -10,14 +13,21 @@ namespace Datadog.Trace.TestHelpers
         private const string MatchesFailureStringFormat = "{0} \"{1}\" was expected to have value {2}, but the value is \"{3}\"";
         private const string PresentFailureStringFormat = "{0} \"{1}\" was expected to be present";
         private const string MatchesOneOfFailure = "{0} \"{1}\" was expected to have one of the following values {2}, but the value is \"{3}\"";
+        private const string NoRemainingTagsFailureFormat = "Expected to have no remaining tags, but the following tags were found: [{0}]";
 
         protected static string GenerateMatchesFailureString(string propertyKind, string propertyName, string expectedValue, string actualValue) =>
-            string.Format(MatchesFailureStringFormat, propertyKind, propertyName, expectedValue, actualValue);
+            string.Format(MatchesFailureStringFormat, propertyKind, propertyName, expectedValue, actualValue ?? "(null)");
 
         protected static string GenerateMatchesOneOfFailureString(string propertyKind, string propertyName, string expectedValue, string actualValue) =>
-            string.Format(MatchesOneOfFailure, propertyKind, propertyName, expectedValue, actualValue);
+            string.Format(MatchesOneOfFailure, propertyKind, propertyName, expectedValue, actualValue ?? "(null)");
 
         protected static string GeneratePresentFailureString(string propertyKind, string propertyName) =>
             string.Format(PresentFailureStringFormat, propertyKind, propertyName);
+
+        protected static string GenerateNoRemainingTagsFailureString(IDictionary<string, string> tags)
+        {
+            var stringArray = tags.ToArray().Select(kvp => $"\"{kvp.Key}\"=\"{kvp.Value}\"");
+            return string.Format(NoRemainingTagsFailureFormat, string.Join(",", stringArray));
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -407,6 +407,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Name, "http.request")
                 .Matches(Type, "http"))
             .Tags(s => s
+                .IsOptional("http-client-handler-type")
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace.TestHelpers
             .Tags(s => s
                 .IsOptional("cosmosdb.container")
                 .IsOptional("db.name")
-                .Matches("b.type", "cosmosdb")
+                .Matches("db.type", "cosmosdb")
                 .IsPresent("out.host")
                 .Matches("component", "CosmosDb")
                 .Matches("span.kind", "client"));

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -67,8 +67,10 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("aspnet.action")
                 .IsOptional("aspnet.controller")
                 .IsPresent("aspnet.route")
+                .IsPresent("http.client_ip")
                 .IsPresent("http.method")
                 .IsPresent("http.request.headers.host")
+                .IsPresent("http.route")
                 // BUG: When WebApi2 throws an exception, we cannot immediately set the
                 // status code because the response hasn't been written yet.
                 // For ASP.NET, we register a callback to populate http.status_code
@@ -76,9 +78,12 @@ namespace Datadog.Trace.TestHelpers
                 // What we should do is instrument OWIN and assert that that has the
                 // "http.status_code" tag
                 // .IsPresent("http.status_code")
+                .IsOptional("http.status_code")
+                .IsPresent("http.useragent")
                 .IsPresent("http.url")
                 // BUG: component tag is not set
                 // .Matches("component", "aspnet")
+                .IsPresent("network.client.ip")
                 .Matches("span.kind", "server"));
 
         public static Result IsAspNetCore(this MockSpan span) => Result.FromSpan(span)
@@ -186,6 +191,17 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "Grpc")
                 .MatchesOneOf("span.kind", "client", "server"));
 
+        public static Result IsHotChocolate(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .MatchesOneOf(Name, "graphql.execute", "graphql.validate")
+                .Matches(Type, "graphql"))
+            .Tags(s => s
+                .IsOptional("graphql.operation.name")
+                .IsOptional("graphql.operation.type")
+                .IsPresent("graphql.source")
+                .Matches("component", "HotChocolate")
+                .Matches("span.kind", "server"));
+
         public static Result IsHttpMessageHandler(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s
                 .Matches(Name, "http.request")
@@ -242,6 +258,8 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsPresent("db.name")
+                .IsPresent("db.user")
+                .IsPresent("out.host")
                 .Matches("db.type", "mysql")
                 .Matches("component", "MySql")
                 .Matches("span.kind", "client"));
@@ -252,6 +270,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsPresent("db.name")
+                .IsPresent("out.host")
                 .Matches("db.type", "postgres")
                 .Matches("component", "Npgsql")
                 .Matches("span.kind", "client"));
@@ -265,6 +284,14 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("db.type", "oracle")
                 .Matches("component", "Oracle")
                 .Matches("span.kind", "client"));
+
+        public static Result IsProcess(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Name, "command_execution")
+                .Matches(Type, "system"))
+            .Tags(s => s
+                .IsOptional("cmd.environment_variables")
+                .Matches("span.kind", "internal"));
 
         public static Result IsRabbitMQ(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s
@@ -336,6 +363,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsOptional("db.name")
+                .IsPresent("out.host")
                 .Matches("db.type", "sqlite")
                 .Matches("component", "Sqlite")
                 .Matches("span.kind", "client"));
@@ -346,6 +374,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsOptional("db.name")
+                .IsPresent("out.host")
                 .Matches("db.type", "sql-server")
                 .Matches("component", "SqlClient")
                 .Matches("span.kind", "client"));
@@ -355,6 +384,8 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Name, "wcf.request")
                 .Matches(Type, "web"))
             .Tags(s => s
+                .IsOptional("http.method")
+                .IsOptional("http.request.headers.host")
                 .IsPresent("http.url")
                 .Matches("component", "Wcf")
                 .Matches("span.kind", "server"));

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
+
 namespace Datadog.Trace.TestHelpers
 {
 #pragma warning disable SA1601 // Partial elements should be documented
@@ -34,12 +36,16 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Name, "aspnet.request")
                 .Matches(Type, "web"))
             .Tags(s => s
+                .IsPresent("http.client_ip")
                 .IsPresent("http.method")
                 .IsPresent("http.request.headers.host")
+                .IsOptional("http.route")
                 .IsPresent("http.status_code")
+                .IsPresent("http.useragent")
                 .IsPresent("http.url")
                 // BUG: component tag is not set
                 // .Matches("component", "aspnet")
+                .IsPresent("network.client.ip")
                 .Matches("span.kind", "server"));
 
         public static Result IsAspNetMvc(this MockSpan span) => Result.FromSpan(span)
@@ -54,6 +60,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.request.headers.host")
                 .IsPresent("http.status_code")
+                .IsPresent("http.useragent")
                 .IsPresent("http.url")
                 // BUG: component tag is not set
                 // .Matches("component", "aspnet")
@@ -67,10 +74,10 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("aspnet.action")
                 .IsOptional("aspnet.controller")
                 .IsPresent("aspnet.route")
-                .IsPresent("http.client_ip")
+                .IsOptional("http.client_ip")
                 .IsPresent("http.method")
                 .IsPresent("http.request.headers.host")
-                .IsPresent("http.route")
+                .IsOptional("http.route")
                 // BUG: When WebApi2 throws an exception, we cannot immediately set the
                 // status code because the response hasn't been written yet.
                 // For ASP.NET, we register a callback to populate http.status_code
@@ -83,20 +90,24 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.url")
                 // BUG: component tag is not set
                 // .Matches("component", "aspnet")
-                .IsPresent("network.client.ip")
+                .IsOptional("network.client.ip")
                 .Matches("span.kind", "server"));
 
-        public static Result IsAspNetCore(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsAspNetCore(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
             .Properties(s => s
                 .Matches(Name, "aspnet_core.request")
                 .Matches(Type, "web"))
             .Tags(s => s
                 .IsOptional("aspnet_core.endpoint")
                 .IsOptional("aspnet_core.route")
+                .IsPresent("http.client_ip")
                 .IsPresent("http.method")
                 .IsPresent("http.request.headers.host")
+                .IsOptional("http.route")
                 .IsPresent("http.status_code")
+                .IsPresent("http.useragent")
                 .IsPresent("http.url")
+                .IsPresent("network.client.ip")
                 .Matches("component", "aspnet_core")
                 .Matches("span.kind", "server"));
 
@@ -109,6 +120,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("aspnet_core.area")
                 .IsPresent("aspnet_core.controller")
                 .IsOptional("aspnet_core.page")
+                .IsPresent("aspnet_core.route")
                 .Matches("component", "aspnet_core")
                 .Matches("span.kind", "server"));
 
@@ -177,7 +189,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "GraphQL")
                 .Matches("span.kind", "server"));
 
-        public static Result IsGrpc(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsGrpc(this MockSpan span, ISet<string> excludeTags) => Result.FromSpan(span, excludeTags)
             .Properties(s => s
                 .Matches(Name, "grpc.request")
                 .Matches(Type, "grpc"))

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
@@ -23,6 +23,8 @@ namespace Datadog.Trace.TestHelpers
 #pragma warning disable SA1201 // Elements should appear in the correct order
     public class Result
     {
+        public static readonly Result DefaultSuccess = FromSpan(null);
+
         public MockSpan Span { get; }
 
         public ISet<string> ExcludeTags { get; }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
@@ -10,74 +10,10 @@ using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.TestHelpers
 {
-#pragma warning disable SA1601 // Partial elements should be documented
     public static partial class SpanMetadataRules
     {
         internal static (string PropertyName, string Result) Name(MockSpan span) => (nameof(span.Name), span.Name);
 
         internal static (string PropertyName, string Result) Type(MockSpan span) => (nameof(span.Type), span.Type);
-    }
-
-#pragma warning disable SA1402 // File may only contain a single type
-
-#pragma warning disable SA1201 // Elements should appear in the correct order
-    public class Result
-    {
-        public static readonly Result DefaultSuccess = FromSpan(null);
-
-        public MockSpan Span { get; }
-
-        public ISet<string> ExcludeTags { get; }
-
-        public List<string> Errors { get; }
-
-        public bool Success
-        {
-            get => Errors.Count == 0;
-        }
-
-        private Result(MockSpan span, ISet<string> excludeTags)
-        {
-            Span = span;
-            ExcludeTags = excludeTags;
-            Errors = new List<string>();
-        }
-
-        public static Result FromSpan(MockSpan span, ISet<string> excludeTags = null)
-        {
-            return new Result(span, excludeTags ?? new HashSet<string>());
-        }
-
-        public Result WithFailure(string failureMessage)
-        {
-            Errors.Add(failureMessage);
-            return this;
-        }
-
-        public Result Properties(Action<SpanPropertyAssertion> propertyAssertions)
-        {
-            var p = new SpanPropertyAssertion(this);
-            propertyAssertions(p);
-            return this;
-        }
-
-        public Result Tags(Action<SpanTagAssertion> tagAssertions)
-        {
-            var t = new SpanTagAssertion(this, this.Span.Tags);
-            tagAssertions(t);
-
-            SpanTagAssertion.DefaultTagAssertions(t);
-            SpanTagAssertion.AssertNoRemainingTags(t);
-            return this;
-        }
-
-        public override string ToString()
-        {
-            string errorMessage = string.Concat(Errors.Select(s => $"{Environment.NewLine}- {s}"));
-
-            return $"Result: {Success}{Environment.NewLine}"
-                 + $"Span: {Span}{Environment.NewLine}"
-                 + $"Errors:{errorMessage}";
-        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -24,6 +25,8 @@ namespace Datadog.Trace.TestHelpers
     {
         public MockSpan Span { get; }
 
+        public ISet<string> ExcludeTags { get; }
+
         public List<string> Errors { get; }
 
         public bool Success
@@ -31,15 +34,16 @@ namespace Datadog.Trace.TestHelpers
             get => Errors.Count == 0;
         }
 
-        public Result(MockSpan span)
+        private Result(MockSpan span, ISet<string> excludeTags)
         {
             Span = span;
+            ExcludeTags = excludeTags;
             Errors = new List<string>();
         }
 
-        public static Result FromSpan(MockSpan span)
+        public static Result FromSpan(MockSpan span, ISet<string> excludeTags = null)
         {
-            return new Result(span);
+            return new Result(span, excludeTags ?? new HashSet<string>());
         }
 
         public Result WithFailure(string failureMessage)

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRulesHelpers.cs
@@ -57,8 +57,11 @@ namespace Datadog.Trace.TestHelpers
 
         public Result Tags(Action<SpanTagAssertion> tagAssertions)
         {
-            var t = new SpanTagAssertion(this);
+            var t = new SpanTagAssertion(this, this.Span.Tags);
             tagAssertions(t);
+
+            SpanTagAssertion.DefaultTagAssertions(t);
+            SpanTagAssertion.AssertNoRemainingTags(t);
             return this;
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Datadog.Trace.TestHelpers
@@ -10,15 +13,43 @@ namespace Datadog.Trace.TestHelpers
     public class SpanTagAssertion : SpanAssertion
     {
         private readonly Result _result;
+        private readonly IDictionary<string, string> _tags;
 
-        internal SpanTagAssertion(Result result)
+        internal SpanTagAssertion(Result result, IDictionary<string, string> tags)
         {
             _result = result;
+            _tags = new Dictionary<string, string>(tags);
+        }
+
+        public static void DefaultTagAssertions(SpanTagAssertion s) => s
+            .IsPresent("env")
+            .IsOptional("runtime-id") // TODO: Make runtime-id required on all spans, per our span attributes push
+            .IsOptional("language") // TODO: Make language required on all spans, per our span attributes push
+            .IsOptional("version")
+            .IsOptional("_dd.p.dm")
+            .IsOptional("error.msg")
+            .IsOptional("error.type")
+            .IsOptional("error.stack");
+
+        public static void AssertNoRemainingTags(SpanTagAssertion s)
+        {
+            s._tags.Remove("_dd.p.dm");
+
+            if (s._tags.Count > 0)
+            {
+                s._result.WithFailure(GenerateNoRemainingTagsFailureString(s._tags));
+            }
         }
 
         public SpanTagAssertion IsPresent(string tagName)
         {
-            if (_result.Span.GetTag(tagName) is null)
+            bool keyExists = _tags.TryGetValue(tagName, out string value);
+            if (keyExists)
+            {
+                _tags.Remove(tagName);
+            }
+
+            if (!keyExists || value is null)
             {
                 _result.WithFailure(GeneratePresentFailureString("tag", tagName));
             }
@@ -26,14 +57,28 @@ namespace Datadog.Trace.TestHelpers
             return this;
         }
 
-        public SpanTagAssertion IsOptional(string key) => this;
+        public SpanTagAssertion IsOptional(string tagName)
+        {
+            bool keyExists = _tags.TryGetValue(tagName, out string value);
+            if (keyExists)
+            {
+                _tags.Remove(tagName);
+            }
+
+            return this;
+        }
 
         public SpanTagAssertion Matches(string tagName, string expectedValue)
         {
-            var actualValue = _result.Span.GetTag(tagName);
-            if (actualValue != expectedValue)
+            bool keyExists = _tags.TryGetValue(tagName, out string value);
+            if (keyExists)
             {
-                _result.WithFailure(GenerateMatchesFailureString("tag", tagName, expectedValue, actualValue));
+                _tags.Remove(tagName);
+            }
+
+            if (value != expectedValue)
+            {
+                _result.WithFailure(GenerateMatchesFailureString("tag", tagName, expectedValue, value));
             }
 
             return this;
@@ -41,14 +86,19 @@ namespace Datadog.Trace.TestHelpers
 
         public SpanTagAssertion MatchesOneOf(string tagName, params string[] expectedValues)
         {
-            var actualValue = _result.Span.GetTag(tagName);
-            if (expectedValues.Where(s => s == actualValue).SingleOrDefault() is null)
+            bool keyExists = _tags.TryGetValue(tagName, out string value);
+            if (keyExists)
+            {
+                _tags.Remove(tagName);
+            }
+
+            if (expectedValues.Where(s => s == value).SingleOrDefault() is null)
             {
                 string expectedValueString = "["
                              + string.Join(",", expectedValues.Select(s => $"\"{s}\"").ToArray())
                              + "]";
 
-                _result.WithFailure(GenerateMatchesOneOfFailureString("tag", tagName, expectedValueString, actualValue));
+                _result.WithFailure(GenerateMatchesOneOfFailureString("tag", tagName, expectedValueString, value));
             }
 
             return this;

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -33,7 +33,10 @@ namespace Datadog.Trace.TestHelpers
 
         public static void AssertNoRemainingTags(SpanTagAssertion s)
         {
-            s._tags.Remove("_dd.p.dm");
+            foreach (var tag in s._result.ExcludeTags)
+            {
+                s._tags.Remove(tag);
+            }
 
             if (s._tags.Count > 0)
             {


### PR DESCRIPTION
## Summary of changes
A whole bunch of improvements to the span metadata rules infra in our integration test code.

## Reason for change
Currently the span metadata rules are not required when adding a new integration and I believe they help make strong checks on the spans we produce.

## Implementation details
- Make span assertions more strict to raise an error when unexpected tags are present, and fix the rules that began failing with the stricter checks
- Add a SpanMetadataRule entries for the new `HotChocolate` and `Process` integrations
- Add ability to exclude tags from assertions (e.g. header tags added from tracer configuration)
- Require each integration test to implement a SpanMetadataRule by making them derive from a new `TracingIntegrationTest` class
- Add a GitHub Action to enforce that `docs/span_metadata.md` is up-to-date with `tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs`

## Test coverage
For integration tests, I ran as many tests locally as I could.

For the GitHub Action, you can see it [fail](https://github.com/DataDog/dd-trace-dotnet/actions/runs/3070913999/jobs/4961119851) before updating the markdown and then [succeed](https://github.com/DataDog/dd-trace-dotnet/actions/runs/3070935263/jobs/4961160151) after updating the markdown.

## Other details
N/A
