### PR TITLE
GZip the data streams monitoring data sent to the agent

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Datadog.Trace.DataStreamsMonitoring.Utils;
 
 namespace Datadog.Trace.DataStreamsMonitoring.Aggregation;
@@ -53,24 +54,22 @@ internal class DataStreamsAggregator
     /// <summary>
     /// Serialize the aggregated results using message pack
     /// </summary>
-    /// <param name="buffer">The buffer to write the stats into. This may be replaced with a larger buffer
-    /// if it needs to grow</param>
-    /// <param name="offset">The offset into the buffer which to start writing</param>
+    /// <param name="stream">The buffer to write the stats into</param>
     /// <param name="maxBucketFlushTimeNs">Don't flush buckets that start (or include) this time (in Ns)</param>
-    /// <returns>The number of bytes written into the buffer</returns>
-    public int Serialize(ref byte[] buffer, int offset, long maxBucketFlushTimeNs)
+    /// <returns>True if data was serialized to the stream</returns>
+    public bool Serialize(Stream stream, long maxBucketFlushTimeNs)
     {
         var statsToAdd = Export(maxBucketFlushTimeNs);
         if (statsToAdd?.Count > 0)
         {
-            var bytesWritten = _formatter.Serialize(ref buffer, offset, _bucketDurationInNs, statsToAdd);
+            _formatter.Serialize(stream, _bucketDurationInNs, statsToAdd);
 
             Clear(statsToAdd);
 
-            return bytesWritten;
+            return true;
         }
 
-        return 0;
+        return false;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Transport/DataStreamsApi.cs
@@ -33,14 +33,15 @@ internal class DataStreamsApi : IDataStreamsApi
             Log.Debug<int>("Sending {Count} bytes to the data streams intake", bytes.Count);
             var request = _requestFactory.Create(_endpoint);
 
-            using var response = await request.PostAsync(bytes, MimeTypes.MsgPack).ConfigureAwait(false);
+            using var response = await request.PostAsync(bytes, MimeTypes.MsgPack, "gzip").ConfigureAwait(false);
             if (response.StatusCode is >= 200 and < 300)
             {
                 Log.Debug("Data streams monitoring data sent successfully");
                 return true;
             }
 
-            Log.Warning<string, int>("Error sending data streams monitoring data to '{Endpoint}' {StatusCode} ", _requestFactory.Info(_endpoint), response.StatusCode);
+            var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+            Log.Warning<string, int, string>("Error sending data streams monitoring data to '{Endpoint}' {StatusCode} {Content}", _requestFactory.Info(_endpoint), response.StatusCode, responseContent);
             return false;
         }
         catch (Exception ex)

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
@@ -65,13 +65,14 @@ public class DataStreamsAggregatorTests
     {
         var aggregator = CreateAggregatorWithData(T1, T2);
 
-        var buffer = Array.Empty<byte>();
-        var bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
-        bytesWritten.Should().BePositive();
+        using var ms1 = new MemoryStream();
+        var bytesWritten = aggregator.Serialize(ms1, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().BeTrue();
 
         // serializing clears the stats, so shouldn't write anything on the second attempt;
-        bytesWritten = aggregator.Serialize(ref buffer, offset: 0, maxBucketFlushTimeNs: T2);
-        bytesWritten.Should().Be(0);
+        using var ms2 = new MemoryStream();
+        bytesWritten = aggregator.Serialize(ms2, maxBucketFlushTimeNs: T2);
+        bytesWritten.Should().BeFalse();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
@@ -29,7 +29,6 @@ public class DataStreamsMessagePackFormatterTests
         var edgeTags = new[] { "edge-1" };
         var formatter = new DataStreamsMessagePackFormatter(env, service);
 
-        var bytes = new byte[100];
         var timeNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
 
         var bucketStartTimeNs1 = timeNs - (timeNs % bucketDuration);
@@ -73,9 +72,10 @@ public class DataStreamsMessagePackFormatterTests
                 }),
         };
 
-        var bytesWritten = formatter.Serialize(ref bytes, offset: 0, bucketDurationNs: bucketDuration, statsBuckets: buckets);
+        using var ms = new MemoryStream();
+        formatter.Serialize(ms, bucketDurationNs: bucketDuration, statsBuckets: buckets);
 
