### PR TITLE
[Serverless] Support base-class AWS Lambda methods

### DIFF
--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -17,6 +17,11 @@ services:
     - serverless-lambda-no-param-void
     - serverless-lambda-one-param-void
     - serverless-lambda-two-params-void
+    - serverless-lambda-base-no-param-sync
+    - serverless-lambda-base-two-params-sync
+    - serverless-lambda-base-one-param-sync-with-context
+    - serverless-lambda-base-one-param-async
+    - serverless-lambda-base-two-params-void
     environment:
     - AWS_LAMBDA_ENDPOINT_NO_PARAM_SYNC=http://serverless-lambda-no-param-sync:8080
     - AWS_LAMBDA_ENDPOINT_ONE_PARAM_SYNC=http://serverless-lambda-one-param-sync:8080
@@ -30,6 +35,11 @@ services:
     - AWS_LAMBDA_ENDPOINT_NO_PARAM_VOID=http://serverless-lambda-no-param-void:8080
     - AWS_LAMBDA_ENDPOINT_ONE_PARAM_VOID=http://serverless-lambda-one-param-void:8080
     - AWS_LAMBDA_ENDPOINT_TWO_PARAMS_VOID=http://serverless-lambda-two-params-void:8080
+    - AWS_LAMBDA_ENDPOINT_BASE_NO_PARAM_SYNC=http://serverless-lambda-base-no-param-sync:8080
+    - AWS_LAMBDA_ENDPOINT_BASE_TWO_PARAMS_SYNC=http://serverless-lambda-base-two-params-sync:8080
+    - AWS_LAMBDA_ENDPOINT_BASE_ONE_PARAM_SYNC_WITH_CONTEXT=http://serverless-lambda-base-one-param-sync-with-context:8080
+    - AWS_LAMBDA_ENDPOINT_BASE_ONE_PARAM_ASYNC=http://serverless-lambda-base-one-param-async:8080
+    - AWS_LAMBDA_ENDPOINT_BASE_TWO_PARAMS_VOID=http://serverless-lambda-base-two-params-void:8080
 
   StartDependencies.Serverless:
     image: andrewlock/wait-for-dependencies
@@ -48,9 +58,14 @@ services:
     - serverless-lambda-no-param-void
     - serverless-lambda-one-param-void
     - serverless-lambda-two-params-void
+    - serverless-lambda-base-no-param-sync
+    - serverless-lambda-base-two-params-sync
+    - serverless-lambda-base-one-param-sync-with-context
+    - serverless-lambda-base-one-param-async
+    - serverless-lambda-base-two-params-void
     environment:
       - TIMEOUT_LENGTH=120
-    command: serverless-lambda-no-param-sync:8080 serverless-lambda-one-param-sync:8080 serverless-lambda-two-params-sync:8080 serverless-lambda-no-param-sync-with-context:8080 serverless-lambda-one-param-sync-with-context:8080 serverless-lambda-two-params-sync-with-context:8080 serverless-lambda-no-param-async:8080 serverless-lambda-one-param-async:8080 serverless-lambda-two-params-async:8080 serverless-integration-extension-mock:9003 serverless-integration-extension-mock-with-context:9004 serverless-lambda-no-param-void:8080 serverless-lambda-one-param-void:8080 serverless-lambda-two-params-void:8080
+    command: serverless-lambda-no-param-sync:8080 serverless-lambda-one-param-sync:8080 serverless-lambda-two-params-sync:8080 serverless-lambda-no-param-sync-with-context:8080 serverless-lambda-one-param-sync-with-context:8080 serverless-lambda-two-params-sync-with-context:8080 serverless-lambda-no-param-async:8080 serverless-lambda-one-param-async:8080 serverless-lambda-two-params-async:8080 serverless-integration-extension-mock:9003 serverless-integration-extension-mock-with-context:9004 serverless-lambda-no-param-void:8080 serverless-lambda-one-param-void:8080 serverless-lambda-two-params-void:8080 serverless-lambda-base-no-param-sync:8080 serverless-lambda-base-two-params-sync:8080 serverless-lambda-base-one-param-sync-with-context:8080 serverless-lambda-base-one-param-async:8080 serverless-lambda-base-two-params-void:8080
   
   serverless-lambda-no-param-sync:
     build:
@@ -255,7 +270,92 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+  
+  serverless-lambda-base-no-param-sync:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-integration-extension-mock
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerNoParamSync"
+    image: dd-trace-dotnet/serverless-lambda-base-no-param-sync
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://serverless-integration-extension-mock:9003
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
 
+  serverless-lambda-base-two-params-sync:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-integration-extension-mock
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerTwoParamsSync"
+    image: dd-trace-dotnet/serverless-lambda-base-two-params-sync
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://serverless-integration-extension-mock:9003
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+
+  serverless-lambda-base-one-param-sync-with-context:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-integration-extension-mock-with-context
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerOneParamSyncWithContext"
+    image: dd-trace-dotnet/serverless-lambda-base-one-param-sync-with-context
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://serverless-integration-extension-mock-with-context:9004
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+
+  serverless-lambda-base-one-param-async:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-integration-extension-mock
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerOneParamAsync"
+    image: dd-trace-dotnet/serverless-lambda-base-one-param-async
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://serverless-integration-extension-mock:9003
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+
+  serverless-lambda-base-two-params-void:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-integration-extension-mock
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerTwoParamsVoid"
+    image: dd-trace-dotnet/serverless-lambda-base-two-params-void
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://serverless-integration-extension-mock:9003
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+  
   serverless-integration-extension-mock:
     build:
       context: ./tracer/build/_build/docker

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaHandler.cs
@@ -11,26 +11,28 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
     internal class LambdaHandler
     {
         private static readonly string[] Separator = { "::" };
-        private string[] _handlerTokens;
 
         internal LambdaHandler(string handlerName)
         {
-            _handlerTokens = handlerName.Split(Separator, StringSplitOptions.None);
-            ParamTypeArray = BuidParamTypeArray();
+            var handlerTokens = handlerName.Split(Separator, StringSplitOptions.None);
+            Assembly = handlerTokens[0];
+            FullType = handlerTokens[1];
+            MethodName = handlerTokens[2];
+            ParamTypeArray = BuildParamTypeArray();
         }
 
         internal string[] ParamTypeArray { get; }
 
-        internal string GetAssembly() => _handlerTokens[0];
+        internal string Assembly { get; }
 
-        internal string GetFullType() => _handlerTokens[1];
+        internal string FullType { get; }
 
-        internal string GetMethodName() => _handlerTokens[2];
+        internal string MethodName { get; }
 
-        private string[] BuidParamTypeArray()
+        private string[] BuildParamTypeArray()
         {
-            Type myClassType = Type.GetType(GetTypeName());
-            MethodInfo customerMethodInfo = myClassType.GetMethod(GetMethodName());
+            Type myClassType = Type.GetType($"{FullType},{Assembly}");
+            MethodInfo customerMethodInfo = myClassType.GetMethod(MethodName);
             ParameterInfo[] methodParameters = customerMethodInfo.GetParameters();
 
             string[] paramType = new string[methodParameters.Length + 1];
@@ -41,11 +43,6 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
             }
 
             return paramType;
-        }
-
-        private string GetTypeName()
-        {
-            return GetFullType() + "," + GetAssembly();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaHandler.cs
@@ -29,7 +29,7 @@ internal class LambdaHandler
         // The method body may be in a different type, e.g. a base type
         // In that case we need the FullType to point to the base type
         FullType = handlerMethod.DeclaringType?.FullName ?? handlerTokens[1];
-        // If the fullType == the declaring type, skip calling Assembly.GetName and use handler token directly
+        // If the handlerType == the declaring type, skip calling Assembly.GetName and use handler token directly
         Assembly = handlerType == handlerMethod.DeclaringType
                        ? handlerTokens[0]
                        : handlerMethod.DeclaringType?.Assembly.GetName().Name ?? handlerTokens[0];

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
                     var integrationType = GetIntegrationType(handler.ParamTypeArray[0], paramCount);
                     callTargetDefinitions = new NativeCallTargetDefinition[]
                     {
-                        new(handler.GetAssembly(), handler.GetFullType(), handler.GetMethodName(), handler.ParamTypeArray, 0, 0, 0, 65535, 65535, 65535, assemblyName, integrationType)
+                        new(handler.Assembly, handler.FullType, handler.MethodName, handler.ParamTypeArray, 0, 0, 0, 65535, 65535, 65535, assemblyName, integrationType)
                     };
 
                     LifetimeManager.Instance.AddShutdownTask(RunShutdown);

--- a/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
@@ -5,8 +5,9 @@
 
 using System;
 using System.IO;
-
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -31,5 +32,96 @@ namespace Datadog.Trace.Tests
             handler.ParamTypeArray[0].Should().Be("System.String");
             handler.ParamTypeArray[1].Should().Be("System.String");
         }
