### PR TITLE
[Dynamic Instrumentation] Added missing tags to `RcmClientTracer`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -369,33 +369,9 @@ namespace Datadog.Trace.ClrProfiler
                     {
                         var rcmSettings = RemoteConfigurationSettings.FromDefaultSource();
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
-                        var tags = tracer.Settings.GlobalTags.Select(pair => pair.Key + ":" + pair.Value).ToList();
+                        var tags = GetGlobalTags(tracer, rcmSettings);
 
-                        var environment = tracer.Settings.Environment;
-                        if (!string.IsNullOrEmpty(environment))
-                        {
-                            tags.Add($"env:{environment}");
-                        }
-
-                        var serviceVersion = tracer.Settings.ServiceVersion;
-                        if (!string.IsNullOrEmpty(serviceVersion))
-                        {
-                            tags.Add($"version:{serviceVersion}");
-                        }
-
-                        var tracerVersion = rcmSettings.TracerVersion;
-                        if (!string.IsNullOrEmpty(tracerVersion))
-                        {
-                            tags.Add($"tracer_version:{tracerVersion}");
-                        }
-
-                        var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
-                        if (!string.IsNullOrEmpty(hostName))
-                        {
-                            tags.Add($"host_name:{hostName}");
-                        }
-
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, environment, serviceVersion, tags);
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion, tags);
                         // see comment above
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmFeaturesProduct);
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmDataProduct);
@@ -413,6 +389,37 @@ namespace Datadog.Trace.ClrProfiler
                              .ConfigureAwait(false);
                     }
                 });
+        }
+
+        private static List<string> GetGlobalTags(Tracer tracer, RemoteConfigurationSettings rcmSettings)
+        {
+            var tags = tracer.Settings.GlobalTags.Select(pair => pair.Key + ":" + pair.Value).ToList();
+
+            var environment = tracer.Settings.Environment;
+            if (!string.IsNullOrEmpty(environment))
+            {
+                tags.Add($"env:{environment}");
+            }
+
+            var serviceVersion = tracer.Settings.ServiceVersion;
+            if (!string.IsNullOrEmpty(serviceVersion))
+            {
+                tags.Add($"version:{serviceVersion}");
+            }
+
+            var tracerVersion = rcmSettings.TracerVersion;
+            if (!string.IsNullOrEmpty(tracerVersion))
+            {
+                tags.Add($"tracer_version:{tracerVersion}");
+            }
+
+            var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
+            if (!string.IsNullOrEmpty(hostName))
+            {
+                tags.Add($"host_name:{hostName}");
+            }
+
+            return tags;
         }
 
         internal static async Task<bool> WaitForDiscoveryService(IDiscoveryService discoveryService)

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -369,8 +369,33 @@ namespace Datadog.Trace.ClrProfiler
                     {
                         var rcmSettings = RemoteConfigurationSettings.FromDefaultSource();
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
+                        var tags = tracer.Settings.GlobalTags.Select(pair => pair.Key + ":" + pair.Value).ToList();
 
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion);
+                        var environment = tracer.Settings.Environment;
+                        if (!string.IsNullOrEmpty(environment))
+                        {
+                            tags.Add($"env:{environment}");
+                        }
+
+                        var serviceVersion = tracer.Settings.ServiceVersion;
+                        if (!string.IsNullOrEmpty(serviceVersion))
+                        {
+                            tags.Add($"version:{serviceVersion}");
+                        }
+
+                        var tracerVersion = rcmSettings.TracerVersion;
+                        if (!string.IsNullOrEmpty(tracerVersion))
+                        {
+                            tags.Add($"tracer_version:{tracerVersion}");
+                        }
+
+                        var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
+                        if (!string.IsNullOrEmpty(hostName))
+                        {
+                            tags.Add($"host_name:{hostName}");
+                        }
+
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, environment, serviceVersion, tags);
                         // see comment above
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmFeaturesProduct);
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmDataProduct);

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -369,7 +369,7 @@ namespace Datadog.Trace.ClrProfiler
                     {
                         var rcmSettings = RemoteConfigurationSettings.FromDefaultSource();
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
-                        var tags = GetGlobalTags(tracer, rcmSettings);
+                        var tags = GetTags(tracer, rcmSettings);
 
                         var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion, tags);
                         // see comment above
@@ -391,9 +391,9 @@ namespace Datadog.Trace.ClrProfiler
                 });
         }
 
-        private static List<string> GetGlobalTags(Tracer tracer, RemoteConfigurationSettings rcmSettings)
+        private static List<string> GetTags(Tracer tracer, RemoteConfigurationSettings rcmSettings)
         {
-            var tags = tracer.Settings.GlobalTags.Select(pair => pair.Key + ":" + pair.Value).ToList();
+            var tags = tracer.Settings.GlobalTags?.Select(pair => pair.Key + ":" + pair.Value).ToList() ?? new List<string>();
 
             var environment = tracer.Settings.Environment;
             if (!string.IsNullOrEmpty(environment))

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientTracer.cs
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 {
     internal class RcmClientTracer
     {
-        public RcmClientTracer(string runtimeId, string tracerVersion, string service, string env, string appVersion)
+        public RcmClientTracer(string runtimeId, string tracerVersion, string service, string env, string appVersion, IReadOnlyList<string> tags)
         {
             RuntimeId = runtimeId;
             Language = TracerConstants.Language;
@@ -17,6 +18,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
             Service = service;
             Env = env;
             AppVersion = appVersion;
+            Tags = tags;
         }
 
         [JsonProperty("runtime_id")]
@@ -36,5 +38,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
 
         [JsonProperty("app_version")]
         public string AppVersion { get; }
+
+        [JsonProperty("tags")]
+        public IReadOnlyList<string> Tags { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -75,7 +75,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             RemoteConfigurationSettings settings,
             string serviceName,
             string? environment,
-            string? serviceVersion)
+            string? serviceVersion,
+            IReadOnlyList<string> tags)
         {
             lock (LockObject)
             {
@@ -83,7 +84,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                     discoveryService,
                     remoteConfigurationApi,
                     id: settings.Id,
-                    rcmTracer: new RcmClientTracer(settings.RuntimeId, settings.TracerVersion, serviceName, environment, serviceVersion),
+                    rcmTracer: new RcmClientTracer(settings.RuntimeId, settings.TracerVersion, serviceName, environment, serviceVersion, tags),
                     pollInterval: settings.PollInterval);
             }
 


### PR DESCRIPTION
## Summary of changes
Added the global tags (`DD_TAGS`) together with the default tags env, service version, tracer version and host name as part of RCM requests.

## Reason for change
The support of Source-Code Integration in the Dynamic Instrumentation product relies on the tags `git.commit.sha` and `git.repository_url` to be presented in the RCM request as done in the Java client library: https://github.com/DataDog/dd-trace-java/blob/dd965263e69bc9822caa9be9292a1dfed6c56c1a/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java#L124.