### PR TITLE
Add ability to capture hang dumps on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -489,6 +489,8 @@ services:
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
       - ./:/project
+    cap_add:
+      - SYS_PTRACE
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
@@ -561,6 +563,8 @@ services:
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
       - ./:/project
+    cap_add:
+      - SYS_PTRACE
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
@@ -617,6 +621,8 @@ services:
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:
       - ./:/project
+    cap_add:
+      - SYS_PTRACE
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -146,75 +146,30 @@ namespace Datadog.Trace.TestHelpers
 
         public async Task<bool> TakeMemoryDump(Process process)
         {
-            // We don't know if procdump is available, so download it fresh
-            if (!EnvironmentTools.IsWindows())
-            {
-                Output.WriteLine("Not running on windows, skipping memory dump");
-                return false;
-            }
-
             try
             {
-                const string url = @"https://download.sysinternals.com/files/Procdump.zip";
-                var client = new HttpClient();
-                var zipFilePath = Path.GetTempFileName();
-                Output.WriteLine($"Downloading Procdump to '{zipFilePath}'");
-                using (var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead))
+                if (EnvironmentTools.IsLinux())
                 {
-                    using var bodyStream = await response.Content.ReadAsStreamAsync();
-                    using Stream streamToWriteTo = File.Open(zipFilePath, FileMode.Create);
-                    await bodyStream.CopyToAsync(streamToWriteTo);
+                    var dotnetRuntimeFolder = Path.GetDirectoryName(typeof(object).Assembly.Location);
+                    var createDumpExecutable = Path.Combine(dotnetRuntimeFolder!, "createdump");
+                    // createdump automatically puts the dump in the /tmp/ directory, which is where we grab it from
+                    var args = process.Id.ToString();
+                    return CaptureMemoryDump(createDumpExecutable, args);
                 }
-
-                var unpackedDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
-                Output.WriteLine($"Procdump downloaded. Unpacking to '{unpackedDirectory}'");
-                System.IO.Compression.ZipFile.ExtractToDirectory(zipFilePath, unpackedDirectory);
-
-                var procDump = Path.Combine(unpackedDirectory, "procdump.exe");
-                var processId = process.Id;
-
-                var args = $"-ma {processId} -accepteula";
-                Output.WriteLine($"Capturing memory dump using '{procDump} {args}'");
-
-                using var procDumpProcess = Process.Start(new ProcessStartInfo(procDump, args)
+                else if (EnvironmentTools.IsWindows())
                 {
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                });
-
-                procDumpProcess.OutputDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        Output.WriteLine($"[procdump][stdout] {args.Data}");
-                    }
-                };
-                procDumpProcess.BeginOutputReadLine();
-
-                procDumpProcess.ErrorDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        Output.WriteLine($"[procdump][stderr] {args.Data}");
-                    }
-                };
-                procDumpProcess.BeginErrorReadLine();
-
-                if (!procDumpProcess.HasExited)
-                {
-                    procDumpProcess.WaitForExit(30_000);
+                    var procDumpExecutable = await DownloadProcdumpZipAndExtract();
+                    var args = $"-ma {process.Id} -accepteula";
+                    return CaptureMemoryDump(procDumpExecutable, args);
                 }
-
-                Output.WriteLine($"Memory dump captured using '{procDump} {args}'");
-                return true;
             }
             catch (Exception ex)
             {
                 Output.WriteLine("Error taking memory dump: " + ex);
                 return false;
             }
+
+            return false;
         }
 
         public ProcessResult RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000)
@@ -233,8 +188,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 var tookMemoryDump = TakeMemoryDump(process);
                 process.Kill();
-                // should we throw a skip exception on Linux as we don't have a memory dump?
-                throw new Exception($"The sample did not exit in {timeoutMs}ms. Memory dump taken: {tookMemoryDump}. Killing process.");
+                throw new Exception($"The sample did not exit in {timeoutMs}ms. Memory dump taken: {tookMemoryDump.Result}. Killing process.");
             }
 
             var exitCode = process.ExitCode;
@@ -672,6 +626,67 @@ namespace Datadog.Trace.TestHelpers
 
         private bool IsServerSpan(MockSpan span) =>
             span.Tags.GetValueOrDefault(Tags.SpanKind) == SpanKinds.Server;
