### PR TITLE
Update `SetTag()` source generator to avoid incorrect usage

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TagsListGenerator/Sources.cs
@@ -191,6 +191,32 @@ namespace ");
                 ");
                 }
 
+                var haveReadOnlyTags = false;
+                for (int i = 0; i < tagList.TagProperties.Count; i++)
+                {
+                    var property = tagList.TagProperties[i];
+                    if (property.IsReadOnly)
+                    {
+                        haveReadOnlyTags = true;
+                        sb.Append(@"case """)
+                          .Append(property.TagValue)
+                          .Append(
+                               @""": 
+                ");
+                    }
+                }
+
+                if (haveReadOnlyTags)
+                {
+                    sb
+                       .Append(@"    Logger.Value.Warning(""Attempted to set readonly tag {TagName} on {TagType}. Ignoring."", key, nameof(")
+                       .Append(tagList.ClassName)
+                       .Append(
+                            @"));
+                    break;
+                ");
+                }
+
                 sb.Append(
                     @"default: 
                     base.SetTag(key, value);
@@ -302,6 +328,32 @@ namespace ");
                       .Append(property.PropertyName)
                       .Append(
                            @" = value;
+                    break;
+                ");
+                }
+
+                var haveReadOnlyMetrics = false;
+                for (int i = 0; i < tagList.MetricProperties.Count; i++)
+                {
+                    var property = tagList.MetricProperties[i];
+                    if (property.IsReadOnly)
+                    {
+                        haveReadOnlyMetrics = true;
+                        sb.Append(@"case """)
+                          .Append(property.TagValue)
+                          .Append(
+                               @""": 
+                ");
+                    }
+                }
+
+                if (haveReadOnlyMetrics)
+                {
+                    sb
+                       .Append(@"    Logger.Value.Warning(""Attempted to set readonly metric {MetricName} on {TagType}. Ignoring."", key, nameof(")
+                       .Append(tagList.ClassName)
+                       .Append(
+                            @"));
                     break;
                 ");
                 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aerospike.userkey": 
                     UserKey = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AerospikeTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
@@ -69,6 +69,10 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "component": 
+                case "aws.agent": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSdkTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Tagging
                 case "aws.queue.url": 
                     QueueUrl = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSqsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aas.function.trigger": 
                     TriggerType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AzureFunctionsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
@@ -48,6 +48,11 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     Host = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                case "db.type": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CosmosDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.Tagging
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CouchbaseTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
                 case "elasticsearch.url": 
                     Url = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ElasticsearchTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
                 case "graphql.operation.type": 
                     OperationType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GraphQLTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
@@ -63,6 +63,10 @@ namespace Datadog.Trace.Tagging
                 case "grpc.status.code": 
                     StatusCode = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GrpcTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
@@ -53,6 +53,10 @@ namespace Datadog.Trace.Tagging
                 case "kafka.group": 
                     ConsumerGroup = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(KafkaTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MongoDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MsmqTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "cmd.environment_variables": 
                     EnvironmentVariables = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ProcessCommandStartTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "amqp.queue": 
                     Queue = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RabbitMQTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
@@ -48,6 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RedisTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
@@ -90,6 +90,9 @@ namespace Datadog.Trace.ServiceFabric
                 case "service-fabric.service-remoting.invocation-id": 
                     RemotingInvocationId = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ServiceRemotingTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     OutHost = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(SqlTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -234,6 +234,9 @@ namespace Datadog.Trace.Ci.Tagging
                 case "test.status": 
                     Status = value;
                     break;
+                case "test.bundle": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TraceAnnotationTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WcfTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "http.client_ip": 
                     HttpClientIp = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WebTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aerospike.userkey": 
                     UserKey = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AerospikeTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
@@ -69,6 +69,10 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "component": 
+                case "aws.agent": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSdkTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Tagging
                 case "aws.queue.url": 
                     QueueUrl = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSqsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aas.function.trigger": 
                     TriggerType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AzureFunctionsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
@@ -48,6 +48,11 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     Host = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                case "db.type": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CosmosDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.Tagging
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CouchbaseTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
                 case "elasticsearch.url": 
                     Url = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ElasticsearchTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
                 case "graphql.operation.type": 
                     OperationType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GraphQLTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
@@ -63,6 +63,10 @@ namespace Datadog.Trace.Tagging
                 case "grpc.status.code": 
                     StatusCode = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GrpcTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
@@ -53,6 +53,10 @@ namespace Datadog.Trace.Tagging
                 case "kafka.group": 
                     ConsumerGroup = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(KafkaTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MongoDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MsmqTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "cmd.environment_variables": 
                     EnvironmentVariables = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ProcessCommandStartTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "amqp.queue": 
                     Queue = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RabbitMQTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
@@ -48,6 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RedisTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
@@ -90,6 +90,9 @@ namespace Datadog.Trace.ServiceFabric
                 case "service-fabric.service-remoting.invocation-id": 
                     RemotingInvocationId = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ServiceRemotingTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     OutHost = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(SqlTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -234,6 +234,9 @@ namespace Datadog.Trace.Ci.Tagging
                 case "test.status": 
                     Status = value;
                     break;
+                case "test.bundle": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TraceAnnotationTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WcfTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "http.client_ip": 
                     HttpClientIp = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WebTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aerospike.userkey": 
                     UserKey = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AerospikeTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
@@ -69,6 +69,10 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "component": 
+                case "aws.agent": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSdkTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Tagging
                 case "aws.queue.url": 
                     QueueUrl = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSqsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aas.function.trigger": 
                     TriggerType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AzureFunctionsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
@@ -48,6 +48,11 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     Host = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                case "db.type": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CosmosDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.Tagging
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CouchbaseTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
                 case "elasticsearch.url": 
                     Url = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ElasticsearchTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
                 case "graphql.operation.type": 
                     OperationType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GraphQLTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
@@ -63,6 +63,10 @@ namespace Datadog.Trace.Tagging
                 case "grpc.status.code": 
                     StatusCode = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GrpcTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
@@ -53,6 +53,10 @@ namespace Datadog.Trace.Tagging
                 case "kafka.group": 
                     ConsumerGroup = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(KafkaTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MongoDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MsmqTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "cmd.environment_variables": 
                     EnvironmentVariables = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ProcessCommandStartTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "amqp.queue": 
                     Queue = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RabbitMQTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
@@ -48,6 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RedisTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
@@ -90,6 +90,9 @@ namespace Datadog.Trace.ServiceFabric
                 case "service-fabric.service-remoting.invocation-id": 
                     RemotingInvocationId = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ServiceRemotingTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     OutHost = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(SqlTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -234,6 +234,9 @@ namespace Datadog.Trace.Ci.Tagging
                 case "test.status": 
                     Status = value;
                     break;
+                case "test.bundle": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TraceAnnotationTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WcfTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "http.client_ip": 
                     HttpClientIp = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WebTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AerospikeTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aerospike.userkey": 
                     UserKey = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AerospikeTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AspNetCoreTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "aspnet_core.route": 
                     AspNetCoreRoute = value;
                     break;
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AspNetCoreTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSdkTags.g.cs
@@ -69,6 +69,10 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "component": 
+                case "aws.agent": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSdkTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AwsSqsTags.g.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.Tagging
                 case "aws.queue.url": 
                     QueueUrl = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AwsSqsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/AzureFunctionsTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "aas.function.trigger": 
                     TriggerType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(AzureFunctionsTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CosmosDbTags.g.cs
@@ -48,6 +48,11 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     Host = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                case "db.type": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CosmosDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/CouchbaseTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.Tagging
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(CouchbaseTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ElasticsearchTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
                 case "elasticsearch.url": 
                     Url = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ElasticsearchTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GraphQLTags.g.cs
@@ -45,6 +45,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL
                 case "graphql.operation.type": 
                     OperationType = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GraphQLTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/GrpcTags.g.cs
@@ -63,6 +63,10 @@ namespace Datadog.Trace.Tagging
                 case "grpc.status.code": 
                     StatusCode = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(GrpcTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "http.status_code": 
                     HttpStatusCode = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/KafkaTags.g.cs
@@ -53,6 +53,10 @@ namespace Datadog.Trace.Tagging
                 case "kafka.group": 
                     ConsumerGroup = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(KafkaTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MongoDbTags.g.cs
@@ -57,6 +57,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MongoDbTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -51,6 +51,10 @@ namespace Datadog.Trace.Tagging
                 case "msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
+                case "span.kind": 
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(MsmqTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ProcessCommandStartTags.g.cs
@@ -30,6 +30,9 @@ namespace Datadog.Trace.Tagging
                 case "cmd.environment_variables": 
                     EnvironmentVariables = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ProcessCommandStartTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RabbitMQTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "amqp.queue": 
                     Queue = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RabbitMQTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/RedisTags.g.cs
@@ -48,6 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
                 case "out.port": 
                     Port = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(RedisTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/ServiceRemotingTags.g.cs
@@ -90,6 +90,9 @@ namespace Datadog.Trace.ServiceFabric
                 case "service-fabric.service-remoting.invocation-id": 
                     RemotingInvocationId = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(ServiceRemotingTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/SqlTags.g.cs
@@ -54,6 +54,9 @@ namespace Datadog.Trace.Tagging
                 case "out.host": 
                     OutHost = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(SqlTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -234,6 +234,9 @@ namespace Datadog.Trace.Ci.Tagging
                 case "test.status": 
                     Status = value;
                     break;
+                case "test.bundle": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TraceAnnotationTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TraceAnnotationTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WcfTags.g.cs
@@ -24,6 +24,9 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
+                case "component": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WcfTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/WebTags.g.cs
@@ -66,6 +66,9 @@ namespace Datadog.Trace.Tagging
                 case "http.client_ip": 
                     HttpClientIp = value;
                     break;
+                case "span.kind": 
+                    Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(WebTags));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;

--- a/tracer/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagsList.cs
@@ -3,15 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Tagging
 {
     internal abstract class TagsList : ITags
     {
+        protected static readonly Lazy<IDatadogLogger> Logger = new(() => DatadogLogging.GetLoggerFor<TagsList>());
         private List<KeyValuePair<string, string>> _tags;
         private List<KeyValuePair<string, double>> _metrics;
 

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TagsListGeneratorTests.cs
@@ -370,6 +370,9 @@ namespace MyTests.TestListNameSpace
         [Tag(""IdTag"")]
     	public string Id { get; } = ""Some Value"";
 
+        [Tag(""TestId"")]
+    	public string Test { get; set; };
+
         [Tag(""NameTag"")]
     	public string Name => ""Some Name"";
     }
@@ -386,6 +389,8 @@ namespace MyTests.TestListNameSpace
     {
         // IdBytes = System.Text.Encoding.UTF8.GetBytes(""IdTag"");
         private static readonly byte[] IdBytes = new byte[] { 73, 100, 84, 97, 103 };
+        // TestBytes = System.Text.Encoding.UTF8.GetBytes(""TestId"");
+        private static readonly byte[] TestBytes = new byte[] { 84, 101, 115, 116, 73, 100 };
         // NameBytes = System.Text.Encoding.UTF8.GetBytes(""NameTag"");
         private static readonly byte[] NameBytes = new byte[] { 78, 97, 109, 101, 84, 97, 103 };
 
@@ -394,6 +399,7 @@ namespace MyTests.TestListNameSpace
             return key switch
             {
                 ""IdTag"" => Id,
+                ""TestId"" => Test,
                 ""NameTag"" => Name,
                 _ => base.GetTag(key),
             };
@@ -403,6 +409,13 @@ namespace MyTests.TestListNameSpace
         {
             switch(key)
             {
+                case ""TestId"": 
+                    Test = value;
+                    break;
+                case ""IdTag"": 
+                case ""NameTag"": 
+                    Logger.Value.Warning(""Attempted to set readonly tag {TagName} on {TagType}. Ignoring."", key, nameof(TestList));
+                    break;
                 default: 
                     base.SetTag(key, value);
                     break;
@@ -414,6 +427,11 @@ namespace MyTests.TestListNameSpace
             if (Id is not null)
             {
                 processor.Process(new TagItem<string>(""IdTag"", Id, IdBytes));
+            }
+
+            if (Test is not null)
+            {
+                processor.Process(new TagItem<string>(""TestId"", Test, TestBytes));
             }
 
             if (Name is not null)
@@ -430,6 +448,13 @@ namespace MyTests.TestListNameSpace
             {
                 sb.Append(""IdTag (tag):"")
                   .Append(Id)
+                  .Append(',');
+            }
+
+            if (Test is not null)
+            {
+                sb.Append(""TestId (tag):"")
+                  .Append(Test)
                   .Append(',');
             }
 
@@ -461,6 +486,9 @@ namespace MyTests.TestListNameSpace
         [Metric(""IdMetric"")]
     	public double? Id { get; } = ""Some Value"";
 
+        [Metric(""TestId"")]
+    	public double? Test { get; set; }
+
         [Metric(""NameMetric"")]
     	public double? Name => ""Some Name"";
     }
@@ -477,6 +505,8 @@ namespace MyTests.TestListNameSpace
     {
         // IdBytes = System.Text.Encoding.UTF8.GetBytes(""IdMetric"");
         private static readonly byte[] IdBytes = new byte[] { 73, 100, 77, 101, 116, 114, 105, 99 };
+        // TestBytes = System.Text.Encoding.UTF8.GetBytes(""TestId"");
+        private static readonly byte[] TestBytes = new byte[] { 84, 101, 115, 116, 73, 100 };
         // NameBytes = System.Text.Encoding.UTF8.GetBytes(""NameMetric"");
         private static readonly byte[] NameBytes = new byte[] { 78, 97, 109, 101, 77, 101, 116, 114, 105, 99 };
 
@@ -485,6 +515,7 @@ namespace MyTests.TestListNameSpace
             return key switch
             {
                 ""IdMetric"" => Id,
+                ""TestId"" => Test,
                 ""NameMetric"" => Name,
                 _ => base.GetMetric(key),
             };
@@ -494,6 +525,13 @@ namespace MyTests.TestListNameSpace
         {
             switch(key)
             {
+                case ""TestId"": 
+                    Test = value;
+                    break;
+                case ""IdMetric"": 
+                case ""NameMetric"": 
+                    Logger.Value.Warning(""Attempted to set readonly metric {MetricName} on {TagType}. Ignoring."", key, nameof(TestList));
+                    break;
                 default: 
                     base.SetMetric(key, value);
                     break;
@@ -505,6 +543,11 @@ namespace MyTests.TestListNameSpace
             if (Id is not null)
             {
                 processor.Process(new TagItem<double>(""IdMetric"", Id.Value, IdBytes));
+            }
+
+            if (Test is not null)
+            {
+                processor.Process(new TagItem<double>(""TestId"", Test.Value, TestBytes));
             }
 
             if (Name is not null)
@@ -521,6 +564,13 @@ namespace MyTests.TestListNameSpace
             {
                 sb.Append(""IdMetric (metric):"")
                   .Append(Id.Value)
+                  .Append(',');
+            }
+
+            if (Test is not null)
+            {
+                sb.Append(""TestId (metric):"")
+                  .Append(Test.Value)
                   .Append(',');
             }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
@@ -9,18 +9,36 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using FluentAssertions;
 
 namespace Datadog.Trace.TestHelpers
 {
     internal class MockApi : IApi
     {
-        private readonly ManualResetEventSlim _resetEvent = new();
-        private List<List<MockSpan>> _objects = null;
+        private readonly ManualResetEventSlim _resetEvent;
+        private readonly object _lock = new();
+        private List<List<MockSpan>> _objects = new();
 
-        public List<List<MockSpan>> Wait()
+        public MockApi(ManualResetEventSlim resetEvent = null)
         {
-            _resetEvent.Wait();
-            var objects = Interlocked.Exchange(ref _objects, null);
+            _resetEvent = resetEvent ?? new();
+        }
+
+        public List<List<MockSpan>> Traces
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _objects;
+                }
+            }
+        }
+
+        public List<List<MockSpan>> Wait(TimeSpan? timeout = null)
+        {
+            _resetEvent.Wait(timeout ?? TimeSpan.FromMinutes(1)).Should().BeTrue();
+            var objects = Traces;
             _resetEvent.Reset();
             return objects;
         }
@@ -32,14 +50,10 @@ namespace Datadog.Trace.TestHelpers
 
             if (spans.Count > 0)
             {
-                var previous = Interlocked.Exchange(ref _objects, null);
-                if (previous is not null)
+                lock (_lock)
                 {
-                    Interlocked.Exchange(ref _objects, previous.Concat(spans).ToList());
-                }
-                else
-                {
-                    Interlocked.Exchange(ref _objects, spans);
+                    var previous = _objects;
+                    _objects = previous.Concat(spans).ToList();
                 }
 
                 _resetEvent.Set();

--- a/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockApi.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
-using FluentAssertions;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -37,7 +36,7 @@ namespace Datadog.Trace.TestHelpers
 
         public List<List<MockSpan>> Wait(TimeSpan? timeout = null)
         {
-            _resetEvent.Wait(timeout ?? TimeSpan.FromMinutes(1)).Should().BeTrue();
+            _resetEvent.Wait(timeout ?? TimeSpan.FromMinutes(1));
             var objects = Traces;
             _resetEvent.Reset();
             return objects;

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -204,7 +204,7 @@ namespace Datadog.Trace.Tests.Tagging
             var traceChunks = _testApi.Wait(TimeSpan.FromSeconds(20));
 
             var deserializedSpan = traceChunks.Should().ContainSingle().Which.Should().ContainSingle().Subject;
-            deserializedSpan.Tags.Should().ContainKey(Tags.SpanKind).WhoseValue.Should().Be(SpanKinds.Server);
+            deserializedSpan.Tags.Should().Contain(Tags.SpanKind, SpanKinds.Server);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

If you try to set a tag which is readonly, ignored it, and log a warning.

## Reason for change

Currently, you can set a tag _twice_ if you try to set an `ITags` implementation which has a readonly property:

```csharp
internal partial class WebTags : InstrumentationTags, IHasStatusCode
{
    [Tag(Trace.Tags.SpanKind)]
    public override string SpanKind => SpanKinds.Server;
}

new WebTags().SetTag(SpanKinds.Client); // <-- Adds the Tags.SpanKind tag _twice_ 
```

This causes errors during deserialization in .NET (not evaluated the effect on the agent).

## Implementation details

Updated the Source generators to explicitly skip a tag if it's one of the well-known readonly values. The implementation and its effect is easiest to see in this commit: https://github.com/DataDog/dd-trace-dotnet/commit/f6b3b6e3a12b536550af2005a6c46030cdafcc19

## Test coverage

Added a unit test demonstrating the incorrect behaviour, which previously would fail because the `MockApi` throws when deserializing the tag. As part of this, messed around with the `MockApi` a little to add a timeout

## Other details
Don't panic about all the files, they're mostly source generator output 😉 
