### PR TITLE
Add DD_TAGS colon edge case test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -101,6 +101,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.GlobalTags, "keyonly:,nocolon,:,:valueonly,k2:v2", CreateFunc(s => s.GlobalTags), TagsK2V2 };
             yield return new object[] { "DD_TRACE_GLOBAL_TAGS", "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags), TagsK1V1K2V2 };
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1,k1:v2", CreateFunc(s => s.GlobalTags.Count), 1 };
+            yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, a.b_c:a://b.c, k2:v2", CreateFunc(s => s.GlobalTags), { "k1", "v1" }, { "a.b_c", "a://b.c" }, { "k2", "v2" }  };
 
 #pragma warning disable 618 // App Analytics is deprecated but still supported
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "true", CreateFunc(s => s.AnalyticsEnabled), true };

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -56,11 +56,11 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [Fact]
         public void LogSpecificGlobalTagsFallBackToTracerGlobalTags()
         {
-            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
+            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "a.b_c", "a://b.c" }, { "test2", "value2" }, };
 
             var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
             {
-                { ConfigurationKeys.GlobalTags, "test1:value1, test2:value2" },
+                { ConfigurationKeys.GlobalTags, "test1:value1, a.b_c:a://b.c, test2:value2" },
             }));
 
             tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -56,11 +56,11 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [Fact]
         public void LogSpecificGlobalTagsFallBackToTracerGlobalTags()
         {
-            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "a.b_c", "a://b.c" }, { "test2", "value2" }, };
+            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
 
             var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
             {
-                { ConfigurationKeys.GlobalTags, "test1:value1, a.b_c:a://b.c, test2:value2" },
+                { ConfigurationKeys.GlobalTags, "test1:value1, test2:value2" },
             }));
 
             tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags


### PR DESCRIPTION
## Summary of changes

Add a test case covering the DD_TAGS colon edge case.

## Reason for change

Colons are allowed in Datadog tags:
https://docs.datadoghq.com/getting_started/tagging/#define-tags

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