+
+        private async Task<string> DownloadProcdumpZipAndExtract()
+        {
+            // We don't know if procdump is available, so download it fresh
+            const string url = @"https://download.sysinternals.com/files/Procdump.zip";
+            var client = new HttpClient();
+            var zipFilePath = Path.GetTempFileName();
+            Output.WriteLine($"Downloading Procdump to '{zipFilePath}'");
+            using (var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead))
+            {
+                using var bodyStream = await response.Content.ReadAsStreamAsync();
+                using Stream streamToWriteTo = File.Open(zipFilePath, FileMode.Create);
+                await bodyStream.CopyToAsync(streamToWriteTo);
+            }
+
+            var unpackedDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
+            Output.WriteLine($"Procdump downloaded. Unpacking to '{unpackedDirectory}'");
+            System.IO.Compression.ZipFile.ExtractToDirectory(zipFilePath, unpackedDirectory);
+
+            var procDump = Path.Combine(unpackedDirectory, "procdump.exe");
+            return procDump;
+        }
+
+        private bool CaptureMemoryDump(string tool, string args)
+        {
+            Output.WriteLine($"Capturing memory dump using '{tool} {args}'");
+
+            using var dumpToolProcess = Process.Start(new ProcessStartInfo(tool, args)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            });
+
+            dumpToolProcess.OutputDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    Output.WriteLine($"[dump][stdout] {args.Data}");
+                }
+            };
+            dumpToolProcess.BeginOutputReadLine();
+
+            dumpToolProcess.ErrorDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    Output.WriteLine($"[dump][stderr] {args.Data}");
+                }
+            };
+            dumpToolProcess.BeginErrorReadLine();
+
+            if (!dumpToolProcess.HasExited)
+            {
+                dumpToolProcess.WaitForExit(30_000);
+            }
+
+            Output.WriteLine($"Memory dump captured using '{tool} {args}', exit code: {dumpToolProcess.ExitCode}");
+            return true;
+        }
 
         protected internal class TupleList<T1, T2> : List<Tuple<T1, T2>>
         {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -661,28 +661,11 @@ namespace Datadog.Trace.TestHelpers
                 RedirectStandardError = true,
             });
 
-            dumpToolProcess.OutputDataReceived += (sender, args) =>
-            {
-                if (args.Data != null)
-                {
-                    Output.WriteLine($"[dump][stdout] {args.Data}");
-                }
-            };
-            dumpToolProcess.BeginOutputReadLine();
-
-            dumpToolProcess.ErrorDataReceived += (sender, args) =>
-            {
-                if (args.Data != null)
-                {
-                    Output.WriteLine($"[dump][stderr] {args.Data}");
-                }
-            };
-            dumpToolProcess.BeginErrorReadLine();
-
-            if (!dumpToolProcess.HasExited)
-            {
-                dumpToolProcess.WaitForExit(30_000);
-            }
+            using var helper = new ProcessHelper(dumpToolProcess);
+            dumpToolProcess.WaitForExit(30_000);
+            helper.Drain();
+            Output.WriteLine($"[dump][stdout] {helper.StandardOutput}");
+            Output.WriteLine($"[dump][stderr] {helper.ErrorOutput}");
 
             Output.WriteLine($"Memory dump captured using '{tool} {args}', exit code: {dumpToolProcess.ExitCode}");
             return true;


### PR DESCRIPTION
## Summary of changes
If one of our integration tests launches a sample as a child process and it hangs indefinitely, we'd like to capture a memory dump of it to diagnose the hang. 
This functionality was already implemented for Windows using `procdump`.
This PR adds the same functionality for Linux, using [createdump](https://learn.microsoft.com/en-us/troubleshoot/developer/webapps/aspnetcore/practice-troubleshoot-linux/lab-1-3-capture-core-crash-dumps).


## Reason for change
Certain tests (e.g. `SerilogTests.DoesNotInjectLogsWhenDisabled`) are currently flakey on Linux and we hope this change will help us get to the bottom of things.


## Implementation details
In order to be able to capture dumps, `SYS_PTRACE` permission was added to the test containers.
