### PR TITLE
Send Telemetry heartbeat independently of flushed data

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Configuration
 {
@@ -519,6 +520,13 @@ namespace Datadog.Trace.Configuration
             /// <see cref="ExporterSettings.AgentUri"/> instead)
             /// </summary>
             public const string Uri = "DD_INSTRUMENTATION_TELEMETRY_URL";
+
+            /// <summary>
+            /// Configuration key for how often telemetry should be sent, in seconds. Must be between 1 and 3600.
+            /// For testing purposes. Defaults to 60
+            /// <see cref="TelemetrySettings.HeartbeatInterval"/>
+            /// </summary>
+            public const string HeartbeatIntervalSeconds = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
         }
 
         internal static class TagPropagation

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
@@ -18,6 +18,6 @@ namespace Datadog.Trace.Telemetry
         public const string ApiVersionHeader = "DD-Telemetry-API-Version";
         public const string RequestTypeHeader = "DD-Telemetry-Request-Type";
 
-        public static readonly TimeSpan RefreshInterval = TimeSpan.FromMinutes(1);
+        public static readonly TimeSpan DefaultFlushInterval = TimeSpan.FromMinutes(1);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
@@ -23,8 +23,7 @@ namespace Datadog.Trace.Telemetry
             HostTelemetryData? host,
             ICollection<TelemetryValue>? configuration,
             ICollection<DependencyTelemetryData>? dependencies,
-            ICollection<IntegrationTelemetryData>? integrations,
-            bool sendHeartbeat)
+            ICollection<IntegrationTelemetryData>? integrations)
         {
             if (application is null)
             {
@@ -77,12 +76,6 @@ namespace Datadog.Trace.Telemetry
                 return new[] { GetRequest(application, host, TelemetryRequestTypes.AppDependenciesLoaded, payload), };
             }
 
-            if (sendHeartbeat)
-            {
-                Log.Debug("No changes in telemetry, sending heartbeat");
-                return new[] { GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null) };
-            }
-
             Log.Debug("No changes in telemetry");
             return Array.Empty<TelemetryData>();
         }
@@ -101,6 +94,9 @@ namespace Datadog.Trace.Telemetry
 
             return GetRequest(application, host, TelemetryRequestTypes.AppClosing, payload: null);
         }
+
+        public TelemetryData BuildHeartbeatData(ApplicationTelemetryData application, HostTelemetryData host)
+            => GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null);
 
         private TelemetryData GetRequest(
             ApplicationTelemetryData application,

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -32,7 +32,8 @@ namespace Datadog.Trace.Telemetry
                         Dependencies,
                         Integrations,
                         factory,
-                        TelemetryConstants.RefreshInterval);
+                        TelemetryConstants.DefaultFlushInterval,
+                        settings.HeartbeatInterval);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.Telemetry
             }
 
             var rawInterval = source?.GetInt32(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds);
-            var heartbeatInterval = rawInterval is { } interval and > 0 and < 3600 ? interval : 60;
+            var heartbeatInterval = rawInterval is { } interval and > 0 and <= 3600 ? interval : 60;
 
             return new TelemetrySettings(telemetryEnabled, configurationError, agentless, TimeSpan.FromSeconds(heartbeatInterval));
         }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -13,11 +13,16 @@ namespace Datadog.Trace.Telemetry
 {
     internal class TelemetrySettings
     {
-        public TelemetrySettings(bool telemetryEnabled, string? configurationError, AgentlessSettings? agentlessSettings)
+        public TelemetrySettings(
+            bool telemetryEnabled,
+            string? configurationError,
+            AgentlessSettings? agentlessSettings,
+            TimeSpan heartbeatInterval)
         {
             TelemetryEnabled = telemetryEnabled;
             ConfigurationError = configurationError;
             Agentless = agentlessSettings;
+            HeartbeatInterval = heartbeatInterval;
         }
 
         /// <summary>
@@ -29,6 +34,8 @@ namespace Datadog.Trace.Telemetry
         public string? ConfigurationError { get; }
 
         public AgentlessSettings? Agentless { get; }
+
+        public TimeSpan HeartbeatInterval { get; }
 
         public static TelemetrySettings FromDefaultSources() => FromSource(GlobalConfigurationSource.Instance);
 
@@ -94,7 +101,10 @@ namespace Datadog.Trace.Telemetry
                 agentless = new AgentlessSettings(agentlessUri, apiKey!);
             }
 
-            return new TelemetrySettings(telemetryEnabled, configurationError, agentless);
+            var rawInterval = source?.GetInt32(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds);
+            var heartbeatInterval = rawInterval is { } interval and > 0 and < 3600 ? interval : 60;
+
+            return new TelemetrySettings(telemetryEnabled, configurationError, agentless, TimeSpan.FromSeconds(heartbeatInterval));
         }
 
         public class AgentlessSettings

