### PR TITLE
Run serverless tests on .NET 5.0 and .NET 6.0

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1231,8 +1231,18 @@ stages:
       TestAllPackageVersions: false
       IncludeMinorPackageVersions:  false
       baseImage: "centos7"
-      publishTargetFramework: "netcoreapp3.1"
 
+    strategy:
+      matrix:
+        netcoreapp3_1:
+          publishTargetFramework: "netcoreapp3.1"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:core3.1"
+        net5:
+          publishTargetFramework: "net5.0"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:5.0"
+        net6:
+          publishTargetFramework: "net6.0"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:6"
     pool:
       name: azure-linux-scale-set
 
@@ -1270,6 +1280,7 @@ stages:
         docker-compose -p ddtrace_$(Build.BuildNumber) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
+          --build-arg framework=$(publishTargetFramework) \
           pull --include-deps StartDependencies.Serverless
 
         docker-compose -p ddtrace_$(Build.BuildNumber) \
@@ -1279,6 +1290,7 @@ stages:
       env:
         baseImage: $(baseImage)
         framework: $(publishTargetFramework)
+        lambdaBaseImage: $(lambdaBaseImage)
       displayName: docker-compose build IntegrationTests.Serverless and run StartDependencies.Serverless
       retryCountOnTaskFailure: 5
 
@@ -1289,6 +1301,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
+          lambdaBaseImage=$(lambdaBaseImage)
         dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) IntegrationTests.Serverless
         additionalDockerComposeFiles: |
           docker-compose.serverless.yml

--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -149,6 +149,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -172,6 +173,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -195,6 +197,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -218,6 +221,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -241,6 +245,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -264,6 +269,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -287,6 +293,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -310,6 +317,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -333,6 +341,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -356,6 +365,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -379,6 +389,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -402,6 +413,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -425,6 +437,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -448,6 +461,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -471,6 +485,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -494,6 +509,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -517,6 +533,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -540,6 +557,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -563,6 +581,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -586,6 +605,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -609,6 +629,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -632,6 +653,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -655,6 +677,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -678,6 +701,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -701,6 +725,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -724,6 +749,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -747,6 +773,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -770,6 +797,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:
@@ -793,6 +821,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_SERVICE=Samples.Aws.Lambda
     ports:
     - "8080"
     volumes:

--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -136,6 +136,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamSync"
@@ -156,6 +159,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamSync"
@@ -176,6 +182,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsSync"
@@ -196,6 +205,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamSyncWithContext"
@@ -216,6 +228,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamSyncWithContext"
@@ -236,6 +251,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsSyncWithContext"
@@ -256,6 +274,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamAsync"
@@ -276,6 +297,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamAsync"
@@ -296,6 +320,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsAsync"
@@ -316,6 +343,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamVoid"
@@ -336,6 +366,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamVoid"
@@ -356,6 +389,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsVoid"
@@ -376,6 +412,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerNoParamSync"
@@ -396,6 +435,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerTwoParamsSync"
@@ -416,6 +458,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerOneParamSyncWithContext"
@@ -436,6 +481,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerOneParamAsync"
@@ -456,6 +504,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::BaseHandlerTwoParamsVoid"
@@ -476,6 +527,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerStructParam"
@@ -496,6 +550,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNestedClassParam"
@@ -516,6 +573,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNestedStructParam"
@@ -536,6 +596,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerGenericDictionaryParam"
@@ -556,6 +619,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNestedGenericDictionaryParam"
@@ -576,6 +642,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerDoublyNestedGenericDictionaryParam"
@@ -596,6 +665,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandler"
@@ -616,6 +688,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandlerAsync"
@@ -636,6 +711,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandlerAsyncTask"
@@ -656,6 +734,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandler"
@@ -676,6 +757,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandlerAsync"
@@ -696,6 +780,9 @@ services:
     build:
       context: ./tracer/test/test-applications/integrations/Samples.AWS.Lambda
       dockerfile: serverless.lambda.dockerfile
