### PR TITLE
Move `SpanSampler` into `AgentWriter.WriteTrace`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -41,6 +42,8 @@ namespace Datadog.Trace.Agent
 
         private readonly IStatsAggregator _statsAggregator;
 
+        private readonly ISpanSampler _spanSampler;
+
         /// <summary>
         /// The currently active buffer.
         /// Note: Thread-safetiness in this class relies on the fact that only the serialization thread can change the active buffer
@@ -65,12 +68,12 @@ namespace Datadog.Trace.Agent
             EmptyPayload = new ArraySegment<byte>(data);
         }
 
-        public AgentWriter(IApi api, IStatsAggregator statsAggregator, IDogStatsd statsd, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100)
-        : this(api, statsAggregator, statsd, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush, maxBufferSize, batchInterval)
+        public AgentWriter(IApi api, IStatsAggregator statsAggregator, IDogStatsd statsd, ISpanSampler spanSampler, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100)
+        : this(api, statsAggregator, statsd, spanSampler, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush, maxBufferSize, batchInterval)
         {
         }
 
-        internal AgentWriter(IApi api, IStatsAggregator statsAggregator, IDogStatsd statsd, IKeepRateCalculator traceKeepRateCalculator, bool automaticFlush, int maxBufferSize, int batchInterval)
+        internal AgentWriter(IApi api, IStatsAggregator statsAggregator, IDogStatsd statsd, ISpanSampler spanSampler, IKeepRateCalculator traceKeepRateCalculator, bool automaticFlush, int maxBufferSize, int batchInterval)
         {
             _statsAggregator = statsAggregator;
 
@@ -78,6 +81,8 @@ namespace Datadog.Trace.Agent
             _statsd = statsd;
             _batchInterval = batchInterval;
             _traceKeepRateCalculator = traceKeepRateCalculator;
+
+            _spanSampler = spanSampler;
 
             var formatterResolver = SpanFormatterResolver.Instance;
 
@@ -390,6 +395,8 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
+            RunSpanSampler(spans);
+
             if (CanComputeStats)
             {
                 spans = _statsAggregator?.ProcessTrace(spans) ?? spans;
@@ -456,6 +463,22 @@ namespace Datadog.Trace.Agent
             {
                 _statsd.Increment(TracerMetricNames.Queue.DroppedTraces);
                 _statsd.Increment(TracerMetricNames.Queue.DroppedSpans, spans.Count);
+            }
+        }
+
+        private void RunSpanSampler(ArraySegment<Span> spans)
+        {
+            if (_spanSampler is null)
+            {
+                return;
+            }
+
+            foreach (var span in spans)
+            {
+                if (span.Context.TraceContext?.SamplingPriority <= 0)
+                {
+                    _spanSampler.MakeSamplingDecision(span);
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -473,11 +473,11 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
-            foreach (var span in spans)
+            if (spans.Array![spans.Offset].Context.TraceContext?.SamplingPriority <= 0)
             {
-                if (span.Context.TraceContext?.SamplingPriority <= 0)
+                for (int i = 0; i < spans.Count; i++)
                 {
-                    _spanSampler.MakeSamplingDecision(span);
+                    _spanSampler.MakeSamplingDecision(spans.Array[i + spans.Offset]);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs
@@ -31,12 +31,12 @@ namespace Datadog.Trace.Ci.Agent
             var api = new Api(apiRequestFactory, null, rates => sampler.SetDefaultSampleRates(rates), partialFlushEnabled);
             var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
-            _agentWriter = new AgentWriter(api, statsAggregator, null, maxBufferSize: maxBufferSize);
+            _agentWriter = new AgentWriter(api, statsAggregator, null, null, maxBufferSize: maxBufferSize);
         }
 
         public ApmAgentWriter(IApi api, int maxBufferSize = DefaultMaxBufferSize)
         {
-            _agentWriter = new AgentWriter(api, null, null, maxBufferSize: maxBufferSize);
+            _agentWriter = new AgentWriter(api, null, null, null, maxBufferSize: maxBufferSize);
         }
 
         public void WriteEvent(IEvent @event)

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, ISpanSampler spanSampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName)
-            : base(settings, agentWriter, sampler, spanSampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, new Trace.Processors.ITraceProcessor[]
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, new Trace.Processors.ITraceProcessor[]
             {
                 new Trace.Processors.NormalizerTraceProcessor(),
                 new Trace.Processors.TruncatorTraceProcessor(),

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -38,7 +38,6 @@ namespace Datadog.Trace.Ci
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
             ITraceSampler sampler,
-            ISpanSampler spanSampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetrics,
@@ -48,7 +47,7 @@ namespace Datadog.Trace.Ci
             DataStreamsManager dataStreamsManager,
             string defaultServiceName)
         {
-            return new CITracerManager(settings, agentWriter, sampler, spanSampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
+            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName);
         }
 
         protected override ITraceSampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/IDatadogTracer.cs
+++ b/tracer/src/Datadog.Trace/IDatadogTracer.cs
@@ -19,8 +19,6 @@ namespace Datadog.Trace
 
         ITraceSampler Sampler { get; }
 
-        ISpanSampler SpanSampler { get; }
-
         ImmutableTracerSettings Settings { get; }
 
         void Write(ArraySegment<Span> span);

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -98,12 +98,6 @@ namespace Datadog.Trace
                 Profiler.Instance.ContextTracker.SetEndpoint(span.RootSpanId, span.ResourceName);
             }
 
-            // Determine whether we will sample a dropped span with single span sampling rules
-            if (_samplingPriority <= 0)
-            {
-                Tracer.SpanSampler?.MakeSamplingDecision(span);
-            }
-
             lock (_syncRoot)
             {
                 _spans.Add(span);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -76,8 +76,8 @@ namespace Datadog.Trace
         /// Note that this API does NOT replace the global Tracer instance.
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
-        internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null, ISpanSampler spanSampler = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null, spanSampler))
+        internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null))
         {
         }
 
@@ -218,11 +218,6 @@ namespace Datadog.Trace
         /// Gets the <see cref="ITraceSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
         ITraceSampler IDatadogTracer.Sampler => TracerManager.Sampler;
-
-        /// <summary>
-        /// Gets the <see cref="ISpanSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
-        /// </summary>
-        ISpanSampler IDatadogTracer.SpanSampler => TracerManager.SpanSampler;
 
         internal static string RuntimeId => DistributedTracer.Instance.GetRuntimeId();
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -53,7 +53,6 @@ namespace Datadog.Trace
             ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
             ITraceSampler sampler,
-            ISpanSampler spanSampler,
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetricsWriter,
@@ -67,7 +66,6 @@ namespace Datadog.Trace
             Settings = settings;
             AgentWriter = agentWriter;
             Sampler = sampler;
-            SpanSampler = spanSampler;
             ScopeManager = scopeManager;
             Statsd = statsd;
             RuntimeMetrics = runtimeMetricsWriter;
@@ -126,11 +124,6 @@ namespace Datadog.Trace
         /// Gets the <see cref="ITraceSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
         public ITraceSampler Sampler { get; }
-
-        /// <summary>
-        /// Gets the <see cref="ISpanSampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
-        /// </summary>
-        public ISpanSampler SpanSampler { get; }
 
         public DirectLogSubmissionManager DirectLogSubmission { get; }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.IntegrationTests
         {
             var settings = new TracerSettings();
             _testApi = new MockApi();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -207,29 +207,6 @@ namespace Datadog.Trace.IntegrationTests
         }
 
         [Fact]
-        public void SpanSampler_ShouldNotTag_WhenTraceContext_IsNull()
-        {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
-
-            var inputSpan = new Span(new SpanContext(5, 6, null, serviceName: "test"), DateTimeOffset.Now) { OperationName = "test" };
-            inputSpan.Context.TraceContext.Should().BeNull();
-            var spans = new Span[1];
-            spans[0] = inputSpan;
-            _writer.WriteTrace(new ArraySegment<Span>(spans));
-
-            var trace = _testApi.Wait();
-            trace.Should().HaveCount(1);
-            trace[0].Should().HaveCount(1);
-
-            var span = trace[0].Single();
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
-        }
-
-        [Fact]
         public void SpanSampler_ShouldNotTag_WhenSamplingPriority_IsNull()
         {
             var expectedRuleRate = "1";

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -230,28 +230,6 @@ namespace Datadog.Trace.IntegrationTests
         }
 
         [Fact]
-        public void SpanSampler_ShouldTag_WhenDropped_AfterFinished_ButNotWrittenYet()
-        {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
-
-            var scope = _tracer.StartActive("root");
-            scope.Dispose();
-            // drop it after disposing
-            ((SpanContext)scope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
-
-            var trace = _testApi.Wait();
-            trace.Should().HaveCount(1);
-            trace[0].Should().HaveCount(1);
-
-            var span = trace[0].Single();
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
-        }
-
-        [Fact]
         public void SpanSampler_ShouldNotTag_WhenTraceContext_IsNull()
         {
             var expectedRuleRate = "1";

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -75,28 +75,6 @@ namespace Datadog.Trace.IntegrationTests
         }
 
         [Fact]
-        public void SpanSampler_ShouldTag_WhenSpanIsDropped_AfterFinishing()
-        {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
-
-            var scope = _tracer.StartActive("root");
-            scope.Dispose();
-            // drop it after disposing
-            ((SpanContext)scope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
-
-            var trace = _testApi.Wait();
-            trace.Should().HaveCount(1);
-            trace[0].Should().HaveCount(1);
-
-            var span = trace[0].Single();
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
-        }
-
-        [Fact]
         public void SpanSampler_ShouldTagMultiple_OnSpanFinish()
         {
             var expectedRuleRate = "1";

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -24,10 +24,9 @@ namespace Datadog.Trace.IntegrationTests
         {
             _testApi = new MockApi();
             var matchAllRule = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":1.0, \"max_per_second\":1000.0}]";
-            var settings = new TracerSettings() { SpanSamplingRules = matchAllRule };
+            var settings = new TracerSettings();
             var spanSampler = new SpanSampler(SpanSamplingRule.BuildFromConfigurationString(matchAllRule));
             _writer = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: spanSampler);
-            // a spanSampler should be generated due to the TracerSettings containing the SpanSamplingRules
             _tracer = new Tracer(settings, _writer, sampler: null, scopeManager: null, statsd: null);
         }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -236,24 +236,19 @@ namespace Datadog.Trace.IntegrationTests
             var expectedMaxPerSecond = "1000";
             var expectedSamplingMechanism = "8";
 
-            var traceContext = new TraceContext(_tracer);
-            traceContext.SetSamplingPriority(null);
-            var spanContext = new SpanContext(null, traceContext, "serviceName");
-
-            var inputSpan = new Span(spanContext, DateTimeOffset.Now) { OperationName = "test" };
-            inputSpan.Context.TraceContext.SamplingPriority.Should().BeNull();
+            var spanContext = new SpanContext(4, 5, samplingPriority: null, serviceName: "serviceName");
+            var span = new Span(spanContext, DateTimeOffset.Now) { OperationName = "test" };
             var spans = new Span[1];
-            spans[0] = inputSpan;
+            spans[0] = span;
             _writer.WriteTrace(new ArraySegment<Span>(spans));
-
             var trace = _testApi.Wait();
             trace.Should().HaveCount(1);
             trace[0].Should().HaveCount(1);
 
-            var span = trace[0].Single();
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            var writtenSpan = trace[0].Single();
+            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.IntegrationTests
     public class SpanTagTests
     {
         private readonly Tracer _tracer;
+        private readonly AgentWriter _writer;
         private readonly MockApi _testApi;
 
         public SpanTagTests()
@@ -24,58 +25,31 @@ namespace Datadog.Trace.IntegrationTests
             _testApi = new MockApi();
             var matchAllRule = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":1.0, \"max_per_second\":1000.0}]";
             var settings = new TracerSettings() { SpanSamplingRules = matchAllRule };
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+            var spanSampler = new SpanSampler(SpanSamplingRule.BuildFromConfigurationString(matchAllRule));
+            _writer = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: spanSampler);
             // a spanSampler should be generated due to the TracerSettings containing the SpanSamplingRules
-            _tracer = new Tracer(settings, agentWriter, sampler: null, spanSampler: null, scopeManager: null, statsd: null);
-        }
-
-        [Fact]
-        public void SpanSampler_ShouldAddTags_OnSpanClose_ForDroppedTrace()
-        {
-            var traceContext = new TraceContext(_tracer);
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
-            var span = new Span(new SpanContext(5, 6, null, serviceName: "service"), DateTimeOffset.Now) { OperationName = "operation" };
-            var span2 = new Span(new SpanContext(5, 7, null, serviceName: "service"), DateTimeOffset.Now) { OperationName = "operation" };
-            // mechanism not important, but we've decided to drop the trace
-            traceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
-            traceContext.AddSpan(span);
-            traceContext.AddSpan(span2);
-
-            traceContext.CloseSpan(span);
-            traceContext.CloseSpan(span2);
-
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
-
-            span2.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span2.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
-            span2.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
+            _tracer = new Tracer(settings, _writer, sampler: null, scopeManager: null, statsd: null);
         }
 
         [Fact]
         public void SpanSampler_ShouldNotAddTags_OnSpanClose_ForKeptTrace()
         {
-            var traceContext = new TraceContext(_tracer);
-            var span = new Span(new SpanContext(5, 6, null, serviceName: "service"), DateTimeOffset.Now) { OperationName = "operation" };
-            var span2 = new Span(new SpanContext(5, 7, null, serviceName: "service"), DateTimeOffset.Now) { OperationName = "operation" };
-            // mechanism not important, but we've decided to keep the trace
-            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Manual);
-            traceContext.AddSpan(span);
-            traceContext.AddSpan(span2);
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
 
-            traceContext.CloseSpan(span);
-            traceContext.CloseSpan(span2);
+            using (var scope = _tracer.StartActive("root"))
+            {
+            }
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            var trace = _testApi.Wait();
+            trace.Should().HaveCount(1);
+            trace[0].Should().HaveCount(1);
 
-            span2.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span2.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span2.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            var span = trace[0].Single();
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
 
         [Fact]
@@ -90,6 +64,28 @@ namespace Datadog.Trace.IntegrationTests
                 // drop it
                 ((SpanContext)scope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
             }
+
+            var trace = _testApi.Wait();
+            trace.Should().HaveCount(1);
+            trace[0].Should().HaveCount(1);
+
+            var span = trace[0].Single();
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldTag_WhenSpanIsDropped_AfterFinishing()
+        {
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
+
+            var scope = _tracer.StartActive("root");
+            scope.Dispose();
+            // drop it after disposing
+            ((SpanContext)scope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
 
             var trace = _testApi.Wait();
             trace.Should().HaveCount(1);
@@ -143,6 +139,166 @@ namespace Datadog.Trace.IntegrationTests
                 span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
                 span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldTagMultiple_OnSpanFinish_WhenSamplingPriorityChanges()
+        {
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
+
+            using (var rootScope = _tracer.StartActive("root"))
+            {
+                // keep it (should be kept by default, but enforcing it in this test)
+                ((SpanContext)rootScope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Manual);
+
+                using (var childScope = _tracer.StartActive("child1"))
+                {
+                }
+
+                using (var childScope = _tracer.StartActive("child2"))
+                {
+                }
+
+                // drop it
+                ((SpanContext)rootScope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
+            }
+
+            var traces = _testApi.Wait();
+            traces.Should().HaveCount(1); // 1 trace...
+            traces[0].Should().HaveCount(3); // ...with 3 spans
+
+            var rootSpan = traces[0].SingleOrDefault(s => s.ParentId is null or 0)!;
+            rootSpan.Should().NotBeNull();
+
+            // assert that root span has the span sampling tags
+            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+
+            // assert child spans have span sampling tags
+            var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
+
+            foreach (var span in childSpans)
+            {
+                span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            }
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldNotTag_WhenSpansAreKept()
+        {
+            var ruleRate = "1";
+            var maxPerSecond = "1000";
+            var samplingMechanism = "8";
+
+            using (var rootScope = _tracer.StartActive("root"))
+            {
+                using (var childScope = _tracer.StartActive("child1"))
+                {
+                }
+
+                using (var childScope = _tracer.StartActive("child2"))
+                {
+                }
+            }
+
+            var traces = _testApi.Wait();
+            traces.Should().HaveCount(1); // 1 trace...
+            traces[0].Should().HaveCount(3); // ...with 3 spans
+
+            var rootSpan = traces[0].SingleOrDefault(s => s.ParentId is null or 0)!;
+            rootSpan.Should().NotBeNull();
+
+            // assert that root span has the span sampling tags
+            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, ruleRate);
+            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, maxPerSecond);
+            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, samplingMechanism);
+
+            // assert child spans have span sampling tags
+            var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
+
+            foreach (var span in childSpans)
+            {
+                span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, ruleRate);
+                span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, maxPerSecond);
+                span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, samplingMechanism);
+            }
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldTag_WhenDropped_AfterFinished_ButNotWrittenYet()
+        {
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
+
+            var scope = _tracer.StartActive("root");
+            scope.Dispose();
+            // drop it after disposing
+            ((SpanContext)scope.Span.Context).TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
+
+            var trace = _testApi.Wait();
+            trace.Should().HaveCount(1);
+            trace[0].Should().HaveCount(1);
+
+            var span = trace[0].Single();
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldNotTag_WhenTraceContext_IsNull()
+        {
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
+
+            var inputSpan = new Span(new SpanContext(5, 6, null, serviceName: "test"), DateTimeOffset.Now) { OperationName = "test" };
+            inputSpan.Context.TraceContext.Should().BeNull();
+            var spans = new Span[1];
+            spans[0] = inputSpan;
+            _writer.WriteTrace(new ArraySegment<Span>(spans));
+
+            var trace = _testApi.Wait();
+            trace.Should().HaveCount(1);
+            trace[0].Should().HaveCount(1);
+
+            var span = trace[0].Single();
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+        }
+
+        [Fact]
+        public void SpanSampler_ShouldNotTag_WhenSamplingPriority_IsNull()
+        {
+            var expectedRuleRate = "1";
+            var expectedMaxPerSecond = "1000";
+            var expectedSamplingMechanism = "8";
+
+            var traceContext = new TraceContext(_tracer);
+            traceContext.SetSamplingPriority(null);
+            var spanContext = new SpanContext(null, traceContext, "serviceName");
+
+            var inputSpan = new Span(spanContext, DateTimeOffset.Now) { OperationName = "test" };
+            inputSpan.Context.TraceContext.SamplingPriority.Should().BeNull();
+            var spans = new Span[1];
+            spans[0] = inputSpan;
+            _writer.WriteTrace(new ArraySegment<Span>(spans));
+
+            var trace = _testApi.Wait();
+            trace.Should().HaveCount(1);
+            trace[0].Should().HaveCount(1);
+
+            var span = trace[0].Single();
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingPriorityTests.cs" company="Datadog">
+// <copyright file="SamplingPriorityTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -22,7 +22,7 @@ public class SamplingPriorityTests
         _testApi = new MockApi();
 
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
         _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
     }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingPriorityTests_MultipleChunksWithUpstreamService.cs" company="Datadog">
+// <copyright file="SamplingPriorityTests_MultipleChunksWithUpstreamService.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -26,7 +26,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
         _testApi = new MockApi();
 
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
         _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
     }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs" company="Datadog">
+// <copyright file="SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -26,7 +26,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
         _testApi = new MockApi();
 
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
         _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
     }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTagTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.IntegrationTests
             _testApi = new MockApi();
 
             var settings = new TracerSettings();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TraceTags.cs" company="Datadog">
