### PR TITLE
Native loader build

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -164,7 +164,6 @@ if (ISMACOS)
         coreclr
         fmt-lib
         spdlog-headers
-        managed-loader-objs
     )
 elseif(ISLINUX)
     target_link_libraries("Datadog.Trace.ClrProfiler.Native"
@@ -174,8 +173,7 @@ elseif(ISLINUX)
         coreclr
         fmt-lib
         spdlog-headers
-        managed-loader-objs
     )
 endif()
 
-add_dependencies("Datadog.Trace.ClrProfiler.Native" fmt-lib coreclr re2-lib spdlog-headers managed-loader-objs)
+add_dependencies("Datadog.Trace.ClrProfiler.Native" fmt-lib coreclr spdlog-headers)


### PR DESCRIPTION
## Summary of changes

Fix CodeQl jobs

## Reason for change

Recent change in the CMake architecture introduce a useless dependencies for the native loader. This prevent the native loader from compiling successfully.

## Implementation details

Remove useless dependency

## Test coverage

## Other details
<!-- Fixes #{issue} -->
