### PR TITLE
[Tracer] refactor trace serialization part 4: `env` and `version`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/CachedStringBytes.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/CachedStringBytes.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="CachedStringBytes.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Text;
+
+namespace Datadog.Trace.Agent.MessagePack;
+
+internal readonly struct CachedStringBytes
+{
+    public readonly byte[]? Environment;
+
+    public readonly byte[]? ServiceVersion;
+
+    public CachedStringBytes(Encoding encoding, string? environment, string? serviceVersion)
+    {
+        Environment = !string.IsNullOrEmpty(environment) ? encoding.GetBytes(environment) : null;
+        ServiceVersion = !string.IsNullOrEmpty(serviceVersion) ? encoding.GetBytes(serviceVersion) : null;
+    }
+}

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -18,6 +18,14 @@ namespace Datadog.Trace.Agent.MessagePack
     {
         public static readonly SpanMessagePackFormatter Instance = new();
 
+        // Cache the UTF-8 bytes for string constants (like tag names)
+        // and values that are constant within the lifetime of a service (like process id).
+        //
+        // Don't make these static to avoid the additional redirection when this
+        // assembly is loaded in the shared domain. We only create a single instance of
+        // this class so that's fine.
+
+        // top-level span fields
         private readonly byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
         private readonly byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
         private readonly byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
@@ -29,16 +37,18 @@ namespace Datadog.Trace.Agent.MessagePack
         private readonly byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
         private readonly byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
 
-        // name of string tag dictionary
+        // string tags
         private readonly byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
 
         private readonly byte[] _languageNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Language);
         private readonly byte[] _languageValueBytes = StringEncoding.UTF8.GetBytes(TracerConstants.Language);
+
         private readonly byte[] _runtimeIdNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.RuntimeId);
         private readonly byte[] _runtimeIdValueBytes = StringEncoding.UTF8.GetBytes(Tracer.RuntimeId);
+
         private readonly byte[] _originNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
 
-        // name of numeric tag dictionary
+        // numeric tags
         private readonly byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
 
         private readonly byte[] _processIdNameBytes = StringEncoding.UTF8.GetBytes(Trace.Metrics.ProcessId);

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -33,6 +33,10 @@ internal readonly struct TraceChunkModel
 
     public readonly int? SamplingPriority = null;
 
+    public readonly string? Environment = null;
+
+    public readonly string? ServiceVersion = null;
+
     public readonly TraceTagCollection? Tags = null;
 
     public readonly ulong? LocalRootSpanId = null;
@@ -47,6 +51,8 @@ internal readonly struct TraceChunkModel
         if (traceContext is not null)
         {
             SamplingPriority = traceContext.SamplingPriority;
+            Environment = traceContext.Environment;
+            ServiceVersion = traceContext.ServiceVersion;
             Tags = traceContext.Tags;
         }
     }

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
@@ -19,12 +19,10 @@ internal partial class TestSpanTags : TestSuiteSpanTags
         Name = testName;
         SuiteId = suiteTags.SuiteId;
         Suite = suiteTags.Suite;
-        Environment = suiteTags.Environment;
         Framework = suiteTags.Framework;
         Module = suiteTags.Module;
         Status = suiteTags.Status;
         Type = suiteTags.Type;
-        Version = suiteTags.Version;
         FrameworkVersion = suiteTags.FrameworkVersion;
         GitBranch = suiteTags.GitBranch;
         GitCommit = suiteTags.GitCommit;

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSuiteSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSuiteSpanTags.cs
@@ -17,12 +17,10 @@ internal partial class TestSuiteSpanTags : TestModuleSpanTags
     public TestSuiteSpanTags(TestModuleSpanTags moduleTags, string suiteName)
     {
         Suite = suiteName;
-        Environment = moduleTags.Environment;
         Framework = moduleTags.Framework;
         Module = moduleTags.Module;
         Status = moduleTags.Status;
         Type = moduleTags.Type;
-        Version = moduleTags.Version;
         FrameworkVersion = moduleTags.FrameworkVersion;
         GitBranch = moduleTags.GitBranch;
         GitCommit = moduleTags.GitCommit;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
@@ -14,70 +14,7 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] SamplingLimitDecisionBytes = new byte[] { 95, 100, 100, 46, 108, 105, 109, 105, 116, 95, 112, 115, 114 };
         // TracesKeepRateBytes = System.Text.Encoding.UTF8.GetBytes("_dd.tracer_kr");
         private static readonly byte[] TracesKeepRateBytes = new byte[] { 95, 100, 100, 46, 116, 114, 97, 99, 101, 114, 95, 107, 114 };