+      args:
+        - lambdaBaseImage=${lambdaBaseImage:-public.ecr.aws/lambda/dotnet:core3.1}
+        - framework=${framework:-netcoreapp3.1}
     depends_on:
     - serverless-dummy-api
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::ThrowingHandlerAsyncTask"

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1272,7 +1272,7 @@ partial class Build
                         "Samples.Security.AspNetCoreBare" => Framework == TargetFramework.NET6_0 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NETCOREAPP3_0,
                         "Samples.GraphQL4" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NET6_0,
                         "Samples.HotChocolate" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NET6_0,
-                        "Samples.AWS.Lambda" => Framework == TargetFramework.NETCOREAPP3_1,
+                        "Samples.AWS.Lambda" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NET6_0,
                         var name when projectsToSkip.Contains(name) => false,
                         var name when multiPackageProjects.Contains(name) => false,
                         "Samples.Probes" => true,

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
@@ -139,7 +140,8 @@ namespace Datadog.Trace.Configuration
 
             var urlSubstringSkips = source?.GetString(ConfigurationKeys.HttpClientExcludedUrlSubstrings) ??
                                     // default value
-                                    (AzureAppServices.Metadata.IsRelevant ? AzureAppServices.Metadata.DefaultHttpClientExclusions : null);
+                                    (AzureAppServices.Metadata.IsRelevant ? AzureAppServices.Metadata.DefaultHttpClientExclusions :
+                                     Serverless.Metadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : null);
 
             if (urlSubstringSkips != null)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -7,12 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
-using Newtonsoft.Json;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,8 +21,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 {
     [UsesVerify]
     [Trait("RequiresDockerDependency", "true")]
-    public class AwsLambdaTests : TestHelper, IDisposable
+    public class AwsLambdaTests : TestHelper
     {
+        private static readonly Regex StackRegex = new(@"(      error.stack:)(?:\n|\r){1,2}(?:[^,]*(?:\n|\r){1,2})+.*(,(?:\r|\n){1,2})");
+        private static readonly Regex ErrorMsgRegex = new(@"(      error.msg:).*(,(\r|\n){1,2})");
+
         public AwsLambdaTests(ITestOutputHelper output)
             : base("AWS.Lambda", output)
         {
@@ -79,6 +82,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                               .ToList();
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
+
+                // We get different stack traces from the exception in each framework, so scrub them to all look the same
+                settings.AddRegexScrubber(StackRegex, "$1 Cannot assign requested address (SocketException)$2");
+                settings.AddRegexScrubber(ErrorMsgRegex, "$1 Cannot assign requested address$2");
+
                 await VerifyHelper.VerifySpans(allSpans, settings)
                                   .UseFileName(nameof(AwsLambdaTests));
             }

--- a/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
@@ -22,9 +22,9 @@ namespace Datadog.Trace.Tests
             var originalValue = Environment.GetEnvironmentVariable(FunctionNameEnvVar);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, string.Empty);
             string path = Directory.GetCurrentDirectory() + "/invalid";
-            var res = Serverless.IsRunningInLambda(path);
+            var res = Serverless.LambdaMetadata.Create(path);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, originalValue);
-            res.Should().Be(false);
+            res.IsRunningInLambda.Should().BeFalse();
         }
 
         [Fact]
@@ -33,9 +33,9 @@ namespace Datadog.Trace.Tests
             var originalValue = Environment.GetEnvironmentVariable(FunctionNameEnvVar);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, "my-test-function");
             string path = Directory.GetCurrentDirectory() + "/invalid";
-            var res = Serverless.IsRunningInLambda(path);
+            var res = Serverless.LambdaMetadata.Create(path);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, originalValue);
-            res.Should().Be(false);
+            res.IsRunningInLambda.Should().BeFalse();
         }
 
         [Fact]
@@ -45,9 +45,9 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, string.Empty);
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
-            var res = Serverless.IsRunningInLambda(existingFile);
+            var res = Serverless.LambdaMetadata.Create(existingFile);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, originalValue);
-            res.Should().Be(false);
+            res.IsRunningInLambda.Should().BeFalse();
         }
 
         [Fact]
