### PR TITLE
[Dynamic Instrumentation] Activating line probe on async methods + Fixed snapshot serialization issues

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Models/ProbeSnapshot.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/ProbeSnapshot.cs
@@ -165,7 +165,7 @@ namespace Datadog.Trace.Debugger
                 Locals = SnapshotSerializationHelpers.ToCapturedValue(locals);
             }
 
-            if (_additionalData.TryGetValue("token", out var fields))
+            if (_additionalData.TryGetValue("fields", out var fields))
             {
                 Fields = SnapshotSerializationHelpers.ToCapturedValue(fields);
             }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -191,8 +191,6 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             if (currentDepth >= _maximumDepthOfMembersToCopy)
             {
-                jsonWriter.WritePropertyName("type");
-                jsonWriter.WriteValue(type.Name);
                 WriteNotCapturedReason(jsonWriter, NotCapturedReason.depth);
                 return;
             }
@@ -215,8 +213,6 @@ namespace Datadog.Trace.Debugger.Snapshots
         {
             // According the the debugger snapshot json structure RFC, the "this" value, unlike all other complex types,
             // should NOT contain a "fields" property, but rather the fields should be serialized directly under the "this" object.
-            bool writeFieldsJsonElement = !jsonWriter.Path.EndsWith(".this.value");
-
             int index = 0;
             foreach (var field in fields)
             {
@@ -233,7 +229,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                     continue;
                 }
 
-                if (index == 0 && writeFieldsJsonElement)
+                if (index == 0)
                 {
                     jsonWriter.WritePropertyName(fieldsObjectName);
                     jsonWriter.WriteStartObject();
@@ -255,7 +251,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                 }
             }
 
