### PR TITLE
[ASM] Prevent waf from breaking app if non compatible native library file is loaded by tracer

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -305,44 +305,33 @@ partial class Build
         UncompressZip(libDdwafZip, uncompressFolder);
     }
 
-    Target CopyLibDdwaf =>
-        _ =>
-            _.Unlisted()
-                .After(Clean)
-                .After(DownloadLibDdwaf)
-                .Executes(() =>
-                {
-                    if (IsWin)
-                    {
-                        foreach (var architecture in WafWindowsArchitectureFolders)
-                        {
-                            var source =
-                                LibDdwafDirectory()
-                                / "runtimes"
-                                / architecture
-                                / "native"
-                                / "ddwaf.dll";
-                            var dest = MonitoringHomeDirectory / architecture;
-                            CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
-                        }
-                    }
-                    else
-                    {
-                        var (sourceArch, ext) = GetLibDdWafUnixArchitectureAndExtension();
-                        var (destArch, _) = GetUnixArchitectureAndExtension();
+    Target CopyLibDdwaf => _ => _
+        .Unlisted()
+        .After(Clean)
+        .After(DownloadLibDdwaf)
+        .Executes(() =>
+        {
+          if (IsWin)
+          {
+              foreach (var architecture in WafWindowsArchitectureFolders)
+              {
+                  var source = LibDdwafDirectory() / "runtimes" / architecture / "native" / "ddwaf.dll";
+                  var dest = MonitoringHomeDirectory / architecture;
+                  CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+              }
+          }
+          else
+          {
+              var (sourceArch, ext) = GetLibDdWafUnixArchitectureAndExtension();
+              var (destArch, _) = GetUnixArchitectureAndExtension();
 
-                        var ddwafFileName = $"libddwaf.{ext}";
+              var ddwafFileName = $"libddwaf.{ext}";
 
-                        var source =
-                            LibDdwafDirectory()
-                            / "runtimes"
-                            / sourceArch
-                            / "native"
-                            / ddwafFileName;
-                        var dest = MonitoringHomeDirectory / destArch;
-                        CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
-                    }
-                });
+              var source = LibDdwafDirectory() / "runtimes" / sourceArch / "native" / ddwafFileName;
+              var dest = MonitoringHomeDirectory / destArch;
+              CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+          }
+        });
 
     Target CopyNativeFilesForAppSecUnitTests => _ => _
                 .Unlisted()

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -61,7 +61,7 @@ partial class Build
 
     const string OlderLibDdwafVersion = "1.4.0";
 
-    AbsolutePath LibDdwafDirectory => (NugetPackageDirectory ?? RootDirectory / "packages") / $"libddwaf.{LibDdwafVersion}";
+    AbsolutePath LibDdwafDirectory(string libDdwafVersion = null) => (NugetPackageDirectory ?? RootDirectory / "packages") / $"libddwaf.{libDdwafVersion ?? LibDdwafVersion}";
 
     AbsolutePath SourceDirectory => TracerDirectory / "src";
     AbsolutePath BuildDirectory => TracerDirectory / "build";
@@ -279,7 +279,7 @@ partial class Build
 
     Target DownloadLibDdwaf => _ => _.Unlisted().After(CreateRequiredDirectories).Executes(() => DownloadWafVersion());
 
-    async Task DownloadWafVersion(string libddwafVersion = null, string uncompressFolder = null)
+    async Task DownloadWafVersion(string libddwafVersion = null, string uncompressFolderTarget = null)
     {
         var libDdwafUri = new Uri(
             $"https://www.nuget.org/api/v2/package/libddwaf/{libddwafVersion ?? LibDdwafVersion}"
@@ -297,10 +297,10 @@ partial class Build
             await stream.CopyToAsync(file);
         }
 
-        uncompressFolder ??= LibDdwafDirectory(libddwafVersion);
-        Console.WriteLine($"{libDdwafZip} downloaded. Extracting to {uncompressFolder}...");
+        uncompressFolderTarget ??= LibDdwafDirectory(libddwafVersion);
+        Console.WriteLine($"{libDdwafZip} downloaded. Extracting to {uncompressFolderTarget}...");
 
-        UncompressZip(libDdwafZip, uncompressFolder);
+        UncompressZip(libDdwafZip, uncompressFolderTarget);
     }
 
     Target CopyLibDdwaf => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -361,7 +361,7 @@ partial class Build
                                 var dest = testBinFolder / fmk / arch;
                                 CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
 
