### PR TITLE
Remove workaround for missing profiler support in PyPI version of dd-apm-test-agent

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1585,11 +1585,6 @@ partial class Build
 
             // profiler occasionally throws this if shutting down
             knownPatterns.Add(new(@".*LinuxStackFramesCollector::CollectStackSampleImplementation: Unable to send signal .*Error code: No such process", RegexOptions.Compiled));
-            // Temporary workaround until PyPi version is updated with profiler support
-            if (IsWin)
-            {
-                knownPatterns.Add(new(@".*Failed to send profile. Http code: 404", RegexOptions.Compiled));
-            }
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });


### PR DESCRIPTION
## Summary of changes

- Removes the temporary workaround added in #3299

## Reason for change

The latest version on PyPI now has profiler support: https://github.com/DataDog/dd-apm-test-agent/actions/runs/3182710308

## Implementation details

Removed the hack

## Test coverage

Hopefully the smoke tests all pass!