@@ -57,9 +57,10 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, "my-test-function");
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
-            var res = Serverless.IsRunningInLambda(existingFile);
+            var res = Serverless.LambdaMetadata.Create(existingFile);
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, originalValue);
-            res.Should().Be(true);
+            res.IsRunningInLambda.Should().BeTrue();
+            res.FunctionName.Should().Be("my-test-function");
         }
 
         [Fact]

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -1310,12 +1310,8 @@
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandler,
@@ -1337,12 +1333,8 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsync,
@@ -1364,12 +1356,8 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
@@ -1391,12 +1379,8 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandler,
@@ -1418,12 +1402,8 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsync,
@@ -1445,12 +1425,8 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     Error: 1,
     Tags: {
       component: WebRequest,
-      error.msg: Cannot assign requested address Cannot assign requested address,
-      error.stack:
-System.Net.WebException: Cannot assign requested address Cannot assign requested address
----> System.Net.Http.HttpRequestException: Cannot assign requested address
----> System.Net.Sockets.SocketException (99): Cannot assign requested address
-at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken),
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -300,7 +300,7 @@
     SpanId: Id_59,
     Name: manual.HandlerNoParamSync,
     Resource: manual.HandlerNoParamSync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_2,
     Tags: {
       language: dotnet,
@@ -319,7 +319,7 @@
     SpanId: Id_60,
     Name: manual.HandlerOneParamSync,
     Resource: manual.HandlerOneParamSync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_4,
     Tags: {
       language: dotnet,
@@ -338,7 +338,7 @@
     SpanId: Id_61,
     Name: manual.HandlerTwoParamsSync,
     Resource: manual.HandlerTwoParamsSync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_6,
     Tags: {
       language: dotnet,
@@ -357,7 +357,7 @@
     SpanId: Id_62,
     Name: manual.HandlerNoParamAsync,
     Resource: manual.HandlerNoParamAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_8,
     Tags: {
       language: dotnet,
@@ -376,7 +376,7 @@
     SpanId: Id_63,
     Name: manual.HandlerOneParamAsync,
     Resource: manual.HandlerOneParamAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_10,
     Tags: {
       language: dotnet,
@@ -395,7 +395,7 @@
     SpanId: Id_64,
     Name: manual.HandlerTwoParamsAsync,
     Resource: manual.HandlerTwoParamsAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_12,
     Tags: {
       language: dotnet,
@@ -414,7 +414,7 @@
     SpanId: Id_65,
     Name: manual.HandlerNoParamVoid,
     Resource: manual.HandlerNoParamVoid,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_14,
     Tags: {
       language: dotnet,
@@ -433,7 +433,7 @@
     SpanId: Id_66,
     Name: manual.HandlerOneParamVoid,
     Resource: manual.HandlerOneParamVoid,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_16,
     Tags: {
       language: dotnet,
@@ -452,7 +452,7 @@
     SpanId: Id_67,
     Name: manual.HandlerTwoParamsVoid,
     Resource: manual.HandlerTwoParamsVoid,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_18,
     Tags: {
       language: dotnet,
@@ -471,7 +471,7 @@
     SpanId: Id_68,
     Name: manual.HandlerNoParamSyncWithContext,
     Resource: manual.HandlerNoParamSyncWithContext,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_20,
     Tags: {
       language: dotnet,
@@ -489,7 +489,7 @@
     SpanId: Id_69,
     Name: manual.HandlerOneParamSyncWithContext,
     Resource: manual.HandlerOneParamSyncWithContext,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_22,
     Tags: {
       language: dotnet,
@@ -507,7 +507,7 @@
     SpanId: Id_70,
     Name: manual.HandlerTwoParamsSyncWithContext,
     Resource: manual.HandlerTwoParamsSyncWithContext,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_24,
     Tags: {
       language: dotnet,
@@ -525,7 +525,7 @@
     SpanId: Id_71,
     Name: manual.BaseHandlerNoParamSync,
     Resource: manual.BaseHandlerNoParamSync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_26,
     Tags: {
       language: dotnet,
@@ -544,7 +544,7 @@
     SpanId: Id_72,
     Name: manual.BaseHandlerTwoParamsSync,
     Resource: manual.BaseHandlerTwoParamsSync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_28,
     Tags: {
       language: dotnet,
@@ -563,7 +563,7 @@
     SpanId: Id_73,
     Name: manual.BaseHandlerOneParamSyncWithContext,
     Resource: manual.BaseHandlerOneParamSyncWithContext,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_30,
     Tags: {
       language: dotnet,
@@ -581,7 +581,7 @@
     SpanId: Id_74,
     Name: manual.BaseHandlerOneParamAsync,
     Resource: manual.BaseHandlerOneParamAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_32,
     Tags: {
       language: dotnet,
@@ -600,7 +600,7 @@
     SpanId: Id_75,
     Name: manual.BaseHandlerTwoParamsVoid,
     Resource: manual.BaseHandlerTwoParamsVoid,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_34,
     Tags: {
       language: dotnet,
@@ -619,7 +619,7 @@
     SpanId: Id_76,
     Name: manual.HandlerStructParam,
     Resource: manual.HandlerStructParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_36,
     Tags: {
       language: dotnet,
@@ -638,7 +638,7 @@
     SpanId: Id_77,
     Name: manual.HandlerNestedClassParam,
     Resource: manual.HandlerNestedClassParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_38,
     Tags: {
       language: dotnet,
@@ -657,7 +657,7 @@
     SpanId: Id_78,
     Name: manual.HandlerNestedStructParam,
     Resource: manual.HandlerNestedStructParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_40,
     Tags: {
       language: dotnet,
@@ -676,7 +676,7 @@
     SpanId: Id_79,
     Name: manual.HandlerGenericDictionaryParam,
     Resource: manual.HandlerGenericDictionaryParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_42,
     Tags: {
       language: dotnet,
@@ -695,7 +695,7 @@
     SpanId: Id_80,
     Name: manual.HandlerNestedGenericDictionaryParam,
     Resource: manual.HandlerNestedGenericDictionaryParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_44,
     Tags: {
       language: dotnet,
@@ -714,7 +714,7 @@
     SpanId: Id_81,
     Name: manual.HandlerDoublyNestedGenericDictionaryParam,
     Resource: manual.HandlerDoublyNestedGenericDictionaryParam,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_46,
     Tags: {
       language: dotnet,
@@ -733,7 +733,7 @@
     SpanId: Id_82,
     Name: manual.ThrowingHandler,
     Resource: manual.ThrowingHandler,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_48,
     Tags: {
       language: dotnet,
@@ -752,7 +752,7 @@
     SpanId: Id_83,
     Name: manual.ThrowingHandlerAsync,
     Resource: manual.ThrowingHandlerAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_50,
     Tags: {
       language: dotnet,
@@ -771,7 +771,7 @@
     SpanId: Id_84,
     Name: manual.ThrowingHandlerAsyncTask,
     Resource: manual.ThrowingHandlerAsyncTask,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_52,
     Tags: {
       language: dotnet,
@@ -790,7 +790,7 @@
     SpanId: Id_85,
     Name: manual.ThrowingHandler,
     Resource: manual.ThrowingHandler,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_54,
     Tags: {
       language: dotnet,
@@ -808,7 +808,7 @@
     SpanId: Id_86,
     Name: manual.ThrowingHandlerAsync,
     Resource: manual.ThrowingHandlerAsync,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_56,
     Tags: {
       language: dotnet,
@@ -826,7 +826,7 @@
     SpanId: Id_87,
     Name: manual.ThrowingHandlerAsyncTask,
     Resource: manual.ThrowingHandlerAsyncTask,
-    Service: Bootstrap,
+    Service: Samples.Aws.Lambda,
     ParentId: Id_58,
     Tags: {
       language: dotnet,
@@ -844,7 +844,7 @@
     SpanId: Id_88,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_59,
     Tags: {
@@ -864,7 +864,7 @@
     SpanId: Id_89,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_60,
     Tags: {
@@ -884,7 +884,7 @@
     SpanId: Id_90,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_61,
     Tags: {
@@ -904,7 +904,7 @@
     SpanId: Id_91,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_62,
     Tags: {
@@ -924,7 +924,7 @@
     SpanId: Id_92,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_63,
     Tags: {
@@ -944,7 +944,7 @@
     SpanId: Id_93,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_64,
     Tags: {
@@ -964,7 +964,7 @@
     SpanId: Id_94,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamVoid,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_65,
     Tags: {
@@ -984,7 +984,7 @@
     SpanId: Id_95,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamVoid,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_66,
     Tags: {
@@ -1004,7 +1004,7 @@
     SpanId: Id_96,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsVoid,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_67,
     Tags: {
@@ -1024,7 +1024,7 @@
     SpanId: Id_97,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSyncWithContext,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_68,
     Tags: {
@@ -1044,7 +1044,7 @@
     SpanId: Id_98,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSyncWithContext,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_69,
     Tags: {
@@ -1064,7 +1064,7 @@
     SpanId: Id_99,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSyncWithContext,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_70,
     Tags: {
@@ -1084,7 +1084,7 @@
     SpanId: Id_100,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerNoParamSync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_71,
     Tags: {
@@ -1104,7 +1104,7 @@
     SpanId: Id_101,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsSync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_72,
     Tags: {
@@ -1124,7 +1124,7 @@
     SpanId: Id_102,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamSyncWithContext,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_73,
     Tags: {
@@ -1144,7 +1144,7 @@
     SpanId: Id_103,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_74,
     Tags: {
@@ -1164,7 +1164,7 @@
     SpanId: Id_104,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsVoid,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_75,
     Tags: {
@@ -1184,7 +1184,7 @@
     SpanId: Id_105,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerStructParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_76,
     Tags: {
@@ -1204,7 +1204,7 @@
     SpanId: Id_106,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedClassParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_77,
     Tags: {
@@ -1224,7 +1224,7 @@
     SpanId: Id_107,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedStructParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_78,
     Tags: {
@@ -1244,7 +1244,7 @@
     SpanId: Id_108,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_79,
     Tags: {
@@ -1264,7 +1264,7 @@
     SpanId: Id_109,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_80,
     Tags: {
@@ -1284,7 +1284,7 @@
     SpanId: Id_110,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_81,
     Tags: {
@@ -1304,7 +1304,7 @@
     SpanId: Id_111,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandler,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_82,
     Error: 1,
@@ -1331,7 +1331,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     SpanId: Id_112,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_83,
     Error: 1,
@@ -1358,7 +1358,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     SpanId: Id_113,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsyncTask,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_84,
     Error: 1,
@@ -1385,7 +1385,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     SpanId: Id_114,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandler,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_85,
     Error: 1,
@@ -1412,7 +1412,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     SpanId: Id_115,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsync,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_86,
     Error: 1,
@@ -1439,7 +1439,7 @@ at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, Cancellat
     SpanId: Id_116,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsyncTask,
-    Service: Bootstrap-http-client,
+    Service: Samples.Aws.Lambda-http-client,
     Type: http,
     ParentId: Id_87,
     Error: 1,

--- a/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Samples.AWS.Lambda.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Lambda/Samples.AWS.Lambda.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
     <RequiresDockerDependency>true</RequiresDockerDependency>

--- a/tracer/test/test-applications/integrations/Samples.AWS.Lambda/serverless.lambda.dockerfile
+++ b/tracer/test/test-applications/integrations/Samples.AWS.Lambda/serverless.lambda.dockerfile
@@ -1,4 +1,5 @@
-FROM public.ecr.aws/lambda/dotnet:core3.1
+ARG lambdaBaseImage
+FROM $lambdaBaseImage
 
 # Create log path
 RUN mkdir -p /var/log/datadog/dotnet && \
@@ -7,10 +8,12 @@ RUN mkdir -p /var/log/datadog/dotnet && \
 # Add Tracer
 COPY ./bin/artifacts/monitoring-home /opt/datadog
 
+ARG framework
+
 # Add Tests
-COPY ./bin/Release/netcoreapp3.1/*.dll /var/task/
-COPY ./bin/Release/netcoreapp3.1/*.deps.json /var/task/
-COPY ./bin/Release/netcoreapp3.1/*.runtimeconfig.json /var/task/
+COPY ./bin/Release/$framework/*.dll /var/task/
+COPY ./bin/Release/$framework/*.deps.json /var/task/
+COPY ./bin/Release/$framework/*.runtimeconfig.json /var/task/
 
 ENV DD_LOG_LEVEL="DEBUG"
 ENV DD_TRACE_ENABLED=true


### PR DESCRIPTION
## Summary of changes

- Generalise the serverless tests for multiple frameworks
- Fix support for .NET 5 and .NET 6

## Reason for change

We support these frameworks, so we should probably test them, especially as we may need to add .NET 6 specific features (top-level functions).

In the course of this testing, discovered that we are generating spans from the _lambda runtime_ itself, as this uses HttpClient, so we want to exclude those.

<details><summary>If you're interested, the extra http-client requests we generate in the extension look like this</summary><code><pre>
  {
    TraceId: Id_173,
    SpanId: Id_174,
    Name: http.request,
    Resource: GET localhost:00000/?/runtime/invocation/next,
    Service: Amazon.Lambda.RuntimeSupport-http-client,
    Type: http,
    Tags: {
      component: HttpMessageHandler,
      http-client-handler-type: System.Net.Http.HttpClientHandler,
      http.method: GET,
      http.status_code: 200,
      http.url: http://localhost:00000/2018-06-01/runtime/invocation/next,
      runtime-id: Guid_29,
      span.kind: client,
      _dd.p.dm: -0
    },
    Metrics: {
      process_id: 0,
      _dd.agent_psr: 1.0,
      _dd.top_level: 1.0,
      _dd.tracer_kr: 1.0,
      _sampling_priority_v1: 1.0
    }
  },
  {
    TraceId: Id_183,
    SpanId: Id_184,
    Name: http.request,
    Resource: POST localhost:00000/?/runtime/invocation/?/error,
    Service: Amazon.Lambda.RuntimeSupport-http-client,
    Type: http,
    Tags: {
      component: HttpMessageHandler,
      http-client-handler-type: System.Net.Http.HttpClientHandler,
      http.method: POST,
      http.status_code: 202,
      http.url: http://localhost:00000/2018-06-01/runtime/invocation/Guid_34/error,
      runtime-id: Guid_28,
      span.kind: client,
      _dd.p.dm: -0
    },
    Metrics: {
      process_id: 0,
      _dd.agent_psr: 1.0,
      _dd.top_level: 1.0,
      _dd.tracer_kr: 1.0,
      _sampling_priority_v1: 1.0
    }
  },
  {
    TraceId: Id_185,
    SpanId: Id_186,
    Name: http.request,
    Resource: POST localhost:00000/?/runtime/invocation/?/response,
    Service: Amazon.Lambda.RuntimeSupport-http-client,
    Type: http,
    Tags: {
      component: HttpMessageHandler,
      http-client-handler-type: System.Net.Http.HttpClientHandler,
      http.method: POST,
      http.status_code: 202,
      http.url: http://localhost:00000/2018-06-01/runtime/invocation/Guid_35/response,
      runtime-id: Guid_1,
      span.kind: client,
      _dd.p.dm: -0
    },
    Metrics: {
      process_id: 0,
      _dd.agent_psr: 1.0,
      _dd.top_level: 1.0,
      _dd.tracer_kr: 1.0,
      _sampling_priority_v1: 1.0
    }
  },
</pre></code></details>


## Implementation details

Generalise the lambda docker files and build process to use a matrix.

Exclude the lambda endpoints from the list of traced http requests. 

## Test coverage

Yep

## Other details
Based on #3367, so need to merge that one first.

Also, I noticed that the default service name used in .NET Core 3.1 and .NET 5/6 changes, so I'm normalizing that by setting `DD_SERVICE` for now, but we should address the default value used here in a later PR, once we've confirmed this is relevant (i.e. it was mentioned the Lambda extension ignores this, so will consider that)