-                                CopyFile(oldVersionPath, dest / $"ddwaf{OlderLibDdwafVersion}.dll", FileExistsPolicy.Overwrite);
+                                CopyFile(oldVersionPath, dest / $"ddwaf-{OlderLibDdwafVersion}.dll", FileExistsPolicy.Overwrite);
                             }
                         }
                     }
@@ -385,7 +385,7 @@ partial class Build
                             // use the files from the monitoring native folder
                             CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
 
-                            CopyFile(oldVersionPath, dest / $"libddwaf{OlderLibDdwafVersion}.{ext}", FileExistsPolicy.Overwrite);
+                            CopyFile(oldVersionPath, dest / $"libddwaf-{OlderLibDdwafVersion}.{ext}", FileExistsPolicy.Overwrite);
                         }
                     }
                 });

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -61,9 +61,7 @@ partial class Build
 
     const string OlderLibDdwafVersion = "1.4.0";
 
-    AbsolutePath LibDdwafDirectory(string libDdwafVersion = null) =>
-        (NugetPackageDirectory ?? RootDirectory / "packages")
-        / $"libddwaf.{libDdwafVersion ?? LibDdwafVersion}";
+    AbsolutePath LibDdwafDirectory => (NugetPackageDirectory ?? RootDirectory / "packages") / $"libddwaf.{LibDdwafVersion}";
 
     AbsolutePath SourceDirectory => TracerDirectory / "src";
     AbsolutePath BuildDirectory => TracerDirectory / "build";

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -356,33 +356,23 @@ partial class Build
                     {
                         foreach (var arch in WafWindowsArchitectureFolders)
                         {
-                            var oldVersionPath =
-                                oldVersionTempPath / "runtimes" / arch / "native" / "ddwaf.dll";
+                            var oldVersionPath = oldVersionTempPath / "runtimes" / arch / "native" / "ddwaf.dll";
                             var source = MonitoringHomeDirectory / arch;
                             foreach (var fmk in frameworks)
                             {
                                 var dest = testBinFolder / fmk / arch;
-                                CopyDirectoryRecursively(
-                                    source,
-                                    dest,
-                                    DirectoryExistsPolicy.Merge,
-                                    FileExistsPolicy.Overwrite
-                                );
+                                CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
 
-                                CopyFile(
-                                    oldVersionPath,
-                                    dest / $"ddwaf{OlderLibDdwafVersion}.dll",
-                                    FileExistsPolicy.Overwrite
-                                );
+                                CopyFile(oldVersionPath, dest / $"ddwaf{OlderLibDdwafVersion}.dll", FileExistsPolicy.Overwrite);
                             }
                         }
                     }
                     else
                     {
-                        var (arch, ext) = GetUnixArchitectureAndExtension();
+                        var (arch, _) = GetUnixArchitectureAndExtension();
+                        var (archWaf, ext) = GetLibDdWafUnixArchitectureAndExtension();
                         var source = MonitoringHomeDirectory / arch;
-                        var oldVersionPath =
-                            oldVersionTempPath / "runtimes" / arch / "native" / $"libddwaf.{ext}";
+                        var oldVersionPath = oldVersionTempPath / "runtimes" / archWaf / "native" / $"libddwaf.{ext}";
                         foreach (var fmk in frameworks)
                         {
                             // We have to copy into the _root_ test bin folder here, not the arch sub-folder.
@@ -395,19 +385,9 @@ partial class Build
                             var dest = testBinFolder / fmk;
 
                             // use the files from the monitoring native folder
-                            CopyDirectoryRecursively(
-                                source,
-                                dest,
-                                DirectoryExistsPolicy.Merge,
-                                FileExistsPolicy.Overwrite
-                            );
+                            CopyDirectoryRecursively(source, dest, DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
 
-                            CopyFile(
-                                oldVersionPath,
-                                dest / $"libddwaf{OlderLibDdwafVersion}.{ext}",
-                                FileExistsPolicy.Overwrite
-                            );
-                            ;
+                            CopyFile(oldVersionPath, dest / $"libddwaf{OlderLibDdwafVersion}.{ext}", FileExistsPolicy.Overwrite);
                         }
                     }
                 });
