### PR TITLE
Bump DatadogLogger version to 0.0.28

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -233,7 +233,7 @@ namespace Datadog.Trace.TestHelpers
                 throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
             }
 
-            exitCode.Should().Be(0);
+            ExitCodeException.ThrowIfNonZero(exitCode);
 
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.27" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.28" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.26" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.27" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Bump DatadogLogger version to 0.0.28 that includes support `ITestOutputHelper` messages.

https://github.com/tonyredondo/datadog-test-logger/pull/6