### PR TITLE
Exitcode should be zero

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -20,6 +20,7 @@ using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -225,7 +226,7 @@ namespace Datadog.Trace.TestHelpers
                 throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
             }
 
-            Assert.True(exitCode >= 0, $"Process exited with code {exitCode}");
+            exitCode.Should().Be(0);
 
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }

--- a/tracer/test/test-applications/integrations/Samples.MySql/Samples.MySql.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MySql/Samples.MySql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">8.0.17</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">8.0.30</ApiVersion>
     <RequiresDockerDependency>true</RequiresDockerDependency>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->


### PR DESCRIPTION
## Summary of changes

- Exit code should be zero
- Bumped version of MySqlClient we use in "disabled" tests

## Reason for change

- Exit code should be zero
- MySql test throws an exception with the old version of the client ([something to do with charsets](https://stackoverflow.com/questions/41930040/net-mysql-error-the-given-key-was-not-present-in-the-dictionary))

## Implementation details

- Exit code should be zero
- Bump version in MySql sample

## Test coverage

It works!

## Other details
