### PR TITLE
Minor remote config fixes

### DIFF
--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -53,6 +53,11 @@ namespace PrepareRelease
             return Regex.Replace(text, VersionPattern(fourPartVersion: true), FourPartVersionString(), RegexOptions.Singleline);
         }
 
+        private string ThreePartSemVerReplace(string text)
+        {
+            return Regex.Replace(text, VersionPattern(), VersionString(), RegexOptions.Singleline);
+        }
+
         private string FullVersionReplace(string text, string split, string prefix = "")
         {
             return Regex.Replace(text, prefix + VersionPattern(split), prefix + VersionString(split), RegexOptions.Singleline);
@@ -283,7 +288,8 @@ namespace PrepareRelease
                 // Four-part AssemblyVersion update
                 SynchronizeVersion(
                     "src/Datadog.Trace/TracerConstants.cs",
-                    FourPartVersionReplace);
+                    // upgrading four part, then three part *seems* safe
+                    text => ThreePartSemVerReplace(FourPartVersionReplace(text)));
 
                 // Top-level CMakeLists.txt
                 SynchronizeVersion(

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -53,7 +53,7 @@ namespace PrepareRelease
             return Regex.Replace(text, VersionPattern(fourPartVersion: true), FourPartVersionString(), RegexOptions.Singleline);
         }
 
-        private string ThreePartSemVerReplace(string text)
+        private string ThreePartVersionReplace(string text)
         {
             return Regex.Replace(text, VersionPattern(), VersionString(), RegexOptions.Singleline);
         }
@@ -289,7 +289,7 @@ namespace PrepareRelease
                 SynchronizeVersion(
                     "src/Datadog.Trace/TracerConstants.cs",
                     // upgrading four part, then three part *seems* safe
-                    text => ThreePartSemVerReplace(FourPartVersionReplace(text)));
+                    text => ThreePartVersionReplace(FourPartVersionReplace(text)));
 
                 // Top-level CMakeLists.txt
                 SynchronizeVersion(

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
@@ -10,13 +10,14 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmClientState
     {
-        public RcmClientState(int rootVersion, int targetsVersion, List<RcmConfigState> configStates, bool hasError, string error)
+        public RcmClientState(int rootVersion, int targetsVersion, List<RcmConfigState> configStates, bool hasError, string error, string backendClientState)
         {
             RootVersion = rootVersion;
             TargetsVersion = targetsVersion;
             ConfigStates = configStates;
             HasError = hasError;
             Error = error;
+            BackendClientState = backendClientState;
         }
 
         [JsonProperty("root_version")]
@@ -33,5 +34,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 
         [JsonProperty("error")]
         public string Error { get; }
+
+        [JsonProperty("backend_client_state")]
+        public string BackendClientState { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Signed.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Signed.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf
         [JsonProperty("version")]
         public int Version { get; set; }
 
+        [JsonProperty("custom")]
         public TargetsCustom Custom { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -44,6 +44,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         private string? _lastPollError;
         private bool _isPollingStarted;
         private bool _isRcmEnabled;
+        private string? _backendClientState;
 
         private RemoteConfigurationManager(
             IDiscoveryService discoveryService,
@@ -187,6 +188,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 {
                     ProcessResponse(response, products);
                     _targetsVersion = response.Targets.Signed.Version;
+                    _backendClientState = response.Targets.Signed.Custom.OpaqueBackendState;
                 }
             }
             catch (Exception e)
@@ -217,7 +219,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             Array.Reverse(capabilitiesArray);
 #endif
 
-            var rcmState = new RcmClientState(_rootVersion, _targetsVersion, configStates, _lastPollError != null, _lastPollError);
+            var rcmState = new RcmClientState(_rootVersion, _targetsVersion, configStates, _lastPollError != null, _lastPollError, _backendClientState);
             var rcmClient = new RcmClient(_id, products.Keys, _rcmTracer, rcmState, capabilitiesArray);
             var rcmRequest = new GetRcmRequest(rcmClient, cachedTargetFiles);
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -188,7 +188,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 {
                     ProcessResponse(response, products);
                     _targetsVersion = response.Targets.Signed.Version;
-                    _backendClientState = response.Targets.Signed.Custom.OpaqueBackendState;
+                    _backendClientState = response.Targets.Signed.Custom?.OpaqueBackendState;
                 }
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         {
             Id = Guid.NewGuid().ToString();
             RuntimeId = Util.RuntimeId.Get();
-            TracerVersion = TracerConstants.AssemblyVersion;
+            TracerVersion = TracerConstants.AssemblySemVer;
 
             var pollInterval = configurationSource?.GetInt32(ConfigurationKeys.Rcm.PollInterval);
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         {
             Id = Guid.NewGuid().ToString();
             RuntimeId = Util.RuntimeId.Get();
-            TracerVersion = TracerConstants.AssemblySemVer;
+            TracerVersion = TracerConstants.ThreePartVersion;
 
             var pollInterval = configurationSource?.GetInt32(ConfigurationKeys.Rcm.PollInterval);
 

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -15,6 +15,6 @@ namespace Datadog.Trace
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
 
         public const string AssemblyVersion = "2.18.0.0";
-        public const string AssemblySemVer = "2.18.0";
+        public const string ThreePartVersion = "2.18.0";
     }
 }

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -15,5 +15,6 @@ namespace Datadog.Trace
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
 
         public const string AssemblyVersion = "2.18.0.0";
+        public const string AssemblySemVer = "2.18.0";
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
@@ -17,16 +17,16 @@ namespace Datadog.Trace.TestHelpers
 {
     public static class RemoteConfigTestHelper
     {
-        public static void SetupRcm(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName)
+        public static void SetupRcm(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
         {
-            var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName);
+            var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName, opaqueBackEndSate);
             agent.RcmResponse = response;
             output.WriteLine("Using RCM response: " + response);
         }
 
-        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName)
+        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
         {
-            var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName);
+            var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName, opaqueBackEndSate);
             agent.RcmResponse = response;
             output.WriteLine("Using RCM response: " + response);
             var res = await agent.WaitRcmRequestAndReturnLast();
@@ -34,9 +34,9 @@ namespace Datadog.Trace.TestHelpers
             return res;
         }
 
-        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(string Config, string Id)> configurations, string productName)
+        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(string Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
         {
-            var response = BuildRcmResponse(configurations, productName);
+            var response = BuildRcmResponse(configurations, productName, opaqueBackEndSate);
             agent.RcmResponse = response;
             output.WriteLine("Using RCM response: " + response);
             var res = await agent.WaitRcmRequestAndReturnLast();
@@ -78,7 +78,7 @@ namespace Datadog.Trace.TestHelpers
             return request;
         }
 
-        private static string BuildRcmResponse(IEnumerable<(string Config, string Id)> configurations, string productName)
+        private static string BuildRcmResponse(IEnumerable<(string Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
         {
             var targetFiles = new List<RcmFile>();
             var targets = new Dictionary<string, Target>();
@@ -106,7 +106,11 @@ namespace Datadog.Trace.TestHelpers
             {
                 Signed = new Signed()
                 {
-                    Targets = targets
+                    Targets = targets,
+                    Custom = new TargetsCustom()
+                    {
+                        OpaqueBackendState = opaqueBackEndSate
+                    }
                 }
             };
 


### PR DESCRIPTION
## Summary of changes

* The tracer version must use sematic version numbers: only three point version numbers
* The field backed_client_state was missing

## Test coverage

Add the test to the feature toggle test, where we tests a lot of other RC features.

These should maybe refactored into unit tests in the future?

