### PR TITLE
Samples.Probes must always be built

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1274,6 +1274,7 @@ partial class Build
                         "Samples.AWS.Lambda" => Framework == TargetFramework.NETCOREAPP3_1,
                         var name when projectsToSkip.Contains(name) => false,
                         var name when multiPackageProjects.Contains(name) => false,
+                        "Samples.Probes" => true,
                         "Samples.AspNetCoreRazorPages" => true,
                         _ when !string.IsNullOrWhiteSpace(SampleName) => x.project?.Name?.Contains(SampleName) ?? false,
                         _ => true,


### PR DESCRIPTION
## Summary of changes

Always build Samples.Probes when building linux tests

## Reason for change

Currently, there's a hard dependency of the integration tests on `Samples.Probes`, so we have to make sure we always build that sample. Previously, it would be skipped if you were trying to restrict the samples being built, e.g. using `-SampleName Samples.Kafka`

## Implementation details

Just force `Samples.Probes`, same as we do for `Samples.AspNetCoreRazorPages`.

## Test coverage
N/A

## Other details
There are larger changes going on with Samples.Probes which will remove the need for this, but until then, this is necessary
