### PR TITLE
Fix documentation URL

### DIFF
--- a/tracer/src/Directory.Build.props
+++ b/tracer/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <IsPackable>true</IsPackable>
     <PackageIconUrl>https://github.com/DataDog/dd-trace-dotnet/raw/master/datadog-logo-64x64.png</PackageIconUrl>
     <PackageIcon>packageIcon.png</PackageIcon>
-    <PackageProjectUrl>https://docs.datadoghq.com/tracing/setup/dotnet/</PackageProjectUrl>
+    <PackageProjectUrl>https://docs.datadoghq.com/tracing/trace_collection/dd_libraries</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>See release notes at https://github.com/DataDog/dd-trace-dotnet/releases</PackageReleaseNotes>


### PR DESCRIPTION
## Summary of changes

Change the documentation URL embedded in NuGet packages

## Reason for change

It points to an old URL
![image](https://user-images.githubusercontent.com/18755388/194589818-844312f7-21a5-4979-bcee-672735c2fea2.png)


## Implementation details

Updated to point to this page

![image](https://user-images.githubusercontent.com/18755388/194589875-f0a0d8c9-0881-4a3d-86fb-48be1089f584.png)
