### PR TITLE
Stop the native build from writing to `stderr` every time

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -95,12 +95,14 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 
 include(ExternalProject)
 set(EXTERNAL_INSTALL_LOCATION ${OUTPUT_DEPS_DIR}/fmt/)
-ExternalProject_Add(fmt
-        GIT_REPOSITORY https://github.com/DataDog/fmt.git
-        GIT_TAG 5.3.0
-        GIT_CONFIG advice.detachedHead=false
+execute_process(
+        COMMAND git clone --quiet --depth 1 --branch 5.3.0 --config advice.detachedHead=false https://github.com/DataDog/fmt.git
+        WORKING_DIRECTORY "${OUTPUT_DEPS_DIR}"
         TIMEOUT 5
+        )
+ExternalProject_Add(fmt
         CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
+        SOURCE_DIR "${EXTERNAL_INSTALL_LOCATION}"
         PREFIX "${EXTERNAL_INSTALL_LOCATION}"
         INSTALL_COMMAND ""
         )

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -97,30 +97,14 @@ include(ExternalProject)
 set(EXTERNAL_INSTALL_LOCATION ${OUTPUT_DEPS_DIR}/fmt/)
 set(fmt_GIT_REPO https://github.com/DataDog/fmt.git)
 set(fmt_GIT_TAG 5.3.0)
-if (ISARM64)
-    ExternalProject_Add(fmt
-        GIT_REPOSITORY "${fmt_GIT_REPO}"
-        GIT_TAG "${fmt_GIT_TAG}"
-        GIT_CONFIG advice.detachedHead=false
-        TIMEOUT 5
-        CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-        PREFIX "${EXTERNAL_INSTALL_LOCATION}"
-        INSTALL_COMMAND ""
-        )
-else ()
-    # This doesn't seem to work on arm64, but I'm not sure why :shrug:
-    execute_process(
-            COMMAND git clone --quiet --depth 1 --branch "${fmt_GIT_TAG}" --config advice.detachedHead=false "${fmt_GIT_REPO}"
-            WORKING_DIRECTORY "${OUTPUT_DEPS_DIR}"
-            TIMEOUT 5
-            )
-    ExternalProject_Add(fmt
-            CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-            SOURCE_DIR "${EXTERNAL_INSTALL_LOCATION}"
-            PREFIX "${EXTERNAL_INSTALL_LOCATION}"
-            INSTALL_COMMAND ""
-            )
-endif()
+ExternalProject_Add(fmt
+    DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch "${fmt_GIT_TAG}" --config advice.detachedHead=false "${fmt_GIT_REPO}"
+    TIMEOUT 5
+    CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0 .
+    SOURCE_DIR "${EXTERNAL_INSTALL_LOCATION}"
+    PREFIX "${EXTERNAL_INSTALL_LOCATION}"
+    INSTALL_COMMAND ""
+)
 ExternalProject_Get_Property(fmt source_dir)
 set(fmt_INCLUDE_DIR ${source_dir}/include)
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -95,17 +95,32 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 
 include(ExternalProject)
 set(EXTERNAL_INSTALL_LOCATION ${OUTPUT_DEPS_DIR}/fmt/)
-execute_process(
-        COMMAND git clone --quiet --depth 1 --branch 5.3.0 --config advice.detachedHead=false https://github.com/DataDog/fmt.git
-        WORKING_DIRECTORY "${OUTPUT_DEPS_DIR}"
+set(fmt_GIT_REPO https://github.com/DataDog/fmt.git)
+set(fmt_GIT_TAG 5.3.0)
+if (ISARM64)
+    ExternalProject_Add(fmt
+        GIT_REPOSITORY "${fmt_GIT_REPO}"
+        GIT_TAG "${fmt_GIT_TAG}"
+        GIT_CONFIG advice.detachedHead=false
         TIMEOUT 5
-        )
-ExternalProject_Add(fmt
         CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-        SOURCE_DIR "${EXTERNAL_INSTALL_LOCATION}"
         PREFIX "${EXTERNAL_INSTALL_LOCATION}"
         INSTALL_COMMAND ""
         )
+else ()
+    # This doesn't seem to work on arm64, but I'm not sure why :shrug:
+    execute_process(
+            COMMAND git clone --quiet --depth 1 --branch "${fmt_GIT_TAG}" --config advice.detachedHead=false "${fmt_GIT_REPO}"
+            WORKING_DIRECTORY "${OUTPUT_DEPS_DIR}"
+            TIMEOUT 5
+            )
+    ExternalProject_Add(fmt
+            CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
+            SOURCE_DIR "${EXTERNAL_INSTALL_LOCATION}"
+            PREFIX "${EXTERNAL_INSTALL_LOCATION}"
+            INSTALL_COMMAND ""
+            )
+endif()
 ExternalProject_Get_Property(fmt source_dir)
 set(fmt_INCLUDE_DIR ${source_dir}/include)
 


### PR DESCRIPTION
## Summary of changes

- Don't use `ExternalProject_Add` to clone fmt

## Reason for change

`ExternalProject_Add` doesn't add the `--quiet` flag, which means `git clone` writes to `stderr`. In the macos build, this is interpretted by Azure DevOps as a build error. That's annoying.

## Implementation details

Do the git clone manually so we can specify `--quiet`, and just use `ExternalProject_Add` to work with the pre-cloned repo. Also added `--depth 1` for good measure.

## Test coverage
Tested that we build successfully on linux + macos, and that we no longer have build errors reported

## Other details
ARM64 apparently didn't like this change, so using the "noisy" version in that case. It's not _actually_ noisy, because it's in a container, so doesn't matter too much, but it does bug me _why_ it's different when we are running the same code in the same container 😬 
