### PR TITLE
Update the list of expected file changes when doing a version bump

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -410,6 +410,8 @@ partial class Build
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",
                 "profiler/src/ProfilerEngine/ProductVersion.props",
+                "shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
+                "shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc",
                 "shared/src/msi-installer/WindowsInstaller.wixproj",
                 "tracer/build/_build/Build.cs",
                 "tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",


### PR DESCRIPTION
## Summary of changes

- Update the list of expected file changes when doing a version bump

## Reason for change

#3147 updated the native loader to set the version correctly. That means we expect these two files to change when we do a version bump (e.g. as in #3258).

## Implementation details

Add the missing files to the list