### PR TITLE
Ensure test parameters are constant across test runs

### DIFF
--- a/Datadog.Trace.Debugger.slnf
+++ b/Datadog.Trace.Debugger.slnf
@@ -17,8 +17,9 @@
       "tracer\\test\\Datadog.Trace.Tests\\Datadog.Trace.Tests.csproj",
       "tracer\\test\\test-applications\\debugger\\Samples.Probes\\Samples.Probes.csproj",
       "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.External\\Samples.Probes.External.csproj",
-	"tracer\\test\\Datadog.Trace.TestHelpers.AutoInstrumentation\\Datadog.Trace.TestHelpers.AutoInstrumentation.csproj",
-	"tracer\\src\\Datadog.Trace.Annotations\\Datadog.Trace.Annotations.csproj"
+	  "tracer\\test\\Datadog.Trace.TestHelpers.AutoInstrumentation\\Datadog.Trace.TestHelpers.AutoInstrumentation.csproj",
+	  "tracer\\src\\Datadog.Trace.AspNet\\Datadog.Trace.AspNet.csproj",
+	  "tracer\\src\\Datadog.Trace.Annotations\\Datadog.Trace.Annotations.csproj"
     ]
   }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SupportedTypesServiceTests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Tests.Debugger
 {
     public class SupportedTypesServiceTests
     {
-        private static readonly object[] Objects = { 3, DateTime.Now, TimeSpan.FromSeconds(3), DateTimeOffset.Now, Guid.NewGuid(), "Hello", new int?(5), new DateTime?(DateTime.Now), ConsoleColor.Blue };
+        private static readonly object[] Objects = { 3, DateTime.MinValue, TimeSpan.FromSeconds(3), DateTimeOffset.MinValue, Guid.Empty, "Hello", new int?(5), new DateTime?(DateTime.MinValue), ConsoleColor.Blue };
 
         public static System.Collections.Generic.IEnumerable<object[]> ObjectsCanCallToStringOn() => Objects.Select(o => new object[] { o });
 


### PR DESCRIPTION
## Summary of changes

Ensure that when tests are parameterized, the parameters are constant values that do not change in each run.

## Reason for change

In order to be able to monitor the amount of tests that are being executed in each CI runs, and be able to effectively catch cases where we unintentionally disable / remove a bunch of tests, we need the number of tests to be stable. 

When a given test is executed with a different set of parameters each time (e.g. if the parameter value is `Guid.NewGuid()` or `DateTime.Now`), we run the risk that the test fails and gets re-executed with a new set of values on retry. In that scenario, the reported number of tests will be larger than it actually is, because these kind of tests generate a new fingerprint (hash) each time they run.