### PR TITLE
[Profiler] Bump libdatadog version to 0.9.0

### DIFF
--- a/profiler/build/cmake/FindLibdatadog.cmake
+++ b/profiler/build/cmake/FindLibdatadog.cmake
@@ -1,6 +1,6 @@
 include(ExternalProject)
 
-set(LIBDATADOG_VERSION "v0.8.0" CACHE STRING "libdatadog version")
+set(LIBDATADOG_VERSION "v0.9.0" CACHE STRING "libdatadog version")
 
 if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
    set(LIBDATADOG_BASE_DIR ${CMAKE_CURRENT_BINARY_DIR}/libdatadog-${LIBATADOG_VERSION}/src/libdatadog-build/libdatadog/libdatadog-${CMAKE_SYSTEM_PROCESSOR}-alpine-linux-musl)
@@ -10,15 +10,15 @@ endif()
 
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
   if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
-    set(SHA256_LIBDATADOG "68919ddf9bc6491927bf16fb819b18fd052209d77774097b57f7879ebafc9bdf" CACHE STRING "libdatadog sha256")
+    set(SHA256_LIBDATADOG "a094bae08153b521d467435e3ef5364d3099e4b8aac1291a16c70c51ccc2f171" CACHE STRING "libdatadog sha256")
   else()
-    set(SHA256_LIBDATADOG "9c6dd7058c7d0c9af8ffe18b4565fcda08462debc81f60ce0eb87aa5f7b74a0b" CACHE STRING "libdatadog sha256")
+    set(SHA256_LIBDATADOG "9e55e8917521edf57c28bc2dad363bcc0a68570380480244f898714e31f356fb" CACHE STRING "libdatadog sha256")
   endif()
 else()
   if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
-    set(SHA256_LIBDATADOG "e410300255d93f016562e7e072dcb09f94d0550ff3e289f97fff4cd155a4d3a4" CACHE STRING "libdatadog sha256")
+    set(SHA256_LIBDATADOG "15e6d94208b94ff5f0e757310c8de372da67099e982d6ebd5cc88fdf8d9c2756" CACHE STRING "libdatadog sha256")
   else()