@@ -660,7 +640,7 @@ partial class Build
                 replacement:$@";$1;./{arch}/Datadog.");
             File.WriteAllText(assetsDirectory / FileNames.LoaderConf, contents: loaderConfContents);
 
- // Copy createLogPath.sh script and set the permissions 
+            // Copy createLogPath.sh script and set the permissions 
             CopyFileToDirectory(BuildDirectory / "artifacts" / FileNames.CreateLogPathScript, assetsDirectory);
             chmod.Invoke($"+x {assetsDirectory / FileNames.CreateLogPathScript}");
 

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace.AppSec
         internal InstrumentationGateway InstrumentationGateway => _instrumentationGateway;
 
         internal bool WafExportsErrorHappened => _waf.InitializationResult.ExportErrors;
-            
+
         /// <summary>
         /// Gets <see cref="SecuritySettings"/> instance
         /// </summary>
@@ -266,14 +266,15 @@ namespace Datadog.Trace.AppSec
 
         private void SetRemoteConfigCapabilites()
         {
-            RemoteConfigurationManager.CallbackWithInitializedInstance(rcm =>
-            {
-                rcm.SetCapability(RcmCapabilitiesIndices.AsmActivation, _settings.CanBeEnabled);
-                // TODO set to '_settings.Rules == null' when https://github.com/DataDog/dd-trace-dotnet/pull/3120 is merged
-                rcm.SetCapability(RcmCapabilitiesIndices.AsmDdRules, false);
-                // TODO set to true when https://github.com/DataDog/dd-trace-dotnet/pull/3171 is merged
-                rcm.SetCapability(RcmCapabilitiesIndices.AsmIpBlocking, false);
-            });
+            RemoteConfigurationManager.CallbackWithInitializedInstance(
+                rcm =>
+                {
+                    rcm.SetCapability(RcmCapabilitiesIndices.AsmActivation, _settings.CanBeEnabled);
+                    // TODO set to '_settings.Rules == null' when https://github.com/DataDog/dd-trace-dotnet/pull/3120 is merged
+                    rcm.SetCapability(RcmCapabilitiesIndices.AsmDdRules, false);
+                    // TODO set to true when https://github.com/DataDog/dd-trace-dotnet/pull/3171 is merged
+                    rcm.SetCapability(RcmCapabilitiesIndices.AsmIpBlocking, false);
+                });
         }
 
         private void FeaturesProductConfigChanged(object sender, ProductConfigChangedEventArgs e)
@@ -291,6 +292,7 @@ namespace Datadog.Trace.AppSec
         private void UpdateStatus()
         {
             if (_enabled == _settings.Enabled) { return; }
+
             lock (_settings)
             {
                 if (_settings.Enabled)

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -138,7 +138,7 @@ namespace Datadog.Trace.AppSec
 
         internal InstrumentationGateway InstrumentationGateway => _instrumentationGateway;
 
-        internal bool WafExportsErrorHappened => _waf.InitializationResult.ExportErrors;
+        internal bool WafExportsErrorHappened => _waf?.InitializationResult?.ExportErrors ?? false;
 
         /// <summary>
         /// Gets <see cref="SecuritySettings"/> instance

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -517,7 +517,7 @@ namespace Datadog.Trace.AppSec
                 span.SetTag(Tags.AppSecWafInitRuleErrors, _waf.InitializationResult.ErrorMessage);
             }
 
-            span.SetTag(Tags.AppSecWafVersion, _waf.Version.ToString());
+            span.SetTag(Tags.AppSecWafVersion, _waf.Version);
         }
 
         private void RunShutdown()

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -138,6 +138,8 @@ namespace Datadog.Trace.AppSec
 
         internal InstrumentationGateway InstrumentationGateway => _instrumentationGateway;
 
+        internal bool WafExportsErrorHappened => _waf.InitializationResult.ExportErrors;
+            
         /// <summary>
         /// Gets <see cref="SecuritySettings"/> instance
         /// </summary>

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLoader.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLoader.cs
@@ -17,11 +17,11 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(LibraryLoader));
 
