### PR TITLE
Add Data Streams Monitoring support when using manual instrumentation with Kafka

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 {
                     if (attribute is string attributeName &&
                         (attributeName.StartsWith("x-datadog", StringComparison.OrdinalIgnoreCase)
-                            || attributeName.Equals(DataStreamsContextPropagator.PropagationKey, StringComparison.OrdinalIgnoreCase)))
+                            || attributeName.Equals(DataStreamsPropagationHeaders.PropagationKey, StringComparison.OrdinalIgnoreCase)))
                     {
 #if !NETCOREAPP2_1_OR_GREATER
                         attributesToRemove ??= new List<string>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             _headers.Remove(name);
         }
 
-        public byte[] TryGetBytes(string name)
+        public byte[] TryGetLastBytes(string name)
         {
             return _headers.TryGetLastBytes(name, out var bytes) ? bytes : null;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -181,7 +181,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 {
                     span.Context.MergePathwayContext(pathwayContext);
 
-                    // TODO: we could cache this list in a thread local similar to StringBuilderCache to reduce allocations
+                    // TODO: we could pool these arrays to reduce allocations
                     var edgeTags = string.IsNullOrEmpty(topic)
                                        ? new[] { $"group:{groupId}", "type:kafka", }
                                        : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
@@ -107,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 PathwayContext? pathwayContext = null;
 
                 // Try to extract propagated context from headers
-                if (message is not null && message.Headers is not null)
+                if (message?.Headers is not null)
                 {
                     var headers = new KafkaHeadersCollectionAdapter(message.Headers);
 
@@ -179,14 +180,43 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 if (dataStreamsManager.IsEnabled)
                 {
-                    span.Context.MergePathwayContext(pathwayContext);
+                    // remove any leftover junk they may be left in the headers
+                    message?.Headers?.Remove(DataStreamsPropagationHeaders.TemporaryBase64PathwayContext);
+                    message?.Headers?.Remove(DataStreamsPropagationHeaders.TemporaryEdgeTags);
 
-                    // TODO: we could pool these arrays to reduce allocations
-                    var edgeTags = string.IsNullOrEmpty(topic)
-                                       ? new[] { $"group:{groupId}", "type:kafka", }
-                                       : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };
+                    if (!tracer.Settings.KafkaCreateConsumerScopeEnabled && message?.Headers is not null)
+                    {
+                        // This is a brilliant and horrible approach to let customers who are already
+                        // extracting the span context from a Kafka message automatically get
+                        // checkpointing support in their custom instrumentation
+                        if (message.Headers.TryGetLastBytes(DataStreamsPropagationHeaders.PropagationKey, out var bytes))
+                        {
+                            // annoyingly we have to re-encode the pathwayContext as base64 so we can read it as
+                            // a string in SpanContextExtractor.Extract
+                            // if there was no pathway context, we don't need to encode it
+                            var base64PathwayContext = System.Convert.ToBase64String(bytes);
+                            message.Headers.Add(DataStreamsPropagationHeaders.TemporaryBase64PathwayContext, Encoding.UTF8.GetBytes(base64PathwayContext));
+                        }
 
-                    span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
+                        // ','is not a valid character in kafka topic or group names, so we use as the
+                        // separator here NOTE: the tags must be sorted in alphabetical order
+                        var edgeTags = string.IsNullOrEmpty(topic)
+                                           ? $"group:{groupId},type:kafka"
+                                           : $"group:{groupId},topic:{topic},type:kafka";
+                        message.Headers.Add(DataStreamsPropagationHeaders.TemporaryEdgeTags, Encoding.UTF8.GetBytes(edgeTags));
+                    }
+                    else
+                    {
+                        span.Context.MergePathwayContext(pathwayContext);
+
+                        // TODO: we could pool these arrays to reduce allocations
+                        // NOTE: the tags must be sorted in alphabetical order
+                        var edgeTags = string.IsNullOrEmpty(topic)
+                                           ? new[] { $"group:{groupId}", "type:kafka", }
+                                           : new[] { $"group:{groupId}", $"topic:{topic}", "type:kafka", };
+
+                        span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
+                    }
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -15,8 +15,6 @@ namespace Datadog.Trace.DataStreamsMonitoring;
 /// </summary>
 internal class DataStreamsContextPropagator
 {
-    internal const string PropagationKey = "dd-pathway-ctx";
-
     public static DataStreamsContextPropagator Instance { get; } = new();
 
     /// <summary>
@@ -31,7 +29,7 @@ internal class DataStreamsContextPropagator
     {
         if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
 
-        headers.Add(PropagationKey, PathwayContextEncoder.Encode(context));
+        headers.Add(DataStreamsPropagationHeaders.PropagationKey, PathwayContextEncoder.Encode(context));
     }
 
     /// <summary>
@@ -45,7 +43,7 @@ internal class DataStreamsContextPropagator
     {
         if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
 
-        var bytes = headers.TryGetBytes(PropagationKey);
+        var bytes = headers.TryGetBytes(DataStreamsPropagationHeaders.PropagationKey);
 
         return bytes is { } ? PathwayContextEncoder.Decode(bytes) : null;
     }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsContextPropagator.cs
@@ -43,7 +43,7 @@ internal class DataStreamsContextPropagator
     {
         if (headers is null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
 
-        var bytes = headers.TryGetBytes(DataStreamsPropagationHeaders.PropagationKey);
+        var bytes = headers.TryGetLastBytes(DataStreamsPropagationHeaders.PropagationKey);
 
         return bytes is { } ? PathwayContextEncoder.Decode(bytes) : null;
     }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -53,16 +53,7 @@ internal class DataStreamsManager
         IDiscoveryService discoveryService,
         string defaultServiceName)
     {
-        var enableDsm = settings.IsDataStreamsMonitoringEnabled;
-        if (enableDsm && !settings.KafkaCreateConsumerScopeEnabled)
-        {
-            Log.Warning(
-                $"Data Streams Monitoring was enabled, but required setting {ConfigurationKeys.KafkaCreateConsumerScopeEnabled} was disabled. "
-              + $"Data Streams Monitoring currently requires {ConfigurationKeys.KafkaCreateConsumerScopeEnabled}=1. This will be relaxed in a future version.");
-            enableDsm = false;
-        }
-
-        var writer = enableDsm
+        var writer = settings.IsDataStreamsMonitoringEnabled
                          ? DataStreamsWriter.Create(settings, discoveryService, defaultServiceName)
                          : null;
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsPropagationHeaders.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsPropagationHeaders.cs
@@ -8,4 +8,6 @@ namespace Datadog.Trace.DataStreamsMonitoring;
 internal static class DataStreamsPropagationHeaders
 {
     public const string PropagationKey = "dd-pathway-ctx";
+    public const string TemporaryEdgeTags = "x-datadog-temp-edge-tags";
+    public const string TemporaryBase64PathwayContext = "x-datadog-temp-base64-context";
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsPropagationHeaders.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsPropagationHeaders.cs
@@ -1,0 +1,11 @@
+﻿// <copyright file="DataStreamsPropagationHeaders.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+namespace Datadog.Trace.DataStreamsMonitoring;
+
+internal static class DataStreamsPropagationHeaders
+{
+    public const string PropagationKey = "dd-pathway-ctx";
+}

--- a/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Headers;
 internal interface IBinaryHeadersCollection
 {
     /// <summary>
-    /// Returns the first header value for a specified header stored in the collection.
+    /// Returns the last header value for a specified header stored in the collection.
     /// </summary>
     /// <param name="name">The specified header to return values for.</param>
     /// <returns>Zero or more header strings.</returns>

--- a/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/IBinaryHeadersCollection.cs
@@ -17,7 +17,7 @@ internal interface IBinaryHeadersCollection
     /// </summary>
     /// <param name="name">The specified header to return values for.</param>
     /// <returns>Zero or more header strings.</returns>
-    byte[]? TryGetBytes(string name);
+    byte[]? TryGetLastBytes(string name);
 
     /// <summary>
     /// Adds the specified header and its value into the collection.

--- a/tracer/src/Datadog.Trace/ISpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/ISpanContextExtractor.cs
@@ -14,11 +14,15 @@ namespace Datadog.Trace
     /// The ISpanContextExtractor is responsible for extracting SpanContext in the rare cases where the Tracer couldn't propagate it itself.
     /// This can happen for instance when libraries add an extra layer above the instrumented ones
     /// (eg consuming Kafka messages and enqueuing them prior to generate a span).
+    /// When enabled (and present in the headers) also used to set data streams monitoring checkpoints.
     /// </summary>
     public interface ISpanContextExtractor
     {
         /// <summary>
         /// Given a SpanContext carrier and a function to access the values, this method will extract SpanContext if any
+        /// When enabled (and present in the headers) a data streams monitoring checkpoint is set.
+        /// You should only call <see cref="Extract{TCarrier}"/> once on the message <paramref name="carrier"/>. Calling
+        /// multiple times may lead to incorrect stats when using Data Streams Monitoring.
         /// </summary>
         /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
         /// <param name="getter">Given a key name, returns values from the carrier</param>

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -5,6 +5,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Propagators;
 
 #nullable enable
@@ -14,8 +17,45 @@ namespace Datadog.Trace
     /// <inheritdoc />
     public class SpanContextExtractor : ISpanContextExtractor
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SpanContextExtractor>();
+
         /// <inheritdoc />
         public ISpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
-            => SpanContextPropagator.Instance.Extract(carrier, getter);
+        {
+            var spanContext = SpanContextPropagator.Instance.Extract(carrier, getter);
+            if (spanContext is not null
+             && Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm
+             && getter(carrier, DataStreamsPropagationHeaders.TemporaryEdgeTags).FirstOrDefault() is { Length: > 0 } edgeTagString)
+            {
+                var base64PathwayContext = getter(carrier, DataStreamsPropagationHeaders.TemporaryBase64PathwayContext).FirstOrDefault();
+                var pathwayContext = TryGetPathwayContext(base64PathwayContext);
+
+                var edgeTags = edgeTagString.Split(',');
+                spanContext.MergePathwayContext(pathwayContext);
+                spanContext.SetCheckpoint(dsm, edgeTags);
+            }
+
+            return spanContext;
+        }
+
+        private static PathwayContext? TryGetPathwayContext(string? base64PathwayContext)
+        {
+            if (string.IsNullOrEmpty(base64PathwayContext))
+            {
+                return null;
+            }
+
+            try
+            {
+                var bytes = Convert.FromBase64String(base64PathwayContext);
+                return PathwayContextEncoder.Decode(bytes);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug(ex, "Error extracting pathway context from base64 encoded pathway {Base64PathwayContext}", base64PathwayContext);
+            }
+
+            return null;
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -4,11 +4,8 @@
 // </copyright>
 
 using System.Collections.Concurrent;
-using System.Collections.Specialized;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Agent.DiscoveryService;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DataStreamsMonitoring.Aggregation;
 using Datadog.Trace.DataStreamsMonitoring.Hashes;
@@ -19,27 +16,6 @@ namespace Datadog.Trace.Tests.DataStreamsMonitoring;
 
 public class DataStreamsManagerTests
 {
-    [Fact]
-    public void WhenEnabled_ButKafkaConsumerIsDisabled_DoesNotInjectContext()
-    {
-        var settings = new TracerSettings(
-            new NameValueConfigurationSource(
-                new NameValueCollection
-                {
-                    { ConfigurationKeys.KafkaCreateConsumerScopeEnabled, "0" },
-                    { ConfigurationKeys.DataStreamsMonitoring.Enabled, "1" },
-                })).Build();
-
-        var dsm = DataStreamsManager.Create(settings, new NullDiscoveryService(), "service");
-
-        var headers = new TestHeadersCollection();
-        var context = new PathwayContext(new PathwayHash(123), 1234, 5678);
-
-        dsm.InjectPathwayContext(context, headers);
-
-        headers.Values.Should().BeEmpty();
-    }
-
     [Fact]
     public void WhenDisabled_DoesNotInjectContext()
     {

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/TestHeadersCollection.cs
@@ -12,7 +12,7 @@ public class TestHeadersCollection : IBinaryHeadersCollection
 {
     public Dictionary<string, byte[]> Values { get; } = new();
 
-    public byte[] TryGetBytes(string name)
+    public byte[] TryGetLastBytes(string name)
         => Values.TryGetValue(name, out var value) ? value : null;
 
     public void Add(string name, byte[] value)

--- a/tracer/test/snapshots/DataStreamsMonitoringTests.HandlesFanIn.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringTests.HandlesFanIn.verified.txt
@@ -1,0 +1,106 @@
+﻿{
+  Env: integration_tests,
+  Service: Samples.DataStreams.Kafka,
+  TracerVersion: 2.x.x.x,
+  Lang: dotnet,
+  Stats: [
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.fan-in-consumer,
+            topic:data-streams-fan-in-out-1,
+            type:kafka
+          ],
+          Hash: 3105828891717699610,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5552541411198779357,
+          ParentHash: 3105828891717699610,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.topic-2-consumer,
+            topic:data-streams-fan-in-out-2,
+            type:kafka
+          ],
+          Hash: 2741788255479747849,
+          ParentHash: 5552541411198779357,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: current
+        }
+      ]
+    },
+    {
+      Start: 1661520120000000000,
+      Duration: 10000000000,
+      Stats: [
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.fan-in-consumer,
+            topic:data-streams-fan-in-out-1,
+            type:kafka
+          ],
+          Hash: 3105828891717699610,
+          ParentHash: 12926600137239154356,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            type:internal
+          ],
+          Hash: 5552541411198779357,
+          ParentHash: 3105828891717699610,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        },
+        {
+          EdgeTags: [
+            group:Samples.DataStreams.Kafka.topic-2-consumer,
+            topic:data-streams-fan-in-out-2,
+            type:kafka
+          ],
+          Hash: 2741788255479747849,
+          ParentHash: 5552541411198779357,
+          PathwayLatency: /w==,
+          EdgeLatency: /w==,
+          TimestampType: origin
+        }
+      ]
+    }
+  ]
+}

--- a/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka/Program.cs
@@ -1,104 +1,234 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Newtonsoft.Json;
+using Samples;
 using Samples.DataStreams.Kafka;
 using Samples.Kafka;
 using Config = Samples.Kafka.Config;
 
-// Create Topics
 var sw = new Stopwatch();
-var topicPrefix = "data-streams";
+sw.Start();
 
-var topic1 = $"{topicPrefix}-1";
-var topic2 = $"{topicPrefix}-2";
-var topic3 = $"{topicPrefix}-3";
-var allTopics = new[] { topic1, topic2, topic3 };
-var topic3ConsumeCount = 0;
+var runFanIn = args.Contains("--fan-in");
+var extractScopesManually = Environment.GetEnvironmentVariable("DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED") == "0";
 
-var config = Config.Create();
-Console.WriteLine("Creating topics...");
-foreach (var topic in allTopics)
+await (runFanIn ? RunFanInAndOutScenario() : RunStandardPipelineScenario());
+
+async Task RunStandardPipelineScenario()
 {
-    await TopicHelpers.TryDeleteTopic(topic, config);
-    await TopicHelpers.TryCreateTopic(topic, numPartitions: 3, replicationFactor: 1, config);
-}
+    // Create Topics
+    var topicPrefix = "data-streams";
 
-LogWithTime("Finished creating topics");
-Console.WriteLine($"Creating consumers...");
-var consumer1 = Consumer.Create(topic1, "consumer-1", HandleAndProduceToTopic2);
-var consumer2 = Consumer.Create(topic2, "consumer-2", HandleAndProduceToTopic3);
-var consumer3 = Consumer.Create(topic3, "consumer-3", HandleTopic3);
+    var topic1 = $"{topicPrefix}-1";
+    var topic2 = $"{topicPrefix}-2";
+    var topic3 = $"{topicPrefix}-3";
+    var allTopics = new[] { topic1, topic2, topic3 };
+    var topic3ConsumeCount = 0;
 
-Console.WriteLine("Starting consumers...");
-var cts = new CancellationTokenSource();
-var consumeTasks = new Task[3];
-consumeTasks[0] = Task.Run(() => consumer1.Consume(cts.Token));
-consumeTasks[1] = Task.Run(() => consumer2.Consume(cts.Token));
-consumeTasks[2] = Task.Run(() => consumer3.Consume(cts.Token));
-
-
-LogWithTime("Finished starting consumers");
-Console.WriteLine($"Producing messages");
-Producer.Produce(topic1, numMessages: 3, config, handleDelivery: true, isTombstone: false);
-Producer.Produce(topic2, numMessages: 3, config, handleDelivery: true, isTombstone: false);
-
-LogWithTime("Finished producing messages");
-Console.WriteLine($"Waiting for final consumption...");
-
-// Wait for all messages to be consumed
-// This assumes that the topics all start empty, and ultimately 6 messages end up consumed from topic 3
-var deadline = DateTime.UtcNow.AddSeconds(30);
-while (true)
-{
-    var consumed = Volatile.Read(ref topic3ConsumeCount);
-    if (consumed >= 6)
+    var config = Config.Create();
+    Console.WriteLine("Creating topics...");
+    foreach (var topic in allTopics)
     {
-        Console.WriteLine($"All messages produced and consumed");
-        break;
+        await TopicHelpers.TryDeleteTopic(topic, config);
+        await TopicHelpers.TryCreateTopic(topic, numPartitions: 3, replicationFactor: 1, config);
     }
 
-    if (DateTime.UtcNow > deadline)
+    LogWithTime("Finished creating topics");
+
+    Console.WriteLine($"Creating consumers...");
+    var consumer1 = Consumer.Create(topic1, "consumer-1", HandleAndProduceToTopic2);
+    var consumer2 = Consumer.Create(topic2, "consumer-2", HandleAndProduceToTopic3);
+    var consumer3 = Consumer.Create(topic3, "consumer-3", HandleTopic3);
+
+    Console.WriteLine("Starting consumers...");
+    var cts = new CancellationTokenSource();
+    var consumeTasks = new Task[3];
+    consumeTasks[0] = Task.Run(() => consumer1.Consume(cts.Token));
+    consumeTasks[1] = Task.Run(() => consumer2.Consume(cts.Token));
+    consumeTasks[2] = Task.Run(() => consumer3.Consume(cts.Token));
+    LogWithTime("Finished starting consumers");
+
+    Console.WriteLine($"Producing messages");
+    Producer.Produce(topic1, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+    Producer.Produce(topic2, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+    LogWithTime("Finished producing messages");
+
+    // Wait for all messages to be consumed
+    // This assumes that the topics all start empty, and ultimately 6 messages end up consumed from topic 3
+    Console.WriteLine($"Waiting for final consumption...");
+    var deadline = DateTime.UtcNow.AddSeconds(30);
+    while (true)
     {
-        Console.WriteLine($"Exiting consumer: did not consume all messages: {consumed}");
-        break;
+        var consumed = Volatile.Read(ref topic3ConsumeCount);
+        if (consumed >= 6)
+        {
+            Console.WriteLine($"All messages produced and consumed");
+            break;
+        }
+
+        if (DateTime.UtcNow > deadline)
+        {
+            Console.WriteLine($"Exiting consumer: did not consume all messages: {consumed}");
+            break;
+        }
+
+        await Task.Delay(1000);
     }
 
-    await Task.Delay(1000);
+    LogWithTime("Finished waiting for messages");
+
+    Console.WriteLine($"Waiting for graceful exit...");
+    cts.Cancel();
+
+    await Task.WhenAny(
+        Task.WhenAll(consumeTasks),
+        Task.Delay(TimeSpan.FromSeconds(5)));
+
+    LogWithTime("Shut down complete");
+
+
+    void HandleTopic3(ConsumeResult<string, string> consumeResult)
+    {
+        using var scope = CreateScope(consumeResult, "kafka.consume");
+        Handle(consumeResult);
+
+        var consumeCount = Interlocked.Increment(ref topic3ConsumeCount);
+        Console.WriteLine($"Consumed message {consumeCount} in Topic({topic3})");
+    }
+
+    void HandleAndProduceToTopic2(ConsumeResult<string, string> consumeResult)
+        => HandleAndProduce(consumeResult, topic2);
+
+    void HandleAndProduceToTopic3(ConsumeResult<string, string> consumeResult)
+        => HandleAndProduce(consumeResult, topic3);
+
+    void HandleAndProduce(ConsumeResult<string, string> consumeResult, string produceToTopic)
+    {
+        using var outer = SampleHelpers.CreateScope("manual.outer");
+        using var scope = CreateScope(consumeResult, "kafka.consume");
+        using var inner = SampleHelpers.CreateScope("manual.inner");
+        Handle(consumeResult);
+
+        Console.WriteLine($"Producing to {produceToTopic}");
+        Producer.Produce(produceToTopic, numMessages: 1, config, handleDelivery: true, isTombstone: false);
+    }
 }
 
-LogWithTime("Finished waiting for messages");
-
-Console.WriteLine($"Waiting for graceful exit...");
-cts.Cancel();
-
-await Task.WhenAny(Task.WhenAll(consumeTasks),
-                   Task.Delay(TimeSpan.FromSeconds(5)));
-
-LogWithTime("Shut down complete");
-
-void HandleTopic3(ConsumeResult<string,string> consumeResult)
+async Task RunFanInAndOutScenario()
 {
-    Handle(consumeResult);
+    // Create Topics
+    var topicPrefix = "data-streams-fan-in-out";
 
-    var consumeCount = Interlocked.Increment(ref topic3ConsumeCount);
-    Console.WriteLine($"Consumed message {consumeCount} in Topic({topic3})");
-}
+    var topic1 = $"{topicPrefix}-1";
+    var topic2 = $"{topicPrefix}-2";
+    var allTopics = new[] { topic1, topic2};
+    var topic2ConsumeCount = 0;
 
-void HandleAndProduceToTopic2(ConsumeResult<string, string> consumeResult)
-    => HandleAndProduce(consumeResult, topic2);
+    List<ConsumeResult<string, string>> _fanInMessages = new();
 
-void HandleAndProduceToTopic3(ConsumeResult<string, string> consumeResult)
-    => HandleAndProduce(consumeResult, topic3);
+    var config = Config.Create();
+    Console.WriteLine("Creating topics...");
+    foreach (var topic in allTopics)
+    {
+        await TopicHelpers.TryDeleteTopic(topic, config);
+        await TopicHelpers.TryCreateTopic(topic, numPartitions: 3, replicationFactor: 1, config);
+    }
 
-void HandleAndProduce(ConsumeResult<string,string> consumeResult, string produceToTopic)
-{
-    Handle(consumeResult);
-    
-    Console.WriteLine($"Producing to {produceToTopic}");
-    Producer.Produce(produceToTopic, numMessages: 1, config, handleDelivery: true, isTombstone: false);
+    LogWithTime("Finished creating topics");
+
+    Console.WriteLine($"Creating consumers...");
+    var fanInConsumer = Consumer.Create(topic1, "fan-in-consumer", HandleFanIn);
+    var finalConsumer = Consumer.Create(topic2, "topic-2-consumer", HandleTopic2);
+
+    Console.WriteLine("Starting consumers...");
+    var cts = new CancellationTokenSource();
+    var consumeTasks = new Task[2];
+    consumeTasks[0] = Task.Run(() => finalConsumer.Consume(cts.Token));
+    consumeTasks[1] = Task.Run(() => fanInConsumer.Consume(cts.Token));
+    LogWithTime("Finished starting consumers");
+
+    Console.WriteLine($"Producing messages");
+    Producer.Produce(topic1, numMessages: 3, config, handleDelivery: true, isTombstone: false);
+    LogWithTime("Finished producing messages");
+
+    // Wait for all messages to be consumed
+    // This assumes that the topics all start empty, and ultimately 2 messages end up consumed from topic 2
+    Console.WriteLine($"Waiting for final consumption...");
+    var deadline = DateTime.UtcNow.AddSeconds(30);
+    while (true)
+    {
+        var consumed = Volatile.Read(ref topic2ConsumeCount);
+        if (consumed >= 2)
+        {
+            Console.WriteLine($"All messages produced and consumed");
+            break;
+        }
+
+        if (DateTime.UtcNow > deadline)
+        {
+            Console.WriteLine($"Exiting consumer: did not consume all messages: {consumed}");
+            break;
+        }
+
+        await Task.Delay(1000);
+    }
+
+    LogWithTime("Finished waiting for messages");
+
+    Console.WriteLine($"Waiting for graceful exit...");
+    cts.Cancel();
+
+    await Task.WhenAny(
+        Task.WhenAll(consumeTasks),
+        Task.Delay(TimeSpan.FromSeconds(5)));
+
+    LogWithTime("Shut down complete");
+
+
+    void HandleTopic2(ConsumeResult<string, string> consumeResult)
+    {
+        using var s = SampleHelpers.CreateScopeWithPropagation(
+            "kafka.consume",
+            consumeResult.Message.Headers,
+            ConsumerBase.ExtractValues);
+        Handle(consumeResult);
+
+        var consumeCount = Interlocked.Increment(ref topic2ConsumeCount);
+        Console.WriteLine($"Consumed message {consumeCount} in Topic({topic2})");
+    }
+
+    void HandleFanIn(ConsumeResult<string, string> consumeResult)
+    {
+        Handle(consumeResult);
+
+        _fanInMessages.Add(consumeResult);
+        if (_fanInMessages.Count == 3)
+        {
+            Stack<IDisposable> scopes = new();
+            foreach (var fanInMessage in _fanInMessages)
+            {
+                scopes.Push(
+                    SampleHelpers.CreateScopeWithPropagation(
+                        "kafka.consume",
+                        fanInMessage.Message.Headers,
+                        ConsumerBase.ExtractValues));
+            }
+            
+            Console.WriteLine($"Producing to {topic2} x2");
+            Producer.Produce(topic2, numMessages: 2, config, handleDelivery: true, isTombstone: false);
+            foreach (var scope in scopes)
+            {
+                scope.Dispose();
+            }
+        }
+
+        Console.WriteLine($"Consumed message {_fanInMessages.Count} in Topic({topic1})");
+    }
 }
 
 void Handle(ConsumeResult<string, string> consumeResult)
@@ -114,4 +244,22 @@ void LogWithTime(string message)
 {
     Console.WriteLine($"{message}: {sw.Elapsed:g}");
     sw.Restart();
+}
+
+IDisposable CreateScope(ConsumeResult<string, string> consumeResult, string operationName)
+{
+    if (!extractScopesManually)
+    {
+        return new NoOpDisposable();
+    }
+
+    return SampleHelpers.CreateScopeWithPropagation(
+        operationName,
+        consumeResult.Message.Headers,
+        ConsumerBase.ExtractValues);
+}
+
+class NoOpDisposable : IDisposable
+{
+    public void Dispose() { }
 }

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Consumer.cs
@@ -22,24 +22,7 @@ namespace Samples.Kafka
             Console.WriteLine($"{ConsumerName}: Consuming {kafkaMessage.Key}, {consumeResult.TopicPartitionOffset}");
 
             var messageHeaders = kafkaMessage.Headers;
-            SampleHelpers.ExtractScope(messageHeaders, GetValues, out var traceId, out var spanId);
-
-            IEnumerable<string> GetValues(Headers headers, string name)
-            {
-                if (headers.TryGetLastBytes(name, out var bytes))
-                {
-                    try
-                    {
-                        return new[] { Encoding.UTF8.GetString(bytes) };
-                    }
-                    catch (Exception)
-                    {
-                        // ignored
-                    }
-                }
-
-                return Enumerable.Empty<string>();
-            }
+            SampleHelpers.ExtractScope(messageHeaders, ExtractValues, out var traceId, out var spanId);
 
             if (traceId is 0 || spanId is 0)
             {

--- a/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/ConsumerBase.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
@@ -143,5 +146,22 @@ internal abstract class ConsumerBase : IDisposable
         Console.WriteLine($"{ConsumerName}: Closing consumer");
         _consumer?.Close();
         _consumer?.Dispose();
+    }
+
+    public static IEnumerable<string> ExtractValues(Headers headers, string name)
+    {
+        if (headers.TryGetLastBytes(name, out var bytes))
+        {
+            try
+            {
+                return new[] { Encoding.UTF8.GetString(bytes) };
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        return Enumerable.Empty<string>();
     }
 }


### PR DESCRIPTION
> Note that this PR looks a little scary, but there's only actually 3 files changed in the tracer, the rest is in the test files

## Summary of changes

- Reverts #3311 
- Add support for Data Streams Monitoring when customers set `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=0` and use manual scope extraction
- Add integration tests for the manual scope approach, and a "fan-in" scenario

## Reason for change

Currently, due to the design of the .NET APIs, we can't _always_ create a scope for Kafka messages. This may be the case when customers _aren't_ calling `Consume()` in a simple loop, or when they (or a library) are adding messages to a queue for later processing. In this case, customers set `DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED=0`, and use `SpanContextExtractor` to extract an `ISpanContext` from the message. Unfortunately, this _also_ means that we can't correctly call the DSM checkpoints in this situation.

The proposal in this PR uses our automatic instrumentation to add extra headers to the consumed message, so that we can then automatically extract them when the customer calls `Extract()`, and do the checkpointing immediately, removing the need for the customer to change or add code.

## Implementation details

We evaluated various proposals to work around this, but they all required the customer to write additional custom code to get checkpointing. While this likely not a huge ask (as they are necessarily already using custom code), it nevertheless is a burden, and is easy to get wrong.

In this PR we calculate the edge tags inside the `Consume()` integration, and add an extra header to the consumed message. We also need to extract the pathwaycontext (if there is one), base64 encode it, and add it as a _separate_ header. This is because Kafka stores binary data, and we can't safely just `Encoding.UTF8.GetString()` on it. Going via base64 makes it safe (though annoyingly more allocatey)

In the `SpanContextExtractor.Extract()` method, we look for the edge tags header. If it's there, we try to get the base64 pathway header too. We then call `SetCheckpoint()`, and set the new `PathwayContext` on the `SpanContext`. This is then propagated to the `Span` when it's used to create a scope using `Tracer.Instance.StartActive("my.span", parentSpanContext)`.

Advantages:
* No additional code changes required by the customer
* Reduced chance of incorrect pathway contexts

Disadvantages:
* We're changing the Kafka message from the one that was on the topic (by adding extra headers)
* There's extra allocation involved in encoding+decoding the pathway context etc
* If the customer calls `Extract()` more than once, they will set multiple checkpoints.

## Test coverage

The existing `DataStreamsMonitoringTests` confirm that the changes don't impact the original implementation. I also added a "manual extraction" version of the tests, which is analogous. It uses the same snapshot, so confirms the pathways are calculated to be exactly the same.

I also added a simple "fan-in" test scenario, that looks a bit like this:

```mermaid
stateDiagram-v2
    direction LR
    t1: data-streams-fan-in-out-1
    t2: data-streams-fan-in-out-2
    c1: consumer 1
    c2: consumer 2
    [*] --> t1
    [*] --> t1
    [*] --> t1
    t1 --> c1
    t1 --> c1
    t1 --> c1
    c1 --> t2
    c1 --> t2
    t2 --> c2
    t2 --> c2
```            

The service sends 3 messages to `data-streams-fan-in-out-1`. `Consumer 1` reads these messages, puts them in a list until it receives all 3. It then "processes" them all, one by one. Finally it pushes 2 messages to `data-streams-fan-in-out-2`, which are consumed by `Consumer 2`. 

It's a simple scenario, but it works as expected, so that's something.

## Other details
We _could_ use a similar approach to this to "fix" the child/sibling hierarchy mismatch where customers use manual extraction of scopes from messages by replacing/adding another header in the consume method, but that's out of scope for this scenario.