-    set(SHA256_LIBDATADOG "94f52edaed31f8c2a25cd569b0b065f8bb221120706d57ef2ca592b0512333f2" CACHE STRING "libdatadog sha256")
+    set(SHA256_LIBDATADOG "277d638d7e1cd9c6724ba3094fab5ce0e3a87a2c26b1cf0a89a86ae2a7f1ddc8" CACHE STRING "libdatadog sha256")
   endif()
 endif()
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props" Condition="Exists('..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" />
+  <Import Project="..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props" Condition="Exists('..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -250,6 +250,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props'))" />
   </Target>
 </Project>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/packages.config
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libdatadog" version="0.8.0" targetFramework="native" />
+  <package id="libdatadog" version="0.9.0" targetFramework="native" />
 </packages>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props" Condition="Exists('..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" />
+  <Import Project="..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props" Condition="Exists('..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -367,6 +367,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props'))" />
+    <Error Condition="!Exists('..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props'))" />
   </Target>
 </Project>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -41,6 +41,10 @@ std::string const LibddprofExporter::ProcessId = std::to_string(OpSysTools::GetP
 
 int32_t const LibddprofExporter::RequestTimeOutMs = 10000;
 
+std::string const LibddprofExporter::LibraryName = "dd-profiling-dotnet";
+
+std::string const LibddprofExporter::LibraryVersion = PROFILER_VERSION;
+
 std::string const LibddprofExporter::LanguageFamily = "dotnet";
 
 std::string const LibddprofExporter::RequestFileName = "auto.pprof";
@@ -88,11 +92,12 @@ LibddprofExporter::~LibddprofExporter()
 ddog_ProfileExporter* LibddprofExporter::CreateExporter(const ddog_Vec_tag* tags, ddog_Endpoint endpoint)
 {
     auto result = ddog_ProfileExporter_new(
-        FfiHelper::StringToCharSlice(std::string("dd-profiling-dotnet")),
-        FfiHelper::StringToCharSlice(std::string(PROFILER_VERSION)),
+        FfiHelper::StringToCharSlice(LibraryName),
+        FfiHelper::StringToCharSlice(LibraryVersion),
         FfiHelper::StringToCharSlice(LanguageFamily),
         tags,
         endpoint);
+
     if (result.tag == DDOG_NEW_PROFILE_EXPORTER_RESULT_OK)
     {
         return result.ok;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -87,7 +87,12 @@ LibddprofExporter::~LibddprofExporter()
 
 ddog_ProfileExporter* LibddprofExporter::CreateExporter(const ddog_Vec_tag* tags, ddog_Endpoint endpoint)
 {
-    auto result = ddog_ProfileExporter_new(FfiHelper::StringToCharSlice(LanguageFamily), tags, endpoint);
+    auto result = ddog_ProfileExporter_new(
+        FfiHelper::StringToCharSlice(std::string("dd-profiling-dotnet")),
+        FfiHelper::StringToCharSlice(std::string(PROFILER_VERSION)),
+        FfiHelper::StringToCharSlice(LanguageFamily),
+        tags,
+        endpoint);
     if (result.tag == DDOG_NEW_PROFILE_EXPORTER_RESULT_OK)
     {
         return result.ok;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -129,6 +129,8 @@ private:
     static tags CommonTags;
     static std::string const ProcessId;
     static int const RequestTimeOutMs;
+    static std::string const LibraryName;
+    static std::string const LibraryVersion;
     static std::string const LanguageFamily;
 
     // TODO: this should be passed in the constructor to avoid overwriting

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/packages.config
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="libdatadog" version="0.8.0" targetFramework="native" />
+  <package id="libdatadog" version="0.9.0" targetFramework="native" />
 </packages>

--- a/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
@@ -62,6 +62,18 @@ namespace Datadog.Profiler.IntegrationTests
                 text = reader.ReadToEnd();
             }
 
+            /*
+             we want to extract the "tags_profiler" attribute from the http body. The format is as followed:
+             {
+                 "start":"<START DATE>",
+                 "end":"<END DATE>",
+                 "attachments":["<ATTACHMENT1>", "<ATTACHMENT2>"],
+                 "tags_profiler":"<PROFILER TAGS>",
+                 "family":"<FAMILY>",
+                 "version":"4"
+             }
+             <PROFILER TAGS> is a list of tag (2 strings separated by ':') separated by ','
+             */
             var match_tags = Regex.Match(text, "\"tags_profiler\":\"(?<tags>[^\"]*)\"", RegexOptions.Compiled);
 
             if (!match_tags.Success || string.IsNullOrWhiteSpace(match_tags.Groups["tags"].Value))

--- a/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
@@ -11,7 +11,6 @@ using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Profiler.IntegrationTests
@@ -71,9 +70,15 @@ namespace Datadog.Profiler.IntegrationTests
 
         private static string ExtractTag(string tagName, string input)
         {
-            var match = Regex.Match(input, $"^{tagName}:(?<tag>[A-Z0-9-]+)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            var match_tags = Regex.Match(input, "\"tags_profiler\":\"(?<tags>[^\"]*)\"", RegexOptions.Compiled);
 
-            return match.Success ? match.Groups["tag"].Value : null;
+            if (!match_tags.Success || string.IsNullOrWhiteSpace(match_tags.Groups["tags"].Value))
+            {
+                return null;
+            }
+
+            var tags = match_tags.Groups["tags"].Value.Split(',').Select(s => s.Split(':')).ToDictionary(s => s[0], s => s[1]);
+            return tags.GetValueOrDefault(tagName);
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
@@ -62,23 +62,19 @@ namespace Datadog.Profiler.IntegrationTests
                 text = reader.ReadToEnd();
             }
 
-            return (
-                ServiceName: ExtractTag("service", text),
-                Environment: ExtractTag("env", text),
-                Version: ExtractTag("version", text));
-        }
-
-        private static string ExtractTag(string tagName, string input)
-        {
-            var match_tags = Regex.Match(input, "\"tags_profiler\":\"(?<tags>[^\"]*)\"", RegexOptions.Compiled);
+            var match_tags = Regex.Match(text, "\"tags_profiler\":\"(?<tags>[^\"]*)\"", RegexOptions.Compiled);
 
             if (!match_tags.Success || string.IsNullOrWhiteSpace(match_tags.Groups["tags"].Value))
             {
-                return null;
+                return (ServiceName: null, Environment: null, Version: null);
             }
 
             var tags = match_tags.Groups["tags"].Value.Split(',').Select(s => s.Split(':')).ToDictionary(s => s[0], s => s[1]);
-            return tags.GetValueOrDefault(tagName);
+
+            return (
+                ServiceName: tags.GetValueOrDefault("service"),
+                Environment: tags.GetValueOrDefault("env"),
+                Version: tags.GetValueOrDefault("version"));
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props" Condition="Exists('..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" />
+  <Import Project="..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props" Condition="Exists('..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -175,6 +175,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(PackagesDir)\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1.4\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\gmock.1.11.0\build\native\gmock.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\gmock.1.11.0\build\native\gmock.targets'))" />
-    <Error Condition="!Exists('..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\libdatadog.0.8.0\build\native\libdatadog.props'))" />
+    <Error Condition="!Exists('..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\libdatadog.0.9.0\build\native\libdatadog.props'))" />
   </Target>
 </Project>

--- a/profiler/test/Datadog.Profiler.Native.Tests/packages.config
+++ b/profiler/test/Datadog.Profiler.Native.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gmock" version="1.11.0" targetFramework="native" />
-  <package id="libdatadog" version="0.8.0" targetFramework="native" />
+  <package id="libdatadog" version="0.9.0" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1.4" targetFramework="native" />
 </packages>


### PR DESCRIPTION
## Summary of changes

Bump libdatadog version to 0.9.0.

## Reason for change

Get support for Named pipe and AAS tags.

## Implementation details

- Update nuget package version
- Update cmake file

## Test coverage

## Other details
<!-- Fixes #{issue} -->
