### PR TITLE
Test remote config order

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -312,6 +312,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         private void SetRcmEnabled(AgentConfiguration c)
         {
             _isRcmEnabled = !string.IsNullOrEmpty(c.ConfigurationEndpoint);
+            Log.Information("Set RemoteConfigurationManager enabled");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -26,13 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         public void SingleLoaderTest()
         {
-            string tmpFile = Path.GetTempFileName();
-            // Using obsolete variable so we can be sure it will only
-            // contain logs from this sample
-            SetEnvironmentVariable("DD_TRACE_LOG_PATH", tmpFile);
-
-            // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
+            var tmpFile = UseTempLogFile();
 
             using ProcessResult processResult = RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, start: false));
             string[] logFileContent = File.ReadAllLines(tmpFile);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
             SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
 
-            using ProcessResult processResult = RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, doNotBindPorts: true));
+            using ProcessResult processResult = RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, start: false));
             string[] logFileContent = File.ReadAllLines(tmpFile);
             int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));
             Assert.Equal(1, numOfLoadersLoad);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -68,12 +68,12 @@ namespace Datadog.Trace.Security.IntegrationTests
             get { return _process?.ProcessName; }
         }
 
-        public Task<MockTracerAgent> RunOnSelfHosted(bool? enableSecurity, string externalRulesFile = null, int? traceRateLimit = null)
+        public MockTracerAgent RunOnSelfHosted(bool? enableSecurity, string externalRulesFile = null, int? traceRateLimit = null, bool startAgent = true)
         {
             if (_agent == null)
             {
                 var agentPort = TcpPortProvider.GetOpenPort();
-                _agent = MockTracerAgent.Create(Output, agentPort);
+                _agent = MockTracerAgent.Create(Output, agentPort, start: startAgent);
             }
 
             StartSample(
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                 externalRulesFile: externalRulesFile,
                 traceRateLimit: traceRateLimit);
 
-            return Task.FromResult(_agent);
+            return _agent;
         }
 
         public override void Dispose()

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int traceRateLimit, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
             await TestRateLimiter(enableSecurity, url, agent, traceRateLimit, totalRequests, 1);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestPathParamsEndpointRouting(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            var agent = RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             var enableSecurity = true;
 
-            var agent = await RunOnSelfHosted(enableSecurity, DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity, DefaultRuleFile);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int? traceRateLimit, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
             await TestRateLimiter(enableSecurity, url, agent, traceRateLimit.GetValueOrDefault(100), totalRequests, 1);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5WafInitialization.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5WafInitialization.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         public async Task TestSecurityInitialization(bool enableSecurity, HttpStatusCode expectedStatusCode, string ruleset = null)
         {
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
+            var agent = RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, (int)expectedStatusCode, ruleset);
             await TestAppSecRequestWithVerifyAsync(agent, url, null, 1, 1, settings, testInit: true);
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestSecurity(HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings((int)expectedStatusCode, sanitisedUrl);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            var agent = RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBody(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url, string body)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            var agent = RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl, body);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AgentLateStart.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AgentLateStart.cs
@@ -1,0 +1,60 @@
+// <copyright file="AspNetCore5AgentLateStart.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Security.IntegrationTests.Rcm
+{
+    public class AspNetCore5AgentLateStart : RcmBase
+    {
+        public AspNetCore5AgentLateStart(ITestOutputHelper outputHelper)
+            : base(outputHelper, testName: nameof(AspNetCore5AgentLateStart))
+        {
+            SetEnvironmentVariable(ConfigurationKeys.DebugEnabled, "0");
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestAgentLateStart()
+        {
+            var url = "/Health/?[$slice]=value";
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+
+            var agent = RunOnSelfHosted(enableSecurity: null, startAgent: false);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*");
+            await logEntryWatcher.WaitForLogEntry("DATADOG TRACER CONFIGURATION", logEntryWatcherTimeout);
+
+            agent.Start();
+            await logEntryWatcher.WaitForLogEntry("Set RemoteConfigurationManager enabled", logEntryWatcherTimeout);
+
+            agent.SetupRcm(Output, new[] { ((object)new AsmFeatures { Asm = new Asm { Enabled = true } }, "1") }, "ASM_FEATURES");
+            await logEntryWatcher.WaitForLogEntry(AppSecEnabledMessage, logEntryWatcherTimeout);
+            await Task.Delay(TimeSpan.FromSeconds(1.5));
+
+            var spans = await SendRequestsAsync(agent, url);
+
+            await VerifySpans(spans, settings, true);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AgentLateStart.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AgentLateStart.cs
@@ -37,6 +37,10 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         [Trait("RunOnWindows", "True")]
         public async Task TestAgentLateStart()
         {
+            // we expect exceptions in the logs, so write them outside of the usual place
+            // this is so they won't be checked in a later phase of the tests
+            UseTempLogFile();
+
             var url = "/Health/?[$slice]=value";
             var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestBlockedRequestIp(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*");
-            var agent = await RunOnSelfHosted(enableSecurity, "ruleset-withblockips.json");
+            var agent = RunOnSelfHosted(enableSecurity, "ruleset-withblockips.json");
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequestIpWithOneClickActivation(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, "ruleset-withblockips.json");
+            var agent = RunOnSelfHosted(enableSecurity, "ruleset-withblockips.json");
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestSecurityToggling(bool? enableSecurity, uint expectedState, uint expectedCapabilities)
         {
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity);
+            var agent = RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, expectedState, expectedCapabilities);
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*");
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         {
             var enableSecurity = true;
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity);
+            var agent = RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
             var spans1 = await SendRequestsAsync(agent, url);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -628,6 +628,19 @@ namespace Datadog.Trace.TestHelpers
             Assert.Equal(expectedServiceVersion, span.Tags.GetValueOrDefault(Tags.Version));
         }
 
+        protected string UseTempLogFile()
+        {
+            string tmpFile = Path.GetTempFileName();
+            // Using obsolete variable so we can be sure it will only
+            // contain logs from this sample
+            SetEnvironmentVariable("DD_TRACE_LOG_PATH", tmpFile);
+
+            // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
+
+            return tmpFile;
+        }
+
         private bool IsServerSpan(MockSpan span) =>
             span.Tags.GetValueOrDefault(Tags.SpanKind) == SpanKinds.Server;
 

--- a/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
@@ -24,14 +24,14 @@ namespace Datadog.Trace.TestHelpers
         }
 
         // doing multiple things here, waiting for the request and return the latest one
-        internal static async Task<GetRcmRequest> WaitRcmRequestAndReturnLast(this MockTracerAgent agent, int timeoutInMilliseconds = 50000)
+        internal static async Task<GetRcmRequest> WaitRcmRequestAndReturnLast(this MockTracerAgent agent, int timeoutInMilliseconds = 5_000)
         {
             var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
 
             GetRcmRequest request = null;
             while (DateTime.UtcNow < deadline)
             {
-                while (agent.RemoteConfigRequests.IsEmpty)
+                while (agent.RemoteConfigRequests.IsEmpty && DateTime.UtcNow < deadline)
                 {
                     await Task.Delay(200);
                 }

--- a/tracer/test/snapshots/Security.AspNetCore5AgentLateStart._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AgentLateStart._.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /health,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.event: true,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.HealthController.Index (Samples.Security.AspNetCore5),
+      aspnet_core.route: health,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.endpoint: health,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded: 86.242.244.246,
+      http.response.headers.content-length: 3,
+      http.response.headers.content-type: text/plain; charset=utf-8,
+      http.route: health,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Health/?[$slice]=value,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.event_rules.version: 1.4.1,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-942-290","name":"Finds basic MongoDB SQL injection attempts","tags":{"category":"attack_attempt","type":"nosql_injection"}},"rule_matches":[{"operator":"match_regex","operator_value":"(?i:(?:\\[?\\$(?:(?:s(?:lic|iz)|wher)e|e(?:lemMatch|xists|q)|n(?:o[rt]|in?|e)|l(?:ike|te?)|t(?:ext|ype)|a(?:ll|nd)|jsonSchema|between|regex|x?or|div|mod)\\]?))","parameters":[{"address":"server.request.query","highlight":["[$slice]"],"key_path":["[$slice]"],"value":"[$slice]"}]}]}]},
+      _dd.appsec.waf.version: 1.5.1,
+      _dd.origin: appsec,
+      _dd.p.dm: -0,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.event_rules.error_count: 0.0,
+      _dd.appsec.event_rules.loaded: 132.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]


### PR DESCRIPTION

## Summary of changes

Ensures an using the library can start after the agent and still receive remote config updates.

## Reason for change

https://datadoghq.atlassian.net/browse/APPSEC-5523

## Test coverage

This is a test.