-        var data = new ArraySegment<byte>(bytes, offset: 0, count: bytesWritten);
+        var data = new ArraySegment<byte>(ms.GetBuffer());
 
         var result = MessagePackSerializer.Deserialize<MockDataStreamsPayload>(data);
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -1,0 +1,141 @@
+﻿// <copyright file="DataStreamsMonitoringTransportTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.DataStreamsMonitoring.Aggregation;
+using Datadog.Trace.DataStreamsMonitoring.Hashes;
+using Datadog.Trace.DataStreamsMonitoring.Transport;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.Agent;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Tests.DataStreamsMonitoring;
+
+public class DataStreamsMonitoringTransportTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public DataStreamsMonitoringTransportTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public static IEnumerable<object[]> Data =>
+        Enum.GetValues(typeof(TracesTransportType))
+            .Cast<TracesTransportType>()
+#if !NETCOREAPP3_1_OR_GREATER
+            .Where(x => x != TracesTransportType.UnixDomainSocket)
+#endif
+            .Select(x => new object[] { x });
+
+    [SkippableTheory]
+    [MemberData(nameof(Data))]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task TransportsWorkCorrectly(Enum transport)
+    {
+        var transportType = (TracesTransportType)transport;
+        if (transportType != TracesTransportType.WindowsNamedPipe)
+        {
+            await RunTest(transportType);
+            return;
+        }
+
+        // The server implementation of named pipes is flaky so have 3 attempts
+        var attemptsRemaining = 3;
+        while (true)
+        {
+            try
+            {
+                attemptsRemaining--;
+                await RunTest(transportType);
+                return;
+            }
+            catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
+            {
+                _output.WriteLine($"Error executing test. {attemptsRemaining} attempts remaining. {ex}");
+            }
+        }
+    }
+
+    private async Task RunTest(TracesTransportType tracesTransportType)
+    {
+        using var agent = Create(tracesTransportType);
+
+        var bucketDurationMs = 100; // 100 ms
+        var tracerSettings = new TracerSettings { Exporter = GetExporterSettings(agent) };
+        var api = new DataStreamsApi(
+            DataStreamsTransportStrategy.GetAgentIntakeFactory(tracerSettings.Build().Exporter));
+
+        var discovery = new DiscoveryServiceMock();
+        var writer = new DataStreamsWriter(
+            new DataStreamsAggregator(
+                new DataStreamsMessagePackFormatter("env", "service"),
+                bucketDurationMs),
+            api,
+            bucketDurationMs: bucketDurationMs,
+            discovery);
+
+        discovery.TriggerChange();
+
+        writer.Add(CreateStatsPoint());
+
+        await writer.DisposeAsync();
+
+        var payload = agent.DataStreams.Should().ContainSingle().Subject;
+        payload.Env.Should().Be("env");
+        payload.Service.Should().Be("service");
+        var headers = agent.DataStreamsRequestHeaders.Should().ContainSingle().Subject;
+        headers.AllKeys.ToDictionary(x => x, x => headers[x])
+               .Should()
+               .ContainKey("Content-Encoding", "gzip");
+    }
+
+    private StatsPoint CreateStatsPoint()
+        => new StatsPoint(
+            edgeTags: new[] { "type:internal" },
+            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
+            pathwayLatencyNs: 5_000_000_000,
+            edgeLatencyNs: 2_000_000_000);
+
+    private MockTracerAgent Create(TracesTransportType transportType)
+        => transportType switch
+        {
+            TracesTransportType.Default => MockTracerAgent.Create(_output),
+            TracesTransportType.WindowsNamedPipe => MockTracerAgent.Create(_output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}")),
+#if NETCOREAPP3_1_OR_GREATER
+            TracesTransportType.UnixDomainSocket => MockTracerAgent.Create(
+                _output,
+                new UnixDomainSocketConfig(
+                    Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()),
+                    Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()))),
+#endif
+            _ => throw new InvalidOperationException("Unknown transport type " + transportType),
+        };
+
+    private ExporterSettings GetExporterSettings(MockTracerAgent agent)
+        => agent switch
+        {
+            MockTracerAgent.TcpUdpAgent x => new ExporterSettings { AgentUri = new Uri($"http://localhost:{x.Port}") },
+            MockTracerAgent.NamedPipeAgent x => new ExporterSettings { TracesPipeName = x.TracesWindowsPipeName, TracesTransport = TracesTransportType.WindowsNamedPipe },
+#if NETCOREAPP3_1_OR_GREATER
+            MockTracerAgent.UdsAgent x =>  new ExporterSettings { TracesTransport = TracesTransportType.UnixDomainSocket, TracesUnixDomainSocketPath = x.TracesUdsPath },
+#endif
+            _ => throw new InvalidOperationException("Unknown agent type " + agent.GetType()),
+        };
+}


### PR DESCRIPTION
## Summary of changes

GZip the DSM data sent to the agent

## Reason for change

The agent only supports payloads that are gzip encoded, so needed to refactor to support that.

## Implementation details

- Converted serialization code to work on `Stream` instead of `ref byte[]`, so that we can transparently gzip the data on the way.
- Adds support for gzip decoding of `MockTracerAgent` DSM requests

## Test coverage

- Added explicit testing of DSM requests sent over multiple transports to ensure the encoding is working correctly
- Verified that we can gunzip the payload written by the writer
- Manually tested against a real agent

## Other details

Dependent on: 
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3238
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3099
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3154
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3174
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3191
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3192
- [x] https://github.com/DataDog/dd-trace-dotnet/pull/3220

Subsequent PRs to follow:

- Public API/adaptation of existing to handle manual context creation (e.g. when automatic consumer scopes are disabled)

