### PR TITLE
Add `NullDiscoveryService` for CI visibility and testing

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/NullDiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/NullDiscoveryService.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="NullDiscoveryService.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Agent.DiscoveryService;
+
+internal class NullDiscoveryService : IDiscoveryService
+{
+    public static readonly NullDiscoveryService Instance = new();
+
+    public void SubscribeToChanges(Action<AgentConfiguration> callback)
+    {
+    }
+
+    public void RemoveSubscription(Action<AgentConfiguration> callback)
+    {
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -75,5 +75,8 @@ namespace Datadog.Trace.Ci
                 return new CIAgentWriter(settings, sampler, discoveryService, traceBufferSize);
             }
         }
+
+        protected override IDiscoveryService GetDiscoveryService(ImmutableTracerSettings settings)
+            => _settings.Agentless ? NullDiscoveryService.Instance : base.GetDiscoveryService(settings);
     }
 }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace
                                      GetApplicationName() ??
                                      UnknownServiceName;
 
-            discoveryService ??= DiscoveryService.Create(settings.Exporter);
+            discoveryService ??= GetDiscoveryService(settings);
 
             statsd = settings.TracerMetricsEnabled
                          ? (statsd ?? CreateDogStatsdClient(settings, defaultServiceName))
@@ -179,6 +179,9 @@ namespace Datadog.Trace
 
             return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize);
         }
+
+        protected virtual IDiscoveryService GetDiscoveryService(ImmutableTracerSettings settings)
+            => DiscoveryService.Create(settings.Exporter);
 
         private static IDogStatsd CreateDogStatsdClient(ImmutableTracerSettings settings, string serviceName)
         {

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.PlatformHelpers;
@@ -59,8 +60,8 @@ namespace Datadog.Trace.IntegrationTests
                 }
             };
 
-            var immutableSettings = settings.Build();
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            var discovery = DiscoveryService.Create(settings.Build().Exporter);
+            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
             Span span;
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
@@ -207,8 +208,8 @@ namespace Datadog.Trace.IntegrationTests
                 }
             };
 
-            var immutableSettings = settings.Build();
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            var discovery = DiscoveryService.Create(settings.Build().Exporter);
+            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
             var spinSucceeded = SpinWait.SpinUntil(() => tracer.TracerManager.AgentWriter is AgentWriter { CanComputeStats: true }, 5_000);
@@ -367,7 +368,8 @@ namespace Datadog.Trace.IntegrationTests
 
             var immutableSettings = settings.Build();
 
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            var discovery = DiscoveryService.Create(immutableSettings.Exporter);
+            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null, discoveryService: discovery);
 
             // Wait until the discovery service has been reached and we've confirmed that we can send stats
             if (expectStats)


### PR DESCRIPTION
## Summary of changes

- Adds a noop `NullDiscoveryService`
- Use `NullDiscoveryService` for CI visibility when in agentless mode
- Use `NullDiscoveryService` by default with our `internal new Tracer()` constructor (used in tests)

## Reason for change

- The agent isn't available when running in ci-app in agentless mode, so no sense starting the discovery service, as it will never succeed
- In tests that were creating a tracer, they were starting a discoveryservice instance. For unit-tests (where they run without an agent), this would inevitably fail, writing a log message. As we run hundreds of tests, this generates hundreds of logs. On top of that, as the discoveryservice wasn't shut down, it was retrying, ultimately generating thousands of logs across all the different tests.

## Implementation details

Create a `NullDiscoveryService` and use it by default for the internal `Tracer` constructor. This is the same approach we use for Telemetry, and is a pretty safe change to make, as the "normal" API does not use this approach. Need to update any tests which expect the real `DiscoveryService` to be created (e.g. `StatsTests`)

Added `GetDiscoveryService()` overridable method to `TracerManagerFactory` so that ci-visibility can customise as required. 

## Test coverage

No explicit tests for `NullDiscoveryService`, just need to make sure all existing tests pass.

## Other details

Hopefully we don't see any more log explosions in CI 🤞 