### PR TITLE
Update coreclr files to fix errors on Alpine

### DIFF
--- a/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
+++ b/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
@@ -140,7 +140,9 @@ unsigned __stdcall IlmethodEmit(unsigned size, COR_ILMETHOD_FAT* header,
         fatHeader->SetSize(sizeof(COR_ILMETHOD_FAT) / 4);
     }
 #ifndef SOS_INCLUDE
+#ifdef _DEBUG
     assert(&origBuff[size] == outBuff);
+#endif
 #endif // !SOS_INCLUDE
     return(size);
 }

--- a/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
+++ b/shared/src/native-lib/coreclr/src/inc/corhlpr.cpp
@@ -26,15 +26,15 @@
 extern "C" {
 
 /***************************************************************************/
-/* Note that this construtor does not set the LocalSig, but has the
-   advantage that it does not have any dependancy on EE structures.
+/* Note that this constructor does not set the LocalSig, but has the
+   advantage that it does not have any dependency on EE structures.
    inside the EE use the FunctionDesc constructor */
 
 void __stdcall DecoderInit(void *pThis, COR_ILMETHOD *header)
 {
+    memset(pThis, 0, sizeof(COR_ILMETHOD_DECODER));
     COR_ILMETHOD_DECODER *decoder = (COR_ILMETHOD_DECODER *)pThis;
 
-    memset(decoder, 0, sizeof(COR_ILMETHOD_DECODER));
     if (header->Tiny.IsTiny())
     {
         decoder->SetMaxStack(header->Tiny.GetMaxStack());
@@ -48,7 +48,7 @@ void __stdcall DecoderInit(void *pThis, COR_ILMETHOD *header)
 #ifdef HOST_64BIT
         if((((size_t) header) & 3) == 0)        // header is aligned
 #else
-        _ASSERTE((((size_t) header) & 3) == 0);        // header is aligned
+        assert((((size_t) header) & 3) == 0);        // header is aligned
 #endif
         {
             *((COR_ILMETHOD_FAT *)decoder) = header->Fat;
@@ -129,18 +129,18 @@ unsigned __stdcall IlmethodEmit(unsigned size, COR_ILMETHOD_FAT* header,
     }
     else {
             // Fat format
-        _ASSERTE((((size_t) outBuff) & 3) == 0);               // header is dword aligned
+        assert((((size_t) outBuff) & 3) == 0);               // header is dword aligned
         COR_ILMETHOD_FAT* fatHeader = (COR_ILMETHOD_FAT*) outBuff;
         outBuff += sizeof(COR_ILMETHOD_FAT);
         *fatHeader = *header;
         fatHeader->SetFlags(fatHeader->GetFlags() | CorILMethod_FatFormat);
-        _ASSERTE((fatHeader->GetFlags() & CorILMethod_FormatMask) == CorILMethod_FatFormat);
+        assert((fatHeader->GetFlags() & CorILMethod_FormatMask) == CorILMethod_FatFormat);
         if (moreSections)
             fatHeader->SetFlags(fatHeader->GetFlags() | CorILMethod_MoreSects);
         fatHeader->SetSize(sizeof(COR_ILMETHOD_FAT) / 4);
     }
 #ifndef SOS_INCLUDE
-    _ASSERTE(&origBuff[size] == outBuff);
+    assert(&origBuff[size] == outBuff);
 #endif // !SOS_INCLUDE
     return(size);
 }
@@ -211,7 +211,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
     if (size == 0)
        return(0);
 
-    _ASSERTE((((size_t) outBuff) & 3) == 0);               // header is dword aligned
+    assert((((size_t) outBuff) & 3) == 0);               // header is dword aligned
     BYTE* origBuff = outBuff;
     if (ehCount <= 0)
         return 0;
@@ -234,11 +234,11 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
                     fatClause->GetHandlerLength() > 0xFF) {
                 break;  // fall through and generate as FAT
             }
-            _ASSERTE((fatClause->GetFlags() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetTryOffset() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetTryLength() & ~0xFF) == 0);
-            _ASSERTE((fatClause->GetHandlerOffset() & ~0xFFFF) == 0);
-            _ASSERTE((fatClause->GetHandlerLength() & ~0xFF) == 0);
+            assert((fatClause->GetFlags() & ~0xFFFF) == 0);
+            assert((fatClause->GetTryOffset() & ~0xFFFF) == 0);
+            assert((fatClause->GetTryLength() & ~0xFF) == 0);
+            assert((fatClause->GetHandlerOffset() & ~0xFFFF) == 0);
+            assert((fatClause->GetHandlerLength() & ~0xFF) == 0);
 
             COR_ILMETHOD_SECT_EH_CLAUSE_SMALL* smallClause = (COR_ILMETHOD_SECT_EH_CLAUSE_SMALL*)&EHSect->Clauses[i];
             smallClause->SetFlags((CorExceptionFlag) fatClause->GetFlags());
@@ -253,13 +253,9 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
             EHSect->Kind = CorILMethod_Sect_EHTable;
             if (moreSections)
                 EHSect->Kind |= CorILMethod_Sect_MoreSects;
-#ifndef SOS_INCLUDE
-            EHSect->DataSize = EHSect->Size(ehCount);
-#else
             EHSect->DataSize = (BYTE) EHSect->Size(ehCount);
-#endif // !SOS_INCLUDE
             EHSect->Reserved = 0;
-            _ASSERTE(EHSect->DataSize == EHSect->Size(ehCount)); // make sure didn't overflow
+            assert(EHSect->DataSize == EHSect->Size(ehCount)); // make sure didn't overflow
             outBuff = (BYTE*) &EHSect->Clauses[ehCount];
             // Set the offsets for the exception type tokens.
             if (ehTypeOffsets)
@@ -268,7 +264,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
                     COR_ILMETHOD_SECT_EH_CLAUSE_SMALL* smallClause = (COR_ILMETHOD_SECT_EH_CLAUSE_SMALL*)&EHSect->Clauses[i];
                     if (smallClause->GetFlags() == COR_ILEXCEPTION_CLAUSE_NONE)
                     {
-                        _ASSERTE(! IsNilToken(smallClause->GetClassToken()));
+                        assert(! IsNilToken(smallClause->GetClassToken()));
                         ehTypeOffsets[i] = (ULONG)((BYTE *)&smallClause->ClassToken - origBuff);
                     }
                 }
@@ -285,7 +281,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
     EHSect->SetDataSize(EHSect->Size(ehCount));
     memcpy(EHSect->Clauses, clauses, ehCount * sizeof(COR_ILMETHOD_SECT_EH_CLAUSE_FAT));
     outBuff = (BYTE*) &EHSect->Clauses[ehCount];
-    _ASSERTE(&origBuff[size] == outBuff);
+    assert(&origBuff[size] == outBuff);
     // Set the offsets for the exception type tokens.
     if (ehTypeOffsets)
     {
@@ -293,7 +289,7 @@ unsigned __stdcall SectEH_Emit(unsigned size, unsigned ehCount,
             COR_ILMETHOD_SECT_EH_CLAUSE_FAT* fatClause = (COR_ILMETHOD_SECT_EH_CLAUSE_FAT*)&EHSect->Clauses[i];
             if (fatClause->GetFlags() == COR_ILEXCEPTION_CLAUSE_NONE)
             {
-                _ASSERTE(! IsNilToken(fatClause->GetClassToken()));
+                assert(! IsNilToken(fatClause->GetClassToken()));
                 ehTypeOffsets[i] = (ULONG)((BYTE *)&fatClause->ClassToken - origBuff);
             }
         }

--- a/shared/src/native-lib/coreclr/src/inc/corhlpr.h
+++ b/shared/src/native-lib/coreclr/src/inc/corhlpr.h
@@ -17,6 +17,7 @@
 #define CORHLPR_TURNED_FPO_ON 1
 #endif
 
+#include <assert.h>
 #include "cor.h"
 #include "corhdr.h"
 #include "corerror.h"
@@ -82,19 +83,10 @@ do { hr = (EXPR); if(FAILED(hr)) { goto LABEL; } } while (0)
 #endif
 
 
-#ifndef _ASSERTE
-#define _ASSERTE(expr)
-#endif
-
-#ifndef COUNTOF
-#define COUNTOF(a) (sizeof(a) / sizeof(*a))
-#endif
-
 #if !BIGENDIAN
 #define VAL16(x) x
 #define VAL32(x) x
 #endif
-
 
 //*****************************************************************************
 //
@@ -264,7 +256,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return VAL16(TryOffset);
     }
     void SetTryOffset(DWORD Offset) {
-        _ASSERTE((Offset & ~0xffff) == 0);
+        assert((Offset & ~0xffff) == 0);
         TryOffset = VAL16(Offset);
     }
 
@@ -272,7 +264,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return TryLength;
     }
     void SetTryLength(DWORD Length) {
-        _ASSERTE((Length & ~0xff) == 0);
+        assert((Length & ~0xff) == 0);
         TryLength = Length;
     }
 
