### PR TITLE
Duplicated Spans flakiness fix

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -76,7 +76,6 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             var agentPort = TcpPortProvider.GetOpenPort();
             var agent = MockTracerAgent.Create(Output, agentPort);
-            agent.Warmup();
 
             StartSample(
                 agent,

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore2RateLimiter : AspNetBase, IDisposable
     {
         public AspNetCore2RateLimiter(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -35,8 +35,8 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int traceRateLimit, string url = DefaultAttackUrl)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
-            await TestRateLimiter(enableSecurity, url, agent, traceRateLimit, totalRequests, 1);
+            using var fixture = RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            await TestRateLimiter(fixture, enableSecurity, url, traceRateLimit, totalRequests, 1);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int traceRateLimit, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
             await TestRateLimiter(enableSecurity, url, agent, traceRateLimit, totalRequests, 1);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5 : AspNetCoreBase, IDisposable
     {
         public AspNetCore5(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestPathParamsEndpointRouting(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -28,11 +28,11 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestPathParamsEndpointRouting(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity);
+            using var fixture = RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
-            await TestAppSecRequestWithVerifyAsync(agent, url, null, 5, 1,  settings);
+            await TestAppSecRequestWithVerifyAsync(fixture, url, null, 5, 1,  settings);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
@@ -31,9 +31,9 @@ namespace Datadog.Trace.Security.IntegrationTests
         public async Task TestSecurityInitialization(bool enableSecurity, HttpStatusCode expectedStatusCode, string ruleset = null)
         {
             var url = "/Health/?[$slice]=value";
-            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
+            using var fixture = RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, (int)expectedStatusCode, ruleset);
-            await TestAppSecRequestWithVerifyAsync(agent, url, null, 1, 1, settings, testInit: true);
+            await TestAppSecRequestWithVerifyAsync(fixture, url, null, 1, 1, settings, testInit: true);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5AsmInitialization : AspNetBase, IDisposable
     {
         public AspNetCore5AsmInitialization(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         public async Task TestSecurityInitialization(bool enableSecurity, HttpStatusCode expectedStatusCode, string ruleset = null)
         {
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
+            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: ruleset);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, (int)expectedStatusCode, ruleset);
             await TestAppSecRequestWithVerifyAsync(agent, url, null, 1, 1, settings, testInit: true);
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -19,6 +19,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5ExternalRules : AspNetBase, IDisposable
     {
         public AspNetCore5ExternalRules(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -32,11 +32,11 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             var enableSecurity = true;
 
-            using var agent = await RunOnSelfHosted(enableSecurity, DefaultRuleFile);
+            using var fixture = RunOnSelfHosted(enableSecurity, DefaultRuleFile);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
-            await TestAppSecRequestWithVerifyAsync(agent, DefaultAttackUrl, null, 5, 1, settings);
+            await TestAppSecRequestWithVerifyAsync(fixture, DefaultAttackUrl, null, 5, 1, settings);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             var enableSecurity = true;
 
-            var agent = await RunOnSelfHosted(enableSecurity, DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity, DefaultRuleFile);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int? traceRateLimit, string url = DefaultAttackUrl)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
             await TestRateLimiter(enableSecurity, url, agent, traceRateLimit.GetValueOrDefault(100), totalRequests, 1);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -32,8 +32,8 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "ArmUnsupported")]
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int? traceRateLimit, string url = DefaultAttackUrl)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
-            await TestRateLimiter(enableSecurity, url, agent, traceRateLimit.GetValueOrDefault(100), totalRequests, 1);
+            using var fixture = RunOnSelfHosted(enableSecurity, traceRateLimit: traceRateLimit, externalRulesFile: DefaultRuleFile);
+            await TestRateLimiter(fixture, enableSecurity, url, traceRateLimit.GetValueOrDefault(100), totalRequests, 1);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5RateLimiter : AspNetBase, IDisposable
     {
         public AspNetCore5RateLimiter(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -28,12 +28,12 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestSecurity(HttpStatusCode expectedStatusCode, string url)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
+            using var fixture = RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings((int)expectedStatusCode, sanitisedUrl);
 
-            await TestAppSecRequestWithVerifyAsync(agent, url, null, 5, 1, settings);
+            await TestAppSecRequestWithVerifyAsync(fixture, url, null, 5, 1, settings);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestSecurity(HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity: true, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings((int)expectedStatusCode, sanitisedUrl);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -14,6 +14,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCoreBare : AspNetBase, IDisposable
     {
         public AspNetCoreBare(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            using var agent = RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBody(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url, string body)
         {
-            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            using var fixture = RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl, body);
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                 contentType = "application/json";
             }
 
-            await TestAppSecRequestWithVerifyAsync(agent, url, body, 5, 1, settings, contentType);
+            await TestAppSecRequestWithVerifyAsync(fixture, url, body, 5, 1, settings, contentType);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequest(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl);
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBody(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url, string body)
         {
-            var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
+            using var agent = await RunOnSelfHosted(enableSecurity, externalRulesFile: DefaultRuleFile);
 
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, enableSecurity, (int)expectedStatusCode, sanitisedUrl, body);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetFixture.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetFixture.cs
@@ -1,0 +1,70 @@
+// <copyright file="AspNetFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+
+namespace Datadog.Trace.Security.IntegrationTests
+{
+    public class AspNetFixture : MockAgentTestFixture, IDisposable
+    {
+        public AspNetFixture(AspNetBase test, MockTracerAgent agent, int httpPort, Process sample, string shutdownPath)
+            : base(test, agent, httpPort)
+        {
+            Sample = sample;
+            ShutdownPath = shutdownPath;
+        }
+
+        public string ShutdownPath { get; }
+
+        public Process Sample { get; }
+
+        public string SampleProcessName
+        {
+            get { return Sample?.ProcessName; }
+        }
+
+        public int? SampleProcessId
+        {
+            get { return Sample?.Id; }
+        }
+
+        public override void Dispose()
+        {
+            if (!string.IsNullOrEmpty(ShutdownPath))
+            {
+                var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
+                request.GetResponse().Close();
+            }
+
+            if (Sample is not null)
+            {
+                try
+                {
+                    if (!Sample.HasExited)
+                    {
+                        if (!Sample.WaitForExit(5000))
+                        {
+                            Sample.Kill();
+                        }
+                    }
+                }
+                catch
+                {
+                }
+
+                Sample.Dispose();
+            }
+
+            base.Dispose();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -68,7 +68,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetMvc5)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity;
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -88,7 +87,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl, body);
-            return TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, body, 5, 2, settings, "application/json");
+            return TestAppSecRequestWithVerifyAsync(_iisFixture, url, body, 5, 2, settings, "application/json");
         }
 
         [Trait("Category", "EndToEnd")]
@@ -101,7 +100,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var url = "/Health";
 
             var settings = VerifyHelper.GetSpanVerifierSettings(test);
-            await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
+            await TestAppSecRequestWithVerifyAsync(_iisFixture, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
         }
 
         protected override string GetTestName() => _testName;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -110,7 +110,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             }
 
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -122,7 +121,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         public async Task TestRateLimiterSecurity(int totalRequests, string url = DefaultAttackUrl)
         {
             // tracing module and mvc actions
-            await TestRateLimiter(_enableSecurity, url, _iisFixture.Agent, _traceRateLimit.GetValueOrDefault(100), totalRequests, 2);
+            await TestRateLimiter(_iisFixture, _enableSecurity, url, _traceRateLimit.GetValueOrDefault(100), totalRequests, 2);
             // have to wait a second for the rate limiter to reset (or restart iis express completely)
             Thread.Sleep(1000);
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -68,7 +68,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetWebApi)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity; // assume that arm is the same
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -86,7 +85,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl, body);
-            return TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, body, 5, 2, settings, "application/json");
+            return TestAppSecRequestWithVerifyAsync(_iisFixture, url, body, 5, 2, settings, "application/json");
         }
 
         [Trait("Category", "EndToEnd")]
@@ -99,7 +98,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var url = "/api/Health";
 
             var settings = VerifyHelper.GetSpanVerifierSettings(test);
-            await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, 1, settings, userAgent: "Hello/V");
+            await TestAppSecRequestWithVerifyAsync(_iisFixture, url, null, 5, 1, settings, userAgent: "Hello/V");
         }
 
         protected override string GetTestName() => _testName;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -70,7 +70,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetWebForms)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity;
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -88,7 +87,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedUrl, body);
-            return TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, body, 5, 1, settings, "application/x-www-form-urlencoded");
+            return TestAppSecRequestWithVerifyAsync(_iisFixture, url, body, 5, 1, settings, "application/x-www-form-urlencoded");
         }
 
         [Trait("Category", "EndToEnd")]
