### PR TITLE
Change list of expected modified files for release

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -409,6 +409,7 @@ partial class Build
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",
+                "profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt",
                 "profiler/src/ProfilerEngine/ProductVersion.props",
                 "shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
                 "shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc",


### PR DESCRIPTION
## Summary of changes

Following [PR to revisit CMake projects architecture](https://github.com/DataDog/dd-trace-dotnet/pull/3329), a new file now needs the tracer version: profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt

## Reason for change
For next release to expect this modification as well
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
