### PR TITLE
Close the logger on exit

### DIFF
--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -129,6 +129,8 @@ namespace Datadog.Trace
                 {
                     SetSynchronizationContext(current);
                 }
+
+                DatadogLogging.CloseAndFlush();
             }
 
             static void SetSynchronizationContext(SynchronizationContext context)

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -125,6 +125,11 @@ namespace Datadog.Trace.Logging
             return GetLoggerFor(typeof(T));
         }
 
+        internal static void CloseAndFlush()
+        {
+            Log.CloseAndFlush();
+        }
+
         internal static void Reset()
         {
             LoggingLevelSwitch.MinimumLevel = DefaultLogLevel;


### PR DESCRIPTION
## Summary of changes

Make sure to close the logger when the appdomain unloads.

## Reason for change

Serilog doesn't automatically flush the logger on exit. Because of that, the underlying FileStream might be flushed during finalization, which would cause a crash if an I/O error happens at that moment.

## Implementation details

## Test coverage

"Testing the logger stuff is a nightmare"  Andrew Lock, 2022
