### PR TITLE
Add support for nested and generic arguments to Lambda handlers

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1317,6 +1317,8 @@ stages:
           serverless-lambda-nested-class-param \
           serverless-lambda-nested-struct-param \
           serverless-lambda-generic-dict-param \
+          serverless-lambda-nested-generic-dict-param \
+          serverless-lambda-doubly-nested-generic-dict-param \
           serverless-lambda-throwing \
           serverless-lambda-throwing-async \
           serverless-lambda-throwing-async-task \

--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -24,6 +24,8 @@ services:
     - serverless-lambda-nested-class-param
     - serverless-lambda-nested-struct-param
     - serverless-lambda-generic-dict-param
+    - serverless-lambda-nested-generic-dict-param
+    - serverless-lambda-doubly-nested-generic-dict-param
     - serverless-lambda-throwing
     - serverless-lambda-throwing-async
     - serverless-lambda-throwing-async-task
@@ -53,6 +55,8 @@ services:
     - AWS_LAMBDA_ENDPOINT_NESTED_CLASS_PARAM=http://serverless-lambda-nested-class-param:8080
     - AWS_LAMBDA_ENDPOINT_NESTED_STRUCT_PARAM=http://serverless-lambda-nested-struct-param:8080
     - AWS_LAMBDA_ENDPOINT_GENERIC_DICT_PARAM=http://serverless-lambda-generic-dict-param:8080
+    - AWS_LAMBDA_ENDPOINT_NESTED_GENERIC_DICT_PARAM=http://serverless-lambda-nested-generic-dict-param:8080
+    - AWS_LAMBDA_ENDPOINT_DOUBLY_NESTED_GENERIC_DICT_PARAM=http://serverless-lambda-doubly-nested-generic-dict-param:8080
     - AWS_LAMBDA_ENDPOINT_THROWING=http://serverless-lambda-throwing:8080
     - AWS_LAMBDA_ENDPOINT_THROWING_ASYNC=http://serverless-lambda-throwing-async:8080
     - AWS_LAMBDA_ENDPOINT_THROWING_ASYNC_TASK=http://serverless-lambda-throwing-async-task:8080
@@ -85,6 +89,8 @@ services:
     - serverless-lambda-nested-class-param
     - serverless-lambda-nested-struct-param
     - serverless-lambda-generic-dict-param
+    - serverless-lambda-nested-generic-dict-param
+    - serverless-lambda-doubly-nested-generic-dict-param
     - serverless-lambda-throwing
     - serverless-lambda-throwing-async
     - serverless-lambda-throwing-async-task
@@ -116,6 +122,8 @@ services:
       serverless-lambda-nested-class-param:8080
       serverless-lambda-nested-struct-param:8080
       serverless-lambda-generic-dict-param:8080
+      serverless-lambda-nested-generic-dict-param:8080
+      serverless-lambda-doubly-nested-generic-dict-param:8080
       serverless-lambda-throwing:8080
       serverless-lambda-throwing-async:8080
       serverless-lambda-throwing-async-task:8080
@@ -543,6 +551,46 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs/serverless-lambda-generic-dict-param:/var/log/datadog/dotnet
+
+  serverless-lambda-nested-generic-dict-param:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-dummy-api
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNestedGenericDictionaryParam"
+    image: dd-trace-dotnet/serverless-lambda-nested-generic-dict-param
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
+    - DUMMY_API_HOST=http://serverless-dummy-api:9005
+    - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs/serverless-lambda-nested-generic-dict-param:/var/log/datadog/dotnet
+
+  serverless-lambda-doubly-nested-generic-dict-param:
+    build:
+      context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
+      dockerfile: serverless.lambda.dockerfile
+    depends_on:
+    - serverless-dummy-api
+    command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerDoublyNestedGenericDictionaryParam"
+    image: dd-trace-dotnet/serverless-lambda-doubly-nested-generic-dict-param
+    environment:
+    - DD_TRACE_AGENT_URL=http://integrationtests:5002
+    - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
+    - DUMMY_API_HOST=http://serverless-dummy-api:9005
+    - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
+    ports:
+    - "8080"
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs/serverless-lambda-doubly-nested-generic-dict-param:/var/log/datadog/dotnet
 
   serverless-lambda-throwing:
     build:

