### PR TITLE
[Profiler] Customize wall time and CPU sampling constants

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -56,6 +56,8 @@ Configuration::Configuration()
     _contentionSampleLimit = GetEnvironmentValue(EnvironmentVariables::ContentionSampleLimit, 1500);
     _contentionDurationThreshold = GetEnvironmentValue(EnvironmentVariables::ContentionDurationThreshold, 100);
     _cpuWallTimeSamplingRate = ExtractCpuWallTimeSamplingRate();
+    _walltimeThreadsThreshold = ExtractWallTimeThreadsThreshold();
+    _cpuThreadsThreshold = ExtractCpuThreadsThreshold();
     _minimumCores = GetEnvironmentValue<double>(EnvironmentVariables::CoreMinimumOverride, 1.0);
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
 }
@@ -146,6 +148,16 @@ int32_t Configuration::ContentionDurationThreshold() const
 std::chrono::nanoseconds Configuration::CpuWallTimeSamplingRate() const
 {
     return _cpuWallTimeSamplingRate;
+}
+
+int32_t Configuration::WalltimeThreadsThreshold() const
+{
+    return _walltimeThreadsThreshold;
+}
+
+int32_t Configuration::CpuThreadsThreshold() const
+{
+    return _cpuThreadsThreshold;
 }
 
 double Configuration::MinimumCores() const
@@ -325,10 +337,30 @@ std::chrono::seconds Configuration::ExtractUploadInterval()
 
 std::chrono::nanoseconds Configuration::ExtractCpuWallTimeSamplingRate()
 {
-    // default sampling rate is 13 ms; could be changed via env vars but down to a minimum of 9 ms
-    int64_t rate = std::max(GetEnvironmentValue(EnvironmentVariables::CpuWallTimeSamplingRate, 13), 9);
+    // default sampling rate is 9 ms; could be changed via env vars but down to a minimum of 5 ms
+    int64_t rate = std::max(GetEnvironmentValue(EnvironmentVariables::CpuWallTimeSamplingRate, 9), 5);
     rate *= 1000000;
     return std::chrono::nanoseconds(rate);
+}
+
+int32_t Configuration::ExtractWallTimeThreadsThreshold()
+{
+    // default threads to sample for wall time is 5; could be changed via env vars from 5 to 64
+    int32_t threshold =
+        std::min(
+            std::max(GetEnvironmentValue(EnvironmentVariables::WalltimeThreadsThreshold, 5), 5),
+            64);
+    return threshold;
+}
+
+int32_t Configuration::ExtractCpuThreadsThreshold()
+{
+    // default threads to sample for CPU profiling is 64; could be changed via env vars from 5 to 128
+    int32_t threshold =
+        std::min(
+            std::max(GetEnvironmentValue(EnvironmentVariables::CpuTimeThreadsThreshold, 64), 5),
+            128);
+    return threshold;
 }
 
 bool Configuration::GetDefaultDebugLogEnabled()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -49,6 +49,8 @@ public:
     int32_t ContentionDurationThreshold() const override;
     std::chrono::nanoseconds CpuWallTimeSamplingRate() const override;
     const std::string& GetNamedPipeName() const override;
+    int32_t WalltimeThreadsThreshold() const override;
+    int32_t CpuThreadsThreshold() const override;
 
 private:
     static tags ExtractUserTags();
@@ -64,6 +66,8 @@ private:
     template <typename T>
     static T GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue);
     static std::chrono::nanoseconds ExtractCpuWallTimeSamplingRate();
+    static int32_t ExtractWallTimeThreadsThreshold();
+    static int32_t ExtractCpuThreadsThreshold();
 
 private:
     static std::string const DefaultProdSite;
@@ -104,6 +108,8 @@ private:
     int32_t _contentionSampleLimit;
     int32_t _contentionDurationThreshold;
     std::chrono::nanoseconds _cpuWallTimeSamplingRate;
+    int32_t _walltimeThreadsThreshold;
+    int32_t _cpuThreadsThreshold;
 
     double _minimumCores;
     std::string _namedPipeName;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -39,6 +39,8 @@ public:
     inline static const shared::WSTRING ContentionSampleLimit       = WStr("DD_INTERNAL_PROFILING_CONTENTION_SAMPLE_LIMIT");
     inline static const shared::WSTRING ContentionDurationThreshold = WStr("DD_INTERNAL_PROFILING_CONTENTION_DURATION_THRESHOLD");
     inline static const shared::WSTRING CpuWallTimeSamplingRate     = WStr("DD_INTERNAL_PROFILING_SAMPLING_RATE");
+    inline static const shared::WSTRING WalltimeThreadsThreshold    = WStr("DD_INTERNAL_PROFILING_WALLTIME_THREADS_THRESHOLD");
+    inline static const shared::WSTRING CpuTimeThreadsThreshold     = WStr("DD_INTERNAL_PROFILING_CPUTIME_THREADS_THRESHOLD");
     inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_INTERNAL_PROFILING_OUTPUT_DIR");
     inline static const shared::WSTRING DevelopmentConfiguration    = WStr("DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION");
     inline static const shared::WSTRING Agentless                   = WStr("DD_PROFILING_AGENTLESS");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -46,4 +46,6 @@ public:
     virtual int32_t ContentionDurationThreshold() const = 0;
     virtual std::chrono::nanoseconds CpuWallTimeSamplingRate() const = 0;
     virtual const std::string& GetNamedPipeName() const = 0;
