### PR TITLE
Fix Pipeline when Pull Request variables are not available

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -124,21 +124,21 @@ variables:
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet
   DD_LOGGER_DD_ENV: CI
   DD_LOGGER_TF_BUILD: True
-  DD_LOGGER_BUILD_BUILDID: $[variables['Build.BuildId']]
-  DD_LOGGER_BUILD_DEFINITIONNAME: $[variables['Build.DefinitionName']]
-  DD_LOGGER_BUILD_SOURCESDIRECTORY: $[variables['Build.SourcesDirectory']]
-  DD_LOGGER_BUILD_REPOSITORY_URI: $[variables['Build.Repository.Uri']]
-  DD_LOGGER_BUILD_SOURCEVERSION: $[variables['Build.SourceVersion']]
-  DD_LOGGER_BUILD_SOURCEBRANCH: $[variables['Build.SourceBranch']]
-  DD_LOGGER_BUILD_SOURCEBRANCHNAME: $[variables['Build.SourceBranchName']]
-  DD_LOGGER_BUILD_SOURCEVERSIONMESSAGE: $[variables['Build.SourceVersionMessage']]
-  DD_LOGGER_BUILD_REQUESTEDFORID: $[variables['Build.RequestedForId']]
-  DD_LOGGER_BUILD_REQUESTEDFOREMAIL: $[variables['Build.RequestedForEmail']]
-  DD_LOGGER_SYSTEM_TEAMFOUNDATIONSERVERURI: $[variables['System.TeamFoundationServerUri']]
-  DD_LOGGER_SYSTEM_TEAMPROJECTID: $[variables['System.TeamProjectId']]
-  DD_LOGGER_SYSTEM_STAGEDISPLAYNAME: $[variables['System.StageDisplayName']]
-  DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $[variables['System.JobDisplayName']]
-  DD_LOGGER_SYSTEM_JOBID: $[variables['System.JobId']]
+  DD_LOGGER_BUILD_BUILDID: $(Build.BuildId)
+  DD_LOGGER_BUILD_DEFINITIONNAME: $(Build.DefinitionName)
+  DD_LOGGER_BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
+  DD_LOGGER_BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
+  DD_LOGGER_BUILD_SOURCEVERSION: $(Build.SourceVersion)
+  DD_LOGGER_BUILD_SOURCEBRANCH: $(Build.SourceBranch)
+  DD_LOGGER_BUILD_SOURCEBRANCHNAME: $(Build.SourceBranchName)
+  DD_LOGGER_BUILD_SOURCEVERSIONMESSAGE: $(Build.SourceVersionMessage)
+  DD_LOGGER_BUILD_REQUESTEDFORID: $(Build.RequestedForId)
+  DD_LOGGER_BUILD_REQUESTEDFOREMAIL: $(Build.RequestedForEmail)
+  DD_LOGGER_SYSTEM_TEAMFOUNDATIONSERVERURI: $(System.TeamFoundationServerUri)
+  DD_LOGGER_SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
+  DD_LOGGER_SYSTEM_STAGEDISPLAYNAME: $(System.StageDisplayName)
+  DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $(System.JobDisplayName)
+  DD_LOGGER_SYSTEM_JOBID: $(System.JobId)
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $[variables['System.PullRequest.SourceRepositoryURI']]
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $[variables['System.PullRequest.SourceCommitId']]
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $[variables['System.PullRequest.SourceBranch']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -140,9 +140,9 @@ variables:
   DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $(System.JobDisplayName)
   DD_LOGGER_SYSTEM_JOBID: $(System.JobId)
 #  DD_LOGGER_SYSTEM_TASKINSTANCEID: $(System.TaskInstanceId)
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $[variables.System.PullRequest.SourceRepositoryURI]
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $[variables.System.PullRequest.SourceCommitId]
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $[variables.System.PullRequest.SourceBranch]
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $[variables['System.PullRequest.SourceRepositoryURI']]
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $[variables['System.PullRequest.SourceCommitId']]
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $[variables['System.PullRequest.SourceBranch']]
   DD_LOGGER_API_KEY_CHECKER_ENABLED: false
   DD_LOGGER_DD_TAGS: test.configuration.job:$(System.JobDisplayName)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -140,9 +140,9 @@ variables:
   DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $(System.JobDisplayName)
   DD_LOGGER_SYSTEM_JOBID: $(System.JobId)
 #  DD_LOGGER_SYSTEM_TASKINSTANCEID: $(System.TaskInstanceId)
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $(System.PullRequest.SourceRepositoryURI)
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $(System.PullRequest.SourceCommitId)
-  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $(System.PullRequest.SourceBranch)
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $[variables.System.PullRequest.SourceRepositoryURI]
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $[variables.System.PullRequest.SourceCommitId]
+  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $[variables.System.PullRequest.SourceBranch]
   DD_LOGGER_API_KEY_CHECKER_ENABLED: false
   DD_LOGGER_DD_TAGS: test.configuration.job:$(System.JobDisplayName)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -124,22 +124,21 @@ variables:
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet
   DD_LOGGER_DD_ENV: CI
   DD_LOGGER_TF_BUILD: True
-  DD_LOGGER_BUILD_BUILDID: $(Build.BuildId)
-  DD_LOGGER_BUILD_DEFINITIONNAME: $(Build.DefinitionName)
-  DD_LOGGER_BUILD_SOURCESDIRECTORY: $(Build.SourcesDirectory)
-  DD_LOGGER_BUILD_REPOSITORY_URI: $(Build.Repository.Uri)
-  DD_LOGGER_BUILD_SOURCEVERSION: $(Build.SourceVersion)
-  DD_LOGGER_BUILD_SOURCEBRANCH: $(Build.SourceBranch)
-  DD_LOGGER_BUILD_SOURCEBRANCHNAME: $(Build.SourceBranchName)
-  DD_LOGGER_BUILD_SOURCEVERSIONMESSAGE: $(Build.SourceVersionMessage)
-  DD_LOGGER_BUILD_REQUESTEDFORID: $(Build.RequestedForId)
-  DD_LOGGER_BUILD_REQUESTEDFOREMAIL: $(Build.RequestedForEmail)
-  DD_LOGGER_SYSTEM_TEAMFOUNDATIONSERVERURI: $(System.TeamFoundationServerUri)
-  DD_LOGGER_SYSTEM_TEAMPROJECTID: $(System.TeamProjectId)
-  DD_LOGGER_SYSTEM_STAGEDISPLAYNAME: $(System.StageDisplayName)
-  DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $(System.JobDisplayName)
-  DD_LOGGER_SYSTEM_JOBID: $(System.JobId)
-#  DD_LOGGER_SYSTEM_TASKINSTANCEID: $(System.TaskInstanceId)
+  DD_LOGGER_BUILD_BUILDID: $[variables['Build.BuildId']]
+  DD_LOGGER_BUILD_DEFINITIONNAME: $[variables['Build.DefinitionName']]
+  DD_LOGGER_BUILD_SOURCESDIRECTORY: $[variables['Build.SourcesDirectory']]
+  DD_LOGGER_BUILD_REPOSITORY_URI: $[variables['Build.Repository.Uri']]
+  DD_LOGGER_BUILD_SOURCEVERSION: $[variables['Build.SourceVersion']]
+  DD_LOGGER_BUILD_SOURCEBRANCH: $[variables['Build.SourceBranch']]
+  DD_LOGGER_BUILD_SOURCEBRANCHNAME: $[variables['Build.SourceBranchName']]
+  DD_LOGGER_BUILD_SOURCEVERSIONMESSAGE: $[variables['Build.SourceVersionMessage']]
+  DD_LOGGER_BUILD_REQUESTEDFORID: $[variables['Build.RequestedForId']]
+  DD_LOGGER_BUILD_REQUESTEDFOREMAIL: $[variables['Build.RequestedForEmail']]
+  DD_LOGGER_SYSTEM_TEAMFOUNDATIONSERVERURI: $[variables['System.TeamFoundationServerUri']]
+  DD_LOGGER_SYSTEM_TEAMPROJECTID: $[variables['System.TeamProjectId']]
+  DD_LOGGER_SYSTEM_STAGEDISPLAYNAME: $[variables['System.StageDisplayName']]
+  DD_LOGGER_SYSTEM_JOBDISPLAYNAME: $[variables['System.JobDisplayName']]
+  DD_LOGGER_SYSTEM_JOBID: $[variables['System.JobId']]
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: $[variables['System.PullRequest.SourceRepositoryURI']]
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID: $[variables['System.PullRequest.SourceCommitId']]
   DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH: $[variables['System.PullRequest.SourceBranch']]


### PR DESCRIPTION
## Summary of changes

This PR fixes the **CIVisibility Test DataLogger** when running master by preventing invalid values in the environment variables of the pipeline.

## Reason for change

Currently the pipeline uses the `macro` approach to define the datalogger variable values. The problem, the macro syntax default to the expression (non empty/null) when the variable value is empty or null as can be seen in: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#runtime-expression-syntax

So, when running on master branch, the pull request variables are not null but like this:

```
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH=$(System.PullRequest.SourceBranch)
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID=$(System.PullRequest.SourceCommitId)
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI=$(System.PullRequest.SourceRepositoryURI)
```

with this PR we change to runtime expressions in the pipeline, fixing the issue to something like:

```
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH=
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID=
  DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI=
```

**Note:** This PR doesn't change all variables (only the ones creating the issue), the reason is some of the [Predefined Variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml) are not working using the runtime expressions (eg: `System.JobDisplayName`).