### PR TITLE
Add missing dependencies to `coverage` and `traces_pipeline` stages

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2703,7 +2703,19 @@ stages:
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [integration_tests_windows, integration_tests_windows_iis, msi_integration_tests_windows, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows, master_commit_id]
+  dependsOn: 
+    - integration_tests_windows
+    - integration_tests_windows_iis
+    - msi_integration_tests_windows
+    - integration_tests_linux
+    - integration_tests_arm64
+    - unit_tests_linux
+    - unit_tests_macos
+    - unit_tests_arm64
+    - unit_tests_windows
+    - master_commit_id
+    - tool_artifacts_tests_windows
+    - tool_artifacts_tests_linux
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:
@@ -3615,6 +3627,9 @@ stages:
     - msi_integration_tests_windows
     - integration_tests_linux
     - integration_tests_arm64
+    - profiler_integration_tests_linux
+    - exploration_tests_windows
+    - exploration_tests_linux
     - benchmarks
     - throughput
     - throughput_appsec
@@ -3622,19 +3637,19 @@ stages:
     - tool_artifacts_tests_linux
     - upload_to_s3
     - upload_to_azure
+    - execution_benchmarks
     - installer_smoke_tests
     - installer_smoke_tests_arm64
     - nuget_installer_smoke_tests
     - nuget_installer_smoke_tests_arm64
     - nuget_installer_smoke_tests_windows
+    - dotnet_tool_nuget_smoke_tests_linux
     - dotnet_tool_smoke_tests_linux
     - dotnet_tool_smoke_tests_arm64
     - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests
     - coverage
-    - exploration_tests_windows
-    - exploration_tests_linux
     - system_tests
   jobs:
   - job: build_and_run


### PR DESCRIPTION
## Summary of changes

Add missing dependencies to the `coverage` and `traces_pipeline` stages

## Reason for change

They depend on these stages. They don't fail, but it could possibly be the source of the inconsistency in the coverage stage.

## Implementation details

Add the missing stages
