### PR TITLE
Increase allowed variation in `SpanSamplerTests` to fix flake

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
@@ -225,7 +225,7 @@ namespace Datadog.Trace.Tests.Sampling
             var rules = new List<SpanSamplingRule>() { allowHalfRule };
             var sampler = new SpanSampler(rules);
 
-            RunSamplerTest(sampler, 500, expectedAutoKeepRate: 0.5f, expectedUserKeepRate: 0.5f, acceptableVariancePercent: 0.1f);
+            RunSamplerTest(sampler, 500, expectedAutoKeepRate: 0.5f, expectedUserKeepRate: 0.5f, acceptableVariancePercent: 0.2f);
         }
 
         /// <summary>
@@ -252,21 +252,15 @@ namespace Datadog.Trace.Tests.Sampling
                 }
             }
 
-            // AUTO_KEEP
+                        // AUTO_KEEP
             var autoKeepRate = numberOfAutoKeep / (float)iterations;
-            var autoKeepRateLowerLimit = expectedAutoKeepRate * (1 - acceptableVariancePercent);
-            var autoKeepRateUpperLimit = expectedAutoKeepRate * (1 + acceptableVariancePercent);
-
-            var autoKeepRateWithinLimits = autoKeepRate >= autoKeepRateLowerLimit && autoKeepRate <= autoKeepRateUpperLimit;
-            autoKeepRateWithinLimits.Should().BeTrue($"Sampling AUTO_KEEP rate expected between {autoKeepRateLowerLimit} and {autoKeepRateUpperLimit}, actual rate is {autoKeepRate}.");
+            var autoKeepPrecision = expectedAutoKeepRate * acceptableVariancePercent;
+            autoKeepRate.Should().BeApproximately(expectedAutoKeepRate, autoKeepPrecision, $"Sampling AUTO_KEEP rate should be approximately expected value.");
 
             // USER_KEEP (aka MANUAL_KEEP)
             var userKeepRate = numberOfUserKeep / (float)iterations;
-            var userKeepRateLowerLimit = expectedUserKeepRate * (1 - acceptableVariancePercent);
-            var userKeepRateUpperLimit = expectedUserKeepRate * (1 + acceptableVariancePercent);
-
-            var userKeepRateWithinLimits = userKeepRate >= userKeepRateLowerLimit && userKeepRate <= userKeepRateUpperLimit;
-            userKeepRateWithinLimits.Should().BeTrue($"Sampling USER_KEEP rate expected between {userKeepRateLowerLimit} and {userKeepRateUpperLimit}, actual rate is {userKeepRate}.");
+            var userKeepPrecision = expectedUserKeepRate * acceptableVariancePercent;
+            userKeepRate.Should().BeApproximately(expectedUserKeepRate, userKeepPrecision, $"Sampling USER_KEEP rate should be approximately expected value.");
         }
 
         private Span GetSpan(ulong traceId)


### PR DESCRIPTION
## Summary of changes

- `SpanSamplerTests.Allow_Half_SamplingRate` is flaky. Bump allowed expected values
- Switch to built-in FluentValidation `BeApproximately()` for simplicity

## Reason for change

`SpanSamplerTests.Allow_Half_SamplingRate` is currently flaky. Expected value is 0.45-0.55, but it often falls just outside this, 0.446, or 0.565. This is blocking PRs

## Implementation details

Bump allowed values to 0.40-0.60. 

