### PR TITLE
Add special ExitCodeException to test suites

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/DebuggerSampleProcessHelper.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Debugger
 
             if (Process.ExitCode != 0)
             {
-                throw new InvalidOperationException($"Process exit code is {Process.ExitCode}");
+                ExitCodeException.Throw(Process.ExitCode, 0);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -94,7 +94,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = MockTracerAgent.Create(Output, agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, aspNetCorePort: 0);
 
-            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+            if (processResult.ExitCode >= 0)
+            {
+                ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+            }
 
             var logs = logsIntake.Logs;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -162,7 +162,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = MockTracerAgent.Create(Output, agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
-            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+            if (processResult.ExitCode >= 0)
+            {
+                ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+            }
 
             var logs = logsIntake.Logs;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -122,7 +122,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = MockTracerAgent.Create(Output, agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
-            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+            if (processResult.ExitCode >= 0)
+            {
+                ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+            }
 
             var logs = logsIntake.Logs;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
@@ -35,7 +35,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     throw new SkipException("Unexpected segmentation fault in NativeProfilerChecks");
                 }
 
-                exitCode.Should().Be(0);
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
+
                 VerifyInstrumentation(processResult.Process);
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -121,7 +121,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = MockTracerAgent.Create(Output, agentPort);
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
-            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+            if (processResult.ExitCode >= 0)
+            {
+                ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+            }
 
             var logs = logsIntake.Logs;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -161,7 +161,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
             }
 
-            Assert.True(expectedExitCode == result.ExitCode, $"Expected exit code: {expectedExitCode}, actual exit code: {result.ExitCode}");
+            if (expectedExitCode != result.ExitCode)
+            {
+                ExitCodeException.Throw(result.ExitCode, expectedExitCode);
+            }
 
             if (expectedExitCode == 0)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -48,7 +48,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
 
                 var spans = agent.WaitForSpans(ExpectedSpans);
 
@@ -74,7 +77,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
 
                 var spans = agent.WaitForSpans(ExpectedSpans);
                 await AssertExpectedSpans(spans);
@@ -99,7 +105,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
 
                 var spans = agent.WaitForSpans(ExpectedSpans);
                 await AssertExpectedSpans(spans);
@@ -146,7 +155,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
                 using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
                 {
-                    Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
+                    if (processResult.ExitCode >= 0)
+                    {
+                        ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                    }
 
                     var spans = agent.WaitForSpans(ExpectedSpans);
                     await AssertExpectedSpans(spans);
@@ -171,7 +183,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                Assert.True(processResult.ExitCode == 0, $"Process exited with code {processResult.ExitCode}");
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
 
                 var spans = agent.WaitForSpans(ExpectedSpans);
                 await AssertExpectedSpans(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -84,7 +84,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
             using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                processResult.ExitCode.Should().Be(0);
+                if (processResult.ExitCode >= 0)
+                {
+                    ExitCodeException.Throw(processResult.ExitCode, 0, processResult.StandardError);
+                }
+
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
                 await VerifyHelper.VerifySpans(spans, VerifyHelper.GetSpanVerifierSettings())

--- a/tracer/test/Datadog.Trace.TestHelpers/ExitCodeException.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ExitCodeException.cs
@@ -1,0 +1,23 @@
+// <copyright file="ExitCodeException.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.TestHelpers;
+
+public class ExitCodeException : Exception
+{
+    public ExitCodeException(int actualExitCode, int expectedExitCode, string message)
+        : base(string.IsNullOrWhiteSpace(message) ?
+                   $"Expected exit code: {expectedExitCode}, actual exit code: {actualExitCode}." :
+                   $"Expected exit code: {expectedExitCode}, actual exit code: {actualExitCode}. Message: {message}")
+    {
+    }
+
+    public static void Throw(int actualExitCode, int expectedExitCode, string message = null)
+    {
+        throw new ExitCodeException(actualExitCode, expectedExitCode, message);
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR adds a special `ExitCodeException` for test suites, the reason is to eliminate disambiguation with other asserts in the CI Visibility exception branch view.

<img width="1562" alt="image" src="https://user-images.githubusercontent.com/69803/200372125-1c8621f6-e309-4edc-be40-65d04735ba7a.png">

## Reason for change

Bad exit codes in our tests are mostly really bad, because there's a high probability that we are hitting an `AccessViolationException` in a sample app due to the tracer behaviour. 

With this change we should be able to detect those crashes in the branch view directly without doing extra clicks on each tests to discover the reason.
