### PR TITLE
Fix the env and service names for AppSec throughput tests and benchmarks

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2700,7 +2700,8 @@ stages:
         ./run-appsec.sh "linux"
       displayName: Crank
       env:
-        DD_SERVICE: dd-trace-dotnet-appsec
+        DD_SERVICE: dd-trace-dotnet
+        DD_ENV: CI
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -2824,6 +2825,7 @@ stages:
       displayName: Execute Samples.$(sampleName) benchmark
       env:
         DD_SERVICE: dd-trace-dotnet
+        DD_ENV: CI
 
     - task: PowerShell@2
       displayName: Wait 20 seconds to agent flush before finishing pipeline


### PR DESCRIPTION
## Summary of changes

Fix the env and service names for AppSec throughput tests and benchmarks

## Reason for change

CI Visibility groups by env and service name, so we want these to all be included in the same run

## Implementation details

Add/change the required values

## Test coverage

Will see what the run looks like

## Other details
We may need to update the release dashaboards after merging to support these changes