+    virtual int32_t WalltimeThreadsThreshold() const = 0;
+    virtual int32_t CpuThreadsThreshold() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -76,6 +76,8 @@ private:
     ManagedThreadInfo* _targetThread;
     uint32_t _iteratorWallTime;
     uint32_t _iteratorCpuTime;
+    int32_t _walltimeThreadsThreshold;
+    int32_t _cpuThreadsThreshold;
 
 private:
     std::unordered_map<HRESULT, uint64_t> _encounteredStackSnapshotHRs;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -415,13 +415,21 @@ TEST(ConfigurationTest, CheckCpuWallTimeSamplingRateIfEnvVarSet)
     ASSERT_THAT(rate, std::chrono::nanoseconds(123000000));
 }
 
-TEST(ConfigurationTest, CheckCpuWallTimeSamplingRateIfTooSmallValue)
+TEST(ConfigurationTest, CheckCpuWallTimeSamplingRateIfNotSet)
 {
-    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuWallTimeSamplingRate, WStr("5"));
     auto configuration = Configuration{};
     auto rate = configuration.CpuWallTimeSamplingRate();
     auto count = rate.count();
     ASSERT_THAT(rate, std::chrono::nanoseconds(9000000));
+}
+
+TEST(ConfigurationTest, CheckCpuWallTimeSamplingRateIfTooSmallValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuWallTimeSamplingRate, WStr("1"));
+    auto configuration = Configuration{};
+    auto rate = configuration.CpuWallTimeSamplingRate();
+    auto count = rate.count();
+    ASSERT_THAT(rate, std::chrono::nanoseconds(5000000));
 }
 
 TEST(ConfigurationTest, CheckAllocationProfilingIsDisabledByDefault)
@@ -463,4 +471,66 @@ TEST(ConfigurationTest, CheckNamedPipePathWhenProvided)
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::NamedPipeName, shared::ToWSTRING(expectedPath));
     auto configuration = Configuration{};
     EXPECT_EQ(configuration.GetNamedPipeName(), expectedPath);
+}
+
+TEST(ConfigurationTest, CheckWallTimeThreadsThresholdIfNoValue)
+{
+    auto configuration = Configuration{};
+    auto threshold = configuration.WalltimeThreadsThreshold();
+    ASSERT_THAT(threshold, 5);
+}
+
+TEST(ConfigurationTest, CheckWallTimeThreadsThresholdIfTooSmallValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::WalltimeThreadsThreshold, WStr("1"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.WalltimeThreadsThreshold();
+    ASSERT_THAT(threshold, 5);
+}
+
+TEST(ConfigurationTest, CheckWallTimeThreadsThresholdIfTooLargeValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::WalltimeThreadsThreshold, WStr("5000"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.WalltimeThreadsThreshold();
+    ASSERT_THAT(threshold, 64);
+}
+
+TEST(ConfigurationTest, CheckWallTimeThreadsThresholdIfCorrectValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::WalltimeThreadsThreshold, WStr("16"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.WalltimeThreadsThreshold();
+    ASSERT_THAT(threshold, 16);
+}
+
+TEST(ConfigurationTest, CheckCpuThreadsThresholdIfNoValue)
+{
+    auto configuration = Configuration{};
+    auto threshold = configuration.CpuThreadsThreshold();
+    ASSERT_THAT(threshold, 64);
+}
+
+TEST(ConfigurationTest, CheckCpuThreadsThresholdIfTooSmallValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuTimeThreadsThreshold, WStr("1"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.CpuThreadsThreshold();
+    ASSERT_THAT(threshold, 5);
+}
+
+TEST(ConfigurationTest, CheckCpuThreadsThresholdIfTooLargeValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuTimeThreadsThreshold, WStr("5000"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.CpuThreadsThreshold();
+    ASSERT_THAT(threshold, 128);
+}
+
+TEST(ConfigurationTest, CheckCpuThreadsThresholdIfCorrectValue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuTimeThreadsThreshold, WStr("16"));
+    auto configuration = Configuration{};
+    auto threshold = configuration.CpuThreadsThreshold();
+    ASSERT_THAT(threshold, 16);
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -49,6 +49,8 @@ public:
     MOCK_METHOD(int32_t, ContentionDurationThreshold, (), (const override));
     MOCK_METHOD(std::chrono::nanoseconds, CpuWallTimeSamplingRate, (), (const override));
     MOCK_METHOD(std::string const&, GetNamedPipeName, (), (const override));
+    MOCK_METHOD(int32_t, WalltimeThreadsThreshold, (), (const override));
+    MOCK_METHOD(int32_t, CpuThreadsThreshold, (), (const override));
 };
 
 class MockExporter : public IExporter


### PR DESCRIPTION
## Summary of changes
Allow customization of sampling constants thanks to environment variables

## Reason for change
It could be handy for a customer to customize the Wall time / CPU sampling algorithm based on application specificities.
For example, sample less frequently by more threads at a time.

## Implementation details
Read customization from environment variables

## Test coverage
Yes

## Other details
<!-- Fixes #{issue} -->
