### PR TITLE
Fix dotnet install in build

### DIFF
--- a/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
@@ -34,13 +34,14 @@ steps:
       Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
 
       if( "${{ parameters.is64bit }}" -eq "true") {
-        $path = "<auto>"
+        $path = "$HOME\AppData\Local\Microsoft\dotnet"
         $arch = "x64"
-        $noPath = $False
+
+        echo "Manually prepending to path"
+        echo "##vso[task.prependpath]$path"
       } else {
-        $path = "C:\Users\VssAdministrator\AppData\Local\Microsoft\dotnet_32"
+        $path = "$HOME\AppData\Local\Microsoft\dotnet_32"
         $arch = "x86"
-        $noPath = $True
 
         echo "Manually exporting path to DOTNET_EXE_32"
         echo "##vso[task.setvariable variable=DOTNET_EXE_32]$path\dotnet.exe"
@@ -49,9 +50,9 @@ steps:
       echo "Installing dotnet ($arch) to $path"
 
       if("${{ parameters.sdkVersion }}") {
-        ./dotnet-install.ps1 -Version ${{ parameters.sdkVersion }} -Architecture $arch -NoPath:$noPath -InstallDir $path
+        ./dotnet-install.ps1 -Version ${{ parameters.sdkVersion }} -Architecture $arch -NoPath:$True -InstallDir $path
       } else {
-        ./dotnet-install.ps1 -Channel ${{ parameters.channel }} -Architecture $arch -NoPath:$noPath -InstallDir $path
+        ./dotnet-install.ps1 -Channel ${{ parameters.channel }} -Architecture $arch -NoPath:$True -InstallDir $path
       }
 
       rm ./dotnet-install.ps1

--- a/.azure-pipelines/steps/install-dotnet-sdks.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdks.yml
@@ -8,34 +8,21 @@ steps:
   parameters:
     channel: 2.1
 
-- task: UseDotNet@2
-  displayName: install dotnet core sdk 3.0
-  inputs:
-    packageType: sdk
-    version: 3.0.x
-  retryCountOnTaskFailure: 5
+- template: install-dotnet-sdk-manually.yml
+  parameters:
+    channel: 3.0
 
-- task: UseDotNet@2
-  displayName: install dotnet core sdk 3.1
-  inputs:
-    packageType: sdk
-    version: 3.1.x
-  retryCountOnTaskFailure: 5
+- template: install-dotnet-sdk-manually.yml
+  parameters:
+    channel: 3.1
 
-- task: UseDotNet@2
-  displayName: install dotnet core sdk 5
-  inputs:
-    packageType: sdk
-    version: 5.0.x
-  retryCountOnTaskFailure: 5
+- template: install-dotnet-sdk-manually.yml
+  parameters:
+    channel: 5.0
 
-- task: UseDotNet@2
-  displayName: install latest dotnet core sdk
-  inputs:
-    packageType: sdk
-    version: $(dotnetCoreSdkLatestVersion)
-    includePreviewVersions: true
-  retryCountOnTaskFailure: 5
+- template: install-dotnet-sdk-manually.yml
+  parameters:
+    sdkVersion: $(dotnetCoreSdkLatestVersion)
 
 - ${{ if eq(parameters.includeX86, true) }}:
     - template: install-dotnet-sdk-manually.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1640,8 +1640,6 @@ stages:
         masterCommitId: $(masterCommitId)
 
     - template: steps/install-dotnet-sdks.yml
-      parameters:
-        includeX86: true
 
     - template: steps/restore-working-directory.yml
 

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net461.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net461.json
@@ -18,8 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.FakeDbCommand.exe",
-  "processArguments": "no-wait",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net461",
   "environmentVariables": {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -18,8 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.FakeDbCommand.exe",
-  "processArguments": "no-wait",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net6.0",
   "environmentVariables": {

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -18,8 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.FakeDbCommand.exe",
-  "processArguments": "no-wait",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\netcoreapp3.1",
   "environmentVariables": {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net461.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net461.json
@@ -18,7 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.HttpMessageHandler.exe",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.HttpMessageHandler.dll",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\net461",
   "environmentVariables": {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -18,7 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.HttpMessageHandler.exe",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.HttpMessageHandler.dll",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\net6.0",
   "environmentVariables": {

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -18,7 +18,8 @@
       }
     }
   ],
-  "processName": ".\\Samples.HttpMessageHandler.exe",
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.HttpMessageHandler.dll",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\netcoreapp3.1",
   "environmentVariables": {


### PR DESCRIPTION
## Summary of changes

- Fix the broken exploration and execution benchmarks

## Reason for change

In #3324, I changed the way we installed .NET Core 2.1 to resolve the constant build warnings from Azure Devops. Unfortunately, this broke stuff 🤷‍♂️  

## Implementation details

- When installing .NET SDKs, install _all_ of them the same way (using the dotnet-install script), so they're all in the same folder
- Manually update the $PATH correctly
- Don't install the x86 versions of the SDKs in exploration tests (not crucial I think, but not necessary)
- Change the way execution benchmarks are run with timeit. For some reason, the spawned process wasn't working correctly (was not respecting the updated PATH to find the correct `dotnet` exe) when running the `.exe` directly. Running the `.dll` with `dotnet` fixes it. I have no idea why.

## Test coverage

Ran several full builds, including the exploration tests

## Other details

Uncovered some other issues:
- I'm not convinced we're always running the exploration tests when we should (probably should run them on every merge to master?)
- I don't think we ever run the comprehensive (minor) package version suite any more
