### PR TITLE
Allow colons in global tag values (`DD_TAGS`)

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -16,6 +17,8 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public abstract class StringConfigurationSource : IConfigurationSource
     {
+        private static readonly char[] DictionarySeparatorChars = { ',' };
+
         /// <summary>
         /// Returns a <see cref="IDictionary{TKey, TValue}"/> from parsing
         /// <paramref name="data"/>.
@@ -36,8 +39,6 @@ namespace Datadog.Trace.Configuration
         /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
         public static IDictionary<string, string> ParseCustomKeyValues(string data, bool allowOptionalMappings)
         {
-            var dictionary = new ConcurrentDictionary<string, string>();
-
             // A null return value means the key was not present,
             // and CompositeConfigurationSource depends on this behavior
             // (it returns the first non-null value it finds).
@@ -46,31 +47,44 @@ namespace Datadog.Trace.Configuration
                 return null;
             }
 
+            var dictionary = new ConcurrentDictionary<string, string>();
+
             if (string.IsNullOrWhiteSpace(data))
             {
+                // return empty collection
                 return dictionary;
             }
 
-            var entries = data.Split(',');
+            var entries = data.Split(DictionarySeparatorChars, StringSplitOptions.RemoveEmptyEntries);
 
-            foreach (var e in entries)
+            foreach (var entry in entries)
             {
-                var kv = e.Split(':');
-                if (allowOptionalMappings && kv.Length == 1)
+                // we need TrimStart() before looking for ':' so we can skip entries with no key
+                // (that is, entries with a leading ':', like "<empty or whitespace>:value")
+                var trimmedEntry = entry.TrimStart();
+
+                if (trimmedEntry.Length > 0)
                 {
-                    var key = kv[0];
-                    var value = string.Empty;
-                    dictionary[key] = value;
-                }
-                else if (kv.Length != 2)
-                {
-                    continue;
-                }
-                else
-                {
-                    var key = kv[0];
-                    var value = kv[1];
-                    dictionary[key] = value;
+                    // colonIndex == 0 is a leading colon, not valid
+                    var colonIndex = trimmedEntry.IndexOf(':');
+
+                    if (colonIndex < 0 && allowOptionalMappings)
+                    {
+                        // entries with no colon are allowed (e.g. "key1, key2:value2, key3"),
+                        // it's a key with no value.
+                        // note we already did TrimStart(), so we only need TrimEnd().
+                        var key = trimmedEntry.TrimEnd();
+                        dictionary[key] = string.Empty;
+                    }
+                    else if (colonIndex > 0)
+                    {
+                        // split at the first colon only. any other colons are part of the value.
+                        // if a colon is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
+                        // note we already did TrimStart() on the key, so it only needs TrimEnd().
+                        var key = trimmedEntry.Substring(0, colonIndex).TrimEnd();
+                        var value = trimmedEntry.Substring(colonIndex + 1).Trim();
+                        dictionary[key] = value;
+                    }
                 }
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/StringConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/StringConfigurationSourceTests.cs
@@ -1,0 +1,115 @@
+﻿// <copyright file="StringConfigurationSourceTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+public class StringConfigurationSourceTests
+{
+    [Theory]
+    [InlineData("")]        // empty
+    [InlineData(" ")]       // 1 space
+    [InlineData("  ")]      // 2 spaces
+    [InlineData("\t")]      // tab
+    [InlineData(":")]       // lonely pair separator
+    [InlineData(",")]       // lonely key/value separator
+    [InlineData(" : , : ")] // mix of separators and whitespace
+    public void ParseCustomKeyValues_WhitespaceOnly(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry);
+        dictionary.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("key")]      // no space
+    [InlineData("key ")]     // space after key
+    [InlineData(" key")]     // space before key
+    [InlineData(" key ")]    // 1 space around key
+    [InlineData("  key  ")]  // 2 spaces around key
+    [InlineData("key:")]     // no space
+    [InlineData("key :")]    // space after key
+    [InlineData(" key:")]    // space before key
+    [InlineData(" key :")]   // 1 space around key
+    [InlineData("  key  :")] // 2 spaces around key
+    public void ParseCustomKeyValues_WhitespaceAroundKey_NoValue_ValueOptional(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry, allowOptionalMappings: true);
+
+        dictionary.Should().HaveCount(1);
+        dictionary.Should().Contain(new KeyValuePair<string, string>("key", string.Empty));
+    }
+
+    [Theory]
+    [InlineData("key:")]    // no space
+    [InlineData("key :")]   // space after key
+    [InlineData(" key:")]   // space before key
+    [InlineData(" key :")]  // space before and after key
+    [InlineData(" key : ")] // space before and after key and in value
+    public void ParseCustomKeyValues_WhitespaceAroundKey_NoValue_ValueRequired_WithColon(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry, allowOptionalMappings: false);
+
+        dictionary.Should().HaveCount(1);
+        dictionary.Should().Contain(new KeyValuePair<string, string>("key", string.Empty));
+    }
+
+    [Theory]
+    [InlineData("key")]   // no space
+    [InlineData("key ")]  // space after key
+    [InlineData(" key")]  // space before key
+    [InlineData(" key ")] // space before and after
+    public void ParseCustomKeyValues_WhitespaceAroundKey_NoValue_ValueRequired_WithoutColon(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry, allowOptionalMappings: false);
+
+        dictionary.Should().HaveCount(0);
+    }
+
+    [Theory]
+    [InlineData("key:value")]     // no space
+    [InlineData("key :value")]    // space after key
+    [InlineData(" key:value")]    // space before key
+    [InlineData(" key :value")]   // 1 space around key
+    [InlineData("  key  :value")] // 2 spaces around key
+    public void ParseCustomKeyValues_WhitespaceAroundKey_WithValue(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry);
+
+        dictionary.Should().HaveCount(1);
+        dictionary.Should().Contain(new KeyValuePair<string, string>("key", "value"));
+    }
+
+    [Theory]
+    [InlineData("key:value")]     // no space
+    [InlineData("key:value ")]    // space after value
+    [InlineData("key: value")]    // space before value
+    [InlineData("key: value ")]   // 1 space around value
+    [InlineData("key:  value  ")] // 2 spaces around value
+    public void ParseCustomKeyValues_WhitespaceAroundValue(string entry)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry);
+
+        dictionary.Should().HaveCount(1);
+        dictionary.Should().Contain(new KeyValuePair<string, string>("key", "value"));
+    }
+
+    [Theory]
+    [InlineData("key:value", "value")]                   // none
+    [InlineData("key::value", ":value")]                 // leading
+    [InlineData("key:value:", "value:")]                 // trailing
+    [InlineData("key:value:1", "value:1")]               // middle
+    [InlineData("key: : value : 1 : ", ": value : 1 :")] // mix in some spaces
+    public void ParseCustomKeyValues_ColonsInValue(string entry, string expectedValue)
+    {
+        var dictionary = StringConfigurationSource.ParseCustomKeyValues(entry);
+
+        dictionary.Should().HaveCount(1);
+        dictionary.Should().Contain(new KeyValuePair<string, string>("key", expectedValue));
+    }
+}


### PR DESCRIPTION
## Summary of changes

When parsing `DD_TAGS`, we should allow tag values to contain colons (`:`).

## Reason for change

Colons should be allowed in tag values according to Datadog's documentation:
https://docs.datadoghq.com/getting_started/tagging/#define-tags

In particular, Source Code Integration needs to include URLs in tags. For example, `git.repository_url:https://github.com/DataDog/dd-trace-dotnet/`.

## Implementation details

Before this PR, to separate key value pairs, we used `string.Split(':')` and discarded any entries with `Length > 2`.

After this PR, we use `string.IndexOf(':')` to find the _first_ colon, and then `string.Substring()` to split into the key and value.

## Test coverage

- added `StringConfigurationSourceTests` for `StringConfigurationSource.ParseCustomKeyValues()`
- for `DD_TAGS`, added a new test for tag values with colons in `ConfigurationSourceTests`
- there is no regressions in existing tests for other dictionary-based settings

## Other details

[internal link]
https://datadoghq.atlassian.net/wiki/spaces/SRCINT/pages/2625995497/Tagging+convention#Tracers-DD_TAGS-compatibility

See also @jybp's #3326