### PR TITLE
Fix fairly subtle bug with remote config feature ASM_DD

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -281,7 +281,7 @@ namespace Datadog.Trace.AppSec
 
         private void AsmDDProductConfigChanged(object sender, ProductConfigChangedEventArgs e)
         {
-            var asmDD = e.GetDeserializedConfigurations<string>().FirstOrDefault();
+            var asmDD = e.GetConfigurationAsString().FirstOrDefault();
             if (!string.IsNullOrEmpty(asmDD.TypedFile))
             {
                 _remoteRulesJson = asmDD.TypedFile;

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ProductConfigChangedEventArgs.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ProductConfigChangedEventArgs.cs
@@ -32,6 +32,17 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             }
         }
 
+        public IEnumerable<NamedTypedFile<string>> GetConfigurationAsString()
+        {
+            foreach (var configContent in _configContents)
+            {
+                using var stream = new MemoryStream(configContent.RawFile);
+                using var streamReader = new StreamReader(stream);
+                var contents = streamReader.ReadToEnd();
+                yield return new NamedTypedFile<string>(configContent.Name, contents);
+            }
+        }
+
         public void Acknowledge(string filename)
         {
             GetOrCreateApplyDetails(filename, applyDetails =>

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -20,8 +20,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
     internal class RemoteConfigurationApi : IRemoteConfigurationApi
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RemoteConfigurationApi));
-        private static readonly FileStream Stream = File.OpenWrite(@"c:\code\rcm.log");
-        private static readonly StreamWriter LogWriter = new StreamWriter(Stream);
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private string _configEndpoint = null;
@@ -54,7 +52,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
             var apiRequest = _apiRequestFactory.Create(uri);
 
             var requestContent = JsonConvert.SerializeObject(request);
-            LogWriter.WriteLine(requestContent);
             var bytes = Encoding.UTF8.GetBytes(requestContent);
             var payload = new ArraySegment<byte>(bytes);
 
@@ -67,9 +64,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
             }
 
             var content = await apiResponse.ReadAsStringAsync().ConfigureAwait(false);
-            LogWriter.WriteLine(content);
-            LogWriter.Flush();
-            Stream.Flush();
 
             if (apiResponse.StatusCode is not (>= 200 and <= 299))
             {

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,15 +62,15 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
                 return null;
             }
 
-            var content = await apiResponse.ReadAsStringAsync().ConfigureAwait(false);
-
             if (apiResponse.StatusCode is not (>= 200 and <= 299))
             {
+                var content = await apiResponse.ReadAsStringAsync().ConfigureAwait(false);
                 Log.Warning<int, string>("Failed to receive remote configurations {StatusCode} and message: {ResponseContent}", apiResponse.StatusCode, content);
+
                 return null;
             }
 
-            return JsonConvert.DeserializeObject<GetRcmResponse>(content);
+            return await apiResponse.ReadAsTypeAsync<GetRcmResponse>().ConfigureAwait(false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
@@ -38,11 +38,11 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 
             var spans1 = await SendRequestsAsync(agent, url);
 
-            await agent.SetupRcmAndWait(Output, new[] { ((object)GetRules("2.22.222"), "1") }, "ASM_DD");
+            await agent.SetupRcmAndWait(Output, new[] { (GetRules("2.22.222"), "1") }, "ASM_DD");
             await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
             var spans2 = await SendRequestsAsync(agent, url);
 
-            await agent.SetupRcmAndWait(Output, new[] { ((object)GetRules("3.33.333"), "2") }, "ASM_DD");
+            await agent.SetupRcmAndWait(Output, new[] { (GetRules("3.33.333"), "2") }, "ASM_DD");
             await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
             var spans3 = await SendRequestsAsync(agent, url);
 


### PR DESCRIPTION
## Summary of changes

Handle how the data is formatted in production.

## Reason for change

The feature completely broken without this fix.

## Implementation details

Our integration had a subtle difference in the test data sent from the actual data in prod. The Integration tests we were sending everything wrapped in double quotes:

```
"{  "version": "2.2",  "metadata": {   "rules_version": "1.4.2"  }, ... "
```

In prod the data looked like:

```
{  "version": "2.2",  "metadata": {   "rules_version": "1.4.2"  }, ... 
```