@@ -280,7 +272,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return VAL16(HandlerOffset);
     }
     void SetHandlerOffset(DWORD Offset) {
-        _ASSERTE((Offset & ~0xffff) == 0);
+        assert((Offset & ~0xffff) == 0);
         HandlerOffset = VAL16(Offset);
     }
 
@@ -288,7 +280,7 @@ typedef struct tagCOR_ILMETHOD_SECT_EH_CLAUSE_SMALL : public IMAGE_COR_ILMETHOD_
         return HandlerLength;
     }
     void SetHandlerLength(DWORD Length) {
-        _ASSERTE((Length & ~0xff) == 0);
+        assert((Length & ~0xff) == 0);
         HandlerLength = Length;
     }
 
@@ -336,7 +328,7 @@ struct COR_ILMETHOD_SECT
     const COR_ILMETHOD_SECT* Next() const
     {
         if (!More()) return(0);
-        return ((COR_ILMETHOD_SECT*)(((BYTE *)this) + DataSize()))->Align();
+        return ((COR_ILMETHOD_SECT*)Align(((BYTE *)this) + DataSize()));
     }
 
     const BYTE* Data() const
@@ -374,9 +366,9 @@ struct COR_ILMETHOD_SECT
         return((AsSmall()->Kind & CorILMethod_Sect_FatFormat) != 0);
     }
 
