### PR TITLE
Try loading OpenSSL eagerly on `netcoreapp2.0`-`net5.0`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -193,7 +193,7 @@ namespace Datadog.Trace.ClrProfiler
                 }
             }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1
             try
             {
                 // On .NET Core 2.0-3.0 we see an occasional hang caused by OpenSSL being loaded

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler
                 // lived nature of our apps. This appears to be a bug in the runtime (although
                 // we haven't yet confirmed that). Calling the `ToUuid()` method uses an MD5
                 // hash which calls into the native library, triggering the load.
-                var result = string.Empty.ToUUID();
+                _ = string.Empty.ToUUID();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary of changes

Trigger an app to eagerly load OpenSSL on app startup

## Reason for change

While investigating Linux flaky tests, @kevingosse identified that on .NET Core 2.0-3.0 we see an occasional hang caused by OpenSSL being loaded while the app is shutting down. This results in flaky tests due to the short-lived nature of our apps, though it shouldn't be an issue in practice for customers. 

> This _appears_ to be a bug in the runtime (although we haven't yet confirmed that)

To work around the issue, we try to eagerly load OpenSSL, to avoid the load when we're shutting down. 

## Implementation details

Calling the `ToUuid()` method uses an MD5 hash which calls into the native implementation, triggering OpenSSL to load.

## Test coverage
Let's see what happens with the flake 👀 

## Other details
We've only seen this in netcoreapp2.1 and netcoreapp3.0 so far, so only adding for netstandard initially, but it looks like we can probably reproduce up to net5.0, so expanded the `#ifdef`