-        internal static IntPtr LoadAndGetHandle()
+        internal static IntPtr LoadAndGetHandle(string libVersion = null)
         {
             var fd = FrameworkDescription.Instance;
 
-            var libName = GetLibName(fd);
+            var libName = GetLibName(fd, libVersion);
             var runtimeIds = GetRuntimeIds(fd);
 
             // libName or runtimeIds being null means platform is not supported
@@ -182,12 +182,12 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             return success;
         }
 
-        private static string GetLibName(FrameworkDescription fwk)
+        private static string GetLibName(FrameworkDescription fwk, string libVersion = null)
             => fwk.OSPlatform switch
             {
-                OSPlatformName.MacOS => "libddwaf.dylib",
-                OSPlatformName.Linux => "libddwaf.so",
-                OSPlatformName.Windows => "ddwaf.dll",
+                OSPlatformName.MacOS => $"libddwaf{libVersion}.dylib",
+                OSPlatformName.Linux => $"libddwaf{libVersion}.so",
+                OSPlatformName.Windows => $"ddwaf{libVersion}.dll",
                 _ => null, // unsupported
             };
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLoader.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLoader.cs
@@ -123,8 +123,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
 
             // include the appdomain base as this will help framework samples running in IIS find the library
             var currentDir =
-                string.IsNullOrEmpty(AppDomain.CurrentDomain.RelativeSearchPath) ?
-                    AppDomain.CurrentDomain.BaseDirectory : AppDomain.CurrentDomain.RelativeSearchPath;
+                string.IsNullOrEmpty(AppDomain.CurrentDomain.RelativeSearchPath) ? AppDomain.CurrentDomain.BaseDirectory : AppDomain.CurrentDomain.RelativeSearchPath;
 
             if (!string.IsNullOrWhiteSpace(currentDir))
             {
@@ -183,13 +182,21 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
         }
 
         private static string GetLibName(FrameworkDescription fwk, string libVersion = null)
-            => fwk.OSPlatform switch
+        {
+            string versionSuffix = null;
+            if (!string.IsNullOrEmpty(libVersion))
             {
-                OSPlatformName.MacOS => $"libddwaf{libVersion}.dylib",
-                OSPlatformName.Linux => $"libddwaf{libVersion}.so",
-                OSPlatformName.Windows => $"ddwaf{libVersion}.dll",
+                versionSuffix = $"-{libVersion}";
+            }
+
+            return fwk.OSPlatform switch
+            {
+                OSPlatformName.MacOS => $"libddwaf{versionSuffix}.dylib",
+                OSPlatformName.Linux => $"libddwaf{versionSuffix}.so",
+                OSPlatformName.Windows => $"ddwaf{versionSuffix}.dll",
                 _ => null, // unsupported
             };
+        }
 
         private static string[] GetRuntimeIds(FrameworkDescription fwk)
             => fwk.OSPlatform switch

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.AppSec.Waf.ReturnTypesManaged;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -26,15 +27,15 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
         {
             if (wafNative.ExportErrorHappened)
             {
-                Log.Error("Waf couldn't initialize properly because of missing methods in native library, please check the version of libddwaf");
-                return InitializationResult.FromWrongWafVersion();
+                Log.Error("Waf couldn't initialize properly because of missing methods in native library, please make sure the tracer has been correctly installed and that previous versions are correctly uninstalled.");
+                return InitializationResult.FromExportErrors();
             }
 
             var argCache = new List<Obj>();
             var configObj = GetConfigObj(rulesFile, argCache, encoder);
             if (configObj == null)
             {
-                Log.Error("Waf couldn't initialize properly because of an unusable rule file, please check the submitted rulefile");
+                Log.Error("Waf couldn't initialize properly because of an unusable rule file. If you set the environment variable {appsecrule_env}, check the path and content of the file are correct.", ConfigurationKeys.AppSec.Rules);
                 return InitializationResult.FromUnusableRuleFile();
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
@@ -41,7 +41,6 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         private readonly IntPtr _freeObjectFuncField;
         private readonly FreeRulesetInfoDelegate _rulesetInfoFreeField;
         private readonly SetupLogCallbackDelegate _setupLogCallbackField;
-
         private string version = null;
 
         /// <summary>
@@ -91,8 +90,6 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 
         private delegate IntPtr InitContextDelegate(IntPtr powerwafHandle);
 
-        private delegate IntPtr InitMetricsCollectorDelegate(IntPtr powerwafHandle);
-
         private delegate DDWAF_RET_CODE RunDelegate(IntPtr context, IntPtr newArgs, ref DdwafResultStruct result, ulong timeLeftInUs);
 
         private delegate void DestroyDelegate(IntPtr handle);
@@ -137,6 +134,8 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             DDWAF_ERROR,
             DDWAF_AFTER_LAST,
         }
+
+        internal bool ExportErrorHappened { get; private set; }
 
         internal IntPtr ObjectFreeFuncPtr => _freeObjectFuncField;
 
@@ -246,6 +245,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             if (funcPtr == IntPtr.Zero)
             {
                 _log.Error("No function of name {functionName} exists on waf object", functionName);
+                ExportErrorHappened = true;
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitializationResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitializationResult.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InitializationResult));
 