--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -137,11 +137,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-no-param-sync:/var/log/datadog/dotnet
 
   serverless-lambda-one-param-sync:
     build:
@@ -156,11 +157,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-one-param-sync:/var/log/datadog/dotnet
 
   serverless-lambda-two-params-sync:
     build:
@@ -175,11 +177,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-two-params-sync:/var/log/datadog/dotnet
 
   serverless-lambda-no-param-sync-with-context:
     build:
@@ -194,11 +197,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-no-param-sync-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-one-param-sync-with-context:
     build:
@@ -213,11 +217,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-one-param-sync-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-two-params-sync-with-context:
     build:
@@ -232,11 +237,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-two-params-sync-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-no-param-async:
     build:
@@ -251,11 +257,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-no-param-async:/var/log/datadog/dotnet
 
   serverless-lambda-one-param-async:
     build:
@@ -270,11 +277,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-one-param-async:/var/log/datadog/dotnet
 
   serverless-lambda-two-params-async:
     build:
@@ -289,11 +297,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-two-params-async:/var/log/datadog/dotnet
 
   serverless-lambda-no-param-void:
     build:
@@ -308,11 +317,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-no-param-void:/var/log/datadog/dotnet
 
   serverless-lambda-one-param-void:
     build:
@@ -327,11 +337,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-one-param-void:/var/log/datadog/dotnet
 
   serverless-lambda-two-params-void:
     build:
@@ -346,11 +357,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-two-params-void:/var/log/datadog/dotnet
   
   serverless-lambda-base-no-param-sync:
     build:
@@ -365,11 +377,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-base-no-param-sync:/var/log/datadog/dotnet
 
   serverless-lambda-base-two-params-sync:
     build:
@@ -384,11 +397,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-base-two-params-sync:/var/log/datadog/dotnet
 
   serverless-lambda-base-one-param-sync-with-context:
     build:
@@ -403,11 +417,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-base-one-param-sync-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-base-one-param-async:
     build:
@@ -422,11 +437,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-base-one-param-async:/var/log/datadog/dotnet
 
   serverless-lambda-base-two-params-void:
     build:
@@ -441,11 +457,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-base-two-params-void:/var/log/datadog/dotnet
 
   serverless-lambda-struct-param:
     build:
@@ -460,11 +477,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-struct-param:/var/log/datadog/dotnet
 
   serverless-lambda-nested-class-param:
     build:
@@ -479,11 +497,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-nested-class-param:/var/log/datadog/dotnet
 
   serverless-lambda-nested-struct-param:
     build:
@@ -498,11 +517,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-nested-struct-param:/var/log/datadog/dotnet
 
   serverless-lambda-generic-dict-param:
     build:
@@ -517,11 +537,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-generic-dict-param:/var/log/datadog/dotnet
 
   serverless-lambda-throwing:
     build:
@@ -536,11 +557,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing:/var/log/datadog/dotnet
 
   serverless-lambda-throwing-async:
     build:
@@ -555,11 +577,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing-async:/var/log/datadog/dotnet
 
   serverless-lambda-throwing-async-task:
     build:
@@ -574,11 +597,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9003
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing-async-task:/var/log/datadog/dotnet
 
   serverless-lambda-throwing-with-context:
     build:
@@ -593,11 +617,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-throwing-async-with-context:
     build:
@@ -612,11 +637,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing-async-with-context:/var/log/datadog/dotnet
 
   serverless-lambda-throwing-async-task-with-context:
     build:
@@ -631,11 +657,12 @@ services:
     - _DD_EXTENSION_ENDPOINT=http://integrationtests:9004
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+    - DD_TRACE_DEBUG=1
     ports:
     - "8080"
     volumes:
     - ./:/project
-    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/logs/serverless-lambda-throwing-async-task-with-context:/var/log/datadog/dotnet
 
   # The serverless function calls this API, which always returns 200 OK
   serverless-dummy-api:

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 var requests = 9 // param tests
                                   + 3 // param with context
                                   + 5 // base instrumentation
