### PR TITLE
[Profiler] Change log level from error to info in StackSamplerLoopManager

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -231,7 +231,7 @@ void StackSamplerLoopManager::WatcherLoopIteration()
     if (_deadlockInterventionInProgress >= 1)
     {
         _deadlockInterventionInProgress++;
-        Log::Error("StackSamplerLoopManager::WatcherLoopIteration - Deadlock intervention still in progress for thread ", _pTargetThread->GetOsThreadId(),
+        Log::Info("StackSamplerLoopManager::WatcherLoopIteration - Deadlock intervention still in progress for thread ", _pTargetThread->GetOsThreadId(),
                    std::hex, " (= 0x", _pTargetThread->GetOsThreadId(), ")");
         // TODO: Validate that calling resuming again (and again) could unlock the situation.
         // The previous call to ResumeThread failed.


### PR DESCRIPTION
## Summary of changes

Change the level of a log message from Error to Info to report the state of the problem in case we have a Customer issue.

We do not put it to Debug because we want the information information in case of an investigation and this will happen very rarely (and not asking to restart with the Debug flag, and never reproduce it).
