### PR TITLE
Fix flaky `DataStreamsWriter` test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -76,7 +76,7 @@ public class DataStreamsWriterTests
 
         await api.WaitForCount(1, 30_000);
 
-        api.Sent.Should().ContainSingle();
+        HasOneOrTwoPoints(api);
 
         await writer.DisposeAsync();
 


### PR DESCRIPTION
## Summary of changes

- Fix a source of flake in `DataStreamsWriterTests`

## Reason for change

Depending on when bucket boundaries align, we may receive either one or two points. 

## Implementation details

Use the `HasOneOrTwoPoints()` helper

## Test coverage

Will keep monitoring for flake

## Other details
I _think_ this is the last of them in this test. Time will tell...
