### PR TITLE
Fix asm RCM tests flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var request1 = await agent.WaitRcmRequestAndReturnLast();
             if (enableSecurity == true)
             {
-                await logEntryWatcher.WaitForLogEntry("AppSec Disabled", timeoutLogEntry);
+                await logEntryWatcher.WaitForLogEntry("AppSec is now Disabled, coming from remote config: true", timeoutLogEntry);
             }
 
             CheckAckState(request1, expectedState, null, "First RCM call");
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var request2 = await agent.WaitRcmRequestAndReturnLast();
             if (enableSecurity != false)
             {
-                await logEntryWatcher.WaitForLogEntry("AppSec Enabled", timeoutLogEntry);
+                await logEntryWatcher.WaitForLogEntry("AppSec is now Enabled, coming from remote config: true", timeoutLogEntry);
             }
 
             CheckAckState(request2, expectedState, null, "Second RCM call");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
@@ -39,12 +39,13 @@ namespace Datadog.Trace.Security.IntegrationTests
         // * https://github.com/DataDog/dd-trace-dotnet/pull/3171
         // the verify file names will need adjusting too
         [SkippableTheory]
-        [InlineData(true, ApplyStates.ACKNOWLEDGED,  RcmCapabilitiesIndices.AsmActivation)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
+        [InlineData(true, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivation)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
         [InlineData(false, ApplyStates.UNACKNOWLEDGED, 0)] // RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
         [InlineData(null, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivation)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
         [Trait("RunOnWindows", "True")]
         public async Task TestSecurityToggling(bool? enableSecurity, uint expectedState, byte expectedCapabilities)
         {
+            var timeoutLogEntry = TimeSpan.FromSeconds(20);
             var url = "/Health/?[$slice]=value";
             var agent = await RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, expectedState, expectedCapabilities);
@@ -53,29 +54,28 @@ namespace Datadog.Trace.Security.IntegrationTests
 
             var spans1 = await SendRequestsAsync(agent, url);
 
-            agent.SetupRcm(Output, new[] { ((object)new AsmFeatures() { Asm = new Asm() { Enabled = false } }, "1") }, "ASM_FEATURES");
+            agent.SetupRcm(Output, new[] { ((object)new AsmFeatures { Asm = new Asm { Enabled = false } }, "1") }, "ASM_FEATURES");
 
             var request1 = await agent.WaitRcmRequestAndReturnLast();
-            CheckAckState(request1, expectedState, null, "First RCM call");
-            CheckCapabilities(request1, expectedCapabilities, "First RCM call");
             if (enableSecurity == true)
             {
-                await logEntryWatcher.WaitForLogEntry("AppSec Disabled");
-                await Task.Delay(1500);
+                await logEntryWatcher.WaitForLogEntry("AppSec Disabled", timeoutLogEntry);
             }
+
+            CheckAckState(request1, expectedState, null, "First RCM call");
+            CheckCapabilities(request1, expectedCapabilities, "First RCM call");
 
             var spans2 = await SendRequestsAsync(agent, url);
 
-            agent.SetupRcm(Output, new[] { ((object)new AsmFeatures() { Asm = new Asm() { Enabled = true } }, "2") }, "ASM_FEATURES");
-
+            agent.SetupRcm(Output, new[] { ((object)new AsmFeatures { Asm = new Asm { Enabled = true } }, "2") }, "ASM_FEATURES");
             var request2 = await agent.WaitRcmRequestAndReturnLast();
-            CheckAckState(request2, expectedState, null, "Second RCM call");
-            CheckCapabilities(request2, expectedCapabilities, "Second RCM call");
             if (enableSecurity != false)
             {
-                await logEntryWatcher.WaitForLogEntry("AppSec Enabled");
-                await Task.Delay(1500);
+                await logEntryWatcher.WaitForLogEntry("AppSec Enabled", timeoutLogEntry);
             }
+
+            CheckAckState(request2, expectedState, null, "Second RCM call");
+            CheckCapabilities(request2, expectedCapabilities, "Second RCM call");
 
             var spans3 = await SendRequestsAsync(agent, url);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -21,7 +21,12 @@ public class LogEntryWatcher : IDisposable
     public LogEntryWatcher(string logFilePattern)
     {
         var logPath = DatadogLogging.GetLogDirectory();
-        _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
+        _fileWatcher = new FileSystemWatcher
+        {
+            Path = logPath,
+            Filter = logFilePattern,
+            EnableRaisingEvents = true
+        };
 
         var dir = new DirectoryInfo(logPath);
         var lastFile = dir
@@ -58,9 +63,9 @@ public class LogEntryWatcher : IDisposable
             }
 
             var line = await _reader.ReadLineAsync();
-            if (line?.Contains(logEntry) ?? false)
+            if (line != null)
             {
-                isFound = true;
+                isFound = line.Contains(logEntry) == true;
             }
             else
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -21,12 +21,7 @@ public class LogEntryWatcher : IDisposable
     public LogEntryWatcher(string logFilePattern)
     {
         var logPath = DatadogLogging.GetLogDirectory();
-        _fileWatcher = new FileSystemWatcher
-        {
-            Path = logPath,
-            Filter = logFilePattern,
-            EnableRaisingEvents = true
-        };
+        _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
 
         var dir = new DirectoryInfo(logPath);
         var lastFile = dir
@@ -63,9 +58,9 @@ public class LogEntryWatcher : IDisposable
             }
 
             var line = await _reader.ReadLineAsync();
-            if (line != null)
+            if (line?.Contains(logEntry) ?? false)
             {
-                isFound = line?.Contains(logEntry) == true;
+                isFound = true;
             }
             else
             {
@@ -75,7 +70,7 @@ public class LogEntryWatcher : IDisposable
 
         if (!isFound)
         {
-            throw new InvalidOperationException("Log entry was not found.");
+            throw new InvalidOperationException(_reader == null ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}" : "Log entry was not found.");
         }
     }
 


### PR DESCRIPTION
## Summary of changes

remove Task.Delays
add longer timeout 
wait for the file earlier to prevent cases where log entry appears before listening to it
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
