### PR TITLE
[ASM][RCM] Reduce Flake > fix integration tests log watching

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -68,6 +68,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             get { return _process?.ProcessName; }
         }
 
+        public int? SampleProcessId
+        {
+            get { return _process?.Id; }
+        }
+
         public Task<MockTracerAgent> RunOnSelfHosted(bool? enableSecurity, string externalRulesFile = null, int? traceRateLimit = null)
         {
             if (_agent == null)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -55,12 +55,11 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var request1 = await agent.WaitRcmRequestAndReturnLast();
             if (enableSecurity == true)
             {
-                await logEntryWatcher.WaitForLogEntry(AppSecDisabledMessage, logEntryWatcherTimeout);
+                await logEntryWatcher.WaitForLogEntry(AppSecDisabledMessage(), logEntryWatcherTimeout);
             }
 
             CheckAckState(request1, expectedState, null, "First RCM call");
             CheckCapabilities(request1, expectedCapabilities, "First RCM call");
-            await Task.Delay(1500);
 
             var spans2 = await SendRequestsAsync(agent, url);
 
@@ -68,12 +67,11 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var request2 = await agent.WaitRcmRequestAndReturnLast();
             if (enableSecurity != false)
             {
-                await logEntryWatcher.WaitForLogEntry(AppSecEnabledMessage, logEntryWatcherTimeout);
+                await logEntryWatcher.WaitForLogEntry(AppSecEnabledMessage(), logEntryWatcherTimeout);
             }
 
             CheckAckState(request2, expectedState, null, "Second RCM call");
             CheckCapabilities(request2, expectedCapabilities, "Second RCM call");
-            await Task.Delay(1500);
 
             var spans3 = await SendRequestsAsync(agent, url);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -12,8 +12,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm;
 public class RcmBase : AspNetBase
 {
     protected const string LogFileNamePrefix = "dotnet-tracer-managed-";
-    protected const string AppSecDisabledMessage = "AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true";
-    protected const string AppSecEnabledMessage = "AppSec is now Enabled, _settings.Enabled is true, coming from remote config: true";
+
 #pragma warning disable SA1401
     protected readonly TimeSpan logEntryWatcherTimeout = TimeSpan.FromSeconds(20);
 #pragma warning restore SA1401
@@ -23,4 +22,10 @@ public class RcmBase : AspNetBase
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
     }
+
+    protected string AppSecDisabledMessage() => $"AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+
+    protected string AppSecEnabledMessage() => $"AppSec is now Enabled, _settings.Enabled is true, coming from remote config: true  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+
+    protected string RulesUpdatedMessage() => $"rules have been updated and waf status is \"DDWAF_OK\"  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
 }


### PR DESCRIPTION
## Summary of changes

Watch for the log with the right PID.
IntegrationTests might be ran parallelly (between different classes) and writing to the same log file, so without listening to the right PID, we intercept some other's process activation.

## Reason for change

## Implementation details
Removed all Task.Delay, just watcher, watching the right message for the right PID

## Test coverage

## Other details
<!-- Fixes #{issue} -->
