### PR TITLE
Bump some timeouts to reduce test flake

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -154,21 +154,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var shutdownRequest = new RequestInfo() { HttpMethod = "GET", Url = "/shutdown" };
                     SubmitRequest(aspNetCorePort.Value, shutdownRequest);
 
-                    if (!process.WaitForExit(5000))
-                    {
-                        Output.WriteLine("The process didn't exit in time. Taking proc dump and killing it.");
-                        var memoryDumpCaptured = await TakeMemoryDump(process);
-
-                        process.Kill();
-
-                        if (!memoryDumpCaptured)
-                        {
-                            // if we don't have a memory dump, there's no point continuing.
-                            // We know the test will likely fail (telemetry not sent) but it's
-                            // not useful to know that, as we don't have a memory dump
-                            throw new SkipException("The process didn't exit in time but memory dump couldn't be captured");
-                        }
-                    }
+                    WaitForProcessResult(process);
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -108,37 +108,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
+                using var helper = new ProcessHelper(
+                    process,
+                    onDataReceived: data =>
                     {
-                        if (args.Data.Contains("Now listening on:"))
+                        if (data.Contains("Now listening on:"))
                         {
-                            var splitIndex = args.Data.LastIndexOf(':');
-                            aspNetCorePort = int.Parse(args.Data.Substring(splitIndex + 1));
+                            var splitIndex = data.LastIndexOf(':');
+                            aspNetCorePort = int.Parse(data.Substring(splitIndex + 1));
 
                             wh.Set();
                         }
-                        else if (args.Data.Contains("Unable to start Kestrel"))
+                        else if (data.Contains("Unable to start Kestrel"))
                         {
                             wh.Set();
                         }
 
-                        Output.WriteLine($"[webserver][stdout] {args.Data}");
-                    }
-                };
-                process.BeginOutputReadLine();
-
-                process.ErrorDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        Output.WriteLine($"[webserver][stderr] {args.Data}");
-                    }
-                };
-                process.BeginErrorReadLine();
+                        Output.WriteLine($"[webserver][stdout] {data}");
+                    },
+                    onErrorReceived: data => Output.WriteLine($"[webserver][stderr] {data}"));
 
                 wh.WaitOne(15_000);
+
                 if (!aspNetCorePort.HasValue)
                 {
                     throw new Exception("Unable to determine port application is listening on");
@@ -154,7 +145,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var shutdownRequest = new RequestInfo() { HttpMethod = "GET", Url = "/shutdown" };
                     SubmitRequest(aspNetCorePort.Value, shutdownRequest);
 
-                    WaitForProcessResult(process);
+                    WaitForProcessResult(helper);
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -72,35 +72,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
+                using var helper = new ProcessHelper(
+                    process,
+                    onDataReceived: data =>
                     {
-                        if (args.Data.Contains("Now listening on:"))
+                        if (data.Contains("Now listening on:"))
                         {
-                            var splitIndex = args.Data.LastIndexOf(':');
-                            aspNetCorePort = int.Parse(args.Data.Substring(splitIndex + 1));
+                            var splitIndex = data.LastIndexOf(':');
+                            aspNetCorePort = int.Parse(data.Substring(splitIndex + 1));
 
                             wh.Set();
                         }
-                        else if (args.Data.Contains("Unable to start Kestrel"))
+                        else if (data.Contains("Unable to start Kestrel"))
                         {
                             wh.Set();
                         }
 
-                        Output.WriteLine($"[webserver][stdout] {args.Data}");
-                    }
-                };
-                process.BeginOutputReadLine();
-
-                process.ErrorDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        Output.WriteLine($"[webserver][stderr] {args.Data}");
-                    }
-                };
-                process.BeginErrorReadLine();
+                        Output.WriteLine($"[webserver][stdout] {data}");
+                    },
+                    onErrorReceived: data => Output.WriteLine($"[webserver][stderr] {data}"));
 
                 wh.WaitOne(15_000);
                 if (!aspNetCorePort.HasValue)