-                                  + 4 // other parameter types
+                                  + 6 // other parameter types
                                   + 3 // throwing (manual only)
                                   + 3; // throwing with context
 

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -185,7 +185,6 @@
     Name: lambda.invocation,
     Resource: /lambda/end-invocation,
     Service: LambdaExtension,
-    Error: 1,
     Tags: {
       _sampling_priority_v1: 1.0
     }
@@ -196,7 +195,6 @@
     Name: lambda.invocation,
     Resource: /lambda/end-invocation,
     Service: LambdaExtension,
-    Error: 1,
     Tags: {
       _sampling_priority_v1: 1.0
     }
@@ -207,7 +205,6 @@
     Name: lambda.invocation,
     Resource: /lambda/end-invocation,
     Service: LambdaExtension,
-    Error: 1,
     Tags: {
       _sampling_priority_v1: 1.0
     }
@@ -218,7 +215,6 @@
     Name: lambda.invocation,
     Resource: /lambda/end-invocation,
     Service: LambdaExtension,
-    Error: 1,
     Tags: {
       _sampling_priority_v1: 1.0
     }
@@ -229,7 +225,6 @@
     Name: lambda.invocation,
     Resource: /lambda/end-invocation,
     Service: LambdaExtension,
-    Error: 1,
     Tags: {
       _sampling_priority_v1: 1.0
     }