+// <copyright file="TraceTags.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -27,7 +27,7 @@ public class TraceTags
         var settings = new TracerSettings { GlobalSamplingRate = 0 };
 
         _testApi = new MockApi();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
         _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tests.Agent
         public AgentWriterTests()
         {
             _api = new Mock<IApi>();
-            _agentWriter = new AgentWriter(_api.Object, statsAggregator: null, statsd: null);
+            _agentWriter = new AgentWriter(_api.Object, statsAggregator: null, statsd: null, spanSampler: null);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Tests.Agent
             statsAggregator.Setup(x => x.ProcessTrace(spans)).Returns(spans);
             statsAggregator.Setup(x => x.CanComputeStats).Returns(true);
 
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator.Object, statsd: null, automaticFlush: false);
+            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator.Object, statsd: null, spanSampler: null, automaticFlush: false);
 
             agent.WriteTrace(spans);
 
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new AgentWriter(_api.Object, statsAggregator: null, statsd: null);
+            var w = new AgentWriter(_api.Object, statsAggregator: null, statsd: null, spanSampler: null);
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Tests.Agent
             // The flush thread should be able to recover from an error when calling the API
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null);
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, spanSampler: null);
             var mutex = new ManualResetEventSlim();
 
             agent.Flushed += () => mutex.Set();
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             // Make sure that the agent is able to switch to the secondary buffer when the primary is full/busy
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null);
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, spanSampler: null);
 
             var barrier = new Barrier(2);
 