-        public InitializationResult(IntPtr? ruleHandle, ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, string[]> errors, bool unusableRuleFile = false)
+        public InitializationResult(IntPtr? ruleHandle, ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, string[]> errors, bool unusableRuleFile = false, bool wrongWafVersion = false)
         {
             HasErrors = errors.Count > 0;
             Errors = errors;
@@ -26,6 +26,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
             RuleFileVersion = ruleFileVersion;
             RuleHandle = ruleHandle;
             UnusableRuleFile = unusableRuleFile;
+            WrongWafVersion = wrongWafVersion;
         }
 
         internal IntPtr? RuleHandle { get; }
@@ -45,9 +46,13 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
 
         internal bool UnusableRuleFile { get; }
 
+        internal bool WrongWafVersion { get; }
+
         internal string RuleFileVersion { get; }
 
         internal static InitializationResult FromUnusableRuleFile() => new(null, 0, 0, string.Empty, new Dictionary<string, string[]>(), true);
+
+        internal static InitializationResult FromWrongWafVersion() => new(null, 0, 0, string.Empty, new Dictionary<string, string[]>(), wrongWafVersion: true);
 
         internal static InitializationResult From(DdwafRuleSetInfoStruct ddwaRuleSetInfoStruct, IntPtr? ruleHandle)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitializationResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitializationResult.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InitializationResult));
 
-        public InitializationResult(IntPtr? ruleHandle, ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, string[]> errors, bool unusableRuleFile = false, bool wrongWafVersion = false)
+        public InitializationResult(IntPtr? ruleHandle, ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, string[]> errors, bool unusableRuleFile = false, bool exportErrors = false)
         {
             HasErrors = errors.Count > 0;
             Errors = errors;
@@ -26,7 +26,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
             RuleFileVersion = ruleFileVersion;
             RuleHandle = ruleHandle;
             UnusableRuleFile = unusableRuleFile;
-            WrongWafVersion = wrongWafVersion;
+            ExportErrors = exportErrors;
         }
 
         internal IntPtr? RuleHandle { get; }
@@ -46,13 +46,13 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypesManaged
 
         internal bool UnusableRuleFile { get; }
 
-        internal bool WrongWafVersion { get; }
+        internal bool ExportErrors { get; }
 
         internal string RuleFileVersion { get; }
 
         internal static InitializationResult FromUnusableRuleFile() => new(null, 0, 0, string.Empty, new Dictionary<string, string[]>(), true);
 
-        internal static InitializationResult FromWrongWafVersion() => new(null, 0, 0, string.Empty, new Dictionary<string, string[]>(), wrongWafVersion: true);
+        internal static InitializationResult FromExportErrors() => new(null, 0, 0, string.Empty, new Dictionary<string, string[]>(), exportErrors: true);
 
         internal static InitializationResult From(DdwafRuleSetInfoStruct ddwaRuleSetInfoStruct, IntPtr? ruleHandle)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -57,10 +57,11 @@ namespace Datadog.Trace.AppSec.Waf
         /// <param name="obfuscationParameterValueRegex">the regex that will be used to obfuscate possible sensitive data in values that are highlighted WAF as potentially malicious,
         /// empty string means use default embedded in the WAF</param>
         /// <param name="rulesFile">can be null, means use rules embedded in the manifest </param>
