### PR TITLE
[Tracer] Use `Datadog.Trace.Bundle` in `NugetDeployment` samples

### DIFF
--- a/tracer/samples/NugetDeployment/Dockerfile.linux
+++ b/tracer/samples/NugetDeployment/Dockerfile.linux
@@ -29,7 +29,7 @@ ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/app/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/app/datadog
 
-# Run the createLogPath script on Linux to ensure the automatic instrumentation logs are genereated without permission isues
+# Run the createLogPath script on Linux to ensure the automatic instrumentation logs are generated without permission issues
 RUN /app/datadog/createLogPath.sh
 
 ENTRYPOINT ["dotnet", "HttpListenerExample.dll"]

--- a/tracer/samples/NugetDeployment/Dockerfile.linux-arm64
+++ b/tracer/samples/NugetDeployment/Dockerfile.linux-arm64
@@ -29,7 +29,7 @@ ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/app/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so
 ENV DD_DOTNET_TRACER_HOME=/app/datadog
 
-# Run the createLogPath script on Linux to ensure the automatic instrumentation logs are genereated without permission isues
+# Run the createLogPath script on Linux to ensure the automatic instrumentation logs are generated without permission issues
 RUN /app/datadog/createLogPath.sh
 
 ENTRYPOINT ["dotnet", "HttpListenerExample.dll"]

--- a/tracer/samples/NugetDeployment/HttpListenerExample.csproj
+++ b/tracer/samples/NugetDeployment/HttpListenerExample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Monitoring.Distribution" Version="1.28.2" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.16.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net45')) ">

--- a/tracer/samples/NugetDeployment/packages/README.txt
+++ b/tracer/samples/NugetDeployment/packages/README.txt
@@ -1,1 +1,1 @@
-Place the Datadog.Monitoring.Distribution package in here so that it can be restored in the Docker image
+Place the Datadog.Trace.Bundle package in here so that it can be restored in the Docker image


### PR DESCRIPTION
## Summary of changes
Use `Datadog.Trace.Bundle`in `NugetDeployment` samples

## Reason for change
We need to change the samples when we do the release.

## Test coverage
Tested locally with a package from the CI.

## Other details
To be merged after next release
