### PR TITLE
[ASM] Have a different log file for tests using the log entry watcher

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -29,15 +29,10 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 {
     public class AspNetCore5AsmData : RcmBase
     {
-        private readonly string _logDirectory;
-
         public AspNetCore5AsmData(ITestOutputHelper outputHelper)
             : base(outputHelper, testName: nameof(AspNetCore5AsmData))
         {
             SetEnvironmentVariable(ConfigurationKeys.DebugEnabled, "0");
-            var logPath = DatadogLogging.GetLogDirectory();
-            _logDirectory = Path.Combine(logPath, $"{nameof(AspNetCore5AsmData)}Logs");
-            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, _logDirectory);
         }
 
         [SkippableTheory]
@@ -47,7 +42,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestBlockedRequestIp(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
             var agent = await RunOnSelfHosted(enableSecurity);
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", _logDirectory);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", logDirectory);
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
@@ -92,7 +87,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
             var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: new object[] { test, enableSecurity, (int)expectedStatusCode, sanitisedUrl });
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*");
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", logDirectory);
             var spanBeforeAsmData = await SendRequestsAsync(agent, url);
 
             var product = new AsmDataProduct();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var url = "/Health/?[$slice]=value";
             var agent = await RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, expectedState, expectedCapabilities);
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*");
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", logDirectory);
 
             var spans1 = await SendRequestsAsync(agent, url);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 using System;
+using System.IO;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests.Rcm;
@@ -14,6 +16,7 @@ public class RcmBase : AspNetBase
     protected const string LogFileNamePrefix = "dotnet-tracer-managed-";
 
 #pragma warning disable SA1401
+    protected readonly string logDirectory;
     protected readonly TimeSpan logEntryWatcherTimeout = TimeSpan.FromSeconds(20);
 #pragma warning restore SA1401
 
@@ -21,6 +24,9 @@ public class RcmBase : AspNetBase
         : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
+        var logPath = DatadogLogging.GetLogDirectory();
+        logDirectory = Path.Combine(logPath, $"{testName}Logs");
+        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDirectory);
     }
 
     protected string AppSecDisabledMessage() => $"AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true  {{ MachineName: \".\", Process: \"[{SampleProcessId}";

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -75,7 +75,7 @@ public class LogEntryWatcher : IDisposable
 
         if (i != logEntries.Length)
         {
-            throw new InvalidOperationException(_reader == null ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}" : "Log entry was not found.");
+            throw new InvalidOperationException(_reader == null ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}" : $"Log entry was not found {logEntries[i]} in {_fileWatcher.Path} with filter {_fileWatcher.Filter}.");
         }
     }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -18,9 +18,9 @@ public class LogEntryWatcher : IDisposable
     private readonly FileSystemWatcher _fileWatcher;
     private StreamReader _reader;
 
-    public LogEntryWatcher(string logFilePattern)
+    public LogEntryWatcher(string logFilePattern, string logDirectory = null)
     {
-        var logPath = DatadogLogging.GetLogDirectory();
+        var logPath = logDirectory ?? DatadogLogging.GetLogDirectory();
         _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
 
         var dir = new DirectoryInfo(logPath);
@@ -75,7 +75,7 @@ public class LogEntryWatcher : IDisposable
 
         if (i != logEntries.Length)
         {
-            throw new InvalidOperationException(_reader == null ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}" : $"Log entry was not found {logEntries[i]} in {_fileWatcher.Path} with filter {_fileWatcher.Filter}.");
+            throw new InvalidOperationException(_reader == null ? $"Log file was not found for path: {_fileWatcher.Path} with file pattern {_fileWatcher.Filter}" : $"Log entry was not found {logEntries[i]} in {_fileWatcher.Path} with filter {_fileWatcher.Filter}. Cancellation token reached: {cancellationSource.IsCancellationRequested}");
         }
     }
 


### PR DESCRIPTION
## Summary of changes

Adding more test classes amounts to more writing in the same log file, rendering all read operations longer, timing out after 20sec even. Having a dedicated log file for tests that are going to have a `LogEntryWatcher` mechanism makes it very less likely to timeout ( tests within the same class are run parallel)

## Reason for change

`LogEntryWatcher` would time out as we add more asm tests writing to the same file (see IAST current PR)

## Implementation details

Just setting the env variable and reading the file in the right folder from the test.
For now only scoped to RCM tests which specifically need to use the `LogEntryWatcher` to know when a configuration has been applied.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
