### PR TITLE
Bump timeouts in installer smoke tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2635,7 +2635,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 20 # should take ~5 mins
+    timeoutInMinutes: 45 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_smoke_tests_matrix'] ]
     variables:
@@ -2697,7 +2697,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 20 # should take ~5 mins
+    timeoutInMinutes: 45 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.nuget_installer_linux_smoke_tests_matrix'] ]
     variables:
@@ -2767,7 +2767,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 20 # should take ~5 mins
+    timeoutInMinutes: 45 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_nuget_installer_linux_smoke_tests_matrix'] ]
     variables:
@@ -2829,7 +2829,7 @@ stages:
       jobs: [linux]
 
   - job: linux
-    timeoutInMinutes: 20 # should take ~5 mins
+    timeoutInMinutes: 45 # should take ~5 mins
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_installer_linux_smoke_tests_matrix'] ]
     variables:


### PR DESCRIPTION
## Summary of changes

- Bumps timeouts in installer smoke tests

## Reason for change

Sometimes docker/git/nuget takes forever, so better the test takes a long time than fails