### PR TITLE
simplify blocking by updating the test rules

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -548,7 +548,7 @@ namespace Datadog.Trace.AppSec
                 using var wafResult = additiveContext.Run(e.EventData, _settings.WafTimeoutMicroSeconds);
                 if (wafResult.ReturnCode is ReturnCode.Match or ReturnCode.Block)
                 {
-                    var block = wafResult.ReturnCode == ReturnCode.Block || wafResult.Data.Contains("ublock") || wafResult.Actions.Contains("block");
+                    var block = wafResult.Actions.Contains("block");
                     if (block)
                     {
                         e.Transport.WriteBlockedResponse(_settings.BlockedJsonTemplate, _settings.BlockedHtmlTemplate, CanAccessHeaders());

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
@@ -32,6 +32,9 @@
       ],
       "transformers": [
         "lowercase"
+      ],
+      "on_match": [
+        "block"
       ]
     },
     {


### PR DESCRIPTION
## Summary of changes

Simplifies the clause for blocking, makes the integration tests slightly more realistic.
