### PR TITLE
Delete Log Files That are 31 Days or Older

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Util;
@@ -53,6 +54,7 @@ namespace Datadog.Trace.Logging
                 try
                 {
                     logDirectory = GetLogDirectory();
+                    CleanLogFiles(logDirectory);
                 }
                 catch
                 {
@@ -206,6 +208,31 @@ namespace Datadog.Trace.Logging
             }
 
             return logDirectory;
+        }
+
+        internal static void CleanLogFiles(string logsDirectory)
+        {
+            DirectoryInfo logsDirInfo = new DirectoryInfo(logsDirectory);
+            FileInfo[] logFiles = logsDirInfo.GetFiles().OrderBy(p => p.LastWriteTime).ToArray();
+
+            for (int i = 0; i < logFiles.Length; i++)
+            {
+                if ((DateTime.Now - logFiles[i].LastWriteTime).TotalDays >= 31)
+                {
+                    try
+                    {
+                        logFiles[i].Delete();
+                    }
+                    catch
+                    {
+                        // Do nothing when an exception is thrown for attempting to delete the filesystem
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
During startup when we start the logger it will take the user's log directory and delete files `=>` 31 days.

## Reason for change
Because of the log pattern we use and how services can be restarted at random intervals, currently there are some log files that don't get rotated since we rely on Serilog's `retainedFileCountLimit`.

## Implementation details
Using the `System.IO` class to access the logs directory, making a list of the files ordered by `LastWriteTime` and deleting those that are 31 days old or older.

## Test coverage
Created test to confirm that it uses the correct directory and deletes the expected files.