@@ -118,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var shutdownRequest = new RequestInfo() { HttpMethod = "GET", Url = "/shutdown" };
                     SubmitRequest(aspNetCorePort.Value, shutdownRequest);
 
-                    WaitForProcessResult(process);
+                    WaitForProcessResult(helper);
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -118,21 +118,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var shutdownRequest = new RequestInfo() { HttpMethod = "GET", Url = "/shutdown" };
                     SubmitRequest(aspNetCorePort.Value, shutdownRequest);
 
-                    if (!process.WaitForExit(5000))
-                    {
-                        Output.WriteLine("The process didn't exit in time. Taking proc dump and killing it.");
-                        var memoryDumpCaptured = await TakeMemoryDump(process);
-
-                        process.Kill();
-
-                        if (!memoryDumpCaptured)
-                        {
-                            // if we don't have a memory dump, there's no point continuing.
-                            // We know the test will likely fail (telemetry not sent) but it's
-                            // not useful to know that, as we don't have a memory dump
-                            throw new SkipException("The process didn't exit in time but memory dump couldn't be captured");
-                        }
-                    }
+                    WaitForProcessResult(process);
                 }
 
                 var spans = agent.WaitForSpans(expectedSpans);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -178,17 +178,17 @@ namespace Datadog.Trace.TestHelpers
         public ProcessResult RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000)
         {
             var process = StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework);
-
-            return WaitForProcessResult(process);
-        }
-
-        public ProcessResult WaitForProcessResult(Process process)
-        {
             using var helper = new ProcessHelper(process);
 
+            return WaitForProcessResult(helper);
+        }
+
+        public ProcessResult WaitForProcessResult(ProcessHelper helper)
+        {
             // this is _way_ too long, but we want to be v. safe
             // the goal is just to make sure we kill the test before
             // the whole CI run times out
+            var process = helper.Process;
             var timeoutMs = (int)TimeSpan.FromMinutes(10).TotalMilliseconds;
             var ranToCompletion = process.WaitForExit(timeoutMs) && helper.Drain(timeoutMs / 2);
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -179,6 +179,11 @@ namespace Datadog.Trace.TestHelpers
         {
             var process = StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework);
 
+            return WaitForProcessResult(process);
+        }
+
+        public ProcessResult WaitForProcessResult(Process process)
+        {
             using var helper = new ProcessHelper(process);
 
             // this is _way_ too long, but we want to be v. safe

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
             {
                 sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "A message"));
-                mutex.Wait(10_000).Should().BeTrue();
+                mutex.Wait(30_000).Should().BeTrue();
                 mutex.Reset();
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -161,7 +161,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
 
         private static ConcurrentStack<IList<DatadogLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)
         {
-            var deadline = DateTime.UtcNow.AddSeconds(10);
+            var deadline = DateTime.UtcNow.AddSeconds(30);
             var batches = pbs.Batches;
             while (batches.Count < batchCount && DateTime.UtcNow < deadline)
             {


### PR DESCRIPTION
## Summary of changes

- Bump timeout in `BatchingSinkTests`
- Bump timeout in `DatadogSinkTests`
- Update Graphql/HotChocolate to use same process exit/memory dump logic as other tests
- Fix flakiness in a DSM unit test

## Reason for change

#3284 seems to have resolved much of the flake/hang, but we were still getting memory dumps on arm64 for GraphQL. Initial analysis indicates that this is _not_ a hang, we're just killing the process while it's shutting down. This is likely because we had a _much_ shorter timeout in those tests (5s instead of 10mins), and the arm64 instances may be slower, so updated them to use the same logic as other tests instead.

The DSM test was making a false assumption that everything would be in the same API request. The update relaxes that assumption

## Implementation details

Timeout bumps mostly

## Test coverage

Hopefully this test run passes...

## Other details
More flake-fixing PRs to follow
