### PR TITLE
[ASM] Remove warnings and fix flake

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -44,7 +44,10 @@ namespace Datadog.Trace.AppSec
                 var scope = SharedItems.TryPeekScope(context, peekScopeKey);
                 security.InstrumentationGateway.RaiseBodyAvailable(context, scope.Span, bodyDic);
                 security.InstrumentationGateway.RaisePathParamsAvailable(context, scope.Span, pathParamsDic);
-                security.InstrumentationGateway.RaiseBlockingOpportunity(context, scope, Tracer.Instance.Settings, (_) => { });
+                security.InstrumentationGateway.RaiseBlockingOpportunity(context, scope, Tracer.Instance.Settings, args =>
+                {
+                    TracingHttpModule.AddHeaderTagsFromHttpResponse(args.Context, args.Scope);
+                });
             }
         }
     }

--- a/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
+++ b/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
@@ -117,8 +117,7 @@ namespace Datadog.Trace.AppSec
 
         internal void RaiseBlockingOpportunity(HttpContext context, Scope scope, ImmutableTracerSettings tracerSettings, Action<InstrumentationGatewayBlockingEventArgs> doBeforeActualBlocking = null)
         {
-            var ea = new InstrumentationGatewayBlockingEventArgs(context, scope, tracerSettings, doBeforeActualBlocking);
-            BlockingOpportunity?.Invoke(this, ea);
+            BlockingOpportunity?.Invoke(this, new InstrumentationGatewayBlockingEventArgs(context, scope, tracerSettings, doBeforeActualBlocking));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
+++ b/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
@@ -74,7 +74,10 @@ namespace Datadog.Trace.AppSec
             if (LastChanceToWriteTags != null)
             {
                 var transport = new HttpTransport(context);
-                LastChanceToWriteTags.Invoke(this, new InstrumentationGatewayEventArgs(transport, relatedSpan));
+                if (!transport.Blocked)
+                {
+                    LastChanceToWriteTags?.Invoke(this, new InstrumentationGatewayEventArgs(transport, relatedSpan));
+                }
             }
         }
 
@@ -100,8 +103,11 @@ namespace Datadog.Trace.AppSec
             {
                 var eventData = getEventData();
                 var transport = new HttpTransport(context);
-                LogAddressIfDebugEnabled(eventData);
-                eventHandler.Invoke(this, new InstrumentationGatewaySecurityEventArgs(eventData, transport, relatedSpan, eraseExistingAddress));
+                if (!transport.Blocked)
+                {
+                    LogAddressIfDebugEnabled(eventData);
+                    eventHandler?.Invoke(this, new InstrumentationGatewaySecurityEventArgs(eventData, transport, relatedSpan, eraseExistingAddress));
+                }
             }
             catch (Exception ex) when (ex is not BlockException)
             {
@@ -111,7 +117,8 @@ namespace Datadog.Trace.AppSec
 
         internal void RaiseBlockingOpportunity(HttpContext context, Scope scope, ImmutableTracerSettings tracerSettings, Action<InstrumentationGatewayBlockingEventArgs> doBeforeActualBlocking = null)
         {
-            BlockingOpportunity?.Invoke(this, new InstrumentationGatewayBlockingEventArgs(context, scope, tracerSettings, doBeforeActualBlocking));
+            var ea = new InstrumentationGatewayBlockingEventArgs(context, scope, tracerSettings, doBeforeActualBlocking);
+            BlockingOpportunity?.Invoke(this, ea);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -520,6 +520,7 @@ namespace Datadog.Trace.AppSec
                 var transport = args.Transport;
                 var additiveContext = GetOrCreateContext(transport);
                 additiveContext.Dispose();
+
                 throw new BlockException();
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -533,6 +533,8 @@ namespace Datadog.Trace.AppSec
 
         private void RunWafAndReact(object sender, InstrumentationGatewaySecurityEventArgs e)
         {
+            // System.Diagnostics.Debugger.Launch();
+
             try
             {
                 if (e.Transport.Blocked)

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -533,8 +533,6 @@ namespace Datadog.Trace.AppSec
 
         private void RunWafAndReact(object sender, InstrumentationGatewaySecurityEventArgs e)
         {
-            // System.Diagnostics.Debugger.Launch();
-
             try
             {
                 if (e.Transport.Blocked)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -264,14 +264,17 @@ namespace Datadog.Trace.AspNet
                                 return;
                             }
 
-                            // raise path params here for webforms cause there's no other hookpoint for path params, but for mvc/webapi, there's better hookpoint which only gives route params (and not {controller} and {actions} ones) so don't take precedence
-                            security.InstrumentationGateway.RaisePathParamsAvailable(httpContext, scope.Span, httpContext.Request.RequestContext.RouteData.Values, eraseExistingAddress: false);
-                            security.InstrumentationGateway.RaiseRequestEnd(httpContext, httpContext.Request, scope.Span);
-                            security.InstrumentationGateway.RaiseLastChanceToWriteTags(httpContext, scope.Span);
-                            security.InstrumentationGateway.RaiseBlockingOpportunity(httpContext, scope, tracer.Settings, args =>
+                            if (!(httpContext.Items["block"] is bool blocked && blocked))
                             {
-                                AddHeaderTagsFromHttpResponse(args.Context, args.Scope);
-                            });
+                                // raise path params here for webforms cause there's no other hookpoint for path params, but for mvc/webapi, there's better hookpoint which only gives route params (and not {controller} and {actions} ones) so don't take precedence
+                                security.InstrumentationGateway.RaisePathParamsAvailable(httpContext, scope.Span, httpContext.Request.RequestContext.RouteData.Values, eraseExistingAddress: false);
+                                security.InstrumentationGateway.RaiseRequestEnd(httpContext, httpContext.Request, scope.Span);
+                                security.InstrumentationGateway.RaiseLastChanceToWriteTags(httpContext, scope.Span);
+                                security.InstrumentationGateway.RaiseBlockingOpportunity(httpContext, scope, tracer.Settings, args =>
+                                {
+                                    AddHeaderTagsFromHttpResponse(args.Context, args.Scope);
+                                });
+                            }
                         }
 
                         scope.Dispose();

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -155,7 +155,6 @@ namespace Datadog.Trace
         {
             if (IsFinished)
             {
-                // System.Diagnostics.Debugger.Launch();
                 Log.Warning("SetTag should not be called after the span was closed");
                 return this;
             }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -155,6 +155,7 @@ namespace Datadog.Trace
         {
             if (IsFinished)
             {
+                // System.Diagnostics.Debugger.Launch();
                 Log.Warning("SetTag should not be called after the span was closed");
                 return this;
             }


### PR DESCRIPTION
## Summary of changes

We are seeing flake in the ASM blocking tests, where the status code and resource name disappeared from the span:

![framework flake](https://user-images.githubusercontent.com/51381/195104478-2c131e57-f8f0-46a9-bd0b-01a0fb1f0758.png)


## Reason for change

Flake is bad.

## Implementation details

Before this change we dispose systematically disposed a scope / span in the `TracingHttpModule.OnBeginRequest` in the case of an exception, the logic being we won't be able to retrieve it from the http context `TracingHttpModule.OnEndRequest`.

However, this is not always true, if the exception occurs late `TracingHttpModule.OnBeginRequest`, then the span will be in the http context and we'll attempt to update the `TracingHttpModule.OnEndRequest`. This creates a race between data being written to the span object and the span being written to the `AgentWriter`.

In the case where we blocked the request from the call to the WAF in `TracingHttpModule.OnBeginRequest`, we were also calling the WAF again in `TracingHttpModule.OnEndRequest`, which seems unnecessary.