+
+        [Theory]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::HandlerMethod", "Datadog.Trace.Tests.TestHandler")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::HiddenBaseMethod", "Datadog.Trace.Tests.TestHandler")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::OverridenBaseMethod", "Datadog.Trace.Tests.TestHandler")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler2::AbstractBaseMethod", "Datadog.Trace.Tests.TestHandler2")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::BaseHandlerMethod", "Datadog.Trace.Tests.BaseHandler")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::NonOverridenBaseMethod", "Datadog.Trace.Tests.BaseHandler")]
+        public void LambdaHandlerCanParseCustomType(string handlerVariable, string expectedType)
+        {
+            LambdaHandler handler = new LambdaHandler(handlerVariable);
+            handler.FullType.Should().Be(expectedType);
+            handler.ParamTypeArray.Length.Should().Be(1);
+            handler.ParamTypeArray[0].Should().Be(ClrNames.Void);
+        }
+
+        [Fact]
+        public void LambdaHandlerCanParseTypesAcrossAssemblies()
+        {
+            var handlerName = "Datadog.Trace.Tests::Datadog.Trace.Tests.TestMockSpan::GetTag";
+            LambdaHandler handler = new LambdaHandler(handlerName);
+            handler.Assembly.Should().Be("Datadog.Trace.TestHelpers");
+            handler.FullType.Should().Be("Datadog.Trace.TestHelpers.MockSpan");
+            handler.MethodName.Should().Be("GetTag");
+            handler.ParamTypeArray.Length.Should().Be(2);
+            handler.ParamTypeArray[0].Should().Be(ClrNames.String);
+            handler.ParamTypeArray[1].Should().Be(ClrNames.String);
+        }
+    }
+
+#pragma warning disable SA1402 // File may only contain a single type
+    public class TestHandler : BaseHandler
+    {
+        public void HandlerMethod()
+        {
+        }
+
+        public new void HiddenBaseMethod()
+        {
+        }
+
+        public override void OverridenBaseMethod()
+        {
+        }
+    }
+
+    public class TestHandler2 : AbstractBaseHandler
+    {
+        public override void AbstractBaseMethod()
+        {
+        }
+    }
+
+    public class TestHandler3 : AbstractGenericBaseHandler<int>
+    {
+        public override void AbstractBaseMethod()
+        {
+        }
+    }
+
+    public class BaseHandler
+    {
+        public void BaseHandlerMethod()
+        {
+        }
+
+        public void HiddenBaseMethod()
+        {
+        }
+
+        public virtual void NonOverridenBaseMethod()
+        {
+        }
+
+        public virtual void OverridenBaseMethod()
+        {
+        }
+    }
+
+    public abstract class AbstractBaseHandler
+    {
+        public abstract void AbstractBaseMethod();
+    }
+
+    public abstract class AbstractGenericBaseHandler<T>
+    {
+        public abstract void AbstractBaseMethod();
+    }
+
+    public class TestMockSpan : MockSpan
+    {
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
@@ -18,13 +18,13 @@ namespace Datadog.Trace.Tests
         public void LambdaHandlerGetters()
         {
             LambdaHandler handler = new LambdaHandler("mscorlib::System.Environment::ExpandEnvironmentVariables");
-            handler.GetAssembly().Should().Be("mscorlib");
-            handler.GetFullType().Should().Be("System.Environment");
-            handler.GetMethodName().Should().Be("ExpandEnvironmentVariables");
+            handler.Assembly.Should().Be("mscorlib");
+            handler.FullType.Should().Be("System.Environment");
+            handler.MethodName.Should().Be("ExpandEnvironmentVariables");
         }
 
         [Fact]
-        public void LambdaHandlerBuidParamTypeArray()
+        public void LambdaHandlerParamTypeArray()
         {
             LambdaHandler handler = new LambdaHandler("mscorlib::System.Environment::ExpandEnvironmentVariables");
             handler.ParamTypeArray.Length.Should().Be(2);

--- a/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaHandlerTests.cs
@@ -77,6 +77,38 @@ namespace Datadog.Trace.Tests
         }
 
         [Theory]
+        [InlineData("")]
+        [InlineData("::")]
+        [InlineData("A::B")]
+        [InlineData("A:::B")]
+        [InlineData("A::B::C::")]
+        [InlineData("A::B::C::D")]
+        public void LambdaHandlerThrowsWhenInvalidFormat(string handlerVariable)
+        {
+            Assert.Throws<ArgumentException>(() => new LambdaHandler(handlerVariable));
+        }
+
+        [Theory]
+        [InlineData("SomeType::Unknown::WhoKnows")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler::IdontExistAnywhere")]
+        [InlineData("SomeType::::WhoKnows")]
+        [InlineData("SomeType::::")]
+        public void LambdaHandlerThrowsWhenUnknownTypes(string handlerVariable)
+        {
+            Assert.Throws<Exception>(() => new LambdaHandler(handlerVariable));
+        }
+
+        [Theory]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler4::GenericBaseMethod1")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler4::GenericBaseMethod2")]
+        [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler4::GenericBaseMethod3")]
+        public void LambdaHandlerThrowsWhenInstrumentingGenericTypes(string handlerVariable)
+        {
+            // We don't support this yet (we could, we just haven't done the work for it yet)
+            Assert.Throws<Exception>(() => new LambdaHandler(handlerVariable));
+        }
+
+        [Theory]
         [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler+NestedHandler::HandlerMethod", "Datadog.Trace.Tests.TestHandler+NestedHandler")]
         [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler+NestedHandler::HiddenBaseMethod", "Datadog.Trace.Tests.TestHandler+NestedHandler")]
         [InlineData("Datadog.Trace.Tests::Datadog.Trace.Tests.TestHandler+NestedHandler::OverridenBaseMethod", "Datadog.Trace.Tests.TestHandler+NestedHandler")]

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -3,7 +3,7 @@
     TraceId: Id_1,
     SpanId: Id_2,
     Name: http.request,
-    Resource: GET localhost/function/HandlerNoParamAsync,
+    Resource: GET localhost/function/BaseHandlerNoParamSync,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_3,
@@ -18,7 +18,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerNoParamAsync,
+      http.url: http://localhost/function/BaseHandlerNoParamSync,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0
@@ -34,7 +34,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_4,
     SpanId: Id_5,
     Name: http.request,
-    Resource: GET localhost/function/HandlerNoParamSync,
+    Resource: GET localhost/function/BaseHandlerOneParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_6,
@@ -49,7 +49,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerNoParamSync,
+      http.url: http://localhost/function/BaseHandlerOneParamAsync,
       runtime-id: Guid_2,
       span.kind: client,
       _dd.p.dm: -0
@@ -65,7 +65,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_7,
     SpanId: Id_8,
     Name: http.request,
-    Resource: GET localhost/function/HandlerNoParamSyncWithContext,
+    Resource: GET localhost/function/BaseHandlerOneParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_9,
@@ -80,7 +80,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerNoParamSyncWithContext,
+      http.url: http://localhost/function/BaseHandlerOneParamSyncWithContext,
       runtime-id: Guid_3,
       span.kind: client
     },
@@ -95,7 +95,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_10,
     SpanId: Id_11,
     Name: http.request,
-    Resource: GET localhost/function/HandlerNoParamVoid,
+    Resource: GET localhost/function/BaseHandlerTwoParamsSync,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_12,
@@ -110,7 +110,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerNoParamVoid,
+      http.url: http://localhost/function/BaseHandlerTwoParamsSync,
       runtime-id: Guid_4,
       span.kind: client,
       _dd.p.dm: -0
@@ -126,7 +126,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_13,
     SpanId: Id_14,
     Name: http.request,
-    Resource: GET localhost/function/HandlerOneParamAsync,
+    Resource: GET localhost/function/BaseHandlerTwoParamsVoid,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_15,
@@ -141,7 +141,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerOneParamAsync,
+      http.url: http://localhost/function/BaseHandlerTwoParamsVoid,
       runtime-id: Guid_5,
       span.kind: client,
       _dd.p.dm: -0
@@ -157,7 +157,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_16,
     SpanId: Id_17,
     Name: http.request,
-    Resource: GET localhost/function/HandlerOneParamSync,
+    Resource: GET localhost/function/HandlerNoParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_18,
@@ -172,7 +172,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerOneParamSync,
+      http.url: http://localhost/function/HandlerNoParamAsync,
       runtime-id: Guid_6,
       span.kind: client,
       _dd.p.dm: -0
@@ -185,13 +185,13 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_19,
+    TraceId: Id_19,
+    SpanId: Id_20,
     Name: http.request,
-    Resource: GET localhost/function/HandlerOneParamSyncWithContext,
+    Resource: GET localhost/function/HandlerNoParamSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_20,
+    ParentId: Id_21,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -203,9 +203,10 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerOneParamSyncWithContext,
+      http.url: http://localhost/function/HandlerNoParamSync,
       runtime-id: Guid_7,
-      span.kind: client
+      span.kind: client,
+      _dd.p.dm: -0
     },
     Metrics: {
       process_id: 0,
@@ -215,10 +216,10 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_21,
+    TraceId: Id_7,
     SpanId: Id_22,
     Name: http.request,
-    Resource: GET localhost/function/HandlerOneParamVoid,
+    Resource: GET localhost/function/HandlerNoParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_23,
@@ -233,10 +234,9 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerOneParamVoid,
+      http.url: http://localhost/function/HandlerNoParamSyncWithContext,
       runtime-id: Guid_8,
-      span.kind: client,
-      _dd.p.dm: -0
+      span.kind: client
     },
     Metrics: {
       process_id: 0,
@@ -249,7 +249,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_24,
     SpanId: Id_25,
     Name: http.request,
-    Resource: GET localhost/function/HandlerTwoParamsAsync,
+    Resource: GET localhost/function/HandlerNoParamVoid,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_26,
@@ -264,7 +264,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerTwoParamsAsync,
+      http.url: http://localhost/function/HandlerNoParamVoid,
       runtime-id: Guid_9,
       span.kind: client,
       _dd.p.dm: -0
@@ -280,7 +280,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     TraceId: Id_27,
     SpanId: Id_28,
     Name: http.request,
-    Resource: GET localhost/function/HandlerTwoParamsSync,
+    Resource: GET localhost/function/HandlerOneParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_29,
@@ -295,7 +295,7 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerTwoParamsSync,
+      http.url: http://localhost/function/HandlerOneParamAsync,
       runtime-id: Guid_10,
       span.kind: client,
       _dd.p.dm: -0
@@ -308,13 +308,13 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_30,
+    TraceId: Id_30,
+    SpanId: Id_31,
     Name: http.request,
-    Resource: GET localhost/function/HandlerTwoParamsSyncWithContext,
+    Resource: GET localhost/function/HandlerOneParamSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_31,
+    ParentId: Id_32,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -326,9 +326,10 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerTwoParamsSyncWithContext,
+      http.url: http://localhost/function/HandlerOneParamSync,
       runtime-id: Guid_11,
-      span.kind: client
+      span.kind: client,
+      _dd.p.dm: -0
     },
     Metrics: {
       process_id: 0,
@@ -338,10 +339,10 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_32,
+    TraceId: Id_7,
     SpanId: Id_33,
     Name: http.request,
-    Resource: GET localhost/function/HandlerTwoParamsVoid,
+    Resource: GET localhost/function/HandlerOneParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
     ParentId: Id_34,
@@ -356,8 +357,161 @@ System.Net.WebException: Cannot assign requested address Cannot assign requested
 at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
       error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/HandlerTwoParamsVoid,
+      http.url: http://localhost/function/HandlerOneParamSyncWithContext,
       runtime-id: Guid_12,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_36,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerOneParamVoid,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_37,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerOneParamVoid,
+      runtime-id: Guid_13,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_38,
+    SpanId: Id_39,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsAsync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_40,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsAsync,
+      runtime-id: Guid_14,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_41,
+    SpanId: Id_42,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsSync,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_43,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsSync,
+      runtime-id: Guid_15,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_44,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsSyncWithContext,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_45,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsSyncWithContext,
+      runtime-id: Guid_16,
+      span.kind: client
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_46,
+    SpanId: Id_47,
+    Name: http.request,
+    Resource: GET localhost/function/HandlerTwoParamsVoid,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_48,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/HandlerTwoParamsVoid,
+      runtime-id: Guid_17,
       span.kind: client,
       _dd.p.dm: -0
     },

--- a/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Program.cs
@@ -14,7 +14,7 @@ using Amazon.Lambda.Core;
 
 namespace Samples.AWS.Lambda
 {
-    public class Function
+    public class Function: BaseFunction
     {
         private static async Task Main(string[] args)
         {
@@ -46,6 +46,18 @@ namespace Samples.AWS.Lambda
             await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_ONE_PARAM_SYNC_WITH_CONTEXT"));
             Thread.Sleep(1000);
             await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_TWO_PARAMS_SYNC_WITH_CONTEXT"));
+            
+            // base functions
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_BASE_NO_PARAM_SYNC"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_BASE_TWO_PARAMS_SYNC"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_BASE_ONE_PARAM_SYNC_WITH_CONTEXT"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_BASE_ONE_PARAM_ASYNC"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_BASE_TWO_PARAMS_VOID"));
         }
         private static async Task<string> Post(string url)
         {
@@ -61,19 +73,6 @@ namespace Samples.AWS.Lambda
 
             HttpResponseMessage response = await client.SendAsync(request);
             return await response.Content.ReadAsStringAsync();
-        }
-
-        private void Get(string url)
-        {
-            WebRequest request = WebRequest.Create(url);
-            request.Credentials = CredentialCache.DefaultCredentials;
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-            using (Stream dataStream = response.GetResponseStream())
-            {
-                StreamReader reader = new StreamReader(dataStream);
-                reader.ReadToEnd();
-            }
-            response.Close();
         }
 
         public object HandlerNoParamSync()
@@ -159,5 +158,53 @@ namespace Samples.AWS.Lambda
     {
         public string Field1 { get; set; }
         public int Field2 { get; set; }
+    }
+
+    public class BaseFunction
+    {
+        public object BaseHandlerNoParamSync()
+        {
+            Get("http://localhost/function/BaseHandlerNoParamSync");
+            return new { statusCode = 200, body = "ok!" };
+        }
+
+        public object BaseHandlerTwoParamsSync(CustomInput request, ILambdaContext context)
+        {
+            Get("http://localhost/function/BaseHandlerTwoParamsSync");
+            return new { statusCode = 200, body = "ok!" };
+        }
+
+        public object BaseHandlerOneParamSyncWithContext(CustomInput request)
+        {
+            Get("http://localhost/function/BaseHandlerOneParamSyncWithContext");
+            return new { statusCode = 200, body = "ok!" };
+        }
+
+        public async Task<int> BaseHandlerOneParamAsync(CustomInput request)
+        {
+            await Task.Run(() => {
+                Get("http://localhost/function/BaseHandlerOneParamAsync");
+                Thread.Sleep(100);
+            });
+            return 10;
+        }
+
+        public void BaseHandlerTwoParamsVoid(CustomInput request, ILambdaContext context)
+        {
+            Get("http://localhost/function/BaseHandlerTwoParamsVoid");
+        }
+
+        protected void Get(string url)
+        {
+            WebRequest request = WebRequest.Create(url);
+            request.Credentials = CredentialCache.DefaultCredentials;
+            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
+            using (Stream dataStream = response.GetResponseStream())
+            {
+                StreamReader reader = new StreamReader(dataStream);
+                reader.ReadToEnd();
+            }
+            response.Close();
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Support instrumenting of AWS Lambda handler methods that are defined on a base type

## Reason for change

Currently, if you have a handler like this:

```csharp
public class MyFunction : BaseFunction
{
}

public class BaseFunction
{
    public void MyHandler() { }
}
```

And you create a Lambda using the _derived_ type, e.g. `_HANDLER=MyAssembly::MyFunction::MyHandler`, then we fail to instrument the handler. This PR adds support for this scenario.

## Implementation details

We already use reflection to find information about the handler (the number of parameters etc), so this PR adds a step to find the type that declares the body of the method, which is the one we need to instrument.

## Test coverage

- Unit tests for the walking of the hierarchy to find the correct type. 
- Tested overridden methods, hidden methods, abstract implementations, cross-assembly inheritance.
- Integration tests for base-class scenarios (I added 5, seemed sufficient)

## Other details
- Did some minor refactoring of the LambdaHandler while I was at it.
- The snapshot diff makes it looks like there's loads of changes, but there's actually just 5 new snapshots at the start, which changes all the trace IDs in the subsequent spans