@@ -101,7 +100,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var url = "/Health";
 
             var settings = VerifyHelper.GetSpanVerifierSettings(test);
-            await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
+            await TestAppSecRequestWithVerifyAsync(_iisFixture, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
         }
 
         protected override string GetTestName() => _testName;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequestIp(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", LogDirectory);
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedRequestIpWithOneClickActivation(string test, bool enableSecurity, HttpStatusCode expectedStatusCode, string url)
         {
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -27,6 +27,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests.Rcm
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5AsmData : RcmBase
     {
         public AspNetCore5AsmData(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
@@ -32,19 +32,19 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestNewRemoteRules()
         {
             var url = "/Health/?[$slice]=value";
-            using var agent = await RunOnSelfHosted(true);
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", LogDirectory);
+            using var fixture = RunOnSelfHosted(true);
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{fixture.SampleProcessName}*", LogDirectory);
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
-            var spans1 = await SendRequestsAsync(agent, url);
+            var spans1 = await fixture.SendRequestsAsync(url);
 
-            await agent.SetupRcmAndWait(Output, new[] { (GetRules("2.22.222"), "1") }, "ASM_DD");
-            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
-            var spans2 = await SendRequestsAsync(agent, url);
+            await fixture.Agent.SetupRcmAndWait(Output, new[] { (GetRules("2.22.222"), "1") }, "ASM_DD");
+            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(fixture), LogEntryWatcherTimeout);
+            var spans2 = await fixture.SendRequestsAsync(url);
 
-            await agent.SetupRcmAndWait(Output, new[] { (GetRules("3.33.333"), "2") }, "ASM_DD");
-            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
-            var spans3 = await SendRequestsAsync(agent, url);
+            await fixture.Agent.SetupRcmAndWait(Output, new[] { (GetRules("3.33.333"), "2") }, "ASM_DD");
+            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(fixture), LogEntryWatcherTimeout);
+            var spans3 = await fixture.SendRequestsAsync(url);
 
             var spans = new List<MockSpan>();
             spans.AddRange(spans1);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestNewRemoteRules()
         {
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(true);
+            using var agent = await RunOnSelfHosted(true);
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", LogDirectory);
             var settings = VerifyHelper.GetSpanVerifierSettings();
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
@@ -20,6 +20,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests.Rcm
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5AsmRemoteRules : RcmBase
     {
         public AspNetCore5AsmRemoteRules(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -25,6 +25,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.Security.IntegrationTests.Rcm
 {
+    [Collection("AspNetCore Security Tests")]
     public class AspNetCore5AsmToggle : RcmBase
     {
         public AspNetCore5AsmToggle(ITestOutputHelper outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestSecurityToggling(bool? enableSecurity, uint expectedState, uint expectedCapabilities)
         {
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings(enableSecurity, expectedState, expectedCapabilities);
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{SampleProcessName}*", LogDirectory);
 
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         {
             var enableSecurity = true;
             var url = "/Health/?[$slice]=value";
-            var agent = await RunOnSelfHosted(enableSecurity);
+            using var agent = await RunOnSelfHosted(enableSecurity);
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
             var spans1 = await SendRequestsAsync(agent, url);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -26,11 +26,11 @@ public class RcmBase : AspNetBase
 
     protected string LogDirectory => Path.Combine(DatadogLogging.GetLogDirectory(), $"{GetTestName()}Logs");
 
-    protected string AppSecDisabledMessage() => $"AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+    protected string AppSecDisabledMessage(AspNetFixture fixture) => $"AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true  {{ MachineName: \".\", Process: \"[{fixture.SampleProcessId}";
 
-    protected string AppSecEnabledMessage() => $"AppSec is now Enabled, _settings.Enabled is true, coming from remote config: true  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+    protected string AppSecEnabledMessage(AspNetFixture fixture) => $"AppSec is now Enabled, _settings.Enabled is true, coming from remote config: true  {{ MachineName: \".\", Process: \"[{fixture.SampleProcessId}";
 
-    protected string RulesUpdatedMessage() => $"rules have been updated and waf status is \"DDWAF_OK\"  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+    protected string RulesUpdatedMessage(AspNetFixture fixture) => $"rules have been updated and waf status is \"DDWAF_OK\"  {{ MachineName: \".\", Process: \"[{fixture.SampleProcessId}";
 
-    protected string WafUpdateRule() => $"DDAS-0015-00: AppSec loaded 1 from file RemoteConfig.  {{ MachineName: \".\", Process: \"[{SampleProcessId}";
+    protected string WafUpdateRule(AspNetFixture fixture) => $"DDAS-0015-00: AppSec loaded 1 from file RemoteConfig.  {{ MachineName: \".\", Process: \"[{fixture.SampleProcessId}";
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -12,11 +12,6 @@ namespace Datadog.Trace.TestHelpers
 {
     public sealed class IisFixture : MockAgentTestFixture, IDisposable
     {
-        public IisFixture(TestHelper test)
-            : base(test)
-        {
-        }
-
         public (Process Process, string ConfigFile) IisExpress { get; private set; }
 
         public string ShutdownPath { get; set; }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -10,13 +10,14 @@ using System.Net;
 
 namespace Datadog.Trace.TestHelpers
 {
-    public sealed class IisFixture : GacFixture, IDisposable
+    public sealed class IisFixture : MockAgentTestFixture, IDisposable
     {
+        public IisFixture(TestHelper test)
+            : base(test)
+        {
+        }
+
         public (Process Process, string ConfigFile) IisExpress { get; private set; }
-
-        public MockTracerAgent Agent { get; private set; }
-
-        public int HttpPort { get; private set; }
 
         public string ShutdownPath { get; set; }
 
@@ -39,7 +40,7 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             if (IisExpress.Process != null && ShutdownPath != null)
             {
@@ -47,7 +48,7 @@ namespace Datadog.Trace.TestHelpers
                 request.GetResponse().Close();
             }
 
-            Agent?.Dispose();
+            base.Dispose();
 
             lock (this)
             {
@@ -85,6 +86,16 @@ namespace Datadog.Trace.TestHelpers
                     RemoveAssembliesFromGac();
                 }
             }
+        }
+
+        public void AddAssembliesToGac()
+        {
+            GacFixture.AddAssembliesToGac();
+        }
+
+        public void RemoveAssembliesFromGac()
+        {
+            GacFixture.RemoveAssembliesFromGac();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/MockAgentTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/MockAgentTestFixture.cs
@@ -16,19 +16,18 @@ namespace Datadog.Trace.TestHelpers
 {
     public class MockAgentTestFixture : IDisposable
     {
-        public MockAgentTestFixture(TestHelper test)
+        public MockAgentTestFixture()
         {
-            Test = test;
         }
 
         public MockAgentTestFixture(TestHelper test, MockTracerAgent agent, int httpPort)
-            : this(test)
         {
+            Test = test;
             Agent = agent;
             HttpPort = httpPort;
         }
 
-        public TestHelper Test { get; }
+        public TestHelper Test { get; set; }
 
         public MockTracerAgent Agent { get; set; }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/MockAgentTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/MockAgentTestFixture.cs
@@ -1,0 +1,107 @@
+// <copyright file="MockAgentTestFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class MockAgentTestFixture : IDisposable
+    {
+        public MockAgentTestFixture(TestHelper test)
+        {
+            Test = test;
+        }
+
+        public MockAgentTestFixture(TestHelper test, MockTracerAgent agent, int httpPort)
+            : this(test)
+        {
+            Agent = agent;
+            HttpPort = httpPort;
+        }
+
+        public TestHelper Test { get; }
+
+        public MockTracerAgent Agent { get; set; }
+
+        public int HttpPort { get; set; }
+
+        public HttpClient HttpClient { get; } = new();
+
+        public virtual void Dispose()
+        {
+            Agent.Dispose();
+            HttpClient.Dispose();
+        }
+
+        public async Task<(HttpStatusCode StatusCode, string ResponseText)> SubmitRequest(string path, string body, string contentType, string userAgent)
+        {
+            if (!string.IsNullOrEmpty(userAgent) && HttpClient.DefaultRequestHeaders.GetValues("user-agent").All(c => c != userAgent))
+            {
+                HttpClient.DefaultRequestHeaders.Add("user-agent", userAgent);
+            }
+
+            try
+            {
+                var url = $"http://localhost:{HttpPort}{path}";
+                var response =
+                    body == null ? await HttpClient.GetAsync(url) : await HttpClient.PostAsync(url, new StringContent(body, Encoding.UTF8, contentType ?? "application/json"));
+                var responseText = await response.Content.ReadAsStringAsync();
+                return (response.StatusCode, responseText);
+            }
+            catch (HttpRequestException ex)
+            {
+                return (HttpStatusCode.BadRequest, ex.ToString());
+            }
+        }
+
+        public async Task<IImmutableList<MockSpan>> SendRequestsAsync(string url, string body, int numberOfAttacks, int expectedSpans, string phase, string contentType = null, string userAgent = null)
+        {
+            var minDateTime = DateTime.UtcNow; // when ran sequentially, we get the spans from the previous tests!
+            await SendRequestsAsyncNoWaitForSpans(url, body, numberOfAttacks, contentType, userAgent);
+
+            return WaitForSpans(expectedSpans, phase, minDateTime, url);
+        }
+
+        public async Task<IImmutableList<MockSpan>> SendRequestsAsync(params string[] urls)
+        {
+            var spans = new List<MockSpan>();
+            foreach (var url in urls)
+            {
+                spans.AddRange(await SendRequestsAsync(url, null, 1, 1, string.Empty, null));
+            }
+
+            return spans.ToImmutableList();
+        }
+
+        public async Task SendRequestsAsyncNoWaitForSpans(string url, string body, int numberOfAttacks, string contentType = null, string userAgent = null)
+        {
+            for (var x = 0; x < numberOfAttacks; x++)
+            {
+                await SubmitRequest(url, body, contentType, userAgent);
+            }
+        }
+
+        public IImmutableList<MockSpan> WaitForSpans(int expectedSpans, string phase, DateTime minDateTime, string url)
+        {
+            Agent.SpanFilters.Clear();
+            Agent.SpanFilters.Add(s => s.Tags.ContainsKey("http.url") && s.Tags["http.url"].IndexOf(url, StringComparison.InvariantCultureIgnoreCase) > -1);
+
+            var spans = Agent.WaitForSpans(expectedSpans, minDateTime: minDateTime);
+            if (spans.Count != expectedSpans)
+            {
+                Test.Output?.WriteLine($"spans.Count: {spans.Count} != expectedSpans: {expectedSpans}, this is phase: {phase}");
+            }
+
+            return spans;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -61,11 +61,11 @@ namespace Datadog.Trace.TestHelpers
 
         public bool SecurityEnabled { get; private set; }
 
+        public ITestOutputHelper Output { get; }
+
         protected EnvironmentHelper EnvironmentHelper { get; }
 
         protected string TestPrefix => $"{EnvironmentTools.GetBuildConfiguration()}.{EnvironmentHelper.GetTargetFramework()}";
-
-        protected ITestOutputHelper Output { get; }
 
         public virtual void Dispose()
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/GacFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/GacFixture.cs
@@ -8,9 +8,9 @@ using System.IO;
 
 namespace Datadog.Trace.TestHelpers
 {
-    public class GacFixture
+    public static class GacFixture
     {
-        public void AddAssembliesToGac()
+        public static void AddAssembliesToGac()
         {
 #if NETFRAMEWORK
             var publish = new System.EnterpriseServices.Internal.Publish();
@@ -24,7 +24,7 @@ namespace Datadog.Trace.TestHelpers
 #endif
         }
 
-        public void RemoveAssembliesFromGac()
+        public static void RemoveAssembliesFromGac()
         {
 #if NETFRAMEWORK
             var publish = new System.EnterpriseServices.Internal.Publish();

--- a/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
@@ -73,5 +73,20 @@ namespace Datadog.Trace.TestHelpers
         {
             return $"{nameof(TraceId)}: {TraceId}, {nameof(SpanId)}: {SpanId}, {nameof(Name)}: {Name}, {nameof(Resource)}: {Resource}, {nameof(Service)}: {Service}";
         }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is MockSpan span)
+            {
+                return SpanId == span.SpanId;
+            }
+
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return SpanId.GetHashCode();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
@@ -73,20 +73,5 @@ namespace Datadog.Trace.TestHelpers
         {
             return $"{nameof(TraceId)}: {TraceId}, {nameof(SpanId)}: {SpanId}, {nameof(Name)}: {Name}, {nameof(Resource)}: {Resource}, {nameof(Service)}: {Service}";
         }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is MockSpan span)
-            {
-                return SpanId == span.SpanId;
-            }
-
-            return base.Equals(obj);
-        }
-
-        public override int GetHashCode()
-        {
-            return SpanId.GetHashCode();
-        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -13,6 +13,7 @@ using System.IO.Compression;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
@@ -926,6 +927,18 @@ namespace Datadog.Trace.TestHelpers
                 base.Dispose();
                 _listener?.Close();
                 _udpClient?.Close();
+            }
+
+            public void Warmup()
+            {
+                HttpClient httpClient = new HttpClient();
+                httpClient.DefaultRequestHeaders.Add("user-agent", "Warmup");
+                var url = $"http://localhost:{Port}/info";
+                for (int x = 0; x < 5; x++)
+                {
+                    var response = httpClient.GetStringAsync(url).Result;
+                    System.Threading.Thread.Sleep(100);
+                }
             }
 
             private void HandleHttpRequests()

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -929,18 +929,6 @@ namespace Datadog.Trace.TestHelpers
                 _udpClient?.Close();
             }
 
-            public void Warmup()
-            {
-                HttpClient httpClient = new HttpClient();
-                httpClient.DefaultRequestHeaders.Add("user-agent", "Warmup");
-                var url = $"http://localhost:{Port}/info";
-                for (int x = 0; x < 5; x++)
-                {
-                    var response = httpClient.GetStringAsync(url).Result;
-                    System.Threading.Thread.Sleep(100);
-                }
-            }
-
             private void HandleHttpRequests()
             {
                 while (_listener.IsListening)

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -190,7 +190,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
         private async Task<IisFixture> StartIis(IisAppType appType)
         {
-            var fixture = new IisFixture { ShutdownPath = "/shutdown" };
+            var fixture = new IisFixture(this) { ShutdownPath = "/shutdown" };
 
             try
             {

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/IisCheckTests.cs
@@ -190,7 +190,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
         private async Task<IisFixture> StartIis(IisAppType appType)
         {
-            var fixture = new IisFixture(this) { ShutdownPath = "/shutdown" };
+            var fixture = new IisFixture() { Test = this, ShutdownPath = "/shutdown" };
 
             try
             {


### PR DESCRIPTION
## Summary of changes
Added a warmup phase in the Tcp/Udp `MockTracerAgent` in order to prevent socket disposal errors

## Reason for change
Sometimes CI shows received duplicated spans when a socket error occurs while uploading traces to the mock agent.

## Implementation details
SocketDisposed errors usually occur in the first span transmission, specially in Alpine Net5. Introducing a harmless /info warmup round can help, making the error occur in this warmup phase more likely.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
