### PR TITLE
[Tracer] Add stats_computation_enabled in startup logs

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -485,6 +485,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("span_sampling_rules");
                     writer.WriteValue(instanceSettings.SpanSamplingRules);
 
+                    writer.WritePropertyName("stats_computation_enabled");
+                    writer.WriteValue(instanceSettings.StatsComputationEnabled);
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }


### PR DESCRIPTION
## Summary of changes
Just specify if stats are enabled in startup logs

## Reason for change
I realized while setting up AAS that we didn't have that log.