-        // EnvironmentBytes = System.Text.Encoding.UTF8.GetBytes("env");
-        private static readonly byte[] EnvironmentBytes = new byte[] { 101, 110, 118 };
-        // VersionBytes = System.Text.Encoding.UTF8.GetBytes("version");
-        private static readonly byte[] VersionBytes = new byte[] { 118, 101, 114, 115, 105, 111, 110 };
 
-        public override string? GetTag(string key)
-        {
-            return key switch
-            {
-                "env" => Environment,
-                "version" => Version,
-                _ => base.GetTag(key),
-            };
-        }
-
-        public override void SetTag(string key, string value)
-        {
-            switch(key)
-            {
-                case "env": 
-                    Environment = value;
-                    break;
-                case "version": 
-                    Version = value;
-                    break;
-                default: 
-                    base.SetTag(key, value);
-                    break;
-            }
-        }
-
-        public override void EnumerateTags<TProcessor>(ref TProcessor processor)
-        {
-            if (Environment is not null)
-            {
-                processor.Process(new TagItem<string>("env", Environment, EnvironmentBytes));
-            }
-
-            if (Version is not null)
-            {
-                processor.Process(new TagItem<string>("version", Version, VersionBytes));
-            }
-
-            base.EnumerateTags(ref processor);
-        }
-
-        protected override void WriteAdditionalTags(System.Text.StringBuilder sb)
-        {
-            if (Environment is not null)
-            {
-                sb.Append("env (tag):")
-                  .Append(Environment)
-                  .Append(',');
-            }
-
-            if (Version is not null)
-            {
-                sb.Append("version (tag):")
-                  .Append(Version)
-                  .Append(',');
-            }
-
-            base.WriteAdditionalTags(sb);
-        }
         public override double? GetMetric(string key)
         {
             return key switch

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
@@ -14,70 +14,7 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] SamplingLimitDecisionBytes = new byte[] { 95, 100, 100, 46, 108, 105, 109, 105, 116, 95, 112, 115, 114 };
         // TracesKeepRateBytes = System.Text.Encoding.UTF8.GetBytes("_dd.tracer_kr");
         private static readonly byte[] TracesKeepRateBytes = new byte[] { 95, 100, 100, 46, 116, 114, 97, 99, 101, 114, 95, 107, 114 };
-        // EnvironmentBytes = System.Text.Encoding.UTF8.GetBytes("env");
-        private static readonly byte[] EnvironmentBytes = new byte[] { 101, 110, 118 };
-        // VersionBytes = System.Text.Encoding.UTF8.GetBytes("version");
-        private static readonly byte[] VersionBytes = new byte[] { 118, 101, 114, 115, 105, 111, 110 };
 
-        public override string? GetTag(string key)
-        {
-            return key switch
-            {
-                "env" => Environment,
-                "version" => Version,
-                _ => base.GetTag(key),
-            };
-        }
-
-        public override void SetTag(string key, string value)
-        {
-            switch(key)
-            {
-                case "env": 
-                    Environment = value;
-                    break;
-                case "version": 
-                    Version = value;
-                    break;
-                default: 
-                    base.SetTag(key, value);
-                    break;
-            }
-        }
-
-        public override void EnumerateTags<TProcessor>(ref TProcessor processor)
-        {
-            if (Environment is not null)
-            {
-                processor.Process(new TagItem<string>("env", Environment, EnvironmentBytes));
-            }
-
-            if (Version is not null)
-            {
-                processor.Process(new TagItem<string>("version", Version, VersionBytes));
-            }
-
-            base.EnumerateTags(ref processor);
-        }
-
-        protected override void WriteAdditionalTags(System.Text.StringBuilder sb)
-        {
-            if (Environment is not null)
-            {
-                sb.Append("env (tag):")
-                  .Append(Environment)
-                  .Append(',');
-            }
-
-            if (Version is not null)
-            {
-                sb.Append("version (tag):")
-                  .Append(Version)
-                  .Append(',');
-            }
-
-            base.WriteAdditionalTags(sb);
-        }
         public override double? GetMetric(string key)
         {
             return key switch

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
@@ -14,70 +14,7 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] SamplingLimitDecisionBytes = new byte[] { 95, 100, 100, 46, 108, 105, 109, 105, 116, 95, 112, 115, 114 };
         // TracesKeepRateBytes = System.Text.Encoding.UTF8.GetBytes("_dd.tracer_kr");
         private static readonly byte[] TracesKeepRateBytes = new byte[] { 95, 100, 100, 46, 116, 114, 97, 99, 101, 114, 95, 107, 114 };
