### PR TITLE
Waf memory leak fix

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -41,6 +41,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 valueRegex = Marshal.StringToHGlobalAnsi(obfuscationParameterValueRegex);
                 args.KeyRegex = keyRegex;
                 args.ValueRegex = valueRegex;
+                args.FreeWafFunction = wafNative.ObjectFreeFuncPtr;
 
                 var ruleHandle = wafNative.Init(configObj.RawPtr, ref args, ref ruleSetInfo);
                 if (ruleHandle == IntPtr.Zero)


### PR DESCRIPTION
## Summary of changes
Added missing FreeObjet function to native waf init call

## Reason for change
Detected memory leak in appsec enabled applications

## Implementation details
Waf v1.5.0 changed the init API, moving the free function argument from CreateContext to Init function. The line passing the Free function in the call to Init was "missing"

## Test coverage

## Other details
<!-- Fixes #{issue} -->
