### PR TITLE
[Debugger] Resolving Live Debugger's code coverage degradation

### DIFF
--- a/tracer/build/_build/BuildVariables.cs
+++ b/tracer/build/_build/BuildVariables.cs
@@ -9,7 +9,7 @@ partial class Build
     public void AddDebuggerEnvironmentVariables(Dictionary<string, string> envVars)
     {
         AddTracerEnvironmentVariables(envVars);
-        envVars.Add("DD_DEBUGGER_ENABLED", "1");
+        envVars.Add("DD_DYNAMIC_INSTRUMENTATION_ENABLED", "1");
         envVars.Add("DD_INTERNAL_DEBUGGER_INSTRUMENT_ALL", "1");
         envVars.Add("COMPlus_DbgEnableMiniDump", "1");
         envVars.Add("COMPlus_DbgMiniDumpType", "4");

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.Configuration
             /// Default value is false (disabled).
             /// </summary>
             /// <seealso cref="DebuggerSettings.Enabled"/>
-            public const string Enabled = "DD_DEBUGGER_ENABLED";
+            public const string Enabled = "DD_DYNAMIC_INSTRUMENTATION_ENABLED";
 
             /// <summary>
             /// Configuration key for the max object depth to serialize for probe snapshots.

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -123,7 +123,7 @@ namespace Datadog.Trace.Debugger
 
                 if (!_settings.Enabled)
                 {
-                    Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
+                    Log.Information("Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.");
                     return false;
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -26,7 +26,7 @@ internal class LiveDebuggerFactory
         var settings = DebuggerSettings.FromDefaultSource();
         if (!settings.Enabled)
         {
-            Log.Information("Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.");
+            Log.Information("Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.");
             return LiveDebugger.Create(settings, string.Empty, null, null, null, null, null, null);
         }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_environment_variables.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_environment_variables.h
@@ -15,7 +15,7 @@ namespace environment
     const WSTRING internal_instrument_all_enabled = WStr("DD_INTERNAL_DEBUGGER_INSTRUMENT_ALL");
 
     // Determines if the Debugger is enabled.
-    const WSTRING debugger_enabled = WStr("DD_DEBUGGER_ENABLED");
+    const WSTRING debugger_enabled = WStr("DD_DYNAMIC_INSTRUMENTATION_ENABLED");
 
 } // namespace environment
 } // namespace debugger

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/LiveDebuggerTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Debugger;
 public class LiveDebuggerTests : TestHelper
 {
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
-    private const string LiveDebuggerDisabledLogEntry = "Live Debugger is disabled. To enable it, please set DD_DEBUGGER_ENABLED environment variable to 'true'.";
+    private const string LiveDebuggerDisabledLogEntry = "Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.";
 
     public LiveDebuggerTests(ITestOutputHelper output)
         : base("Probes", Path.Combine("test", "test-applications", "debugger"), output)

--- a/tracer/test/test-applications/debugger/Samples.Probes/Samples.Probes.csproj
+++ b/tracer/test/test-applications/debugger/Samples.Probes/Samples.Probes.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\dependency-libs\Samples.Probes.External\Samples.Probes.External.csproj" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/CtorTransparentCodeTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/CtorTransparentCodeTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.Debugger.Instrumentation;
 
 namespace Samples.Probes.SmokeTests
 {


### PR DESCRIPTION
## Summary of changes
In #3164, our sample `Samples.Probes` accidently referenced `Datadog.Trace.csproj` and it affected our code coverage severely as our code coverage tool is patching the assembly on disk to perform the and apparently picked the wrong `Datadog.Trace.dll`.

The second change in this PR is renaming Live Debugger's (now called Dynamic Instrumentation) environment variables enablement from `DD_DEBUGGER_*` -> `DD_DYNAMIC_INSTRUMENTATION_*`.
