### PR TITLE
[Profiler] Rename DD_PROFILING_CONTENTION_ENABLED to DD_PROFILING_LOCK_ENABLED

### DIFF
--- a/profiler/build/Contention.linux.net60.json
+++ b/profiler/build/Contention.linux.net60.json
@@ -27,7 +27,7 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
-        "DD_PROFILING_CONTENTION_ENABLED": "1",
+        "DD_PROFILING_LOCK_ENABLED": "1",
         "DD_TRACE_ENABLED" : "0"
       }
     },
@@ -38,7 +38,7 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_WALLTIME_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
-        "DD_PROFILING_CONTENTION_ENABLED": "1",
+        "DD_PROFILING_LOCK_ENABLED": "1",
         "DD_TRACE_ENABLED" : "0"
       }
     }

--- a/profiler/build/Contention.windows.net60.json
+++ b/profiler/build/Contention.windows.net60.json
@@ -27,7 +27,7 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_WALLTIME_ENABLED": "0",
         "DD_PROFILING_CPU_ENABLED": "0",
-        "DD_PROFILING_CONTENTION_ENABLED": "1",
+        "DD_PROFILING_LOCK_ENABLED": "1",
         "DD_TRACE_ENABLED" : "0"
       }
     },
@@ -38,7 +38,7 @@
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_WALLTIME_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
-        "DD_PROFILING_CONTENTION_ENABLED": "1",
+        "DD_PROFILING_LOCK_ENABLED": "1",
         "DD_TRACE_ENABLED" : "0"
       }
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -66,9 +66,12 @@ private:
     static bool GetDefaultDebugLogEnabled();
     template <typename T>
     static T GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue);
+    template <typename T>
+    static bool IsEnvironmentValueSet(shared::WSTRING const& name, T& value);
     static std::chrono::nanoseconds ExtractCpuWallTimeSamplingRate();
     static int32_t ExtractWallTimeThreadsThreshold();
     static int32_t ExtractCpuThreadsThreshold();
+    static bool GetContention();
 
 private:
     static std::string const DefaultProdSite;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -32,7 +32,8 @@ public:
 
     // only available on .NET 5+
     inline static const shared::WSTRING AllocationProfilingEnabled = WStr("DD_PROFILING_ALLOCATION_ENABLED");
-    inline static const shared::WSTRING ContentionProfilingEnabled = WStr("DD_PROFILING_CONTENTION_ENABLED");
+    inline static const shared::WSTRING DeprecatedContentionProfilingEnabled = WStr("DD_PROFILING_CONTENTION_ENABLED");  // should be deprecated (only used in 2.18)
+    inline static const shared::WSTRING LockContentionProfilingEnabled = WStr("DD_PROFILING_LOCK_ENABLED");
 
     inline static const shared::WSTRING ExceptionSampleLimit        = WStr("DD_INTERNAL_PROFILING_EXCEPTION_SAMPLE_LIMIT");
     inline static const shared::WSTRING AllocationSampleLimit       = WStr("DD_INTERNAL_PROFILING_ALLOCATION_SAMPLE_LIMIT");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -16,7 +16,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string ExceptionProfilerEnabled = "DD_PROFILING_EXCEPTION_ENABLED";
         public const string ExceptionSampleLimit = "DD_INTERNAL_PROFILING_EXCEPTION_SAMPLE_LIMIT";
         public const string AllocationProfilerEnabled = "DD_PROFILING_ALLOCATION_ENABLED";
-        public const string ContentionProfilerEnabled = "DD_PROFILING_CONTENTION_ENABLED";
+        public const string ContentionProfilerEnabled = "DD_PROFILING_LOCK_ENABLED";
         public const string EndpointProfilerEnabled = "DD_PROFILING_ENDPOINT_COLLECTION_ENABLED";
         public const string NamedPipeName = "DD_TRACE_PIPE_NAME";
         public const string TimestampsAsLabelEnabled = "DD_INTERNAL_PROFILING_TIMESTAMPS_AS_LABEL_ENABLED";

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -361,16 +361,46 @@ TEST(ConfigurationTest, CheckContentionProfilingIsDisabledByDefault)
 
 TEST(ConfigurationTest, CheckContentionProfilingIsEnabledIfEnvVarSetToTrue)
 {
-    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LockContentionProfilingEnabled, WStr("1"));
     auto configuration = Configuration{};
     ASSERT_THAT(configuration.IsContentionProfilingEnabled(), true);
 }
 
 TEST(ConfigurationTest, CheckContentionProfilingIsDisabledIfEnvVarSetToFalse)
 {
-    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::ContentionProfilingEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::LockContentionProfilingEnabled, WStr("0"));
     auto configuration = Configuration{};
     ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
+}
+
+TEST(ConfigurationTest, CheckDeprecatedContentionProfilingIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DeprecatedContentionProfilingEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), true);
+}
+
+TEST(ConfigurationTest, CheckDeprecatedContentionProfilingIsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::DeprecatedContentionProfilingEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
+}
+
+TEST(ConfigurationTest, CheckLockProfilingOverrideContentionEnvVarIfSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar1(EnvironmentVariables::LockContentionProfilingEnabled, WStr("0"));
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::DeprecatedContentionProfilingEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), false);
+}
+
+TEST(ConfigurationTest, CheckLockProfilingOverrideContentionEnvVarIfSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar1(EnvironmentVariables::LockContentionProfilingEnabled, WStr("1"));
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::DeprecatedContentionProfilingEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsContentionProfilingEnabled(), true);
 }
 
 TEST(ConfigurationTest, CheckContentionSampleLimitIfEnvVarSet)


### PR DESCRIPTION
## Summary of changes
Enable contention profiler with DD_PROFILING_LOCK_ENABLED instead of DD_PROFILING_CONTENTION_ENABLED

## Reason for change
Reflect UI wording

## Implementation details
DD_PROFILING_LOCK_ENABLED overrides DD_PROFILING_CONTENTION_ENABLED if present

## Test coverage
Tests added accordingly

## Other details
<!-- Fixes #{issue} -->
