### PR TITLE
[CIVisibility] Fix EVP tests by turning off the DD_TRACE_DEBUG flag

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using var logsIntake = new MockLogsIntakeForCiVisibility();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using var logsIntake = new MockLogsIntakeForCiVisibility();
                 EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
                 SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
-                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
+                SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "0");
 
                 using var logsIntake = new MockLogsIntakeForCiVisibility();
                 EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable("DD_CIVISIBILITY_ENABLED", "1");
-                SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+                SetEnvironmentVariable("DD_TRACE_DEBUG", "0");
                 SetEnvironmentVariable("DD_DUMP_ILREWRITE_ENABLED", "1");
 
                 using var logsIntake = new MockLogsIntakeForCiVisibility();


### PR DESCRIPTION
## Summary of changes

This PR it is a simple fix intended to unblock CI jobs. 

While debugging the cause of the flakiness of those test I discover that when the `DD_TRACE_DEBUG` flag is enabled, an `AccessViolationException`  is thrown randomly.

```
Number indicates the number of runs of `XUnitEvpTest` until it crashes with the exception.

With DD_TRACE_DEBUG:
30
6
43
11
11
17
71
40
19
15
3
33

Without DD_TRACE_DEBUG:
didn't crash after 500 cycles
```

Currently, it's no clear what is causing this exception, this flag also affects the native ClrProfiler.

**Note: An investigation of the root cause will start in background.**