@@ -165,7 +165,7 @@ namespace Datadog.Trace.Tests.Agent
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, spanSampler: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             agent.WriteTrace(CreateTraceChunk(1));
             agent.WriteTrace(CreateTraceChunk(1));
@@ -195,7 +195,7 @@ namespace Datadog.Trace.Tests.Agent
             var sizeOfTrace = ComputeSize(CreateTraceChunk(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd.Object, automaticFlush: false, (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
+            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd.Object, spanSampler: null, automaticFlush: false, (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             // Fill the two buffers
             agent.WriteTrace(CreateTraceChunk(1));
@@ -245,7 +245,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public Task WakeUpSerializationTask()
         {
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd: null, batchInterval: 0);
+            var agent = new AgentWriter(Mock.Of<IApi>(), statsAggregator: null, statsd: null, spanSampler: null, batchInterval: 0);
 
             // To reduce flakiness, first we make sure the serialization thread is started
             WaitForDequeue(agent);
@@ -287,7 +287,7 @@ namespace Datadog.Trace.Tests.Agent
             var api = new Mock<IApi>();
             api.Setup(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()))
                .ReturnsAsync(() => true);
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, calculator, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1, batchInterval: 100);
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, spanSampler: null, calculator, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1, batchInterval: 100);
 
             // Fill both buffers
             agent.WriteTrace(spans);
@@ -322,7 +322,7 @@ namespace Datadog.Trace.Tests.Agent
         public void AgentWriterEnqueueFlushTasks()
         {
             var api = new Mock<IApi>();
-            var agentWriter = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false);
+            var agentWriter = new AgentWriter(api.Object, statsAggregator: null, statsd: null, spanSampler: null, automaticFlush: false);
             var flushTcs = new TaskCompletionSource<bool>();
             int invocation = 0;
 

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var settings = new TracerSettings();
             _testApi = new MockApi();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, spanSampler: null);
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -29,7 +29,7 @@ namespace Benchmarks.Trace
 
             var api = new Api(new FakeApiRequestFactory(settings.Exporter.AgentUri), statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
-            AgentWriter = new AgentWriter(api, statsAggregator: null, statsd: null, automaticFlush: false);
+            AgentWriter = new AgentWriter(api, statsAggregator: null, statsd: null, spanSampler: null, automaticFlush: false);
 
             var enrichedSpans = new Span[SpanCount];
             var now = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary of changes

This moves the `SpanSampler` into the `AgentWriter` closer to where the serialization of spans occurs instead of being at the point where a span is closed.

## Reason for change

If a trace had its priority changed from keep to drop any of the spans during the "keep" priority that were closed wouldn't have been sent through the `SpanSampler` and potentially missed.

## Implementation details

I've removed the `SpanSampler` from the overall `Tracer` and put it into the `AgentWriter`. This also causes the sampling decision and tagging to no longer occur in `TraceContext.CloseSpan` for the single span sampling and only when a trace chunk is written.

## Test coverage

- Added additional test coverage to test when priority changes
- Removed some now defunct tests that operated on `TraceContext.CloseSpan` for tagging

## Other details
<!-- Fixes #{issue} -->
