### PR TITLE
[CI Visibility] - Add support for git shallow clone

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -134,14 +134,54 @@ internal class IntelligentTestRunnerClient
     public async Task<long> UploadRepositoryChangesAsync()
     {
         Log.Debug("ITR: Uploading Repository Changes...");
-        var gitOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "log --format=%H -n 1000 --since=\"1 month ago\"", _workingDirectory)).ConfigureAwait(false);
-        if (gitOutput is null)
+
+        try
+        {
+            // We need to check if the git clone is a shallow one before uploading anything.
+            // In the case is a shallow clone we need to reconfigure it to upload the git tree
+            // without blobs so no content will be downloaded.
+            var gitRevParseShallowOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "rev-parse --is-shallow-repository", _workingDirectory)).ConfigureAwait(false);
+            if (gitRevParseShallowOutput is null)
+            {
+                Log.Warning("ITR: 'git rev-parse --is-shallow-repository' command is null");
+                return 0;
+            }
+
+            if (gitRevParseShallowOutput.IndexOf("true", StringComparison.OrdinalIgnoreCase) > -1)
+            {
+                // The git repo is a shallow clone, we need to double check if there are more than just 1 commit in the logs.
+                var gitShallowLogOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "log --format=oneline -n 2", _workingDirectory)).ConfigureAwait(false);
+                if (gitShallowLogOutput is null)
+                {
+                    Log.Warning("ITR: 'git log --format=oneline -n 2' command is null");
+                    return 0;
+                }
+
+                // After asking for 2 logs lines, if the git log command returns just one commit sha, we reconfigure the repo
+                // to ask for git commits and trees of the last month (no blobs)
+                var shallowLogArray = gitShallowLogOutput.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+                if (shallowLogArray.Length == 1)
+                {
+                    // Just one commit SHA. Reconfiguring repo
+                    Log.Information("ITR: The current repo is a shallow clone, reconfiguring git repo and refetching data...");
+                    await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "config remote.origin.partialclonefilter \"blob:none\"", _workingDirectory)).ConfigureAwait(false);
+                    await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "fetch --shallow-since=\"1 month ago\" --update-shallow --refetch", _workingDirectory)).ConfigureAwait(false);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error detecting and reconfiguring git repository for shallow clone.");
+        }
+
+        var gitLogOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "log --format=%H -n 1000 --since=\"1 month ago\"", _workingDirectory)).ConfigureAwait(false);
+        if (gitLogOutput is null)
         {
             Log.Warning("ITR: 'git log...' command is null");
             return 0;
         }
 
-        var localCommits = gitOutput.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
+        var localCommits = gitLogOutput.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
         if (localCommits.Length == 0)
         {
             Log.Debug("ITR: Local commits not found. (since 1 month ago)");


### PR DESCRIPTION
## Summary of changes

This PR adds support for shallow clones of git repositories in CI Visibility.

## Reason for change

As the [Jira ticket](https://datadoghq.atlassian.net/browse/CIAPP-5180) describes: 

>Many CI providers clone their repositories with a shallow clone, which means there is no commit history. In those cases, sending a packfile to the backend would not be the correct choice since we would generate a packfile with a single commit instead of the necessary payload, therefore polluting the state of the backend.

>We can detect if a repository is shallow by running git rev-parse --is-shallow-repository. If that returns the string true, then we check git log --format=oneline -n 2. If the output of that is only one line long, then we run the following sequence of commands to retrieve the necessary commit and tree history:

>git config remote.origin.partialclonefilter "blob:none"
>git fetch --shallow-since="1 month ago" --update-shallow --refetch
 

>The first line configures the repository to avoid downloading blobs, since we don’t need those for git metadata upload. If the Git version does not support partial clones, then this configuration will be ignored.

>The second line tells the git client to refetch the data from the server for the past month.

## Implementation details

This implementation is just a modification to the existing `UploadRepositoryChangesAsync` method, to include both detection and configuration of the repo.

