### PR TITLE
[Profiler] Enable local_only in libunwind

### DIFF
--- a/profiler/build/cmake/FindLibunwind.cmake
+++ b/profiler/build/cmake/FindLibunwind.cmake
@@ -7,7 +7,7 @@ ExternalProject_Add(libunwind
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3 CFLAGS=-fPIC\ -O3 --disable-minidebuginfo && make -j
+    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -DUNW_LOCAL_ONLY=1\ -O3 CFLAGS=-fPIC\ -O3 --disable-minidebuginfo && make -j
     BUILD_ALWAYS false
 )
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -7,8 +7,11 @@
 #include <chrono>
 #include <errno.h>
 #include <iomanip>
+
+#define UNW_LOCAL_ONLY
 #include <libunwind.h>
 #include <mutex>
+
 #include <signal.h>
 #include <sys/syscall.h>
 #include <unordered_map>


### PR DESCRIPTION
## Summary of changes

Enable local_only in libunwind (effectively disabling remote unwinding).

## Reason for change

In theory, some memory checks are bypassed when using local-only, which should reduce the overhead.

## Implementation details

Defining `UNW_LOCAL_ONLY` before including libunwind.h.
