### PR TITLE
Fix BenchmarkDotNet Exporter

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/EventModel/CIVisibilityEventsFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/EventModel/CIVisibilityEventsFactory.cs
@@ -4,19 +4,23 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Ci.Tags;
+
 namespace Datadog.Trace.Ci.EventModel;
 
 internal static class CIVisibilityEventsFactory
 {
     public static IEvent FromSpan(Span span)
-        => span.Type switch
+    {
+        return span.Type switch
         {
-            SpanTypes.Test => new TestEvent(span),
+            SpanTypes.Test => span.GetTag(TestTags.Type) == TestTags.TypeBenchmark ? new TestEvent(span, 1) : new TestEvent(span, 2),
             SpanTypes.TestSuite => new TestSuiteEvent(span),
             SpanTypes.TestModule => new TestModuleEvent(span),
             SpanTypes.TestSession => new TestSessionEvent(span),
             _ => new SpanEvent(span)
         };
+    }
 
     public static Span? GetSpan(IEvent @event)
     {

--- a/tracer/src/Datadog.Trace/Ci/EventModel/TestEvent.cs
+++ b/tracer/src/Datadog.Trace/Ci/EventModel/TestEvent.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.Ci.EventModel;
 
 internal class TestEvent : CIVisibilityEvent<Span>
 {
-    public TestEvent(Span span)
-        : base(SpanTypes.Test, 2, span)
+    public TestEvent(Span span, int version)
+        : base(SpanTypes.Test, version, span)
     {
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes the BenchmarkDotNet exporter by sending benchmark test types with the version 1 of the test model.
