### PR TITLE
Add support for specifying a `Content-Encoding` in `IApiRequest`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -15,5 +15,7 @@ namespace Datadog.Trace.Agent
         Task<IApiResponse> GetAsync();
 
         Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType);
+
+        Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -77,12 +77,20 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
+        public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
+            => PostAsync(bytes, contentType, null);
+
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
         {
             // re-create HttpContent on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
             using (var content = new ByteArrayContent(bytes.Array, bytes.Offset, bytes.Count))
             {
                 content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+                if (!string.IsNullOrEmpty(contentEncoding))
+                {
+                    content.Headers.ContentEncoding.Add(contentEncoding);
+                }
+
                 _postRequest.Content = content;
 
                 var response = await _client.SendAsync(_postRequest).ConfigureAwait(false);

--- a/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
@@ -47,7 +47,10 @@ internal class TestApiRequest : IApiRequest
         return Task.FromResult((IApiResponse)response);
     }
 
-    public virtual Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+    public Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+        => PostAsync(traces, contentType, contentEncoding: null);
+
+    public virtual Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
     {
         var response = new TestApiResponse(_statusCode, _responseContent, _responseContentType);
         Responses.Add(response);

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -322,7 +322,7 @@ public class DiscoveryServiceTests
             throw new WebException("Error in GetAsync");
         }
 
-        public override async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
+        public override async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
         {
             await Task.Yield();
             throw new WebException("Error in PostAsync");

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -110,7 +110,10 @@ namespace Benchmarks.Trace
                 return Task.FromResult<IApiResponse>(new FakeApiResponse());
             }
 
-            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+            public Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+                => PostAsync(traces, contentType, null);
+
+            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType, string contentEncoding)
             {
                 using (var requestStream = Stream.Null)
                 {
@@ -119,6 +122,7 @@ namespace Benchmarks.Trace
 
                 return new FakeApiResponse();
             }
+
         }
 
         private class FakeApiResponse : IApiResponse


### PR DESCRIPTION
## Summary of changes

Adds the ability to set `Content-Encoding` on a `POST` _request_.

## Reason for change

For data streams monitoring we need to set the `Content-Encoding` header. This isn't currently possible with our `IApiRequest` implementation (`HttpClient` is finicky about where you set the header).

## Implementation details

Adds a new overload to `IApiRequest.PostAsync()` for setting the content encoding (similar to the way we set the content type). `Content-Encoding` needs to be set on the request _content_ in `HttpClient`, not on the client itself, so the normal AddHeader() approach doesn't work here.

## Test coverage

The no-encoding pathways are tested by existing tests. I haven't added explicit paths testing the setting of encoding in this PR; it's tested indirectly in a follow-up PR for DSM.

## Other details
- Did a minor cleanup of the request reuse in `ApiWebRequest`. The existing code feels a bit icky, but this doesn't change anything fundamental.
- I didn't add extra unit tests for encoding because it's annoyingly hard to test this code. It feels like we should be able to say "send this request", and verify the HTTP request sent. That'll take a lot of refactoring though, so I've punted for now