### PR TITLE
Add a workaround for missing profiling support in PyPI version of dd-apm-test-agent

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -69,10 +69,18 @@ steps:
     
     echo "Dumping all requests"
     docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) -o /debug_snapshots/${{ parameters.snapshotPrefix }}_requests.json "http://localhost:8126$(REQUESTS_DUMP_ENDPOINT)"
-    
-    echo "Verifying snapshot session (fail on mis-match)"
-    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
-  displayName: check snapshots
+  displayName: dump snapshots
+
+- ${{ if eq(parameters.isLinux, true) }}:
+  - bash: |
+      echo "Verifying snapshot session (fail on mis-match)"
+      docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+    displayName: check snapshots
+- ${{ else }}:
+  - bash: |
+      echo "Verifying snapshot session (fail on mis-match)"
+      docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+    displayName: check snapshots
 
 - task: DockerCompose@0
   displayName: dump docker-compose logs for $(TEST_AGENT_TARGET)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1585,6 +1585,11 @@ partial class Build
 
             // profiler occasionally throws this if shutting down
             knownPatterns.Add(new(@".*LinuxStackFramesCollector::CollectStackSampleImplementation: Unable to send signal .*Error code: No such process", RegexOptions.Compiled));
+            // Temporary workaround until PyPi version is updated with profiler support
+            if (IsWin)
+            {
+                knownPatterns.Add(new(@".*Failed to send profile. Http code: 404", RegexOptions.Compiled));
+            }
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });


### PR DESCRIPTION
## Summary of changes

- Fix the snapshot stage sending invalid `curl` commands in Windows smoke tests
- Temporarily ignore the profiling error in Windows smoke tests

## Reason for change

- #3088 introduced a `--w` argument for `curl` to add a description of how to handle failures. Unfortunately this isn't supported in Windows' version of `curl`, so we were getting lots of errors in the task.
- The latest version of https://github.com/DataDog/dd-apm-test-agent added support for profiling endpoints, but it has not yet been uploaded to PyPI. Our Windows smoke tests pull from PyPI to build the docker image, so the profiler send is failing. We are only noticing this now, because the Profiler started logging when a send fails.

## Implementation details

- Drop the `--w` argument from the Windows `curl` command
- Ignore the profiling log error for now on Windows, we'll start watching for it again once PyPI is updated. 

## Test coverage

Covered by existing tests

## Other details
https://github.com/DataDog/dd-apm-test-agent/issues/98
