### PR TITLE
[Profiler] Change lock-duration to lock-time

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -26,7 +26,7 @@ SampleValueType const SampleTypeDefinitions[] =
     {"alloc-samples", "count"}, // AllocationCount
     {"alloc-size", "bytes"},    // AllocationSize
     {"lock-count", "count"},
-    {"lock-duration", "nanoseconds"}
+    {"lock-time", "nanoseconds"}
 
     // the new ones should be added here at the same time
     // new identifiers are added to SampleValue


### PR DESCRIPTION
## Summary of changes
The contention lock duration column is renamed to "lock-time"

## Reason for change
"-duration" suffix cannot be used here due to special backend processing

## Implementation details

## Test coverage
Generated .pprof validated with backend 

## Other details
<!-- Fixes #{issue} -->
