### PR TITLE
Ensure we always run exploration tests on master

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -111,7 +111,6 @@ variables:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
   # For scheduled builds, only run benchmarks and throughput (and deps). Always do a full build on master.
-  isScheduledBuildOnMain: ${{ and(eq(variables['Build.Reason'], 'Schedule'), in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')) }}
   isBenchmarksOnlyBuild: ${{ and(eq(variables['Build.Reason'], 'Schedule'), not(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'))) }} # only works if you have a main branch
   dotnetToolTag: build-dotnet-tool
   Verify_DisableClipboard: true
@@ -1471,7 +1470,6 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables['isScheduledBuildOnMain'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'],'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
@@ -1529,7 +1527,6 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables['isScheduledBuildOnMain'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'],'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -987,7 +987,7 @@ partial class Build : NukeBuild
 
     static bool IsGitBaseBranch(string baseBranch)
         => string.Equals(
-            GitTasks.Git("git rev-parse --abbrev-ref HEAD").First().Text,
+            GitTasks.Git("rev-parse --abbrev-ref HEAD").First().Text,
             baseBranch,
             StringComparison.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary of changes

Updates the exploration tests variable generation to check if running on master - if so, always run exploration tests

## Reason for change

We were triggering the exploration tests to run on master on the scheduled build, but not actually generating the variables

## Implementation details

- Have the exploration test build check if running on master - if so, run all checks
- Removed the (now unnecessary) `isScheduledBuildOnMain` variable

## Test coverage

YOLO

## Other details
This is a slight behaviour change, as we now _always_ run the exploration tests on master, but I think that's a reasonable update.