--- a/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
@@ -17,6 +17,8 @@ namespace Datadog.Trace.IntegrationTests
 {
     public class TelemetryTransportTests
     {
+        private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(1);
+
         [SkippableFact]
         public async Task CanSendTelemetry()
         {
@@ -25,7 +27,7 @@ namespace Datadog.Trace.IntegrationTests
 
             // Uses framework specific transport
             var transport = TelemetryTransportFactory.Create(
-                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null),
+                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null, HeartbeatInterval),
                 new ImmutableExporterSettings(new ExporterSettings { AgentUri = telemetryUri }));
             var data = GetSampleData();
 
@@ -51,7 +53,7 @@ namespace Datadog.Trace.IntegrationTests
 
             // Uses framework specific transport
             var transport = TelemetryTransportFactory.Create(
-                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null),
+                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null, HeartbeatInterval),
                 new ImmutableExporterSettings(new ExporterSettings { AgentUri = telemetryUri }));
             var data = GetSampleData();
 
@@ -74,7 +76,7 @@ namespace Datadog.Trace.IntegrationTests
 
             // Uses framework specific transport
             var transport = TelemetryTransportFactory.Create(
-                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null),
+                new TelemetrySettings(telemetryEnabled: true, configurationError: null, agentlessSettings: null, HeartbeatInterval),
                 new ImmutableExporterSettings(new ExporterSettings { AgentUri = telemetryUri }));
             var data = GetSampleData();
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Tests.Telemetry
             while (DateTimeOffset.UtcNow < deadline)
             {
                 var heartBeatCount = transport.GetData().Count(x => x.RequestType == TelemetryRequestTypes.AppHeartbeat);
-                if (heartBeatCount > requiredHeartbeats)
+                if (heartBeatCount >= requiredHeartbeats)
                 {
                     break;
                 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
@@ -34,8 +34,8 @@ namespace Datadog.Trace.Tests.Telemetry
         {
             var builder = new TelemetryDataBuilder();
 
-            Assert.Throws<ArgumentNullException>(() => builder.BuildTelemetryData(null, _host, null, null, null, sendHeartbeat: true));
-            Assert.Throws<ArgumentNullException>(() => builder.BuildTelemetryData(_application, null, null, null, null, sendHeartbeat: true));
+            Assert.Throws<ArgumentNullException>(() => builder.BuildTelemetryData(null, _host, null, null, null));
+            Assert.Throws<ArgumentNullException>(() => builder.BuildTelemetryData(_application, null, null, null, null));
 
             Assert.Throws<ArgumentNullException>(() => builder.BuildAppClosingTelemetryData(null, _host));
             Assert.Throws<ArgumentNullException>(() => builder.BuildAppClosingTelemetryData(_application, null));
@@ -55,20 +55,37 @@ namespace Datadog.Trace.Tests.Telemetry
         }
 
         [Fact]
+        public void WhenHasApplicationAndHostData_GeneratesHeartbeatTelemetry()
+        {
+            var builder = new TelemetryDataBuilder();
+
+            var result = builder.BuildHeartbeatData(_application, _host);
+
+            result.Should().NotBeNull();
+            result.Application.Should().Be(_application);
+            result.SeqId.Should().Be(1);
+            result.Payload.Should().BeNull();
+        }
+
+        [Fact]
         public void ShouldGenerateIncrementingIds()
         {
             var builder = new TelemetryDataBuilder();
 
             var config = Array.Empty<TelemetryValue>();
-            var data = builder.BuildTelemetryData(_application, _host, config, null, null, sendHeartbeat: true);
+            var data = builder.BuildTelemetryData(_application, _host, config, null, null);
             data.Should().ContainSingle().Which.SeqId.Should().Be(1);
 
-            data = builder.BuildTelemetryData(_application, _host, config, null, null, sendHeartbeat: true);
+            data = builder.BuildTelemetryData(_application, _host, config, null, null);
             data.Should().ContainSingle().Which.SeqId.Should().Be(2);
 
             var closingData = builder.BuildAppClosingTelemetryData(_application, _host);
             closingData.Should().NotBeNull();
             closingData.SeqId.Should().Be(3);
+
+            var heartbeatData = builder.BuildHeartbeatData(_application, _host);
+            heartbeatData.Should().NotBeNull();
+            heartbeatData.SeqId.Should().Be(4);
         }
 
         [Theory]
@@ -77,7 +94,6 @@ namespace Datadog.Trace.Tests.Telemetry
             bool hasConfiguration,
             bool hasDependencies,
             bool hasIntegrations,
-            bool sendHeartBeat,
             string expectedRequests)
         {
             var config = hasConfiguration ? Array.Empty<TelemetryValue>() : null;
@@ -86,7 +102,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var expected = string.IsNullOrEmpty(expectedRequests) ? Array.Empty<string>() : expectedRequests.Split(',');
             var builder = new TelemetryDataBuilder();
 
-            var result = builder.BuildTelemetryData(_application, _host, config, dependencies, integrations, sendHeartBeat);
+            var result = builder.BuildTelemetryData(_application, _host, config, dependencies, integrations);
 
             result.Should().NotBeNull();
             result.Select(x => x.RequestType)
@@ -131,18 +147,17 @@ namespace Datadog.Trace.Tests.Telemetry
 
         public class TestData
         {
-            public static TheoryData<bool, bool, bool, bool, string> Data => new()
+            public static TheoryData<bool, bool, bool, string> Data => new()
                 // configuration, dependencies, integrations, sendHeartBeat expected request types
                 {
-                    { true, true, true, true, TelemetryRequestTypes.AppStarted },
-                    { true, true, false, true, TelemetryRequestTypes.AppStarted },
-                    { true, false, true, true, TelemetryRequestTypes.AppStarted },
-                    { true, false, false, true, TelemetryRequestTypes.AppStarted },
-                    { false, false, false, true, TelemetryRequestTypes.AppHeartbeat },
-                    { false, false, false, false, string.Empty },
-                    { false, true, false, true, TelemetryRequestTypes.AppDependenciesLoaded },
-                    { false, false, true, true, TelemetryRequestTypes.AppIntegrationsChanged },
-                    { false, true, true, true, $"{TelemetryRequestTypes.AppIntegrationsChanged},{TelemetryRequestTypes.AppDependenciesLoaded}" },
+                    { true, true, true, TelemetryRequestTypes.AppStarted },
+                    { true, true, false, TelemetryRequestTypes.AppStarted },
+                    { true, false, true, TelemetryRequestTypes.AppStarted },
+                    { true, false, false, TelemetryRequestTypes.AppStarted },
+                    { false, false, false, string.Empty },
+                    { false, true, false, TelemetryRequestTypes.AppDependenciesLoaded },
+                    { false, false, true, TelemetryRequestTypes.AppIntegrationsChanged },
+                    { false, true, true, $"{TelemetryRequestTypes.AppIntegrationsChanged},{TelemetryRequestTypes.AppDependenciesLoaded}" },
                 };
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public class TestData
         {
             public static TheoryData<bool, bool, bool, string> Data => new()
-                // configuration, dependencies, integrations, sendHeartBeat expected request types
+                // configuration, dependencies, integrations, expected request types
                 {
                     { true, true, true, TelemetryRequestTypes.AppStarted },
                     { true, true, false, TelemetryRequestTypes.AppStarted },


### PR DESCRIPTION
## Summary of changes

- Send the heartbeat independently of the flushed data
- Expose configuration setting for heartbeat refresh interval (for testing only)

## Reason for change

Requested by system tests so they can reduce the time tests take. Also flagged a mismatch between telemetry teams expectations - they were expecting the heartbeat always be sent, we were only sending it if there wasn't other data to flush

## Implementation details

- Expose the heartbeat interval as an env-var, so system tests could change it
- Extract an extra "heartbeat loop" that executes concurrently with the main loop
- Different flush times for the two loops - data is still flushed with the 1 minute interval, heartbeat is configurable (defaults to 1 minute)

## Test coverage

Covered by existing + some new tests for the change in behaviour

## Other details
