### PR TITLE
Adding Tags Data to Span Started Logs

### DIFF
--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -38,10 +38,15 @@ namespace Datadog.Trace
             Context = context;
             StartTime = start ?? Context.TraceContext.UtcNow;
 
-            Log.Debug(
-                "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
-                new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
-        }
+            if (IsLogLevelDebugEnabled)
+            {
+                var tagsType = Tags.GetType();
+
+                Log.Debug(
+                    "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type:[{tagsType}])",
+                    new object[] { SpanId, Context.ParentId, TraceId, Tags, tagsType });
+            }
+         }
 
         /// <summary>
         /// Gets or sets operation name
@@ -352,10 +357,8 @@ namespace Datadog.Trace
                 if (IsLogLevelDebugEnabled)
                 {
                     Log.Debug(
-                        "Span closed: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
-                        SpanId,
-                        Context.ParentId,
-                        TraceId);
+                        "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
+                        new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace
                 var tagsType = Tags.GetType();
 
                 Log.Debug(
-                    "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type:[{tagsType}])",
+                    "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type: [{tagsType}])",
                     new object[] { SpanId, Context.ParentId, TraceId, Tags, tagsType });
             }
          }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -39,10 +39,8 @@ namespace Datadog.Trace
             StartTime = start ?? Context.TraceContext.UtcNow;
 
             Log.Debug(
-                "Span started: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
-                SpanId,
-                Context.ParentId,
-                TraceId);
+                "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
+                new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -352,8 +352,10 @@ namespace Datadog.Trace
                 if (IsLogLevelDebugEnabled)
                 {
                     Log.Debug(
-                        "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
-                        new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
+                        "Span closed: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
+                        SpanId,
+                        Context.ParentId,
+                        TraceId);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -357,7 +357,7 @@ namespace Datadog.Trace
                 if (IsLogLevelDebugEnabled)
                 {
                     Log.Debug(
-                        "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
+                        "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
                         new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
                 }
             }


### PR DESCRIPTION
## Summary of changes
Added the Span Tags and Tags type details as part of the startup logs so we can have an idea of the span type when it gets started.
## Reason for change
This way we'll have a way to try identifying spans that for some reason may not be getting closed, previously the started span log only included the span related ids.
## Implementation details
Added the log into an `if` statement to log only if Debug mode is enable, similar to what is done for span closed logs.
## Test coverage
I built the MSI for the tracer and was then able to see the new log files, example log after:
```
2022-10-20 13:33:27.422 -04:00 [DBG] Span started: [s_id: 6309444753191957727, p_id: null, t_id: 1350847350902100029] 
with Tags: [component (tag):aspnet_core,span.kind (tag):server,], Tags Type:[Datadog.Trace.Tagging.AspNetCoreEndpointTags]) 
{ MachineName: ".", Process: "[23020 sample-web-app]", AppDomain: "[1 sample-web-app]",
AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.18.0.0" }
```
