### PR TITLE
Bump timeouts in `DiscoveryServiceTests`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -36,7 +36,7 @@ public class DiscoveryServiceTests
         var ds = new DiscoveryService(factory, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
         ds.SubscribeToChanges(x => mutex.Set());
 
-        mutex.Wait(10_000).Should().BeTrue("Should raise subscription changes");
+        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
 
         await ds.DisposeAsync();
     }
@@ -59,7 +59,7 @@ public class DiscoveryServiceTests
                 mutex.Set();
             });
 
-        mutex.Wait(10_000).Should().BeTrue("Should raise subscription changes");
+        mutex.Wait(30_000).Should().BeTrue("Should raise subscription changes");
         config.Should().NotBeNull();
         config.AgentVersion.Should().Be(version);
         config.ConfigurationEndpoint.Should().NotBeNullOrEmpty();
@@ -107,7 +107,7 @@ public class DiscoveryServiceTests
         var ds = new DiscoveryService(factory, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
         // make sure we have config
         ds.SubscribeToChanges(x => mutex.Set());
-        mutex.Wait(10_000).Should().BeTrue("Should make request to api");
+        mutex.Wait(30_000).Should().BeTrue("Should make request to api");
 
         ds.SubscribeToChanges(x => Interlocked.Increment(ref notificationCount));
         Volatile.Read(ref notificationCount).Should().Be(1);
@@ -140,7 +140,7 @@ public class DiscoveryServiceTests
         // fire first request
         mutex1.Set();
         // wait for third request
-        mutex3.Wait(10_000).Should().BeTrue("Should make third request to api");
+        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
 
         Volatile.Read(ref notificationCount).Should().Be(1); // initial
 
@@ -172,7 +172,7 @@ public class DiscoveryServiceTests
         // fire first request
         mutex1.Set();
         // wait for third request
-        mutex3.Wait(10_000).Should().BeTrue("Should make third request to api");
+        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
 
         Volatile.Read(ref notificationCount).Should().Be(2); // initial and second
 
@@ -207,7 +207,7 @@ public class DiscoveryServiceTests
         // fire first request
         mutex1.Set();
         // wait for third request
-        mutex3.Wait(10_000).Should().BeTrue("Should make third request to api");
+        mutex3.Wait(30_000).Should().BeTrue("Should make third request to api");
 
         Volatile.Read(ref notificationCount).Should().Be(1); // callback should only run once
 
@@ -236,7 +236,7 @@ public class DiscoveryServiceTests
         var ds = new DiscoveryService(factory, InitialRetryDelayMs, MaxRetryDelayMs, RecheckIntervalMs);
 
         // should be inside recheck loop
-        mutex.Wait(10_000).Should().BeTrue("Should make request to api");
+        mutex.Wait(30_000).Should().BeTrue("Should make request to api");
 
         var dispose = ds.DisposeAsync();
 


### PR DESCRIPTION
## Summary of changes

Bump timeouts in `DiscoveryServiceTests`

## Reason for change

Noticed some flake in unit tests, so go more conservative.

## Implementation details

`10s` timeout -> `30s` timeout

## Test coverage
N/A

## Other details
N/A
