### PR TITLE
[CI] Fix permissions issue when uploading crash dumps on Linux in missing cases

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1104,6 +1104,11 @@ stages:
           framework=$(publishTargetFramework)
         dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e IncludeTestsRequiringDocker=false IntegrationTests
         projectName: ddtrace_$(Build.BuildNumber)
+    
+    - script: |      
+        sudo chmod -R 644 tracer/build_data/dumps/* || true
+      displayName: Make dumps uploadable to AzDo
+      condition: succeededOrFailed()
 
     - publish: tracer/build_data
       artifact: integration_tests_linux_tracer_logs_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)


### PR DESCRIPTION
in #3229 , I fixed an issue where uploading crash dumps to Azure DevOps fails with an `UnauthorizedAccessException` issue.

Unfortunately, in that PR I hadn't noticed that our Linux Integration Tests stage is comprised of two jobs: "DockerTest" and Test", and I only fixed the former. This PR fixes the latter as well. 