### PR TITLE
Fix broken package version bump + add GitHub action

### DIFF
--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -23,6 +23,7 @@ jobs:
         run: .\tracer\build.ps1 GeneratePackageVersions
 
       - name: Report error
+        if: failure()
         run: |
           echo "## :warning: Error generating package versions" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -1,0 +1,34 @@
+name: Verify integrations map correctly added
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  bump_package_versions:
+    runs-on: windows-latest
+
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.100'
+
+      - name: "Regenerating package versions"
+        run: .\tracer\build.ps1 GeneratePackageVersions
+
+      - name: Report error
+        run: |
+          echo "## :warning: Error generating package versions" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "New integration detected. You must update the [IntegrationGroup.IntegrationMap](tracer/build/_build/Honeypot/IntegrationGroups.cs)" >> $GITHUB_STEP_SUMMARY
+          echo "class to include the new integration." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "If your new integration uses multi-api testing to test multiple package versions," >> $GITHUB_STEP_SUMMARY
+          echo "list the NuGet package in the associated array. Otherwise use an empty array." >> $GITHUB_STEP_SUMMARY
+

--- a/tracer/build/_build/Honeypot/IntegrationGroups.cs
+++ b/tracer/build/_build/Honeypot/IntegrationGroups.cs
@@ -24,6 +24,7 @@ namespace Honeypot
             NugetPackages.Add("System.Messaging", new string[] { });
             NugetPackages.Add("System", new string[] { });
             NugetPackages.Add("System.Diagnostics.Process", new string[] { });
+            NugetPackages.Add("System.Security.Cryptography.Primitives", new string[] { });
 
             NugetPackages.Add("Oracle.DataAccess", new string[] { });
 


### PR DESCRIPTION
## Summary of changes

- #3225 broke the test version bump action
- Added a GitHub action that runs on PRs to ensure this doesn't happen again.

## Reason for change

This is the second time we've broken the auto-version-bump PR by not updating `IntegrationMap` in recent times, so added a GitHub action to fix it.

## Implementation details

The GitHub action runs the same code as the "real" bump action, it just doesn't create a PR.

## Test coverage

You can't test an action until it's merged to master, so YOLO (but I think this should work).

## Other details
Will mark it required after merging
