### PR TITLE
Make sure we remove the DSM propagation header from SQS attributes

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Propagators;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
@@ -44,7 +45,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 // Make sure we do not propagate any other datadog header here in the rare cases where users would have added them manually
                 foreach (var attribute in carrier.MessageAttributes.Keys)
                 {
-                    if (attribute is string attributeName && attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase))
+                    if (attribute is string attributeName && 
+                        (attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase)
+                            || attributeName.Equals(DataStreamsContextPropagator.PropagationKey, StringComparison.OrdinalIgnoreCase)))
                     {
 #if !NETCOREAPP2_1_OR_GREATER
                         attributesToRemove ??= new List<string>();

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.DataStreamsMonitoring;
 /// </summary>
 internal class DataStreamsContextPropagator
 {
-    private const string PropagationKey = "dd-pathway-ctx";
+    internal const string PropagationKey = "dd-pathway-ctx";
 
     public static DataStreamsContextPropagator Instance { get; } = new();
 


### PR DESCRIPTION
## Summary of changes

Make sure we remove the DSM propagation header from SQS attributes

## Reason for change

SQS has a hard limit of 10, so we have to consolidate them into a single header

## Implementation details

Add the `dd-pathway-ctx` key to the list of removed attributes. Annoying that it doesn't conform to the existing `x-datadog` header pattern. 

## Test coverage

😶 

## Other details