+        /// <param name="libVersion">can be null, means use a specific version in the name of the loaded file </param>
         /// <returns>the waf wrapper around waf native</returns>
-        internal static Waf Create(string obfuscationParameterKeyRegex, string obfuscationParameterValueRegex, string rulesFile = null)
+        internal static Waf Create(string obfuscationParameterKeyRegex, string obfuscationParameterValueRegex, string rulesFile = null, string libVersion = null)
         {
-            var libraryHandle = LibraryLoader.LoadAndGetHandle();
+            var libraryHandle = LibraryLoader.LoadAndGetHandle(libVersion);
             if (libraryHandle == IntPtr.Zero)
             {
                 return null;

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -405,17 +405,7 @@ namespace Datadog.Trace
                     writer.WritePropertyName("agent_error");
                     writer.WriteValue(agentError ?? string.Empty);
 
-                    writer.WritePropertyName("appsec_enabled");
-                    writer.WriteValue(Security.Instance.Settings.Enabled);
-
-                    writer.WritePropertyName("appsec_trace_rate_limit");
-                    writer.WriteValue(Security.Instance.Settings.TraceRateLimit);
-
-                    writer.WritePropertyName("appsec_rules_file_path");
-                    writer.WriteValue(Security.Instance.Settings.Rules ?? "(default)");
-
-                    writer.WritePropertyName("appsec_libddwaf_version");
-                    writer.WriteValue(Security.Instance.DdlibWafVersion ?? "(none)");
+                    WriteAsmInfo(writer);
 
                     writer.WritePropertyName("direct_logs_submission_enabled_integrations");
                     writer.WriteStartArray();
@@ -467,6 +457,28 @@ namespace Datadog.Trace
             catch (Exception ex)
             {
                 Log.Warning(ex, "DATADOG TRACER DIAGNOSTICS - Error fetching configuration");
+            }
+        }
+
+        private static void WriteAsmInfo(JsonTextWriter writer)
+        {
+            var security = Security.Instance;
+            writer.WritePropertyName("appsec_enabled");
+            writer.WriteValue(security.Settings.Enabled);
+
+            writer.WritePropertyName("appsec_trace_rate_limit");
+            writer.WriteValue(security.Settings.TraceRateLimit);
+
+            writer.WritePropertyName("appsec_rules_file_path");
+            writer.WriteValue(security.Settings.Rules ?? "(default)");
+
+            writer.WritePropertyName("appsec_libddwaf_version");
+            writer.WriteValue(security.DdlibWafVersion ?? "(none)");
+
+            if (security.WafExportsErrorHappened)
+            {
+                writer.WritePropertyName("appsec_libddwaf_export_errors");
+                writer.WriteValue(security.WafExportsErrorHappened);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         {
             using var waf = Waf.Create(string.Empty, string.Empty, string.Empty, "1.4.0");
             waf.InitializedSuccessfully.Should().BeFalse();
-            waf.InitializationResult.WrongWafVersion.Should().BeTrue();
+            waf.InitializationResult.ExportErrors.Should().BeTrue();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         {
             using var waf = Waf.Create(string.Empty, string.Empty, string.Empty, "1.4.0");
             waf.InitializedSuccessfully.Should().BeFalse();
+            waf.InitializationResult.WrongWafVersion.Should().BeTrue();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
@@ -1,0 +1,25 @@
+// <copyright file="WafCompatibilityTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Specialized;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests
+{
+    [Collection("WafTests")]
+    public class WafCompatibilityTests
+    {
+        [SkippableFact]
+        public void ShouldNotInitialize()
+        {
+            using var waf = Waf.Create(string.Empty, string.Empty, string.Empty, "1.4.0");
+            waf.InitializedSuccessfully.Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
If some export is null then it means we dont have the right underlying waf native file version, so dont init waf. 
`LibraryLoader` can now load a specific version of the waf provided that the file's name contain it, for the purpose of Unit Tests only.
Added in Build.steps the ability to load an older version (arbitrarily 1.4 now) to rename the waf after unzipping 

## Reason for change
make sure waf's breaking change dont break the app

## Implementation details
Depends on https://github.com/DataDog/system-tests/pull/509

## Test coverage
Add a unit test with older waf version to test.

## Other details
<!-- Fixes #{issue} -->