-    const COR_ILMETHOD_SECT* Align() const
+    static const void* Align(const void* p)
     {
-        return((COR_ILMETHOD_SECT*) ((((UINT_PTR) this) + 3) & ~3));
+        return((void*) ((((UINT_PTR) p) + 3) & ~3));
     }
 
 protected:
@@ -506,7 +498,7 @@ typedef struct tagCOR_ILMETHOD_TINY : IMAGE_COR_ILMETHOD_TINY
 
 
 /************************************/
-// This strucuture is the 'fat' layout, where no compression is attempted.
+// This structure is the 'fat' layout, where no compression is attempted.
 // Note that this structure can be added on at the end, thus making it extensible
 typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 {
@@ -579,7 +571,7 @@ typedef struct tagCOR_ILMETHOD_FAT : IMAGE_COR_ILMETHOD_FAT
 
     const COR_ILMETHOD_SECT* GetSect() const {
         if (!More()) return (0);
-        return(((COR_ILMETHOD_SECT*) (GetCode() + GetCodeSize()))->Align());
+        return(((COR_ILMETHOD_SECT*) COR_ILMETHOD_SECT::Align(GetCode() + GetCodeSize())));
     }
 } COR_ILMETHOD_FAT;
 
@@ -624,7 +616,7 @@ struct COR_ILMETHOD
 extern "C" {
 /***************************************************************************/
 /* COR_ILMETHOD_DECODER is the only way functions internal to the EE should
-   fetch data from a COR_ILMETHOD.  This way any dependancy on the file format
+   fetch data from a COR_ILMETHOD.  This way any dependency on the file format
    (and the multiple ways of encoding the header) is centralized to the
    COR_ILMETHOD_DECODER constructor) */
     void __stdcall DecoderInit(void * pThis, COR_ILMETHOD* header);


### PR DESCRIPTION
## Summary of changes

Some files were updated to fix errors with Clang 13: https://github.com/dotnet/runtime/pull/62170

## Reason for change

Tests were throwing exceptions on Alpine 3.16.