### PR TITLE
Optimize blocking

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/BlockException.cs
+++ b/tracer/src/Datadog.Trace/AppSec/BlockException.cs
@@ -27,5 +27,8 @@ namespace Datadog.Trace.AppSec
             : base(info, context)
         {
         }
+
+        // can give a significant performance boost, this exception is currently caught and logged by the host web server
+        public override string ToString() => "BlockException";
     }
 }


### PR DESCRIPTION
## Summary of changes

Blocking can be quite expensive because the host webserver will log all the exception details. Returning a short string from `.ToString()`.

## Test coverage

Covered by throughput tests