-        // EnvironmentBytes = System.Text.Encoding.UTF8.GetBytes("env");
-        private static readonly byte[] EnvironmentBytes = new byte[] { 101, 110, 118 };
-        // VersionBytes = System.Text.Encoding.UTF8.GetBytes("version");
-        private static readonly byte[] VersionBytes = new byte[] { 118, 101, 114, 115, 105, 111, 110 };
 
-        public override string? GetTag(string key)
-        {
-            return key switch
-            {
-                "env" => Environment,
-                "version" => Version,
-                _ => base.GetTag(key),
-            };
-        }
-
-        public override void SetTag(string key, string value)
-        {
-            switch(key)
-            {
-                case "env": 
-                    Environment = value;
-                    break;
-                case "version": 
-                    Version = value;
-                    break;
-                default: 
-                    base.SetTag(key, value);
-                    break;
-            }
-        }
-
-        public override void EnumerateTags<TProcessor>(ref TProcessor processor)
-        {
-            if (Environment is not null)
-            {
-                processor.Process(new TagItem<string>("env", Environment, EnvironmentBytes));
-            }
-
-            if (Version is not null)
-            {
-                processor.Process(new TagItem<string>("version", Version, VersionBytes));
-            }
-
-            base.EnumerateTags(ref processor);
-        }
-
-        protected override void WriteAdditionalTags(System.Text.StringBuilder sb)
-        {
-            if (Environment is not null)
-            {
-                sb.Append("env (tag):")
-                  .Append(Environment)
-                  .Append(',');
-            }
-
-            if (Version is not null)
-            {
-                sb.Append("version (tag):")
-                  .Append(Version)
-                  .Append(',');
-            }
-
-            base.WriteAdditionalTags(sb);
-        }
         public override double? GetMetric(string key)
         {
             return key switch

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CommonTags.g.cs
@@ -14,70 +14,7 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] SamplingLimitDecisionBytes = new byte[] { 95, 100, 100, 46, 108, 105, 109, 105, 116, 95, 112, 115, 114 };
         // TracesKeepRateBytes = System.Text.Encoding.UTF8.GetBytes("_dd.tracer_kr");
         private static readonly byte[] TracesKeepRateBytes = new byte[] { 95, 100, 100, 46, 116, 114, 97, 99, 101, 114, 95, 107, 114 };
-        // EnvironmentBytes = System.Text.Encoding.UTF8.GetBytes("env");
-        private static readonly byte[] EnvironmentBytes = new byte[] { 101, 110, 118 };
-        // VersionBytes = System.Text.Encoding.UTF8.GetBytes("version");
-        private static readonly byte[] VersionBytes = new byte[] { 118, 101, 114, 115, 105, 111, 110 };
 
-        public override string? GetTag(string key)
-        {
-            return key switch
-            {
-                "env" => Environment,
-                "version" => Version,
-                _ => base.GetTag(key),
-            };
-        }
-
-        public override void SetTag(string key, string value)
-        {
-            switch(key)
-            {
-                case "env": 
-                    Environment = value;
-                    break;
-                case "version": 
-                    Version = value;
-                    break;
-                default: 
-                    base.SetTag(key, value);
-                    break;
-            }
-        }
-
-        public override void EnumerateTags<TProcessor>(ref TProcessor processor)
-        {
-            if (Environment is not null)
-            {
-                processor.Process(new TagItem<string>("env", Environment, EnvironmentBytes));
-            }
-
-            if (Version is not null)
-            {
-                processor.Process(new TagItem<string>("version", Version, VersionBytes));
-            }
-
-            base.EnumerateTags(ref processor);
-        }
-
-        protected override void WriteAdditionalTags(System.Text.StringBuilder sb)
-        {
-            if (Environment is not null)
-            {
-                sb.Append("env (tag):")
-                  .Append(Environment)
-                  .Append(',');
-            }
-
-            if (Version is not null)
-            {
-                sb.Append("version (tag):")
-                  .Append(Version)
-                  .Append(',');
-            }
-
-            base.WriteAdditionalTags(sb);
-        }
         public override double? GetMetric(string key)
         {
             return key switch

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -117,18 +117,7 @@ namespace Datadog.Trace.Processors
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L133-L135
-            if (span.Tags is CommonTags commonTags)
-            {
-                commonTags.Environment = TraceUtil.NormalizeTag(commonTags.Environment);
-            }
-            else
-            {
-                string env = span.GetTag("env");
-                if (!string.IsNullOrEmpty(env))
-                {
-                    span.Tags.SetTag("env", TraceUtil.NormalizeTag(env));
-                }
-            }
+            // NOTE: moved to SpanMessagePackFormatter
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L136-L142
             if (span.Tags is IHasStatusCode statusCodeTags)

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -50,17 +50,7 @@ namespace Datadog.Trace.Sampling
                 return defaultRate;
             }
 
