### PR TITLE
Fix ASP.NET and ASP.NET Core resource name template expansion

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetResourceNameHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetResourceNameHelper.cs
@@ -214,8 +214,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     var keyIndex = 0;
                     while (keyIndex < keyLength)
                     {
-                        // this is a case-sensitive comparison, which is probably ok?
-                        if (sb[startIndex + keyIndex] != key[keyIndex])
+                        // this is a case-sensitive comparison
+                        // which is ok as we convert both key and resource template to lower invariant
+                        if (sb[startIndex + keyIndex] != char.ToLowerInvariant(key[keyIndex]))
                         {
                             // no match
                             return false;

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -272,186 +272,6 @@ namespace Datadog.Trace.DiagnosticListeners
         }
 #endif
 
-        private static string SimplifyRoutePattern(
-            RoutePattern routePattern,
-            RouteValueDictionary routeValueDictionary,
-            string areaName,
-            string controllerName,
-            string actionName,
-            bool expandRouteParameters)
-        {
-            var maxSize = routePattern.RawText.Length
-                        + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
-                        + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
-                        + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
-                        + 1; // '/' prefix
-
-            var sb = StringBuilderCache.Acquire(maxSize);
-
-            foreach (var pathSegment in routePattern.PathSegments)
-            {
-                foreach (var part in pathSegment.DuckCast<RoutePatternPathSegmentStruct>().Parts)
-                {
-                    if (part.TryDuckCast(out RoutePatternContentPartStruct contentPart))
-                    {
-                        sb.Append('/');
-                        sb.Append(contentPart.Content);
-                    }
-                    else if (part.TryDuckCast(out RoutePatternParameterPartStruct parameter))
-                    {
-                        var parameterName = parameter.Name;
-                        if (parameterName.Equals("area", StringComparison.OrdinalIgnoreCase))
-                        {
-                            sb.Append('/');
-                            sb.Append(areaName);
-                        }
-                        else if (parameterName.Equals("controller", StringComparison.OrdinalIgnoreCase))
-                        {
-                            sb.Append('/');
-                            sb.Append(controllerName);
-                        }
-                        else if (parameterName.Equals("action", StringComparison.OrdinalIgnoreCase))
-                        {
-                            sb.Append('/');
-                            sb.Append(actionName);
-                        }
-                        else
-                        {
-                            var haveParameter = routeValueDictionary.TryGetValue(parameterName, out var value);
-                            if (!parameter.IsOptional || haveParameter)
-                            {
-                                sb.Append('/');
-                                if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
-                                {
-                                    // write the expanded parameter value
-                                    sb.Append(valueAsString);
-                                }
-                                else
-                                {
-                                    // write the route template value
-                                    sb.Append('{');
-                                    if (parameter.IsCatchAll)
-                                    {
-                                        if (parameter.EncodeSlashes)
-                                        {
-                                            sb.Append("**");
-                                        }
-                                        else
-                                        {
-                                            sb.Append('*');
-                                        }
-                                    }
-
-                                    sb.Append(parameterName);
-                                    if (parameter.IsOptional)
-                                    {
-                                        sb.Append('?');
-                                    }
-
-                                    sb.Append('}');
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            var simplifiedRoute = StringBuilderCache.GetStringAndRelease(sb);
-
-            return string.IsNullOrEmpty(simplifiedRoute) ? "/" : simplifiedRoute.ToLowerInvariant();
-        }
-
-        private static string SimplifyRoutePattern(
-            RouteTemplate routePattern,
-            RouteValueDictionary routeValueDictionary,
-            string areaName,
-            string controllerName,
-            string actionName,
-            bool expandRouteParameters)
-        {
-            var maxSize = routePattern.TemplateText.Length
-                        + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
-                        + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
-                        + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
-                        + 1; // '/' prefix
-
-            var sb = StringBuilderCache.Acquire(maxSize);
-
-            foreach (var pathSegment in routePattern.Segments)
-            {
-                foreach (var part in pathSegment.Parts)
-                {
-                    var partName = part.Name;
-
-                    if (!part.IsParameter)
-                    {
-                        sb.Append('/');
-                        sb.Append(part.Text);
-                    }
-                    else if (partName.Equals("area", StringComparison.OrdinalIgnoreCase))
-                    {
-                        sb.Append('/');
-                        sb.Append(areaName);
-                    }
-                    else if (partName.Equals("controller", StringComparison.OrdinalIgnoreCase))
-                    {
-                        sb.Append('/');
-                        sb.Append(controllerName);
-                    }
-                    else if (partName.Equals("action", StringComparison.OrdinalIgnoreCase))
-                    {
-                        sb.Append('/');
-                        sb.Append(actionName);
-                    }
-                    else
-                    {
-                        var haveParameter = routeValueDictionary.TryGetValue(partName, out var value);
-                        if (!part.IsOptional || haveParameter)
-                        {
-                            sb.Append('/');
-                            if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
-                            {
-                                // write the expanded parameter value
-                                sb.Append(valueAsString);
-                            }
-                            else
-                            {
-                                // write the route template value
-                                sb.Append('{');
-                                if (part.IsCatchAll)
-                                {
-                                    sb.Append('*');
-                                }
-
-                                sb.Append(partName);
-                                if (part.IsOptional)
-                                {
-                                    sb.Append('?');
-                                }
-
-                                sb.Append('}');
-                            }
-                        }
-                    }
-                }
-            }
-
-            var simplifiedRoute = StringBuilderCache.GetStringAndRelease(sb);
-
-            return string.IsNullOrEmpty(simplifiedRoute) ? "/" : simplifiedRoute.ToLowerInvariant();
-        }
-
-        private static bool IsIdentifierSegment(object value, [NotNullWhen(false)] out string valueAsString)
-        {
-            valueAsString = value as string ?? value?.ToString();
-            if (valueAsString is null)
-            {
-                return false;
-            }
-
-            return UriHelpers.IsIdentifierSegment(valueAsString, 0, valueAsString.Length);
-        }
-
         private static void SetLegacyResourceNames(BeforeActionStruct typedArg, Span span)
         {
             ActionDescriptor actionDescriptor = typedArg.ActionDescriptor;
@@ -544,7 +364,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 if (routeTemplate is not null)
                 {
                     // If we have a route, overwrite the existing resource name
-                    var resourcePathName = SimplifyRoutePattern(
+                    var resourcePathName = AspNetCoreResourceNameHelper.SimplifyRouteTemplate(
                         routeTemplate,
                         typedArg.RouteData.Values,
                         areaName: areaName,
@@ -758,7 +578,7 @@ namespace Datadog.Trace.DiagnosticListeners
                                       ? raw as string
                                       : null;
 
-                var resourcePathName = SimplifyRoutePattern(
+                var resourcePathName = AspNetCoreResourceNameHelper.SimplifyRoutePattern(
                     routePattern,
                     routeValues,
                     areaName: areaName,

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
@@ -1,0 +1,198 @@
+﻿// <copyright file="AspNetCoreResourceNameHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if !NETFRAMEWORK
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Util;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
+
+namespace Datadog.Trace.DiagnosticListeners;
+
+internal class AspNetCoreResourceNameHelper
+{
+    internal static string SimplifyRoutePattern(
+        RoutePattern routePattern,
+        RouteValueDictionary routeValueDictionary,
+        string areaName,
+        string controllerName,
+        string actionName,
+        bool expandRouteParameters)
+    {
+        var maxSize = routePattern.RawText.Length
+                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
+                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
+                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
+                    + 1; // '/' prefix
+
+        var sb = StringBuilderCache.Acquire(maxSize);
+
+        foreach (var pathSegment in routePattern.PathSegments)
+        {
+            foreach (var part in pathSegment.DuckCast<AspNetCoreDiagnosticObserver.RoutePatternPathSegmentStruct>().Parts)
+            {
+                if (part.TryDuckCast(out AspNetCoreDiagnosticObserver.RoutePatternContentPartStruct contentPart))
+                {
+                    sb.Append('/');
+                    sb.Append(contentPart.Content);
+                }
+                else if (part.TryDuckCast(out AspNetCoreDiagnosticObserver.RoutePatternParameterPartStruct parameter))
+                {
+                    var parameterName = parameter.Name;
+                    if (parameterName.Equals("area", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append('/');
+                        sb.Append(areaName);
+                    }
+                    else if (parameterName.Equals("controller", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append('/');
+                        sb.Append(controllerName);
+                    }
+                    else if (parameterName.Equals("action", StringComparison.OrdinalIgnoreCase))
+                    {
+                        sb.Append('/');
+                        sb.Append(actionName);
+                    }
+                    else
+                    {
+                        var haveParameter = routeValueDictionary.TryGetValue(parameterName, out var value);
+                        if (!parameter.IsOptional || haveParameter)
+                        {
+                            sb.Append('/');
+                            if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
+                            {
+                                // write the expanded parameter value
+                                sb.Append(valueAsString);
+                            }
+                            else
+                            {
+                                // write the route template value
+                                sb.Append('{');
+                                if (parameter.IsCatchAll)
+                                {
+                                    if (parameter.EncodeSlashes)
+                                    {
+                                        sb.Append("**");
+                                    }
+                                    else
+                                    {
+                                        sb.Append('*');
+                                    }
+                                }
+
+                                sb.Append(parameterName);
+                                if (parameter.IsOptional)
+                                {
+                                    sb.Append('?');
+                                }
+
+                                sb.Append('}');
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        var simplifiedRoute = StringBuilderCache.GetStringAndRelease(sb);
+
+        return string.IsNullOrEmpty(simplifiedRoute) ? "/" : simplifiedRoute.ToLowerInvariant();
+    }
+
+    internal static string SimplifyRouteTemplate(
+        RouteTemplate routePattern,
+        RouteValueDictionary routeValueDictionary,
+        string areaName,
+        string controllerName,
+        string actionName,
+        bool expandRouteParameters)
+    {
+        var maxSize = routePattern.TemplateText.Length
+                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
+                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
+                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
+                    + 1; // '/' prefix
+
+        var sb = StringBuilderCache.Acquire(maxSize);
+
+        foreach (var pathSegment in routePattern.Segments)
+        {
+            foreach (var part in pathSegment.Parts)
+            {
+                var partName = part.Name;
+
+                if (!part.IsParameter)
+                {
+                    sb.Append('/');
+                    sb.Append(part.Text);
+                }
+                else if (partName.Equals("area", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append('/');
+                    sb.Append(areaName);
+                }
+                else if (partName.Equals("controller", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append('/');
+                    sb.Append(controllerName);
+                }
+                else if (partName.Equals("action", StringComparison.OrdinalIgnoreCase))
+                {
+                    sb.Append('/');
+                    sb.Append(actionName);
+                }
+                else
+                {
+                    var haveParameter = routeValueDictionary.TryGetValue(partName, out var value);
+                    if (!part.IsOptional || haveParameter)
+                    {
+                        sb.Append('/');
+                        if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
+                        {
+                            // write the expanded parameter value
+                            sb.Append(valueAsString);
+                        }
+                        else
+                        {
+                            // write the route template value
+                            sb.Append('{');
+                            if (part.IsCatchAll)
+                            {
+                                sb.Append('*');
+                            }
+
+                            sb.Append(partName);
+                            if (part.IsOptional)
+                            {
+                                sb.Append('?');
+                            }
+
+                            sb.Append('}');
+                        }
+                    }
+                }
+            }
+        }
+
+        var simplifiedRoute = StringBuilderCache.GetStringAndRelease(sb);
+
+        return string.IsNullOrEmpty(simplifiedRoute) ? "/" : simplifiedRoute.ToLowerInvariant();
+    }
+
+    private static bool IsIdentifierSegment(object value, [NotNullWhen(false)] out string valueAsString)
+    {
+        valueAsString = value as string ?? value?.ToString();
+        if (valueAsString is null)
+        {
+            return false;
+        }
+
+        return UriHelpers.IsIdentifierSegment(valueAsString, 0, valueAsString.Length);
+    }
+}
+#endif

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
@@ -33,11 +33,17 @@ internal class AspNetCoreResourceNameHelper
 
         foreach (var pathSegment in routePattern.PathSegments)
         {
+            var parts = 0;
             foreach (var part in pathSegment.DuckCast<AspNetCoreDiagnosticObserver.RoutePatternPathSegmentStruct>().Parts)
             {
+                parts++;
                 if (part.TryDuckCast(out AspNetCoreDiagnosticObserver.RoutePatternContentPartStruct contentPart))
                 {
-                    sb.Append('/');
+                    if (parts == 1)
+                    {
+                        sb.Append('/');
+                    }
+
                     sb.Append(contentPart.Content);
                 }
                 else if (part.TryDuckCast(out AspNetCoreDiagnosticObserver.RoutePatternParameterPartStruct parameter))
@@ -45,17 +51,29 @@ internal class AspNetCoreResourceNameHelper
                     var parameterName = parameter.Name;
                     if (parameterName.Equals("area", StringComparison.OrdinalIgnoreCase))
                     {
-                        sb.Append('/');
+                        if (parts == 1)
+                        {
+                            sb.Append('/');
+                        }
+
                         sb.Append(areaName);
                     }
                     else if (parameterName.Equals("controller", StringComparison.OrdinalIgnoreCase))
                     {
-                        sb.Append('/');
+                        if (parts == 1)
+                        {
+                            sb.Append('/');
+                        }
+
                         sb.Append(controllerName);
                     }
                     else if (parameterName.Equals("action", StringComparison.OrdinalIgnoreCase))
                     {
-                        sb.Append('/');
+                        if (parts == 1)
+                        {
+                            sb.Append('/');
+                        }
+
                         sb.Append(actionName);
                     }
                     else
@@ -63,7 +81,11 @@ internal class AspNetCoreResourceNameHelper
                         var haveParameter = routeValueDictionary.TryGetValue(parameterName, out var value);
                         if (!parameter.IsOptional || haveParameter)
                         {
-                            sb.Append('/');
+                            if (parts == 1)
+                            {
+                                sb.Append('/');
+                            }
+
                             if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
                             {
                                 // write the expanded parameter value
@@ -122,28 +144,46 @@ internal class AspNetCoreResourceNameHelper
 
         foreach (var pathSegment in routePattern.Segments)
         {
+            var parts = 0;
             foreach (var part in pathSegment.Parts)
             {
+                parts++;
                 var partName = part.Name;
 
                 if (!part.IsParameter)
                 {
-                    sb.Append('/');
+                    if (parts == 1)
+                    {
+                        sb.Append('/');
+                    }
+
                     sb.Append(part.Text);
                 }
                 else if (partName.Equals("area", StringComparison.OrdinalIgnoreCase))
                 {
-                    sb.Append('/');
+                    if (parts == 1)
+                    {
+                        sb.Append('/');
+                    }
+
                     sb.Append(areaName);
                 }
                 else if (partName.Equals("controller", StringComparison.OrdinalIgnoreCase))
                 {
-                    sb.Append('/');
+                    if (parts == 1)
+                    {
+                        sb.Append('/');
+                    }
+
                     sb.Append(controllerName);
                 }
                 else if (partName.Equals("action", StringComparison.OrdinalIgnoreCase))
                 {
-                    sb.Append('/');
+                    if (parts == 1)
+                    {
+                        sb.Append('/');
+                    }
+
                     sb.Append(actionName);
                 }
                 else
@@ -151,7 +191,11 @@ internal class AspNetCoreResourceNameHelper
                     var haveParameter = routeValueDictionary.TryGetValue(partName, out var value);
                     if (!part.IsOptional || haveParameter)
                     {
-                        sb.Append('/');
+                        if (parts == 1)
+                        {
+                            sb.Append('/');
+                        }
+
                         if (expandRouteParameters && haveParameter && !IsIdentifierSegment(value, out var valueAsString))
                         {
                             // write the expanded parameter value

--- a/tracer/test/Datadog.Trace.Tests/AspNet/AspNetResourceNameHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/AspNet/AspNetResourceNameHelperTests.cs
@@ -20,13 +20,15 @@ namespace Datadog.Trace.Tests.AspNet
             { "action", "Index" },
             { "nonid", "oops" },
             { "idlike", 123 },
+            { "FormValue", "View" },
         };
 
         private static readonly RouteValueDictionary Defaults = new()
         {
             { "controller", "Home" },
             { "action", "Index" },
-            { "id", new object() } // it won't necessarily be a string in here, e.g. for optional values
+            { "id", new object() }, // it won't necessarily be a string in here, e.g. for optional values
+            { "FormValue", "View" }
         };
 
         [Theory]
@@ -46,6 +48,14 @@ namespace Datadog.Trace.Tests.AspNet
         [InlineData("{controller}/{action}/{nonid=2}", "/home/index/oops", true)]
         [InlineData("{controller}/{action}/{nonid:int}", "/home/index/{nonid:int}", false)]
         [InlineData("{controller}/{action}/{nonid:int}", "/home/index/oops", true)]
+        [InlineData("{controller}/{action}/{FormValue}", "/home/index/{formvalue}", false)]
+        [InlineData("{controller}/{action}/{FormValue}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue?}", "/home/index/{formvalue?}", false)]
+        [InlineData("{controller}/{action}/{FormValue?}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue=Edit}", "/home/index/{formvalue=edit}", false)]
+        [InlineData("{controller}/{action}/{FormValue=Edit}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue:int}", "/home/index/{formvalue:int}", false)]
+        [InlineData("{controller}/{action}/{FormValue:int}", "/home/index/view", true)]
         [InlineData("{controller}/{action}/{nonidentity}", "/home/index/{nonidentity}", false)]
         [InlineData("{controller}/{action}/{nonidentity}", "/home/index/{nonidentity}", true)]
         [InlineData("{controller}/{action}/{nonidentity?}", "/home/index/{nonidentity?}", false)]
@@ -91,6 +101,14 @@ namespace Datadog.Trace.Tests.AspNet
         [InlineData("{controller}/{action}/{id=2}", "/home/index", true)]
         [InlineData("{controller}/{action}/{id:int}", "/home/index", false)]
         [InlineData("{controller}/{action}/{id:int}", "/home/index", true)]
+        [InlineData("{controller}/{action}/{FormValue}", "/home/index/{formvalue}", false)]
+        [InlineData("{controller}/{action}/{FormValue}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue?}", "/home/index/{formvalue?}", false)]
+        [InlineData("{controller}/{action}/{FormValue?}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue=2}", "/home/index/{formvalue=2}", false)]
+        [InlineData("{controller}/{action}/{FormValue=2}", "/home/index/view", true)]
+        [InlineData("{controller}/{action}/{FormValue:int}", "/home/index/{formvalue:int}", false)]
+        [InlineData("{controller}/{action}/{FormValue:int}", "/home/index/view", true)]
         [InlineData("{controller}/{action}/{identity}", "/home/index/{identity}", false)]
         [InlineData("{controller}/{action}/{identity}", "/home/index/{identity}", true)]
         [InlineData("{controller}/{action}", "/home/index", false)]

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreResourceNameHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreResourceNameHelperTests.cs
@@ -1,0 +1,180 @@
+﻿// <copyright file="AspNetCoreResourceNameHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if !NETFRAMEWORK
+using Datadog.Trace.DiagnosticListeners;
+using Datadog.Trace.DuckTyping;
+using FluentAssertions;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.Template;
+using Xunit;
+
+namespace Datadog.Trace.Tests.DiagnosticListeners;
+
+public class AspNetCoreResourceNameHelperTests
+{
+    private static readonly RouteValueDictionary Values = new()
+    {
+        { "controller", "Home" },
+        { "action", "Index" },
+        { "nonid", "oops" },
+        { "idlike", 123 },
+        { "FormValue", "View" },
+    };
+
+    private static readonly RouteValueDictionary Defaults = new()
+    {
+        { "controller", "Home" },
+        { "action", "Index" },
+        { "FormValue", "View" }
+    };
+
+    private static readonly RouteValueDictionary ParameterPolicies = new()
+    {
+        { "id", new OptionalRouteConstraint(new IntRouteConstraint()) }
+    };
+
+    /// <summary>
+    /// Gets the route template, expected output, expand names
+    /// </summary>
+    public static TheoryData<string, string, bool> ValidRouteTemplates { get; } = new()
+    {
+        { "{controller}/{action}/{id}", "/home/index/{id}", false },
+        { "{controller}/{action}/{id}", "/home/index/{id}", true },
+        { "{controller}/{action}", "/home/index", false },
+        { "{controller}/{action}", "/home/index", true },
+        { "prefix/{controller}/{action}", "/prefix/home/index", false },
+        { "prefix/{controller}/{action}", "/prefix/home/index", true },
+        { "prefix-{controller}/{action}-suffix", "/prefix-home/index-suffix", false },
+        { "prefix-{controller}/{action}-suffix", "/prefix-home/index-suffix", true },
+        { "{controller}/{action}/{nonid}", "/home/index/{nonid}", false },
+        { "{controller}/{action}/{nonid}", "/home/index/oops", true },
+        { "{controller}/{action}/{nonid?}", "/home/index/{nonid?}", false },
+        { "{controller}/{action}/{nonid?}", "/home/index/oops", true },
+        { "{controller}/{action}/{nonid=2}", "/home/index/{nonid}", false },
+        { "{controller}/{action}/{nonid=2}", "/home/index/oops", true },
+        { "{controller}/{action}/{nonid:int}", "/home/index/{nonid}", false },
+        { "{controller}/{action}/{nonid:int}", "/home/index/oops", true },
+        { "{controller}/{action}/{FormValue}", "/home/index/{formvalue}", false },
+        { "{controller}/{action}/{FormValue}", "/home/index/view", true },
+        { "{controller}/{action}/{FormValue?}", "/home/index/{formvalue?}", false },
+        { "{controller}/{action}/{FormValue?}", "/home/index/view", true },
+        { "{controller}/{action}/{FormValue=Edit}", "/home/index/{formvalue}", false },
+        { "{controller}/{action}/{FormValue=Edit}", "/home/index/view", true },
+        { "{controller}/{action}/{FormValue:int}", "/home/index/{formvalue}", false },
+        { "{controller}/{action}/{FormValue:int}", "/home/index/view", true },
+        { "{controller}/{action}/{nonidentity}", "/home/index/{nonidentity}", false },
+        { "{controller}/{action}/{nonidentity}", "/home/index/{nonidentity}", true },
+        { "{controller}/{action}/{nonidentity?}", "/home/index", false },
+        { "{controller}/{action}/{nonidentity?}", "/home/index", true },
+        { "{controller}/{action}/{nonidentity=2}", "/home/index/{nonidentity}", false },
+        { "{controller}/{action}/{nonidentity=2}", "/home/index/{nonidentity}", true },
+        { "{controller}/{action}/{nonidentity:int}", "/home/index/{nonidentity}", false },
+        { "{controller}/{action}/{nonidentity:int}", "/home/index/{nonidentity}", true },
+        { "{controller}/{action}/{idlike}", "/home/index/{idlike}", false },
+        { "{controller}/{action}/{idlike}", "/home/index/{idlike}", true },
+        { "{controller}/{action}/{id:int}", "/home/index/{id}", false },
+        { "{controller}/{action}/{id:int}", "/home/index/{id}", true },
+        // Note: This is _wrong_ (flips the one * -> **), but it's a breaking change
+        // so leave it as this
+        { "{controller}/{action}/{*nonid}", "/home/index/{**nonid}", false },
+        { "{controller}/{action}/{*nonid}", "/home/index/oops", true },
+        { "{controller}/{action}/{**nonid}", "/home/index/{*nonid}", false },
+        { "{controller}/{action}/{**nonid}", "/home/index/oops", true },
+        { "{controller}", "/home", false },
+        { "{controller}", "/home", true },
+    };
+
+    /// <summary>
+    /// Gets the route template, expected output, expand names
+    /// </summary>
+    public static TheoryData<string, string, bool> ValidRouteTemplatesWithExternalDefaults { get; } = new()
+    {
+        { "{controller}/{action}/{id}", "/home/index/{id}", false },
+        { "{controller}/{action}/{id}", "/home/index/{id}", true },
+        { "{controller}/{action}/{id:int}", "/home/index/{id}", false },
+        { "{controller}/{action}/{id:int}", "/home/index/{id}", true },
+        { "{controller}/{action}/{FormValue}", "/home/index/{formvalue}", false },
+        { "{controller}/{action}/{FormValue}", "/home/index/view", true },
+        { "{controller}/{action}/{FormValue:int}", "/home/index/{formvalue}", false },
+        { "{controller}/{action}/{FormValue:int}", "/home/index/view", true },
+        { "{controller}/{action}/{identity}", "/home/index/{identity}", false },
+        { "{controller}/{action}/{identity}", "/home/index/{identity}", true },
+        { "{controller}/{action}", "/home/index", false },
+        { "{controller}/{action}", "/home/index", true },
+        { "{controller}/{*action}", "/home/index", false },
+        { "{controller}/{*action}", "/home/index", true },
+        { "{controller}/{action:string}", "/home/index", false },
+        { "{controller}/{action:string}", "/home/index", true },
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidRouteTemplates))]
+    public void SimplifyRoutePattern_CleansValidRouteTemplates(string template, string expected, bool expandRouteTemplates)
+    {
+        var originalPattern = RoutePatternFactory.Parse(template);
+        var duckTypedPattern = originalPattern.DuckCast<Datadog.Trace.DiagnosticListeners.RoutePattern>();
+        var resource = AspNetCoreResourceNameHelper.SimplifyRoutePattern(
+            routePattern: duckTypedPattern,
+            routeValueDictionary: Values,
+            areaName: null,
+            controllerName: Values["controller"] as string,
+            actionName: Values["action"] as string,
+            expandRouteTemplates);
+
+        resource.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidRouteTemplatesWithExternalDefaults))]
+    public void SimplifyRoutePattern_CleansValidRouteTemplatesWithDefaults(string template, string expected, bool expandRouteTemplates)
+    {
+        var originalPattern = RoutePatternFactory.Parse(template, Defaults, parameterPolicies: ParameterPolicies);
+        var duckTypedPattern = originalPattern.DuckCast<Datadog.Trace.DiagnosticListeners.RoutePattern>();
+        var resource = AspNetCoreResourceNameHelper.SimplifyRoutePattern(
+            routePattern: duckTypedPattern,
+            routeValueDictionary: Values,
+            areaName: null,
+            controllerName: Values["controller"] as string,
+            actionName: Values["action"] as string,
+            expandRouteTemplates);
+
+        resource.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidRouteTemplates))]
+    public void SimplifyRouteTemplate_CleansValidRouteTemplates(string template, string expected, bool expandRouteTemplates)
+    {
+        var routeTemplate = new RouteTemplate(RoutePatternFactory.Parse(template));
+        var resource = AspNetCoreResourceNameHelper.SimplifyRouteTemplate(
+            routePattern: routeTemplate,
+            routeValueDictionary: Values,
+            areaName: null,
+            controllerName: Values["controller"] as string,
+            actionName: Values["action"] as string,
+            expandRouteTemplates);
+
+        resource.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidRouteTemplatesWithExternalDefaults))]
+    public void SimplifyRouteTemplate_CleansValidRouteTemplatesWithDefaults(string template, string expected, bool expandRouteTemplates)
+    {
+        var routeTemplate = new RouteTemplate(RoutePatternFactory.Parse(template));
+        var resource = AspNetCoreResourceNameHelper.SimplifyRouteTemplate(
+            routePattern: routeTemplate,
+            routeValueDictionary: Values,
+            areaName: null,
+            controllerName: Values["controller"] as string,
+            actionName: Values["action"] as string,
+            expandRouteTemplates);
+
+        resource.Should().Be(expected);
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreResourceNameHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreResourceNameHelperTests.cs
@@ -50,6 +50,10 @@ public class AspNetCoreResourceNameHelperTests
         { "prefix/{controller}/{action}", "/prefix/home/index", true },
         { "prefix-{controller}/{action}-suffix", "/prefix-home/index-suffix", false },
         { "prefix-{controller}/{action}-suffix", "/prefix-home/index-suffix", true },
+        { "prefix-{controller}-{action}-{nonid}-{id}-{FormValue}-suffix", "/prefix-home-index-{nonid}-{id}-{formvalue}-suffix", false },
+        { "prefix-{controller}-{action}-{nonid}-{id}-{FormValue}-suffix", "/prefix-home-index-oops-{id}-view-suffix", true },
+        { "standalone/prefix-{controller}-{action}-{nonid}-{id}-{FormValue}-suffix/standalone", "/standalone/prefix-home-index-{nonid}-{id}-{formvalue}-suffix/standalone", false },
+        { "standalone/prefix-{controller}-{action}-{nonid}-{id}-{FormValue}-suffix/standalone", "/standalone/prefix-home-index-oops-{id}-view-suffix/standalone", true },
         { "{controller}/{action}/{nonid}", "/home/index/{nonid}", false },
         { "{controller}/{action}/{nonid}", "/home/index/oops", true },
         { "{controller}/{action}/{nonid?}", "/home/index/{nonid?}", false },
@@ -78,8 +82,8 @@ public class AspNetCoreResourceNameHelperTests
         { "{controller}/{action}/{idlike}", "/home/index/{idlike}", true },
         { "{controller}/{action}/{id:int}", "/home/index/{id}", false },
         { "{controller}/{action}/{id:int}", "/home/index/{id}", true },
-        // Note: This is _wrong_ (flips the one * -> **), but it's a breaking change
-        // so leave it as this
+        // Note: This is _wrong_ (flips the one * -> ** and vice versa),
+        // but it's a breaking change to fix it, so leave it as is
         { "{controller}/{action}/{*nonid}", "/home/index/{**nonid}", false },
         { "{controller}/{action}/{*nonid}", "/home/index/oops", true },
         { "{controller}/{action}/{**nonid}", "/home/index/{*nonid}", false },
@@ -149,6 +153,9 @@ public class AspNetCoreResourceNameHelperTests
     [MemberData(nameof(ValidRouteTemplates))]
     public void SimplifyRouteTemplate_CleansValidRouteTemplates(string template, string expected, bool expandRouteTemplates)
     {
+        // RouteTemplate doesn't support the concept of encoded slashes, so "fix" the expected value
+        expected = expected.Replace("**", "*");
+
         var routeTemplate = new RouteTemplate(RoutePatternFactory.Parse(template));
         var resource = AspNetCoreResourceNameHelper.SimplifyRouteTemplate(
             routePattern: routeTemplate,


### PR DESCRIPTION
## Summary of changes

- Fixes case-sensitivity bug in ASP.NET resource name route parameter expansion
- Fixes bug in ASP.NET Core resource name for complex segments

## Reason for change

A customer reported that route parameter template expansion wasn't working for their ASP.NET service. They had set `DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED=true`, but their resources that used the route template `{controller}/{action}/{SomeValue}` were appearing as `home/index/{somevalue}`, instead of `home/index/edit` and `home/index/view` as they were expecting. This turned out to be due to the fact the template uses non-lower case parameter names, e.g. `{SomeValue}` (i.e. it works correctly with the template `{controller}/{action}/{somevalue}`.

As part of the investigation, I verified that ASP.NET Core handles casing correctly (it does). However I discovered that the aspnetcore template processor _doesn't_ handle "complex" segments correctly, i.e. segments that _aren't_ bordered by `/`: `prefix-{controller}/{action}-suffix`. Both the segments in this case are complex, and were previously being rendered as `prefix-/home/index/-suffix` (instead of `prefix-home/index-suffix`).

## Implementation details

ASP.NET fix was easy - add unit tests, and handle case sensitivity correctly.

For ASP.NET Core, I extracted the resource name handling code to make it easier to test, and added unit tests. In the next commit, I fixed the behaviour to avoid adding the '/' for subsequent parts of complex segments.

## Test coverage

Added a bunch of unit tests. Also did a manual test of an asp.net to confirm that the customer issue is definitely fixed. Bottom 4 resources show before the fix, top 4 are after the fix

![image](https://user-images.githubusercontent.com/18755388/199274784-0232cedb-2696-481f-93bb-92f399ff0c80.png)


## Other details
When reviewing, I suggest skipping the second commit, as it's just moving a method to the new type unchanged. The third commit fixes the aspnetcore bug.
