### PR TITLE
Disable async probe

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1361,17 +1361,19 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     {
         const auto& methodProbeId = methodProbes[0]->probeId; // TODO accept multiple probeIds
 
-        Logger::Info("Applying Method Probe instrumentation with probeId.", methodProbeId);
 
         if (isAsyncMethod)
         {
-            hr = ApplyAsyncMethodProbe(corProfiler, module_id, module_metadata, caller, debuggerTokens, function_token,
+            Logger::Info("Async probe is disabled");
+            return S_OK;
+            /* hr = ApplyAsyncMethodProbe(corProfiler, module_id, module_metadata, caller, debuggerTokens, function_token,
                                        isStatic, &methodReturnType, methodProbeId, methodLocals, numLocals, rewriterWrapper, asyncMethodStateIndex, callTargetReturnIndex,
                                        returnValueIndex, callTargetReturnToken, firstInstruction, instrumentedMethodIndex, beforeLineProbe,
-                                       newClauses);
+                                       newClauses); */
         }
         else
         {
+            Logger::Info("Applying Method Probe instrumentation with probeId.", methodProbeId);
             hr = ApplyMethodProbe(corProfiler, module_id, module_metadata, caller, debuggerTokens, function_token,
                                   retFuncArg, isVoid, isStatic, methodArguments, numArgs, methodProbeId, rewriter,
                                   methodLocals, numLocals, rewriterWrapper, callTargetStateIndex, exceptionIndex,

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncCallChain.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncCallChain.cs
@@ -15,7 +15,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public async Task<int> Async1(int chain)
         {
             chain++;
@@ -24,7 +24,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public async Task<int> Async2(int chain)
         {
             await Task.Delay(20);

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Samples.Probes.SmokeTests
 {
-    [LineProbeTestData(lineNumber: 21)]
+    [LineProbeTestData(lineNumber: 21, skip: true)]
     public class AsyncInstanceMethod : IAsyncRun
     {
         private const string ClassName = "AsyncInstanceMethod";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
@@ -15,7 +15,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public async Task<string> Method(string input)
         {
             var output = input + ".";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncMethodInsideTaskRun.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncMethodInsideTaskRun.cs
@@ -12,7 +12,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public async Task<string> RunInsideTask()
         {
             return await Task.Run(
@@ -25,7 +25,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public async Task<string> Method(string seed)
         {
             string result = seed + " ";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncRecursiveCall.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncRecursiveCall.cs
@@ -12,7 +12,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData(expectedNumberOfSnapshots:3)]
+        [MethodProbeTestData(expectedNumberOfSnapshots:3, skip: true)]
         public async Task<int> Recursive(int i)
         {
             if (i == 2)

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncStaticMethod.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncStaticMethod.cs
@@ -14,7 +14,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         public static async Task<string> Method(string input)
         {
             var output = input + ".";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncThrowException.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncThrowException.cs
@@ -12,7 +12,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         private async Task<int> Method(string caller)
         {
             await Task.Delay(20);

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncVoid.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncVoid.cs
@@ -20,7 +20,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         private async Task VoidTaskMethod()
         {
             try
@@ -37,7 +37,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData]
+        [MethodProbeTestData(skip: true)]
         private async void VoidMethod(string caller)
         {
             await Task.Delay(20);

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncWithGenericArgumentAndLocal.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncWithGenericArgumentAndLocal.cs
@@ -42,7 +42,7 @@ namespace Samples.Probes.SmokeTests
             private static State[][] _stateArray;
 
             [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-            [MethodProbeTestData]
+            [MethodProbeTestData(skip: true)]
             public async Task<string> Method(NestedAsyncGenericClass<T> generic, string input)
             {
                 var list = new List<T> { new T() };


### PR DESCRIPTION
## Summary of changes
We are disabling async probes feature for now because we have an issue in certain case when we customer code is running in optimize build