### PR TITLE
Bump version of DatadogTestLogger to remove direct reference to Datadog.Trace

### DIFF
--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -19,29 +19,18 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
+  <!-- This property ensures NuGet packages are copied to the bin folder. This happens automatically in netcoreapp3.0+ -->
+  <PropertyGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' AND '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.23">
-      <CopyToOutputDirectory>lib\$(TargetFramework)\*</CopyToOutputDirectory>
-      <FolderName>datadogtestlogger</FolderName>
-    </PackageReference>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.25" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.test.cs" />
   </ItemGroup>
-
-  <Target Name="PackageReferenceCopyToOutput" AfterTargets="Build"  Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <ItemGroup>
-      <PackageReferenceFiles Condition="%(PackageReference.CopyToOutputDirectory) != '' AND %(PackageReference.FolderName) != ''"
-        Include="$(NugetPackageRoot)\%(PackageReference.FolderName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory)" />
-    </ItemGroup>
-    <Message Condition="%(PackageReference.CopyToOutputDirectory) != ''" 
-             Text="> $(NugetPackageRoot) | %(PackageReference.FolderName) | %(PackageReference.Version) | %(PackageReference.CopyToOutputDirectory) [$(NugetPackageRoot)\%(PackageReference.FileName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory) | $(OutDir)]" Importance="high"/>
-    <Message Condition="%(PackageReference.CopyToOutputDirectory) != '' AND '@(PackageReferenceFiles->'%(Identity)')' != ''"
-             Text="  Copy @(PackageReferenceFiles->'%(Identity)') to $(OutDir)"
-             Importance="high"/>
-    <Copy SourceFiles="@(PackageReferenceFiles)" DestinationFolder="$(OutDir)" />
-  </Target>
 
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.25" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.26" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Updates to a newer version of DatadogTestLogger that doesn't reference Datadog.Trace.

## Reason for change

The previous version of DatadogTestLogger referenced Datadog.Trace, and all Datadog.Trace's dependencies transitively. Unfortunately, that means that all the test projects _and all the sample apps_ were transitively reference Datadog.Trace too. This is something we actively try to avoid, as it can cause issues with coverage and testing scenarios etc.

## Implementation details

The latest version of DatadogTestLogger vendors Datadog.Trace directly into the dll, and removes all the external dependencies. Yes, that was as painful as it sounds. I basically had to delete any references to aspnet/aspnetcore stuff, so it's a "slimmed" down version.

## Test coverage

Checked on CIApp and it all looks to be working correctly! 🎉 You can view this branch in the staging or in CIApp (screenshot from previous run below)

![image](https://user-images.githubusercontent.com/18755388/199269616-30956ead-11a6-44ad-822d-d4afaaaf2cb2.png)

## Other details

During the vendoring noticed some things we should fix separately:
- Don't use `#if NET461`, use `#if NETFRAMEWORK`
- The `#if` directives are broken in the vendored regex code for .NET 7