### PR TITLE
Fix edge case in `DataStreamsWriter`

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsWriter.cs
@@ -181,6 +181,7 @@ internal class DataStreamsWriter : IDataStreamsWriter
 
     private async Task ProcessQueueLoopAsync()
     {
+        var isFinalFlush = false;
         while (true)
         {
             try
@@ -204,7 +205,15 @@ internal class DataStreamsWriter : IDataStreamsWriter
 
             if (_processExit.Task.IsCompleted)
             {
-                return;
+                if (isFinalFlush)
+                {
+                    return;
+                }
+
+                // do one more loop to make sure everything is flushed
+                RequestFlush();
+                isFinalFlush = true;
+                continue;
             }
 
             _processingMutex.Wait();


### PR DESCRIPTION
## Summary of changes

- Fixes an edge case in `DataStreamsWriter` that would lose some buckets on dispose

## Reason for change

We were sometimes missing some points when disposing. Also causes the flake in integration tests (I hope)

## Implementation details

If we are currently flushing stats when dispose is called, we wouldn't _necessarily_ flush all stats. This is very timing dependent (depends on the stats buckets) so hard to reproduce but I'm 30% confident this is the sole source of the flake 😄 

## Test coverage

I'm going to hammer the tests repeatedly and make sure I can't reproduce

## Other details

