### PR TITLE
Read performance counter values directly from memory

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
@@ -1,0 +1,593 @@
+// <copyright file="MemoryMappedCounters.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.RuntimeMetrics
+{
+    internal class MemoryMappedCounters : IRuntimeMetricsListener
+    {
+        private const string GarbageCollectionMetrics = $"{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.ContentionCount}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}";
+
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<PerformanceCountersListener>();
+
+        private readonly IDogStatsd _statsd;
+        private readonly int _processId;
+
+        private int? _previousGen0Count;
+        private int? _previousGen1Count;
+        private int? _previousGen2Count;
+
+        private double? _lastContentionCount;
+        private MemoryMappedFile _file;
+        private MemoryMappedViewAccessor _view;
+
+        public MemoryMappedCounters(IDogStatsd statsd)
+        {
+            _statsd = statsd;
+
+            ProcessHelpers.GetCurrentProcessInformation(out _, out _, out _processId);
+
+            MemoryMappedFile file = null;
+            MemoryMappedViewAccessor view = null;
+
+            try
+            {
+                file = MemoryMappedFile.OpenExisting(@"Cor_CLR_WRITER\Cor_SxSPublic_IPCBlock");
+                view = file.CreateViewAccessor();
+
+                if (GC.CollectionCount(0) == 0)
+                {
+                    // This is unlikely to happen, but we must make sure that the GC has run at least once,
+                    // otherwise the GC structure that we use for the sanity check will be empty.
+                    GC.Collect(0, GCCollectionMode.Forced, blocking: true); // Sorry ._.
+                }
+
+                // Sanity check
+                view.Read<IpcControlBlock>(0, out var controlBlock);
+
+                if (controlBlock.Header.Flags == 0)
+                {
+                    throw new InvalidOperationException("The IPC control block is not initialized");
+                }
+
+                if (controlBlock.Perf.GC.ProcessID != _processId)
+                {
+                    throw new InvalidOperationException($"The PID in the IPC control block does not match (expected {_processId}, found {controlBlock.Perf.GC.ProcessID}");
+                }
+            }
+            catch
+            {
+                view?.Dispose();
+                file?.Dispose();
+                throw;
+            }
+
+            _file = file;
+            _view = view;
+        }
+
+        [Flags]
+        private enum IpcHeaderFlags : ushort
+        {
+            IPC_FLAG_USES_FLAGS = 0x1,
+            IPC_FLAG_INITIALIZED = 0x2,
+            IPC_FLAG_X86 = 0x4
+        }
+
+        public void Dispose()
+        {
+            if (_view != null)
+            {
+                _view.Dispose();
+                _view = null;
+            }
+
+            if (_file != null)
+            {
+                _file.Dispose();
+                _file = null;
+            }
+        }
+
+        public void Refresh()
+        {
+            _view.Read<IpcControlBlock>(0, out var controlBlock);
+
+            var perf = controlBlock.Perf;
+
+            if (perf.GC.ProcessID != _processId)
+            {
+                throw new InvalidOperationException($"The PID in the IPC control block does not match (expected {_processId}, found {controlBlock.Perf.GC.ProcessID}");
+            }
+
+            _statsd.Gauge(MetricsNames.Gen0HeapSize, perf.GC.GenHeapSize0);
+            _statsd.Gauge(MetricsNames.Gen1HeapSize, perf.GC.GenHeapSize1);
+            _statsd.Gauge(MetricsNames.Gen2HeapSize, perf.GC.GenHeapSize2);
+            _statsd.Gauge(MetricsNames.LohSize, perf.GC.LargeObjSize);
+
+            var contentionCount = perf.LocksAndThreads.Contention;
+
+            if (_lastContentionCount == null)
+            {
+                _lastContentionCount = contentionCount;
+            }
+            else
+            {
+                _statsd.Counter(MetricsNames.ContentionCount, contentionCount - _lastContentionCount.Value);
+                _lastContentionCount = contentionCount;
+            }
+
+            var gen0 = GC.CollectionCount(0);
+            var gen1 = GC.CollectionCount(1);
+            var gen2 = GC.CollectionCount(2);
+
+            if (_previousGen0Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen0CollectionsCount, gen0 - _previousGen0Count.Value);
+            }
+
+            if (_previousGen1Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen1CollectionsCount, gen1 - _previousGen1Count.Value);
+            }
+
+            if (_previousGen2Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen2CollectionsCount, gen2 - _previousGen2Count.Value);
+            }
+
+            _previousGen0Count = gen0;
+            _previousGen1Count = gen1;
+            _previousGen2Count = gen2;
+
+            Log.Debug("Sent the following metrics to the DD agent: {metrics}", GarbageCollectionMetrics);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct TRICOUNT
+        {
+            public int Current;
+            public int Total;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct IPCHeader
+        {
+            /// <summary>
+            /// Value of 0 is special; means that this block has never been touched before by a writer
+            /// </summary>
+            public readonly int Counter;
+
+            /// <summary>
+            /// Value of 0 is special; means that chunk is currently free (runtime ids are always greater than 0)
+            /// </summary>
+            public readonly int RuntimeId;
+
+            public readonly int Reserved1;
+            public readonly int Reserved2;
+
+            /// <summary>
+            /// Version of the IPC Block
+            /// </summary>
+            public readonly ushort Version;
+
+            /// <summary>
+            /// Flags field
+            /// </summary>
+            public readonly IpcHeaderFlags Flags;
+
+            /// <summary>
+            /// Size of the entire shared memory block
+            /// </summary>
+            public readonly int BlockSize;
+
+            /// <summary>
+            /// Stamp for year built
+            /// </summary>
+            public readonly ushort BuildYear;
+
+            /// <summary>
+            /// Stamp for Month/Day built
+            /// </summary>
+            public readonly ushort BuildNumber;
+
+            /// <summary>
+            /// Number of entries in the table
+            /// </summary>
+            public readonly int NumEntries;
+
+            /// <summary>
+            /// Entry describing each client's block
+            /// </summary>
+            public readonly IPCEntry Table;
+        }
+
+        [StructLayout(LayoutKind.Sequential, Size = 2048)]
+        private readonly struct IpcControlBlock
+        {
+            public readonly IPCHeader Header;
+
+            public readonly PerfCounterIpcControlBlock Perf;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct IPCEntry
+        {
+            /// <summary>
+            /// Offset of the IPC Block from the end of the Full IPC Header
+            /// </summary>
+            public readonly int Offset;
+
+            /// <summary>
+            /// Size (in bytes) of the block
+            /// </summary>
+            public readonly int Size;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfJit
+        {
+            /// <summary>
+            /// Number of methods jitted
+            /// </summary>
+            public readonly int MethodsJitted;
+
+            /// <summary>
+            /// IL jitted stats
+            /// </summary>
+            public readonly TRICOUNT ILJitted;
+
+            /// <summary>
+            /// # of standard Jit failures
+            /// </summary>
+            public readonly int JitFailures;
+
+            /// <summary>
+            /// Time in JIT since last sample
+            /// </summary>
+            public readonly int TimeInJit;
+
+            /// <summary>
+            /// Time in JIT base counter
+            /// </summary>
+            public readonly int TimeInJitBase;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfCounterIpcControlBlock
+        {
+            // Versioning info
+
+            /// <summary>
+            /// Size of this entire block
+            /// </summary>
+            public readonly short Size;
+
+            /// <summary>
+            /// Attributes for this block
+            /// </summary>
+            public readonly short Attributes;
+
+            // Counter Sections
+            public readonly PerfGC GC;
+            public readonly PerfContexts Context;
+            public readonly PerfInterop Interop;
+            public readonly PerfLoading Loading;
+            public readonly PerfExceptions Exceptions;
+            public readonly PerfLocksAndThreads LocksAndThreads;
+            public readonly PerfJit Jit;
+            public readonly PerfSecurity Security;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfSecurity
+        {
+            public readonly int TotalRuntimeChecks;
+
+            /// <summary>
+            ///  % time authenticating
+            /// </summary>
+            public readonly long TimeAuthorize;
+
+            /// <summary>
+            /// Link time checks
+            /// </summary>
+            public readonly int LinkChecks;
+
+            /// <summary>
+            /// % time in Runtime checks
+            /// </summary>
+            public readonly int TimeRTchecks;
+
+            /// <summary>
+            /// % time in Runtime checks base counter
+            /// </summary>
+            public readonly int TimeRTchecksBase;
+
+            /// <summary>
+            /// Depth of stack for security checks
+            /// </summary>
+            public readonly int StackWalkDepth;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfLocksAndThreads
+        {
+            /// <summary>
+            /// # of times in AwareLock::EnterEpilogue()
+            /// </summary>
+            public readonly int Contention;
+
+            public readonly TRICOUNT QueueLength;
+
+            /// <summary>
+            /// Number (created - destroyed) of logical threads
+            /// </summary>
+            public readonly int CurrentThreadsLogical;
+
+            /// <summary>
+            /// Number (created - destroyed) of OS threads
+            /// </summary>
+            public readonly int CurrentThreadsPhysical;
+
+            /// <summary>
+            /// # of Threads execute in runtime's control
+            /// </summary>
+            public readonly TRICOUNT RecognizedThreads;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfExceptions
+        {
+            /// <summary>
+            /// Number of Exceptions thrown
+            /// </summary>
+            public readonly int Thrown;
+
+            /// <summary>
+            /// Number of Filters executed
+            /// </summary>
+            public readonly int FiltersExecuted;
+
+            /// <summary>
+            /// Number of Finallys executed
+            /// </summary>
+            public readonly int FinallysExecuted;
+
+            /// <summary>
+            /// Delta from throw to catch site on stack
+            /// </summary>
+            public readonly int ThrowToCatchStackDepth;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfLoading
+        {
+            public readonly TRICOUNT ClassesLoaded;
+
+            /// <summary>
+            /// Current # of AppDomains
+            /// </summary>
+            public readonly TRICOUNT AppDomains;
+
+            /// <summary>
+            /// Current # of Assemblies
+            /// </summary>
+            public readonly TRICOUNT Assemblies;
+
+            /// <summary>
+            /// % time loading
+            /// </summary>
+            public readonly long TimeLoading;
+
+            /// <summary>
+            /// Avg search length for assemblies
+            /// </summary>
+            public readonly int AsmSearchLength;
+
+            /// <summary>
+            /// Classes Failed to load
+            /// </summary>
+            public readonly int LoadFailures;
+
+            /// <summary>
+            /// Total size of heap used by the loader
+            /// </summary>
+            public readonly nint LoaderHeapSize;
+
+            /// <summary>
+            /// Rate at which app domains are unloaded
+            /// </summary>
+            public readonly int AppDomainsUnloaded;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfInterop
+        {
+            /// <summary>
+            /// Number of CCWs
+            /// </summary>
+            public readonly int CCW;
+
+            /// <summary>
+            /// Number of stubs
+            /// </summary>
+            public readonly int Stubs;
+
+            /// <summary>
+            /// # of time marshalling args and return values
+            /// </summary>
+            public readonly int Marshalling;
+
+            /// <summary>
+            /// Number of tlbs we import
+            /// </summary>
+            public readonly int TLBImports;
+
+            /// <summary>
+            /// Number of tlbs we export
+            /// </summary>
+            public readonly int TLBExports;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfContexts
+        {
+            /// <summary>
+            /// # of remote calls
+            /// </summary>
+            public readonly int RemoteCalls;
+
+            /// <summary>
+            /// Number of current channels
+            /// </summary>
+            public readonly int Channels;
+
+            /// <summary>
+            /// Number of context proxies
+            /// </summary>
+            public readonly int Proxies;
+
+            /// <summary>
+            /// # of Context-bound classes
+            /// </summary>
+            public readonly int Classes;
+
+            /// <summary>
+            /// # of context bound objects allocated
+            /// </summary>
+            public readonly int ObjAlloc;
+
+            /// <summary>
+            /// The current number of contexts
+            /// </summary>
+            public readonly int Contexts;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private readonly struct PerfGC
+        {
+            /// <summary>
+            /// Count of collects gen 0
+            /// </summary>
+            public readonly nint GenCollections0;
+
+            /// <summary>
+            /// Count of collects gen 1
+            /// </summary>
+            public readonly nint GenCollections1;
+
+            /// <summary>
+            /// Count of collects gen 2
+            /// </summary>
+            public readonly nint GenCollections2;
+
+            /// <summary>
+            /// Count of promoted memory from gen 0
+            /// </summary>
+            public readonly nint PromotedMem0;
+
+            /// <summary>
+            /// Count of promoted memory from gen 1
+            /// </summary>
+            public readonly nint PromotedMem1;
+
+            /// <summary>
+            /// Count of memory promoted due to finalization
+            /// </summary>
+            public readonly nint PromotedFinalizationMem;
+
+            /// <summary>
+            /// Process ID
+            /// </summary>
+            public readonly nint ProcessID;
+
+            /// <summary>
+            /// Size of heaps gen 0
+            /// </summary>
+            public readonly nint GenHeapSize0;
+
+            /// <summary>
+            /// Size of heaps gen 1
+            /// </summary>
+            public readonly nint GenHeapSize1;
+
+            /// <summary>
+            /// Size of heaps gen 2
+            /// </summary>
+            public readonly nint GenHeapSize2;
+
+            /// <summary>
+            /// Total number of committed bytes
+            /// </summary>
+            public readonly nint TotalCommittedBytes;
+
+            /// <summary>
+            /// Bytes reserved via VirtualAlloc
+            /// </summary>
+            public readonly nint TotalReservedBytes;
+
+            /// <summary>
+            /// Size of Large Object Heap
+            /// </summary>
+            public readonly nint LargeObjSize;
+
+            /// <summary>
+            /// Count of instances surviving from finalizing
+            /// </summary>
+            public readonly nint SurviveFinalize;
+
+            /// <summary>
+            /// Count of GC handles
+            /// </summary>
+            public readonly nint Handles;
+
+            /// <summary>
+            /// Bytes allocated
+            /// </summary>
+            public readonly nint Alloc;
+
+            /// <summary>
+            /// Bytes allocated for Large Objects
+            /// </summary>
+            public readonly nint LargeAlloc;
+
+            /// <summary>
+            /// Number of explicit GCs
+            /// </summary>
+            public readonly nint InducedGCs;
+
+            /// <summary>
+            /// Time in GC
+            /// </summary>
+            public readonly int TimeInGC;
+
+            /// <summary>
+            /// Must follow time in GC counter
+            /// </summary>
+            public readonly int TimeInGCBase;
+
+            /// <summary>
+            /// # of Pinned Objects
+            /// </summary>
+            public readonly nint PinnedObj;
+
+            /// <summary>
+            /// # of sink blocks
+            /// </summary>
+            public readonly nint SinkBlocks;
+        }
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
@@ -231,7 +231,7 @@ namespace Datadog.Trace.RuntimeMetrics
             public readonly IPCEntry Table;
         }
 
-        [StructLayout(LayoutKind.Sequential, Size = 2048)]
+        [StructLayout(LayoutKind.Sequential)]
         private readonly struct IpcControlBlock
         {
             public readonly IPCHeader Header;

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -156,7 +156,21 @@ namespace Datadog.Trace.RuntimeMetrics
 #if NETCOREAPP
             return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
-            return AzureAppServices.Metadata.IsRelevant ? new AzureAppServicePerformanceCounters(statsd) : new PerformanceCountersListener(statsd);
+
+            if (AzureAppServices.Metadata.IsRelevant)
+            {
+                return new AzureAppServicePerformanceCounters(statsd);
+            }
+
+            try
+            {
+                return new MemoryMappedCounters(statsd);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error while initializing memory-mapped counters. Falling back to performance counters.");
+                return new PerformanceCountersListener(statsd);
+            }
 #else
             return null;
 #endif

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -157,11 +157,6 @@ namespace Datadog.Trace.RuntimeMetrics
             return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
 
-            if (AzureAppServices.Metadata.IsRelevant)
-            {
-                return new AzureAppServicePerformanceCounters(statsd);
-            }
-
             try
             {
                 return new MemoryMappedCounters(statsd);
@@ -169,7 +164,7 @@ namespace Datadog.Trace.RuntimeMetrics
             catch (Exception ex)
             {
                 Log.Warning(ex, "Error while initializing memory-mapped counters. Falling back to performance counters.");
-                return new PerformanceCountersListener(statsd);
+                return AzureAppServices.Metadata.IsRelevant ? new AzureAppServicePerformanceCounters(statsd) : new PerformanceCountersListener(statsd);
             }
 #else
             return null;

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -586,6 +586,9 @@ namespace Datadog.Trace
 
                     Log.Debug("Waiting for disposals.");
                     await Task.WhenAll(flushTracesTask, logSubmissionTask, telemetryTask, discoveryService, dataStreamsTask).ConfigureAwait(false);
+
+                    instance.RuntimeMetrics?.Dispose();
+
                     Log.Debug("Finished waiting for disposals.");
                 }
             }

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/MemoryMappedCountersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/MemoryMappedCountersTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="MemoryMappedCountersTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.Vendors.StatsdClient;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RuntimeMetrics
+{
+    public class MemoryMappedCountersTests
+    {
+        [Fact]
+        public void PushEvents()
+        {
+            var statsd = new Mock<IDogStatsd>();
+
+            using var listener = new MemoryMappedCounters(statsd.Object);
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+            statsd.Invocations.Clear();
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.Is<double>(v => v > 0), 1, null), Times.Once);
+
+            // Those metrics aren't pushed the first time (differential count)
+            statsd.Verify(s => s.Increment(MetricsNames.Gen0CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen1CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<double>(), 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary of changes

Skip the middle-man and directly fetch the value of the performance counters from memory.

## Reason for change

The perf counter API has a few drawbacks:
 - Unstable: we've seen at least one case of crash caused by a corrupted performance counter provider
 - Requires special permissions: by default the IIS worker processes don't have permissions to read the performance counters
 - Hard to deal with: the instance name associated to the performance counter is the name of the process, instead of its pid. Because of that, there is a non-trivial amount of logic involved to find the instance name for a given process.

## Implementation details

There are two perf counter APIs available: v1 and v2. The .NET perf counters use v1.

In the v1 API, the perf counter provider (a DLL registered in the registry) is loaded directly into the process that tries to read the value of the associated performance counters.  To make matters worse, when using the perf counter API exposed by .NET, it causes *all* providers registered on the machine to be loaded into the process (because .NET starts by enumerating all the counters). This is an important reliability and security concern (and because of that, perf counters v2 use a different mechanism).

While looking for alternatives, I realized something: since the perf counter provider is loaded into the process that tries to read the counters, and since we can read counter values for any .NET process on the machine, it means that there is some kind of IPC mechanism involved so that the reader process can ask the performance values from all the .NET applications running. If we could identify that IPC mechanism, maybe we could skip the middle-man and directly query the value of the counters without using the unreliable perf counter API.

After a fair bit of reverse engineering, I discovered that every .NET Framework process exposes the value of the performance counters through a memory-mapped file with special permissions. The provider for the .NET performance counters just enumerates the processes on the system then read the value of the counters from their memory-mapped file.

The name of the memory-mapped file is `Cor_SxSPublic_IPCBlock`. From inside of the process, it can be accessed through the private namespace `Cor_CLR_WRITER`.

The memory-mapped file contains a list of "IPC control blocks". Each control block has a fixed size of 2KB. This is designed to ensure that all versions of .NET Framework after 4.0 can run side-by-side: all the runtimes in the same process share the same memory-mapped file, and they each use their own IPC control block. But since Microsoft never has (and hopefully never will) released a new major version of .NET Framework, we can assume that only the first control block is used.

The control block starts with a header, that contains various information to validate its state and to identify the runtime that owns it. Then it contains a table that lists all the entries. To this day, there is only one entry: the value of the performance counters.

As a sanity check, we validate the process ID exposed by the GC performance counters. If something is wrong, we fallback to the old performance counter implementation.

## Test coverage

The integration test initializes the new listener and makes sure nothing blows up.

Further testing need to be done in IIS and AAS (we might be able to stop using the `AzureAppServicePerformanceCounters` class as well).