### PR TITLE
Exclude xml files from `dd-trace` tool and Datadog.Trace.Bundle

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1989,7 +1989,7 @@ stages:
           **/loader.conf
         path: $(monitoringHome)
 
-    - script: tracer\build.cmd CreateBundleHome BuildBundleNuget BuildRunnerTool BuildStandaloneTool
+    - script: tracer\build.cmd CreateBundleHome BuildBundleNuget BuildRunnerTool PackRunnerToolNuget BuildStandaloneTool
       displayName: Build Bundle NuGet and runner tools
 
     - publish: $(artifacts)/nuget/bundle

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -304,7 +304,10 @@ partial class Build : NukeBuild
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
                 .SetProperty("PackageOutputPath", ArtifactsDirectory / "nuget" / "dd-trace")
-                .SetProperty("BuildStandalone", "false"));
+                .SetProperty("BuildStandalone", "false")
+                .SetProperty("DebugSymbols", "False")
+                .SetProperty("DebugType", "None")
+                .SetProperty("GenerateDocumentationFile", "False"));
         });
 
     Target BuildStandaloneTool => _ => _
@@ -339,6 +342,7 @@ partial class Build : NukeBuild
                 .SetProperty("BuildStandalone", "true")
                 .SetProperty("DebugSymbols", "False")
                 .SetProperty("DebugType", "None")
+                .SetProperty("GenerateDocumentationFile", "False")
                 .CombineWith(runtimes, (c, runtime) => c
                                 .SetProperty("PublishDir", runtime.output)
                                 .SetRuntime(runtime.rid)));

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -298,8 +298,6 @@ partial class Build : NukeBuild
         {
             DotNetBuild(x => x
                 .SetProjectFile(Solution.GetProject(Projects.Tool))
-                .EnableNoRestore()
-                .EnableNoDependencies()
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
@@ -334,7 +332,7 @@ partial class Build : NukeBuild
                 .SetProject(Solution.GetProject(Projects.Tool))
                 // Have to do a restore currently as we're specifying specific runtime
                 // .EnableNoRestore()
-                .EnableNoDependencies()
+                // .EnableNoDependencies()
                 .SetFramework(TargetFramework.NETCOREAPP3_1)
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -27,6 +27,12 @@
   <ItemGroup>
     <Content Update="home\**\readme.txt" Pack="false">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+
+    <Content Update="home\**\*.xml">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -30,7 +30,7 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
 
-    <Content Update="home\**\*.xml">
+    <Content Update="home\**\*.xml" Pack="false">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -45,6 +45,13 @@
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
 
+        <!-- We actually WANT to include these, but single-file spits them out-->
+        <!-- next to the exe, instead of bundling them inside, so we can't -->
+        <Content Update="..\Datadog.Trace.Bundle\home\**\*.pdb">
+          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </Content>
+
         <Content Update="..\Datadog.Trace.Bundle\home\**\*.xml">
           <CopyToOutputDirectory>Never</CopyToOutputDirectory>
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -90,7 +90,7 @@
         <ToolCommandName>dd-trace</ToolCommandName>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <PackageId>dd-trace</PackageId>
         <OutputPath>bin\$(Configuration)\Tool</OutputPath>
       </PropertyGroup>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -47,6 +47,11 @@
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
 
+        <Content Update="..\Datadog.Trace.Bundle\home\**\*.xml">
+          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </Content>
+
         <!-- Remove the assets for other platforms than the one we're targetting (as they'll never be used anyway) -->
         <!-- Need to include the win-x86 and win-x64 assets in both versions -->
         <Content Condition="'$(RuntimeIdentifier)' != 'win-x86' AND '$(RuntimeIdentifier)' != 'win-x64'" Update="..\Datadog.Trace.Bundle\home\win-x86\*.*">
@@ -97,6 +102,10 @@
         </Content>
 
         <Content Update="..\Datadog.Trace.Bundle\home\**\readme.txt" Pack="false">
+          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+        </Content>
+
+        <Content Update="..\Datadog.Trace.Bundle\home\**\*.xml" Pack="false">
           <CopyToOutputDirectory>Never</CopyToOutputDirectory>
         </Content>
       </ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -13,6 +13,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>false</DebugSymbols>
     <DebugType>None</DebugType>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
     <ErrorOnDuplicatePublishOutputFiles>False</ErrorOnDuplicatePublishOutputFiles>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -41,11 +41,6 @@
           <CopyToOutputDirectory>Never</CopyToOutputDirectory>
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
-        
-        <Content Update="..\Datadog.Trace.Bundle\home\**\*.pdb">
-          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
-        </Content>
 
         <Content Update="..\Datadog.Trace.Bundle\home\**\*.xml">
           <CopyToOutputDirectory>Never</CopyToOutputDirectory>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -11,6 +11,8 @@
     <NoWarn>NU5100</NoWarn>
     <RootNamespace>Datadog.Trace.Tools.Runner</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
 
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
     <ErrorOnDuplicatePublishOutputFiles>False</ErrorOnDuplicatePublishOutputFiles>


### PR DESCRIPTION
## Summary of changes

- Remove the XML files from the `dd-trace` tool and Datadog.Trace.Bundle NuGet package home folder
- Add the pdb files to the `dd-trace` home folder (standalone tool mode)
- Remove the XML files from the `dd-trace` _bin_ folder
- Remove the pdb files from the `dd-trace` _bin_ folder

## Reason for change

Xml files are only useful for dev-time experience, but the files in the home folder don't take part in that. Datadog.Trace.Bundle references the Datadog.Trace NuGet which includes them instead.

However, we _do_ want the pdb files in the home folder. So added the ones that were missing.

The XML files and pdb files in the `dd-trace` bin folder aren't necessary.

## Implementation details

MSBuild faffing.

## Test coverage

Check the CI artifacts look correct:

- [x] xml files removed from bundle nuget
- [x] xml files removed from dd-trace nuget home
- [x] xml files removed from dd-trace standalone home
- [x] pdb files added to dd-trace nuget home
- [ ] pdb files added to dd-trace standalone home
- [x] xml files removed from dd-trace nuget bin
- [x] xml files  removed from dd-trace standalone bin
- [x] pdb files removed from dd-trace nuget bin
- [ ] pdb files removed from dd-trace standalone bin


## Other details
~The `dd-trace` tool doesn't currently include the pdbs... I think it should?~ confirmed and fixed
