### PR TITLE
Fix endian bug

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Numerics;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
@@ -18,6 +19,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         void UnregisterProduct(string productName);
 
-        void SetCapability(int index, bool available);
+        void SetCapability(BigInteger index, bool available);
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -3,19 +3,24 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Numerics;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal static class RcmCapabilitiesIndices
     {
-        public const int Reserved = 0;
-        public const int AsmActivation = 1;
-        public const int AsmIpBlocking = 1 << 2;
-        public const int AsmDdRules = 1 << 3;
+#pragma warning disable SA1203 // Constants should appear before fields
+        public const uint ReservedUInt32 = 0;
+        public static readonly BigInteger Reserved = new(ReservedUInt32);
+
+        public const uint AsmActivationUInt32 = 1;
+        public static readonly BigInteger AsmActivation = new(AsmActivationUInt32);
+
+        public const uint AsmIpBlockingUInt32 = 1 << 2;
+        public static readonly BigInteger AsmIpBlocking = new(AsmIpBlockingUInt32);
+
+        public const uint AsmDdRulesUInt32 = 1 << 3;
+        public static readonly BigInteger AsmDdRules = new(AsmDdRulesUInt32);
+#pragma warning restore SA1203 // Constants should appear before fields
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -213,7 +213,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 #if NETCOREAPP
             var capabilitiesArray = _capabilities.ToByteArray(true, true);
 #else
-            var capabilitiesArray = _capabilities.ToByteArray().Reverse().ToArray();
+            var capabilitiesArray = _capabilities.ToByteArray();
+            Array.Reverse(capabilitiesArray);
 #endif
 
             var rcmState = new RcmClientState(_rootVersion, _targetsVersion, configStates, _lastPollError != null, _lastPollError);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmToggle.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
@@ -34,16 +35,16 @@ namespace Datadog.Trace.Security.IntegrationTests
             SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
         }
 
-        // TODO addjust third parameter as the following PRs are merged:
+        // TODO adjust third parameter as the following PRs are merged:
         // * https://github.com/DataDog/dd-trace-dotnet/pull/3120
         // * https://github.com/DataDog/dd-trace-dotnet/pull/3171
         // the verify file names will need adjusting too
         [SkippableTheory]
-        [InlineData(true, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivation)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
+        [InlineData(true, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivationUInt32)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
         [InlineData(false, ApplyStates.UNACKNOWLEDGED, 0)] // RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
-        [InlineData(null, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivation)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
+        [InlineData(null, ApplyStates.ACKNOWLEDGED, RcmCapabilitiesIndices.AsmActivationUInt32)] // RcmCapabilitiesIndices.AsmActivation | RcmCapabilitiesIndices.AsmIpBlocking | RcmCapabilitiesIndices.AsmDdRules)]
         [Trait("RunOnWindows", "True")]
-        public async Task TestSecurityToggling(bool? enableSecurity, uint expectedState, byte expectedCapabilities)
+        public async Task TestSecurityToggling(bool? enableSecurity, uint expectedState, uint expectedCapabilities)
         {
             var timeoutLogEntry = TimeSpan.FromSeconds(20);
             var url = "/Health/?[$slice]=value";
@@ -115,9 +116,9 @@ namespace Datadog.Trace.Security.IntegrationTests
             state.ApplyError.Should().Be(expectedError, message);
         }
 
-        private void CheckCapabilities(GetRcmRequest request, byte expectedState, string message)
+        private void CheckCapabilities(GetRcmRequest request, uint expectedState, string message)
         {
-            var capabilities = BitConverter.ToInt32(request?.Client?.Capabilities);
+            var capabilities = new BigInteger(request?.Client?.Capabilities, true, true);
             capabilities.Should().Be(expectedState, message);
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -115,7 +116,7 @@ public class LiveDebuggerTests
             Products.Remove(productName);
         }
 
-        public void SetCapability(int index, bool available)
+        public void SetCapability(BigInteger index, bool available)
         {
         }
     }


### PR DESCRIPTION
## Summary of changes

"Use a byte array (encoded in json)" they said. "What could possibly go wrong?"

Well, the backend expects big endian and .NET uses little endian by default.

## Reason for change

This was the one thing we didn't want to happen.

## Implementation details

Use a BigInteger which not only allows to have 32+ capabilities but also conveniently allows you to specify the endianness in the output (on some platforms).

## Test coverage

Existing tests have been updated.