@@ -246,8 +241,63 @@
     }
   },
   {
+    TraceId: Id_49,
+    SpanId: Id_50,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Error: 1,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
+    SpanId: Id_52,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Error: 1,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_53,
+    SpanId: Id_54,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Error: 1,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_55,
+    SpanId: Id_56,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Error: 1,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_58,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Error: 1,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
     TraceId: Id_1,
-    SpanId: Id_49,
+    SpanId: Id_59,
     Name: manual.HandlerNoParamSync,
     Resource: manual.HandlerNoParamSync,
     Service: Bootstrap,
@@ -266,7 +316,7 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_50,
+    SpanId: Id_60,
     Name: manual.HandlerOneParamSync,
     Resource: manual.HandlerOneParamSync,
     Service: Bootstrap,
@@ -285,7 +335,7 @@
   },
   {
     TraceId: Id_5,
-    SpanId: Id_51,
+    SpanId: Id_61,
     Name: manual.HandlerTwoParamsSync,
     Resource: manual.HandlerTwoParamsSync,
     Service: Bootstrap,
@@ -304,7 +354,7 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_52,
+    SpanId: Id_62,
     Name: manual.HandlerNoParamAsync,
     Resource: manual.HandlerNoParamAsync,
     Service: Bootstrap,
@@ -323,7 +373,7 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_53,
+    SpanId: Id_63,
     Name: manual.HandlerOneParamAsync,
     Resource: manual.HandlerOneParamAsync,
     Service: Bootstrap,
@@ -342,7 +392,7 @@
   },
   {
     TraceId: Id_11,
-    SpanId: Id_54,
+    SpanId: Id_64,
     Name: manual.HandlerTwoParamsAsync,
     Resource: manual.HandlerTwoParamsAsync,
     Service: Bootstrap,
@@ -361,7 +411,7 @@
   },
   {
     TraceId: Id_13,
-    SpanId: Id_55,
+    SpanId: Id_65,
     Name: manual.HandlerNoParamVoid,
     Resource: manual.HandlerNoParamVoid,
     Service: Bootstrap,
@@ -380,7 +430,7 @@
   },
   {
     TraceId: Id_15,
-    SpanId: Id_56,
+    SpanId: Id_66,
     Name: manual.HandlerOneParamVoid,
     Resource: manual.HandlerOneParamVoid,
     Service: Bootstrap,
@@ -399,7 +449,7 @@
   },
   {
     TraceId: Id_17,
-    SpanId: Id_57,
+    SpanId: Id_67,
     Name: manual.HandlerTwoParamsVoid,
     Resource: manual.HandlerTwoParamsVoid,
     Service: Bootstrap,
@@ -418,7 +468,7 @@
   },
   {
     TraceId: Id_19,
-    SpanId: Id_58,
+    SpanId: Id_68,
     Name: manual.HandlerNoParamSyncWithContext,
     Resource: manual.HandlerNoParamSyncWithContext,
     Service: Bootstrap,
@@ -436,7 +486,7 @@
   },
   {
     TraceId: Id_21,
-    SpanId: Id_59,
+    SpanId: Id_69,
     Name: manual.HandlerOneParamSyncWithContext,
     Resource: manual.HandlerOneParamSyncWithContext,
     Service: Bootstrap,
@@ -454,7 +504,7 @@
   },
   {
     TraceId: Id_23,
-    SpanId: Id_60,
+    SpanId: Id_70,
     Name: manual.HandlerTwoParamsSyncWithContext,
     Resource: manual.HandlerTwoParamsSyncWithContext,
     Service: Bootstrap,
@@ -472,7 +522,7 @@
   },
   {
     TraceId: Id_25,
-    SpanId: Id_61,
+    SpanId: Id_71,
     Name: manual.BaseHandlerNoParamSync,
     Resource: manual.BaseHandlerNoParamSync,
     Service: Bootstrap,
@@ -491,7 +541,7 @@
   },
   {
     TraceId: Id_27,
-    SpanId: Id_62,
+    SpanId: Id_72,
     Name: manual.BaseHandlerTwoParamsSync,
     Resource: manual.BaseHandlerTwoParamsSync,
     Service: Bootstrap,
@@ -510,7 +560,7 @@
   },
   {
     TraceId: Id_29,
-    SpanId: Id_63,
+    SpanId: Id_73,
     Name: manual.BaseHandlerOneParamSyncWithContext,
     Resource: manual.BaseHandlerOneParamSyncWithContext,
     Service: Bootstrap,
@@ -528,7 +578,7 @@
   },
   {
     TraceId: Id_31,
-    SpanId: Id_64,
+    SpanId: Id_74,
     Name: manual.BaseHandlerOneParamAsync,
     Resource: manual.BaseHandlerOneParamAsync,
     Service: Bootstrap,
@@ -547,7 +597,7 @@
   },
   {
     TraceId: Id_33,
-    SpanId: Id_65,
+    SpanId: Id_75,
     Name: manual.BaseHandlerTwoParamsVoid,
     Resource: manual.BaseHandlerTwoParamsVoid,
     Service: Bootstrap,
@@ -566,7 +616,7 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_66,
+    SpanId: Id_76,
     Name: manual.HandlerStructParam,
     Resource: manual.HandlerStructParam,
     Service: Bootstrap,
@@ -585,9 +635,9 @@
   },
   {
     TraceId: Id_37,
-    SpanId: Id_67,
-    Name: manual.ThrowingHandler,
-    Resource: manual.ThrowingHandler,
+    SpanId: Id_77,
+    Name: manual.HandlerNestedClassParam,
+    Resource: manual.HandlerNestedClassParam,
     Service: Bootstrap,
     ParentId: Id_38,
     Tags: {
@@ -604,9 +654,9 @@
   },
   {
     TraceId: Id_39,
-    SpanId: Id_68,
-    Name: manual.ThrowingHandlerAsync,
-    Resource: manual.ThrowingHandlerAsync,
+    SpanId: Id_78,
+    Name: manual.HandlerNestedStructParam,
+    Resource: manual.HandlerNestedStructParam,
     Service: Bootstrap,
     ParentId: Id_40,
     Tags: {
@@ -623,9 +673,9 @@
   },
   {
     TraceId: Id_41,
-    SpanId: Id_69,
-    Name: manual.ThrowingHandlerAsyncTask,
-    Resource: manual.ThrowingHandlerAsyncTask,
+    SpanId: Id_79,
+    Name: manual.HandlerGenericDictionaryParam,
+    Resource: manual.HandlerGenericDictionaryParam,
     Service: Bootstrap,
     ParentId: Id_42,
     Tags: {
@@ -642,14 +692,15 @@
   },
   {
     TraceId: Id_43,
-    SpanId: Id_70,
-    Name: manual.ThrowingHandler,
-    Resource: manual.ThrowingHandler,
+    SpanId: Id_80,
+    Name: manual.HandlerNestedGenericDictionaryParam,
+    Resource: manual.HandlerNestedGenericDictionaryParam,
     Service: Bootstrap,
     ParentId: Id_44,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_22
+      runtime-id: Guid_22,
+      _dd.p.dm: -0
     },
     Metrics: {
       process_id: 0,
@@ -660,14 +711,15 @@
   },
   {
     TraceId: Id_45,
-    SpanId: Id_71,
-    Name: manual.ThrowingHandlerAsync,
-    Resource: manual.ThrowingHandlerAsync,
+    SpanId: Id_81,
+    Name: manual.HandlerDoublyNestedGenericDictionaryParam,
+    Resource: manual.HandlerDoublyNestedGenericDictionaryParam,
     Service: Bootstrap,
     ParentId: Id_46,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_23
+      runtime-id: Guid_23,
+      _dd.p.dm: -0
     },
     Metrics: {
       process_id: 0,
@@ -678,14 +730,107 @@
   },
   {
     TraceId: Id_47,
-    SpanId: Id_72,
-    Name: manual.ThrowingHandlerAsyncTask,
-    Resource: manual.ThrowingHandlerAsyncTask,
+    SpanId: Id_82,
+    Name: manual.ThrowingHandler,
+    Resource: manual.ThrowingHandler,
     Service: Bootstrap,
     ParentId: Id_48,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_24
+      runtime-id: Guid_24,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_49,
+    SpanId: Id_83,
+    Name: manual.ThrowingHandlerAsync,
+    Resource: manual.ThrowingHandlerAsync,
+    Service: Bootstrap,
+    ParentId: Id_50,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_25,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_51,
+    SpanId: Id_84,
+    Name: manual.ThrowingHandlerAsyncTask,
+    Resource: manual.ThrowingHandlerAsyncTask,
+    Service: Bootstrap,
+    ParentId: Id_52,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_26,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_53,
+    SpanId: Id_85,
+    Name: manual.ThrowingHandler,
+    Resource: manual.ThrowingHandler,
+    Service: Bootstrap,
+    ParentId: Id_54,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_27
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_55,
+    SpanId: Id_86,
+    Name: manual.ThrowingHandlerAsync,
+    Resource: manual.ThrowingHandlerAsync,
+    Service: Bootstrap,
+    ParentId: Id_56,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_28
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_87,
+    Name: manual.ThrowingHandlerAsyncTask,
+    Resource: manual.ThrowingHandlerAsyncTask,
+    Service: Bootstrap,
+    ParentId: Id_58,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_29
     },
     Metrics: {
       process_id: 0,
@@ -696,12 +841,12 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_73,
+    SpanId: Id_88,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_49,
+    ParentId: Id_59,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -716,12 +861,12 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_74,
+    SpanId: Id_89,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_50,
+    ParentId: Id_60,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -736,12 +881,12 @@
   },
   {
     TraceId: Id_5,
-    SpanId: Id_75,
+    SpanId: Id_90,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_51,
+    ParentId: Id_61,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -756,12 +901,12 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_76,
+    SpanId: Id_91,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_52,
+    ParentId: Id_62,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -776,12 +921,12 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_77,
+    SpanId: Id_92,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_53,
+    ParentId: Id_63,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -796,12 +941,12 @@
   },
   {
     TraceId: Id_11,
-    SpanId: Id_78,
+    SpanId: Id_93,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_54,
+    ParentId: Id_64,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -816,12 +961,12 @@
   },
   {
     TraceId: Id_13,
-    SpanId: Id_79,
+    SpanId: Id_94,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamVoid,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_55,
+    ParentId: Id_65,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -836,12 +981,12 @@
   },
   {
     TraceId: Id_15,
-    SpanId: Id_80,
+    SpanId: Id_95,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamVoid,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_56,
+    ParentId: Id_66,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -856,12 +1001,12 @@
   },
   {
     TraceId: Id_17,
-    SpanId: Id_81,
+    SpanId: Id_96,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsVoid,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_57,
+    ParentId: Id_67,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -876,12 +1021,12 @@
   },
   {
     TraceId: Id_19,
-    SpanId: Id_82,
+    SpanId: Id_97,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_58,
+    ParentId: Id_68,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -896,12 +1041,12 @@
   },
   {
     TraceId: Id_21,
-    SpanId: Id_83,
+    SpanId: Id_98,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_59,
+    ParentId: Id_69,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -916,12 +1061,12 @@
   },
   {
     TraceId: Id_23,
-    SpanId: Id_84,
+    SpanId: Id_99,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_60,
+    ParentId: Id_70,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -936,12 +1081,12 @@
   },
   {
     TraceId: Id_25,
-    SpanId: Id_85,
+    SpanId: Id_100,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerNoParamSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_61,
+    ParentId: Id_71,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -956,12 +1101,12 @@
   },
   {
     TraceId: Id_27,
-    SpanId: Id_86,
+    SpanId: Id_101,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsSync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_62,
+    ParentId: Id_72,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -976,12 +1121,12 @@
   },
   {
     TraceId: Id_29,
-    SpanId: Id_87,
+    SpanId: Id_102,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamSyncWithContext,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_63,
+    ParentId: Id_73,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -996,12 +1141,12 @@
   },
   {
     TraceId: Id_31,
-    SpanId: Id_88,
+    SpanId: Id_103,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_64,
+    ParentId: Id_74,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1016,12 +1161,12 @@
   },
   {
     TraceId: Id_33,
-    SpanId: Id_89,
+    SpanId: Id_104,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsVoid,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_65,
+    ParentId: Id_75,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1036,12 +1181,12 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_90,
+    SpanId: Id_105,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerStructParam,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_66,
+    ParentId: Id_76,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1056,24 +1201,17 @@
   },
   {
     TraceId: Id_37,
-    SpanId: Id_91,
+    SpanId: Id_106,
     Name: http.request,
-    Resource: GET localhost/function/ThrowingHandler,
+    Resource: GET serverless-dummy-api:9005/function/HandlerNestedClassParam,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_67,
-    Error: 1,
+    ParentId: Id_77,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
-      error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/ThrowingHandler,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/HandlerNestedClassParam,
       runtime-id: Guid_19,
       span.kind: client
     },
@@ -1083,24 +1221,17 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
   },
   {
     TraceId: Id_39,
-    SpanId: Id_92,
+    SpanId: Id_107,
     Name: http.request,
-    Resource: GET localhost/function/ThrowingHandlerAsync,
+    Resource: GET serverless-dummy-api:9005/function/HandlerNestedStructParam,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_68,
-    Error: 1,
+    ParentId: Id_78,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
-      error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/ThrowingHandlerAsync,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/HandlerNestedStructParam,
       runtime-id: Guid_20,
       span.kind: client
     },
@@ -1110,24 +1241,17 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
   },
   {
     TraceId: Id_41,
-    SpanId: Id_93,
+    SpanId: Id_108,
     Name: http.request,
-    Resource: GET localhost/function/ThrowingHandlerAsyncTask,
+    Resource: GET serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_69,
-    Error: 1,
+    ParentId: Id_79,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
-      error.type: System.Net.WebException,
       http.method: GET,
-      http.url: http://localhost/function/ThrowingHandlerAsyncTask,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
       runtime-id: Guid_21,
       span.kind: client
     },
@@ -1137,12 +1261,52 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
   },
   {
     TraceId: Id_43,
-    SpanId: Id_94,
+    SpanId: Id_109,
+    Name: http.request,
+    Resource: GET serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_80,
+    Tags: {
+      component: WebRequest,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
+      runtime-id: Guid_22,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_110,
+    Name: http.request,
+    Resource: GET serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_81,
+    Tags: {
+      component: WebRequest,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
+      runtime-id: Guid_23,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_47,
+    SpanId: Id_111,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandler,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_70,
+    ParentId: Id_82,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1155,7 +1319,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandler,
-      runtime-id: Guid_22,
+      runtime-id: Guid_24,
       span.kind: client
     },
     Metrics: {
@@ -1163,13 +1327,13 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_45,
-    SpanId: Id_95,
+    TraceId: Id_49,
+    SpanId: Id_112,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_71,
+    ParentId: Id_83,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1182,7 +1346,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsync,
-      runtime-id: Guid_23,
+      runtime-id: Guid_25,
       span.kind: client
     },
     Metrics: {
@@ -1190,13 +1354,13 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_47,
-    SpanId: Id_96,
+    TraceId: Id_51,
+    SpanId: Id_113,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsyncTask,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_72,
+    ParentId: Id_84,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1209,84 +1373,6 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
-      runtime-id: Guid_24,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_97,
-    SpanId: Id_98,
-    Name: manual.HandlerGenericDictionaryParam,
-    Resource: manual.HandlerGenericDictionaryParam,
-    Service: Bootstrap,
-    Tags: {
-      language: dotnet,
-      runtime-id: Guid_25,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_97,
-    SpanId: Id_99,
-    Name: http.request,
-    Resource: GET serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
-    Service: Bootstrap-http-client,
-    Type: http,
-    ParentId: Id_98,
-    Tags: {
-      component: WebRequest,
-      http.method: GET,
-      http.status_code: 200,
-      http.url: http://serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
-      runtime-id: Guid_25,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_100,
-    SpanId: Id_101,
-    Name: manual.HandlerNestedClassParam,
-    Resource: manual.HandlerNestedClassParam,
-    Service: Bootstrap,
-    Tags: {
-      language: dotnet,
-      runtime-id: Guid_26,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_100,
-    SpanId: Id_102,
-    Name: http.request,
-    Resource: GET serverless-dummy-api:9005/function/HandlerNestedClassParam,
-    Service: Bootstrap-http-client,
-    Type: http,
-    ParentId: Id_101,
-    Tags: {
-      component: WebRequest,
-      http.method: GET,
-      http.status_code: 200,
-      http.url: http://serverless-dummy-api:9005/function/HandlerNestedClassParam,
       runtime-id: Guid_26,
       span.kind: client
     },
@@ -1295,38 +1381,80 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     }
   },
   {
-    TraceId: Id_103,
-    SpanId: Id_104,
-    Name: manual.HandlerNestedStructParam,
-    Resource: manual.HandlerNestedStructParam,
-    Service: Bootstrap,
+    TraceId: Id_53,
+    SpanId: Id_114,
+    Name: http.request,
+    Resource: GET localhost/function/ThrowingHandler,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_85,
+    Error: 1,
     Tags: {
-      language: dotnet,
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/ThrowingHandler,
       runtime-id: Guid_27,
-      _dd.p.dm: -0
+      span.kind: client
     },
     Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_103,
-    SpanId: Id_105,
+    TraceId: Id_55,
+    SpanId: Id_115,
     Name: http.request,
-    Resource: GET serverless-dummy-api:9005/function/HandlerNestedStructParam,
+    Resource: GET localhost/function/ThrowingHandlerAsync,
     Service: Bootstrap-http-client,
     Type: http,
-    ParentId: Id_104,
+    ParentId: Id_86,
+    Error: 1,
     Tags: {
       component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
       http.method: GET,
-      http.status_code: 200,
-      http.url: http://serverless-dummy-api:9005/function/HandlerNestedStructParam,
-      runtime-id: Guid_27,
+      http.url: http://localhost/function/ThrowingHandlerAsync,
+      runtime-id: Guid_28,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_116,
+    Name: http.request,
+    Resource: GET localhost/function/ThrowingHandlerAsyncTask,
+    Service: Bootstrap-http-client,
+    Type: http,
+    ParentId: Id_87,
+    Error: 1,
+    Tags: {
+      component: WebRequest,
+      error.msg: Cannot assign requested address Cannot assign requested address,
+      error.stack:
+System.Net.WebException: Cannot assign requested address Cannot assign requested address
+---> System.Net.Http.HttpRequestException: Cannot assign requested address
+---> System.Net.Sockets.SocketException (99): Cannot assign requested address
+at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.type: System.Net.WebException,
+      http.method: GET,
+      http.url: http://localhost/function/ThrowingHandlerAsyncTask,
+      runtime-id: Guid_29,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Program.cs
@@ -75,6 +75,10 @@ namespace Samples.AWS.Lambda
             await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_NESTED_STRUCT_PARAM"));
             Thread.Sleep(1000);
             await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_GENERIC_DICT_PARAM"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_NESTED_GENERIC_DICT_PARAM"));
+            Thread.Sleep(1000);
+            await Post(Environment.GetEnvironmentVariable("AWS_LAMBDA_ENDPOINT_DOUBLY_NESTED_GENERIC_DICT_PARAM"));
 
             // Throwing handlers
             Thread.Sleep(1000);
@@ -212,18 +216,36 @@ namespace Samples.AWS.Lambda
         {
             HandleRequest();
         }
+
+        public void HandlerNestedGenericDictionaryParam(NestedGeneric<string, string> request, ILambdaContext context)
+        {
+            HandleRequest();
+        }
+        
+        public void HandlerDoublyNestedGenericDictionaryParam(NestedClass.InnerGeneric<string, NestedClass.InnerGeneric<string, Dictionary<string,string>>> request)
+        {
+            HandleRequest();
+        }
         #endregion
 
         public class NestedClass
         {
             public string Field1 { get; set; }
             public int Field2 { get; set; }
+            
+            public class InnerGeneric<TKey, TValue> : Dictionary<TKey, TValue>
+            {
+            }
         }
 
         public struct NestedStruct
         {
             public string Field1 { get; set; }
             public int Field2 { get; set; }
+        }
+
+        public class NestedGeneric<TKey, TValue> : Dictionary<TKey, TValue>
+        {
         }
     }
 


### PR DESCRIPTION
## Summary of changes

Adds support for handler arguments that are nested types `Handler(Outer.Inner arg)` or generic `Handler(Dictionary<string, string> arg)`.

## Reason for change

We want to support these types of arguments. Previously, Lambda handlers using arguments like the above would not be instrumented correctly, leading to disconnected traces (Note how there's no "parent" lambda span for these examples. There should be 3 spans in each trace, but there's only 2:

![image](https://user-images.githubusercontent.com/18755388/196417357-7e526c9d-e10f-4a7c-8e1b-beb1ac54cf4f.png)
![image](https://user-images.githubusercontent.com/18755388/196417424-bb1d022c-c938-495d-a5f6-a59c870bc20d.png)

## Implementation details

The problem was that `LambdaHandler` previously always called `type.FullName` to get the argument name to instrument, but that's not always the format the native tracer expects:

Handle nested and generic types correctly using new `GetTypeFullName` function, using these rules:

```csharp
// - Standard types: Name including namespace (i.e. ToString() OR FullName, both are the same)
GetTypeFullName(typeof(string)) => "System.String";
// - Nested types: Name must _not_ include qualifying prefix (namespace or parent type)
GetTypeFullName(typeof(Outer.Inner)) => "Inner";
// - Generic types: Name including namespace (ToString() ONLY - FullName incorrectly includes assembly reference)
GetTypeFullName(typeof(Dictionary<string, string>)) => "System.Collections.Generic.Dictionary`2[System.String,System.String]";
// - Generic args: each argument must follow the above rules recursively
GetTypeFullName(typeof(Outer.NestedGeneric<string, Dictionary<string, string)) => "NestedGeneric`2[System.String,System.Collections.Generic.Dictionary`2[System.String,System.String]]";
```

Unfortunately, I couldn't find any properties on methods to get the last format directly, so requires somewhat hacky manual parsing, but it works, and is only called once, so it's probably good enough.

## Test coverage

Unit tests for the parsing, and integration tests for the following cases:

- [x] Generic dictionary parameter
- [x] Nested class parameter
- [x] Nested struct parameter
- [x] Nested generic class parameter
- [x] Nested generic class of a nested generic class of a generic dictionary parameter(!)

These all work as expected, giving three traces each in the snapshots:
![image](https://user-images.githubusercontent.com/18755388/196645997-dad0c343-d05a-469b-bc51-cf6c5cd38dbb.png)

## Other details

Also made it easier to view the logs from each separate handler instance - previously they were all trying to write to the same file (as they have the same process id), now they get separate files, which makes debugging much easier
