### PR TITLE
Use our own VMSS for more builds

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -176,9 +176,11 @@ stages:
     steps:
     - checkout: none
     - bash: |
+        rm -rf ./s
         git clone --quiet --no-checkout --depth 1 --branch master $BUILD_REPOSITORY_URI ./s
         cd s
         MASTER_SHA=$(git rev-parse origin/master)
+        rm -rf ./s
         echo "Using master commit ID $MASTER_SHA"
         echo "##vso[task.setvariable variable=master;isOutput=true]$MASTER_SHA"
       failOnStderr: true

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -171,7 +171,7 @@ stages:
   - job: fetch
     timeoutInMinutes: 60 #default value
     pool:
-      vmImage: ubuntu-20.04
+      name: azure-linux-task-scale-set
 
     steps:
     - checkout: none
@@ -621,7 +621,7 @@ stages:
   dependsOn: [build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-  
+
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -1820,7 +1820,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     # Enable the Datadog Agent service for this job
     services:
@@ -1877,7 +1877,7 @@ stages:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_linux_matrix'] ]
 
     pool:
-      vmImage: ubuntu-20.04
+      name: azure-linux-scale-set
 
     # Enable the Datadog Agent service for this job
     services:
@@ -2284,22 +2284,12 @@ stages:
           name: centos7
           baseImage: centos7
           artifactSuffix: linux-x64
-<<<<<<< HEAD
-          poolImage: ubuntu-20.04
-          poolName:
-=======
           poolName: azure-linux-scale-set
->>>>>>> e27398b6f (Use azure scale-sets for more jobs)
         alpine:
           name: alpine
           baseImage: alpine
           artifactSuffix: linux-musl-x64
-<<<<<<< HEAD
-          poolImage: ubuntu-20.04
-          poolName:
-=======
           poolName: azure-linux-scale-set
->>>>>>> e27398b6f (Use azure scale-sets for more jobs)
         arm64:
           name: arm64
           baseImage: debian

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -621,8 +621,7 @@ stages:
   dependsOn: [build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-  pool:
-    name: azure-windows-scale-set
+  
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -630,6 +629,8 @@ stages:
 
     - job: managed
       timeoutInMinutes: 60 #default value
+      pool:
+        name: azure-windows-scale-set
       steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -656,6 +657,8 @@ stages:
 
     - job: native
       timeoutInMinutes: 60 #default value
+      pool:
+        vmImage: windows-2019
       steps:
       - template: steps/clone-repo.yml
         parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -623,6 +623,8 @@ stages:
   dependsOn: [build_windows_tracer, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  pool:
+    name: azure-windows-scale-set
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -631,8 +633,6 @@ stages:
 
     - job: managed
       timeoutInMinutes: 60 #default value
-      pool:
-        name: azure-windows-scale-set
       steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -659,8 +659,6 @@ stages:
 
     - job: native
       timeoutInMinutes: 60 #default value
-      pool:
-        vmImage: windows-2019
       steps:
       - template: steps/clone-repo.yml
         parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -198,7 +198,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -223,7 +223,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -252,7 +252,7 @@ stages:
 
   - job: build
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -577,7 +577,7 @@ stages:
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
-    vmImage: windows-2019
+    name: azure-windows-scale-set
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -622,7 +622,7 @@ stages:
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
-    vmImage: windows-2019
+    name: azure-windows-scale-set
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -2075,7 +2075,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -2216,7 +2216,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      vmImage: windows-2019
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -2281,23 +2281,29 @@ stages:
           name: centos7
           baseImage: centos7
           artifactSuffix: linux-x64
+<<<<<<< HEAD
           poolImage: ubuntu-20.04
           poolName:
+=======
+          poolName: azure-linux-scale-set
+>>>>>>> e27398b6f (Use azure scale-sets for more jobs)
         alpine:
           name: alpine
           baseImage: alpine
           artifactSuffix: linux-musl-x64
+<<<<<<< HEAD
           poolImage: ubuntu-20.04
           poolName:
+=======
+          poolName: azure-linux-scale-set
+>>>>>>> e27398b6f (Use azure scale-sets for more jobs)
         arm64:
           name: arm64
           baseImage: debian
           artifactSuffix: linux-arm64
-          poolImage:
           poolname: aws-arm64-auto-scaling
 
     pool:
-      vmImage: $(poolImage)
       name: $(poolName)
 
     steps:

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -332,6 +332,8 @@ jobs:
   build_windows:
     name: Build Windows Profiler and Tracer
     runs-on: windows-2019
+    env:
+      NugetPackageDirectory: ./packages
     strategy:
       fail-fast: false
       matrix:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.WithTests.proj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Datadog.Profiler.Native.Windows.WithTests.proj
@@ -33,10 +33,13 @@
     </MSBuild>
   </Target>
 
-  <Target Name="BuildCppTests" DependsOnTargets="Restore">
+  <Target Name="BuildCppTestsOnly">
     <MSBuild Targets="Build" Projects="@(CppTestProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
+  </Target>
+
+  <Target Name="BuildCppTests" DependsOnTargets="Restore;BuildCppTestsOnly">
   </Target>
 
   <Target Name="BuildCppWithAsan"  DependsOnTargets="Restore">

--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -202,7 +202,7 @@ partial class Build
         if (ExplorationTestUseCase == global::ExplorationTestUseCase.Tracer &&
             testDescription.Name is global::ExplorationTestName.paket)
         {
-            Logger.Info("The Exploration Tests: protobuf, are disabled for Tracer because it fails due to poor environment isolation.");
+            Logger.Info("The Exploration Tests: paket, are disabled for Tracer because it fails due to poor environment isolation.");
             return;
         }
 

--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -199,6 +199,13 @@ partial class Build
             throw new InvalidOperationException($"The framework '{Framework}' is not listed in the project's target frameworks of {testDescription.Name}");
         }
 
+        if (ExplorationTestUseCase == global::ExplorationTestUseCase.Tracer &&
+            testDescription.Name is global::ExplorationTestName.paket)
+        {
+            Logger.Info("The Exploration Tests: protobuf, are disabled for Tracer because it fails due to poor environment isolation.");
+            return;
+        }
+
         if (ExplorationTestUseCase == global::ExplorationTestUseCase.Debugger &&
             testDescription.Name is global::ExplorationTestName.protobuf or global::ExplorationTestName.cake or global::ExplorationTestName.paket or global::ExplorationTestName.polly)
         {

--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -199,10 +199,9 @@ partial class Build
             throw new InvalidOperationException($"The framework '{Framework}' is not listed in the project's target frameworks of {testDescription.Name}");
         }
 
-        if (ExplorationTestUseCase == global::ExplorationTestUseCase.Tracer &&
-            testDescription.Name is global::ExplorationTestName.paket)
+        if (testDescription.Name is global::ExplorationTestName.paket)
         {
-            Logger.Info("The Exploration Tests: paket, are disabled for Tracer because it fails due to poor environment isolation.");
+            Logger.Info("The Exploration Tests: paket, are disabled currently in CI because it fails due to poor environment isolation.");
             return;
         }
 

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -105,12 +105,18 @@ partial class Build
                     ? new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86 }
                     : new[] { MSBuildTargetPlatform.x86 };
 
+            var testProjects = ProfilerDirectory.GlobFiles("test/**/*.vcxproj");
+            NuGetTasks.NuGetRestore(s => s
+                .SetTargetPath(ProfilerMsBuildProject)
+                .SetVerbosity(NuGetVerbosity.Normal)
+                .CombineWith(testProjects, (m, testProjects) => m.SetTargetPath(testProjects)));
+
             // Can't use dotnet msbuild, as needs to use the VS version of MSBuild
             MSBuild(s => s
                 .SetTargetPath(ProfilerMsBuildProject)
                 .SetConfiguration(BuildConfiguration)
                 .SetMSBuildPath()
-                .SetTargets("BuildCppTests")
+                .SetTargets("BuildCppTestsOnly")
                 .DisableRestore()
                 .SetMaxCpuCount(null)
                 .CombineWith(platforms, (m, platform) => m

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -109,6 +109,7 @@ partial class Build
             NuGetTasks.NuGetRestore(s => s
                 .SetTargetPath(ProfilerMsBuildProject)
                 .SetVerbosity(NuGetVerbosity.Normal)
+                .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackagesDirectory(NugetPackageDirectory))
                 .CombineWith(testProjects, (m, testProjects) => m.SetTargetPath(testProjects)));
 
             // Can't use dotnet msbuild, as needs to use the VS version of MSBuild

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -389,7 +389,6 @@ partial class Build : NukeBuild
                 DotNetBuild(s => s
                     .SetProjectFile(benchmarksProject)
                     .SetConfiguration(BuildConfiguration)
-                    .SetFramework(TargetFramework.NETCOREAPP3_1)
                     .EnableNoDependencies()
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                 );


### PR DESCRIPTION
## Summary of changes

Moves more of the build to our own VMSS instead of hosted runners

## Reason for change

We keep running into issues with other teams using the shared host instances blocking our CI for hours.

## Implementation details

This PR should reduce the impact, but we're still using the hosted runners for some stages:

- ~The native windows unit tests don't currently build on our VMSS. We should probably look into this in the .NET 7 update.~ Fixed now - it was a NuGet issue, so switched to using Nuke for this
- The installer tests - there's thousands of them, and would likely require a bit of work to get them working correctly on the VMSS machines, so easiest to delegate that out. They're typically not in the hot path, so hopefully not a big deal

## Test coverage

The Paket exploration tests are failing for an unrelated (env var related) issue, so just skipping for now

## Other details
Fixes an issue with the benchmark agents due to accidentally installing the .NET 7 SDK