### PR TITLE
Add fix for method rewriter in non-void method with branch to last return

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -564,13 +564,21 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
             {
                 if (pInstr != methodReturnInstr)
                 {
-                    if (!isVoid)
+                    if (isVoid)
                     {
-                        reWriterWrapper.SetILPosition(pInstr);
-                        reWriterWrapper.StLocal(returnValueIndex);
+                        pInstr->m_opcode = CEE_LEAVE_S;
+                        pInstr->m_pTarget = endFinallyInstr->m_pNext;
                     }
-                    pInstr->m_opcode = CEE_LEAVE_S;
-                    pInstr->m_pTarget = endFinallyInstr->m_pNext;
+                    else
+                    {
+                        pInstr->m_opcode = CEE_STLOC;
+                        pInstr->m_Arg16 = returnValueIndex;
+
+                        ILInstr* leaveInstr = rewriter.NewILInstr();
+                        leaveInstr->m_opcode = CEE_LEAVE_S;
+                        leaveInstr->m_pTarget = endFinallyInstr->m_pNext;
+                        rewriter.InsertAfter(pInstr, leaveInstr);
+                    }
                 }
                 break;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -220,6 +221,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Contains(".VoidMethod", processResult.StandardOutput);
 
                 VerifyInstrumentation(processResult.Process);
+            }
+        }
+
+        [SkippableFact]
+        [Trait("SupportsInstrumentationVerification", "True")]
+        public void ExtraIntegrations()
+        {
+            SetInstrumentationVerification();
+            using (var agent = EnvironmentHelper.GetMockAgent())
+            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "extras"))
+            {
+                int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({0}\\)").Count;
+                int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
+
+                string[] typeNames = { ".NonVoidWithBranchToLastReturn" };
+
+                begin1MethodCount.Should().Be(1);
+                endMethodCount.Should().Be(1);
+
+                processResult.StandardOutput.Should().ContainAll(typeNames);
             }
         }
     }

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Extras.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Extras.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace CallTargetNativeTest;
+
+partial class Program
+{
+    private static void Extras()
+    {
+        Extras extras = new Extras();
+        Console.WriteLine($"{typeof(Extras).FullName}.{nameof(extras.NonVoidWithBranchToLastReturn)}");
+        RunMethod(() => extras.NonVoidWithBranchToLastReturn());
+    }
+}
+
+public class Extras
+{
+    private static readonly Random _random = new();
+    public int NonVoidWithBranchToLastReturn()
+    {
+        var result = _random.Next();
+        if (result % 2 == 0)
+        {
+            Console.WriteLine("Is Even");
+        }
+
+        return result;
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -103,6 +103,9 @@ namespace CallTargetNativeTest
             definitionsList.Add(new(TargetAssembly, typeof(ArgumentsGenericParentType<>.WithOutArguments).FullName, "VoidMethod", new[] { "_", "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(StringAndIntOutVoidIntegration).FullName));
             definitionsList.Add(new(TargetAssembly, typeof(ArgumentsGenericParentType<>.WithOutArguments).FullName, "VoidMethod", new[] { "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(GenericOutModificationVoidIntegration).FullName));
 
+            // Add extra integrations
+            definitionsList.Add(new(TargetAssembly, typeof(Extras).FullName, nameof(CallTargetNativeTest.Extras.NonVoidWithBranchToLastReturn), new[] { "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(Noop0ArgumentsIntegration).FullName));
+            
             definitionsId = Guid.NewGuid().ToString("N");
             definitions = definitionsList.ToArray();
             EnableDefinitions();
@@ -265,6 +268,11 @@ namespace CallTargetNativeTest
                         WithOutArguments();
                         break;
                     }
+                case "extras":
+                    {
+                        Extras();
+                        break;
+                    }
                 case "all":
                     {
                         Argument0();
@@ -340,6 +348,7 @@ namespace CallTargetNativeTest
                         // ParentAbstractMethod();
                         // StructParentAbstractMethod();
                         // GenericParentAbstractMethod();
+                        Extras();
                         break;
                     }
                 default:


### PR DESCRIPTION
## Summary of changes

Added a fix for source of `InvalidProgramException` in method rewriter 

## Reason for change

We recently received a warning that one of our instrumentations was throwing with `System.InvalidProgramException: Common Language Runtime detected an invalid program.` The source of the error was [this method](https://github.com/moozzyk/EFCache/blob/master/src/EFCache/CachingCommand.cs#L174) in [the EFCache library](https://github.com/moozzyk/).

After much memory dumping and investigation, we managed to reproduce this locally, and create a minimal (ish) repro: 

```csharp
public class Extras  
{  
    private static readonly Random _random = new();  
    public int NonVoidWithBranchToLastReturn()  
    {        
	var result = _random.Next();  
        if (result % 2 == 0)  
        {            
	    Console.WriteLine("Even");  
        }  
        return result;  
    }
}
```

Instrumenting the `NonVoidWithBranchToLastReturn()` method gives an `InvalidProgramException` when executed.

## Implementation details


The IL for the problematic method is:

```il
  000001D7D627C620:    ldarg.0
  000001D7D627C380:      ldfld  000000000400000D
  000001D7D627C560:   callvirt  000000000A000036  | System.Random.Next()
  000001D7D627C3E0:        dup
  000001D7D627CDA0:   ldc.i4.2
  000001D7D627C260:        rem
  000001D7D627C800:   brtrue.s  000001D7D627C590
  000001D7D627CC20:      ldstr  00000000700002B5  | "Even"
  000001D7D627C950:       call  000000000A00002F  | System.Console.WriteLine(1 argument{s})
  000001D7D627C590:        ret
```

The important feature is that the return value is kep on the stack, and not stored in a local.

When we look at the rewritten version (ignoring the extra try catches etc) we have code that looks like this

```il
  000001D7D627C620:    ldarg.0
  000001D7D627C380:      ldfld  000000000400000D
  000001D7D627C560:   callvirt  000000000A000036  | System.Random.Next()
  000001D7D627C3E0:        dup
  000001D7D627CDA0:   ldc.i4.2
  000001D7D627C260:        rem
  000001D7D627C800:   brtrue.s  000001D7D627C590
  000001D7D627CC20:      ldstr  00000000700002B5  | "Even"
  000001D7D627C950:       call  000000000A00002F  | System.Console.WriteLine(1 argument{s})
  000001D7D627D7C0:    stloc.0
  000001D7D627C590:    leave.s  000001D7D627D190
```

So we rewrite the final `ret` to a `stloc.0` and `leave.s`.

However, if we look at the line:
```il
  000001D7D627C800:   brtrue.s  000001D7D627C590
```
We can see that it's branching directly to  `000001D7D627C590 leave.s`, whereas it _should_ be branching to `000001D7D627D7C0 stloc.0`.

The fix is the method rewriter:
- Previously we were **inserting** `stlocal` where the `ret` is, then we were **rewriting** the `ret` into a `leave.s`
- The fix is to **rewrite** the `ret` into `stlocal` then **append** the `leave.s`

After the fix we have this instead:

```il
  000001D7D627C800:   brtrue.s  000001D7D627D7C0
```
## Test coverage

Added a test case to `CallTargetNativeTests`. Tested that the error reproduces, and that this PR fixes it.

## Other details
@kevingosse said:

> Also there is some logic in the rewriterWrapper to optimize the `leave.s` instruction and I'm bypassing it. So we probably should use `rewriterWrapper` _somehow_
> but @tonyredondo can figure it out 😅 


