### PR TITLE
Disable DSM if `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=0`

### DIFF
--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -53,7 +53,16 @@ internal class DataStreamsManager
         IDiscoveryService discoveryService,
         string defaultServiceName)
     {
-        var writer = settings.IsDataStreamsMonitoringEnabled
+        var enableDsm = settings.IsDataStreamsMonitoringEnabled;
+        if (!settings.KafkaCreateConsumerScopeEnabled)
+        {
+            Log.Warning(
+                $"Data Streams Monitoring was enabled, but required setting {ConfigurationKeys.KafkaCreateConsumerScopeEnabled} was disabled. "
+              + $"Data Streams Monitoring currently requires {ConfigurationKeys.KafkaCreateConsumerScopeEnabled}=0. This will be relaxed in a future version.");
+            enableDsm = false;
+        }
+
+        var writer = enableDsm
                          ? DataStreamsWriter.Create(settings, discoveryService, defaultServiceName)
                          : null;
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -54,11 +54,11 @@ internal class DataStreamsManager
         string defaultServiceName)
     {
         var enableDsm = settings.IsDataStreamsMonitoringEnabled;
-        if (!settings.KafkaCreateConsumerScopeEnabled)
+        if (enableDsm && !settings.KafkaCreateConsumerScopeEnabled)
         {
             Log.Warning(
                 $"Data Streams Monitoring was enabled, but required setting {ConfigurationKeys.KafkaCreateConsumerScopeEnabled} was disabled. "
-              + $"Data Streams Monitoring currently requires {ConfigurationKeys.KafkaCreateConsumerScopeEnabled}=0. This will be relaxed in a future version.");
+              + $"Data Streams Monitoring currently requires {ConfigurationKeys.KafkaCreateConsumerScopeEnabled}=1. This will be relaxed in a future version.");
             enableDsm = false;
         }
 


### PR DESCRIPTION
## Summary of changes

- Disable DSM if `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=0`

## Reason for change

Currently, this will likely result in incorrect `PathwayContext` propagation, so disable DSM entirely instead for now

## Implementation details

If `IsDataStreamsMonitoringEnabled` and `!KafkaCreateConsumerScopeEnabled` then log an error, and disable DSM

## Test coverage

Added a simple test to confirm it woks as expected

## Other details
This is only a temporary fix while .NET DSM only supports Kafka, and doesn't yet have a public API to enable the correct checkpointing and pathway context flow