-            string env;
-
-            if (span.Tags is CommonTags tags)
-            {
-                env = tags.Environment;
-            }
-            else
-            {
-                env = span.GetTag(Tags.Env);
-            }
-
+            var env = span.Context.TraceContext.Tracer.Settings.Environment;
             var service = span.ServiceName;
 
             var key = new SampleRateKey(service, env);

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -162,6 +162,12 @@ namespace Datadog.Trace
             // some tags have special meaning
             switch (key)
             {
+                case Trace.Tags.Env:
+                    Context.TraceContext.Environment = value;
+                    break;
+                case Trace.Tags.Version:
+                    Context.TraceContext.ServiceVersion = value;
+                    break;
                 case Trace.Tags.Origin:
                     Context.Origin = value;
                     break;
@@ -319,7 +325,11 @@ namespace Datadog.Trace
             switch (key)
             {
                 case Trace.Tags.SamplingPriority:
-                    return Context.TraceContext?.SamplingPriority.ToString();
+                    return Context.TraceContext.SamplingPriority?.ToString();
+                case Trace.Tags.Env:
+                    return Context.TraceContext.Environment;
+                case Trace.Tags.Version:
+                    return Context.TraceContext.ServiceVersion;
                 case Trace.Tags.Origin:
                     return Context.Origin;
                 default:

--- a/tracer/src/Datadog.Trace/Tagging/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/CommonTags.cs
@@ -9,12 +9,6 @@ namespace Datadog.Trace.Tagging
 {
     internal partial class CommonTags : TagsList
     {
-        [Tag(Trace.Tags.Env)]
-        public string Environment { get; set; }
-
-        [Tag(Trace.Tags.Version)]
-        public string Version { get; set; }
-
         [Metric(Trace.Metrics.SamplingPriority)]
         public double? SamplingPriority { get; set; }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -31,8 +31,16 @@ namespace Datadog.Trace
 
         public TraceContext(IDatadogTracer tracer, TraceTagCollection tags = null)
         {
+            var settings = tracer?.Settings;
+
+            if (settings is not null)
+            {
+                Environment = settings.Environment;
+                ServiceVersion = settings.ServiceVersion;
+            }
+
             Tracer = tracer;
-            Tags = tags ?? new TraceTagCollection(tracer?.Settings?.OutgoingTagPropagationHeaderMaxLength ?? TagPropagation.OutgoingTagPropagationHeaderMaxLength);
+            Tags = tags ?? new TraceTagCollection(settings?.OutgoingTagPropagationHeaderMaxLength ?? TagPropagation.OutgoingTagPropagationHeaderMaxLength);
         }
 
         public Span RootSpan { get; private set; }
@@ -53,6 +61,10 @@ namespace Datadog.Trace
         {
             get => _samplingPriority;
         }
+
+        public string Environment { get; set; }
+
+        public string ServiceVersion { get; set; }
 
         private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);
 


### PR DESCRIPTION
## Summary of changes

Don't add `env` and `version` as in-memory span tags. Instead, only track these values in `TraceContext` and inject during serialization.

## Reason for change

- Consolidates trace metadata and removing duplication in spans. This is another step towards supporting trace agent endpoints 0.6/0.7, which supports metadata at the trace and trace chunk levels. 
- Makes the `CommonTags` object (instantiated for every auto-instrumentation span) smaller.

## Implementation details

- remove `Environment` and `Version` from `CommonTags`
- add properties `Environment` and `ServiceVersion` to `TraceContext` and `TraceChunkModel` 
- normalize `env` value like the trace agent would do (to support agentless)
- cache `env` and `version` tags UTF-8 bytes
- inject `env` and `version` tags into all spans during serialization

## Test coverage

We have tests that cover this. There should be no test regressions.

## Other details

Follows from #3135 