-            if (index > 0 && writeFieldsJsonElement)
+            if (index > 0)
             {
                 jsonWriter.WriteEndObject();
             }

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1364,8 +1364,7 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
 
         if (isAsyncMethod)
         {
-            Logger::Info("Async probe is disabled");
-            return S_OK;
+            Logger::Info("Async method probe is disabled");
             /* hr = ApplyAsyncMethodProbe(corProfiler, module_id, module_metadata, caller, debuggerTokens, function_token,
                                        isStatic, &methodReturnType, methodProbeId, methodLocals, numLocals, rewriterWrapper, asyncMethodStateIndex, callTargetReturnIndex,
                                        returnValueIndex, callTargetReturnToken, firstInstruction, instrumentedMethodIndex, beforeLineProbe,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -7,118 +7,36 @@
     "debugger": {
       "snapshot": {
         "captures": {
-          "entry": {
-            "arguments": {
-              "input": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod.RunAsync"
-              }
-            },
-            "fields": {
-              "ClassName": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod"
-              }
-            }
-          },
-          "return": {
-            "arguments": {
-              "input": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod.RunAsync"
-              }
-            },
-            "fields": {
-              "ClassName": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod"
-              }
-            },
-            "locals": {
-              "@return": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod.RunAsync.Method"
-              },
-              "output": {
-                "fields": null,
-                "type": "String",
-                "value": "AsyncInstanceMethod.RunAsync."
-              }
-            }
-          }
-        },
-        "duration": "ScrubbedValue",
-        "id": "ScrubbedValue",
-        "language": "dotnet",
-        "probe": {
-          "id": "ScrubbedValue",
-          "location": {
-            "method": "Method",
-            "type": "Samples.Probes.SmokeTests.AsyncInstanceMethod"
-          }
-        },
-        "stack": [],
-        "timestamp": "ScrubbedValue"
-      }
-    },
-    "logger": {
-      "method": "Method",
-      "name": "Samples.Probes.SmokeTests.AsyncInstanceMethod",
-      "thread_id": "ScrubbedValue",
-      "thread_name": "ScrubbedValue",
-      "version": "2"
-    },
-    "message": "AsyncInstanceMethod+<Method>d__2.MoveNext(input=AsyncInstanceMethod.RunAsync): AsyncInstanceMethod.RunAsync.Method\r\n@return=AsyncInstanceMethod.RunAsync.Method, output=AsyncInstanceMethod.RunAsync.",
-    "service": "Probes"
-  },
-  {
-    "dd.span_id": "ScrubbedValue",
-    "dd.trace_id": "ScrubbedValue",
-    "ddsource": "dd_debugger",
-    "ddtags": "Unknown",
-    "debugger": {
-      "snapshot": {
-        "captures": {
           "lines": {
             "21": {
-              "fields": {
-                "<>1__state": {
-                  "fields": null,
-                  "type": "Int32",
-                  "value": "-1"
-                },
-                "<>4__this": {
+              "arguments": {
+                "this": {
                   "fields": {
-                    "ClassName": {
-                      "fields": null,
-                      "type": "String",
+                    "<>1__state": {
+                      "type": "Int32",
+                      "value": "-1"
+                    },
+                    "<>4__this": {
+                      "type": "AsyncInstanceMethod",
                       "value": "AsyncInstanceMethod"
+                    },
+                    "<>dd_liveDebugger_isReEntryToMoveNext": {
+                      "type": "Boolean",
+                      "value": "False"
+                    },
+                    "<>t__builder": "ScrubbedValue",
+                    "<>u__1": "ScrubbedValue",
+                    "<output>5__1": {
+                      "isNull": "true",
+                      "type": "String"
+                    },
+                    "input": {
+                      "type": "String",
+                      "value": "AsyncInstanceMethod.RunAsync"
                     }
                   },
-                  "type": "AsyncInstanceMethod",
-                  "value": "AsyncInstanceMethod"
-                },
-                "<>dd_liveDebugger_isReEntryToMoveNext": {
-                  "fields": null,
-                  "type": "Boolean",
-                  "value": "True"
-                },
-                "<>t__builder": "ScrubbedValue",
-                "<>u__1": "ScrubbedValue",
-                "<output>5__1": {
-                  "fields": null,
-                  "type": "String",
-                  "value": "null"
-                },
-                "input": {
-                  "fields": null,
-                  "type": "String",
-                  "value": "AsyncInstanceMethod.RunAsync"
+                  "type": "<Method>d__2",
+                  "value": "<Method>d__2"
                 }
               }
             }
@@ -165,7 +83,7 @@
       "thread_name": "ScrubbedValue",
       "version": "2"
     },
-    "message": "AsyncInstanceMethod+<Method>d__2.MoveNext()",
+    "message": "AsyncInstanceMethod+<Method>d__2.MoveNext(this=<Method>d__2)",
     "service": "Probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -68,9 +68,11 @@
                 "value": "Person"
               },
               "this": {
-                "Prop": {
-                  "type": "String",
-                  "value": "GenericMethodWithArguments"
+                "fields": {
+                  "Prop": {
+                    "type": "String",
+                    "value": "GenericMethodWithArguments"
+                  }
                 },
                 "type": "GenericMethodWithArguments",
                 "value": "GenericMethodWithArguments"
@@ -138,9 +140,11 @@
                 "value": "Person"
               },
               "this": {
-                "Prop": {
-                  "type": "String",
-                  "value": "GenericMethodWithArguments"
+                "fields": {
+                  "Prop": {
+                    "type": "String",
+                    "value": "GenericMethodWithArguments"
+                  }
                 },
                 "type": "GenericMethodWithArguments",
                 "value": "GenericMethodWithArguments"
@@ -268,9 +272,11 @@
                   "value": "Person"
                 },
                 "this": {
-                  "Prop": {
-                    "type": "String",
-                    "value": "GenericMethodWithArguments"
+                  "fields": {
+                    "Prop": {
+                      "type": "String",
+                      "value": "GenericMethodWithArguments"
+                    }
                   },
                   "type": "GenericMethodWithArguments",
                   "value": "GenericMethodWithArguments"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
@@ -14,9 +14,11 @@
                 "value": "Last"
               },
               "this": {
-                "FirstName": {
-                  "isNull": "true",
-                  "type": "String"
+                "fields": {
+                  "FirstName": {
+                    "isNull": "true",
+                    "type": "String"
+                  }
                 },
                 "type": "HasArgumentsAndLocals",
                 "value": "HasArgumentsAndLocals"
@@ -30,9 +32,11 @@
                 "value": "Last"
               },
               "this": {
-                "FirstName": {
-                  "type": "String",
-                  "value": "First"
+                "fields": {
+                  "FirstName": {
+                    "type": "String",
+                    "value": "First"
+                  }
                 },
                 "type": "HasArgumentsAndLocals",
                 "value": "HasArgumentsAndLocals"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
@@ -14,19 +14,21 @@
                 "value": "First"
               },
               "this": {
-                "FirstName": {
-                  "fields": {
-                    "IsValueCreated": {
-                      "type": "Boolean",
-                      "value": "True"
+                "fields": {
+                  "FirstName": {
+                    "fields": {
+                      "IsValueCreated": {
+                        "type": "Boolean",
+                        "value": "True"
+                      },
+                      "Value": {
+                        "type": "String",
+                        "value": "First"
+                      }
                     },
-                    "Value": {
-                      "type": "String",
-                      "value": "First"
-                    }
-                  },
-                  "type": "Lazy`1",
-                  "value": "Lazy`1"
+                    "type": "Lazy`1",
+                    "value": "Lazy`1"
+                  }
                 },
                 "type": "HasFieldLazyValueInitialized",
                 "value": "HasFieldLazyValueInitialized"
@@ -40,19 +42,21 @@
                 "value": "First"
               },
               "this": {
-                "FirstName": {
-                  "fields": {
-                    "IsValueCreated": {
-                      "type": "Boolean",
-                      "value": "True"
+                "fields": {
+                  "FirstName": {
+                    "fields": {
+                      "IsValueCreated": {
+                        "type": "Boolean",
+                        "value": "True"
+                      },
+                      "Value": {
+                        "type": "String",
+                        "value": "First"
+                      }
                     },
-                    "Value": {
-                      "type": "String",
-                      "value": "First"
-                    }
-                  },
-                  "type": "Lazy`1",
-                  "value": "Lazy`1"
+                    "type": "Lazy`1",
+                    "value": "Lazy`1"
+                  }
                 },
                 "type": "HasFieldLazyValueInitialized",
                 "value": "HasFieldLazyValueInitialized"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
@@ -14,15 +14,17 @@
                 "value": "Last"
               },
               "this": {
-                "FirstName": {
-                  "fields": {
-                    "IsValueCreated": {
-                      "type": "Boolean",
-                      "value": "False"
-                    }
-                  },
-                  "type": "Lazy`1",
-                  "value": "Lazy`1"
+                "fields": {
+                  "FirstName": {
+                    "fields": {
+                      "IsValueCreated": {
+                        "type": "Boolean",
+                        "value": "False"
+                      }
+                    },
+                    "type": "Lazy`1",
+                    "value": "Lazy`1"
+                  }
                 },
                 "type": "HasFieldLazyValueNotInitialized",
                 "value": "HasFieldLazyValueNotInitialized"
@@ -36,15 +38,17 @@
                 "value": "Last"
               },
               "this": {
-                "FirstName": {
-                  "fields": {
-                    "IsValueCreated": {
-                      "type": "Boolean",
-                      "value": "False"
-                    }
-                  },
-                  "type": "Lazy`1",
-                  "value": "Lazy`1"
+                "fields": {
+                  "FirstName": {
+                    "fields": {
+                      "IsValueCreated": {
+                        "type": "Boolean",
+                        "value": "False"
+                      }
+                    },
+                    "type": "Lazy`1",
+                    "value": "Lazy`1"
+                  }
                 },
                 "type": "HasFieldLazyValueNotInitialized",
                 "value": "HasFieldLazyValueNotInitialized"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -14,9 +14,11 @@
                 "value": "7"
               },
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "7"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "7"
+                  }
                 },
                 "type": "HasLocalsAndReturnValue",
                 "value": "HasLocalsAndReturnValue"
@@ -30,9 +32,11 @@
                 "value": "7"
               },
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "7"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "7"
+                  }
                 },
                 "type": "HasLocalsAndReturnValue",
                 "value": "HasLocalsAndReturnValue"
@@ -106,9 +110,11 @@
             "16": {
               "arguments": {
                 "this": {
-                  "Number": {
-                    "type": "Int32",
-                    "value": "7"
+                  "fields": {
+                    "Number": {
+                      "type": "Int32",
+                      "value": "7"
+                    }
                   },
                   "type": "HasLocalsAndReturnValue",
                   "value": "HasLocalsAndReturnValue"
@@ -176,9 +182,11 @@
             "17": {
               "arguments": {
                 "this": {
-                  "Number": {
-                    "type": "Int32",
-                    "value": "7"
+                  "fields": {
+                    "Number": {
+                      "type": "Int32",
+                      "value": "7"
+                    }
                   },
                   "type": "HasLocalsAndReturnValue",
                   "value": "HasLocalsAndReturnValue"
@@ -250,9 +258,11 @@
                   "value": "7"
                 },
                 "this": {
-                  "Number": {
-                    "type": "Int32",
-                    "value": "7"
+                  "fields": {
+                    "Number": {
+                      "type": "Int32",
+                      "value": "7"
+                    }
                   },
                   "type": "HasLocalsAndReturnValue",
                   "value": "HasLocalsAndReturnValue"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.HasReturnValue.verified.txt
@@ -10,9 +10,11 @@
           "entry": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "0"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "0"
+                  }
                 },
                 "type": "HasReturnValue",
                 "value": "HasReturnValue"
@@ -22,9 +24,11 @@
           "return": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "7"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "7"
+                  }
                 },
                 "type": "HasReturnValue",
                 "value": "HasReturnValue"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
@@ -10,9 +10,11 @@
           "entry": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "0"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "0"
+                  }
                 },
                 "type": "InstanceVoidMethod",
                 "value": "InstanceVoidMethod"
@@ -22,9 +24,11 @@
           "return": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "7"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "7"
+                  }
                 },
                 "type": "InstanceVoidMethod",
                 "value": "InstanceVoidMethod"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -10,9 +10,11 @@
           "entry": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "0"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "0"
+                  }
                 },
                 "type": "MethodThrowExceptionTest",
                 "value": "MethodThrowExceptionTest"
@@ -26,9 +28,11 @@
           "return": {
             "arguments": {
               "this": {
-                "Number": {
-                  "type": "Int32",
-                  "value": "2147483647"
+                "fields": {
+                  "Number": {
+                    "type": "Int32",
+                    "value": "2147483647"
+                  }
                 },
                 "type": "MethodThrowExceptionTest",
                 "value": "MethodThrowExceptionTest"
@@ -116,9 +120,11 @@
             "26": {
               "arguments": {
                 "this": {
-                  "Number": {
-                    "type": "Int32",
-                    "value": "2147483647"
+                  "fields": {
+                    "Number": {
+                      "type": "Int32",
+                      "value": "2147483647"
+                    }
                   },
                   "type": "MethodThrowExceptionTest",
                   "value": "MethodThrowExceptionTest"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -4,18 +4,6 @@
     "debugger": {
       "diagnostics": {
         "Exception": null,
-        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
-        "status": "INSTALLED"
-      }
-    },
-    "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
-  },
-  {
-    "ddsource": "dd_debugger",
-    "debugger": {
-      "diagnostics": {
-        "Exception": null,
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
         "status": "INSTALLED"
       }

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/AsyncInstanceMethod.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Samples.Probes.SmokeTests
 {
-    [LineProbeTestData(lineNumber: 21, skip: true)]
+    [LineProbeTestData(lineNumber: 21)]
     public class AsyncInstanceMethod : IAsyncRun
     {
         private const string ClassName = "AsyncInstanceMethod";


### PR DESCRIPTION
## Summary of changes
- The previous attempt to disable the async method probe mistakenly also disabled async line probe - now only the async method probe scenario is disabled.
- Fixed snapshot serialization issues - adhering to the format of the Snapshot RFC.

## Reason for change
Async line probe is unjustly disabled and we serialize the line probe snapshot (specifically `this`) incorrectly.

## Test coverage
Restored the test `AsyncInstanceMethod` for line probe.