### PR TITLE
[Profiler] Log INVOKE and CALL warning message only once

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/COMHelpers.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/COMHelpers.h
@@ -10,6 +10,10 @@
         HRESULT hr = x;                                                                                       \
         if (FAILED(hr))                                                                                       \
         {                                                                                                     \
+            static bool ddAlreadyLogged = false;                                                              \
+            if (ddAlreadyLogged)                                                                              \
+                return;                                                                                       \
+            ddAlreadyLogged = true;                                                                           \
             Log::Warn("Profiler call failed with result ", HResultConverter::ToStringWithCode(hr), ": ", #x); \
             return;                                                                                           \
         }                                                                                                     \
@@ -20,6 +24,10 @@
         HRESULT hr = x;                                                                                       \
         if (FAILED(hr))                                                                                       \
         {                                                                                                     \
+            static bool ddAlreadyLogged = false;                                                              \
+            if (ddAlreadyLogged)                                                                              \
+                return false;                                                                                 \
+            ddAlreadyLogged = true;                                                                           \
             Log::Warn("Profiler call failed with result ", HResultConverter::ToStringWithCode(hr), ": ", #x); \
             return false;                                                                                     \
         }                                                                                                     \

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/COMHelpers.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/COMHelpers.h
@@ -10,10 +10,10 @@
         HRESULT hr = x;                                                                                       \
         if (FAILED(hr))                                                                                       \
         {                                                                                                     \
-            static bool ddAlreadyLogged = false;                                                              \
-            if (ddAlreadyLogged)                                                                              \
+            static bool callAlreadyLogged = false;                                                            \
+            if (callAlreadyLogged)                                                                            \
                 return;                                                                                       \
-            ddAlreadyLogged = true;                                                                           \
+            callAlreadyLogged = true;                                                                           \
             Log::Warn("Profiler call failed with result ", HResultConverter::ToStringWithCode(hr), ": ", #x); \
             return;                                                                                           \
         }                                                                                                     \
@@ -24,10 +24,10 @@
         HRESULT hr = x;                                                                                       \
         if (FAILED(hr))                                                                                       \
         {                                                                                                     \
-            static bool ddAlreadyLogged = false;                                                              \
-            if (ddAlreadyLogged)                                                                              \
+            static bool invokeAlreadyLogged = false;                                                          \
+            if (invokeAlreadyLogged)                                                                          \
                 return false;                                                                                 \
-            ddAlreadyLogged = true;                                                                           \
+            invokeAlreadyLogged = true;                                                                           \
             Log::Warn("Profiler call failed with result ", HResultConverter::ToStringWithCode(hr), ": ", #x); \
             return false;                                                                                     \
         }                                                                                                     \


### PR DESCRIPTION
## Summary of changes

Log message from INVOKE and CALL macros only once per call site.

## Reason for change

Too avoid cluttering the log files.

## Implementation details

Just add a static in the if body.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
