### PR TITLE
[Build] Fix exported symbols issue with CMake builds

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -93,7 +93,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 # ******************************************************
 
 # Sets compiler options
-add_compile_options(-std=c++17 -fPIC -fms-extensions)
+add_compile_options(-std=c++17 -fPIC -fms-extensions -fvisibility=hidden)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
 add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined)
 if (ISMACOS)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -5,102 +5,104 @@
 #include "dynamic_dispatcher.h"
 #include "util.h"
 
+#ifndef _WIN32
+#undef EXTERN_C
+#define EXTERN_C extern "C" __attribute__((visibility("default")))
+#endif
+
 using namespace datadog::shared::nativeloader;
 
 IDynamicDispatcher* dispatcher;
 
-extern "C"
+EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
-    BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+    // Perform actions based on the reason for calling.
+    switch (ul_reason_for_call)
     {
-        // Perform actions based on the reason for calling.
-        switch (ul_reason_for_call)
+        case DLL_PROCESS_ATTACH:
         {
-            case DLL_PROCESS_ATTACH:
+            // Initialize once for each new process.
+            // Return FALSE to fail DLL load.
+
+            constexpr const bool IsLogDebugEnabledDefault = false;
+            bool isLogDebugEnabled;
+
+            shared::WSTRING isLogDebugEnabledStr = shared::GetEnvironmentValue(EnvironmentVariables::DebugLogEnabled);
+
+            // no environment variable set
+            if (isLogDebugEnabledStr.empty())
             {
-                // Initialize once for each new process.
-                // Return FALSE to fail DLL load.
-                
-                constexpr const bool IsLogDebugEnabledDefault = false;
-                bool isLogDebugEnabled;
+                Log::Info("No \"", EnvironmentVariables::DebugLogEnabled, "\" environment variable has been found.",
+                          " Enable debug log = ", IsLogDebugEnabledDefault, " (default).");
 
-                shared::WSTRING isLogDebugEnabledStr = shared::GetEnvironmentValue(EnvironmentVariables::DebugLogEnabled);
-
-                // no environment variable set
-                if (isLogDebugEnabledStr.empty())
+                isLogDebugEnabled = IsLogDebugEnabledDefault;
+            }
+            else
+            {
+                if (!shared::TryParseBooleanEnvironmentValue(isLogDebugEnabledStr, isLogDebugEnabled))
                 {
-                    Log::Info("No \"", EnvironmentVariables::DebugLogEnabled, "\" environment variable has been found.",
+                    // invalid value for environment variable
+                    Log::Info("Non boolean value \"", isLogDebugEnabledStr, "\" for \"",
+                              EnvironmentVariables::DebugLogEnabled, "\" environment variable.",
                               " Enable debug log = ", IsLogDebugEnabledDefault, " (default).");
 
                     isLogDebugEnabled = IsLogDebugEnabledDefault;
                 }
                 else
                 {
-                    if (!shared::TryParseBooleanEnvironmentValue(isLogDebugEnabledStr, isLogDebugEnabled))
-                    {
-                        // invalid value for environment variable
-                        Log::Info("Non boolean value \"", isLogDebugEnabledStr, "\" for \"",
-                                  EnvironmentVariables::DebugLogEnabled, "\" environment variable.",
-                                  " Enable debug log = ", IsLogDebugEnabledDefault, " (default).");
-
-                        isLogDebugEnabled = IsLogDebugEnabledDefault;
-                    }
-                    else
-                    {
-                        // take environment variable into account
-                        Log::Info("Enable debug log = ", isLogDebugEnabled, " from (", EnvironmentVariables::DebugLogEnabled, " environment variable)");
-                    }
+                    // take environment variable into account
+                    Log::Info("Enable debug log = ", isLogDebugEnabled, " from (", EnvironmentVariables::DebugLogEnabled, " environment variable)");
                 }
-
-                if (isLogDebugEnabled)
-                {
-                    Log::EnableDebug();
-                }
-
-                Log::Debug("DllMain: DLL_PROCESS_ATTACH");
-                Log::Debug("DllMain: Pointer size: ", 8 * sizeof(void*), " bits.");
-
-                dispatcher = new DynamicDispatcherImpl();
-                dispatcher->LoadConfiguration(GetConfigurationFilePath());
-
-                // *****************************************************************************************************************
-                break;
             }
 
-            case DLL_PROCESS_DETACH:
-                // Perform any necessary cleanup.
-                Log::Debug("DllMain: DLL_PROCESS_DETACH");
+            if (isLogDebugEnabled)
+            {
+                Log::EnableDebug();
+            }
 
-                break;
+            Log::Debug("DllMain: DLL_PROCESS_ATTACH");
+            Log::Debug("DllMain: Pointer size: ", 8 * sizeof(void*), " bits.");
+
+            dispatcher = new DynamicDispatcherImpl();
+            dispatcher->LoadConfiguration(GetConfigurationFilePath());
+
+            // *****************************************************************************************************************
+            break;
         }
-        return TRUE; // Successful DLL_PROCESS_ATTACH.
-    }
 
-    HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+        case DLL_PROCESS_DETACH:
+            // Perform any necessary cleanup.
+            Log::Debug("DllMain: DLL_PROCESS_DETACH");
+
+            break;
+    }
+    return TRUE; // Successful DLL_PROCESS_ATTACH.
+}
+
+EXTERN_C HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+{
+    Log::Debug("DllGetClassObject");
+
+    // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
+
+    if (ppv == NULL || rclsid != CLSID_CorProfiler)
     {
-        Log::Debug("DllGetClassObject");
-
-        // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-        const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
-
-        if (ppv == NULL || rclsid != CLSID_CorProfiler)
-        {
-            return E_FAIL;
-        }
-
-        auto factory = new CorProfilerClassFactory(dispatcher);
-        if (factory == NULL)
-        {
-            return E_FAIL;
-        }
-
-        return factory->QueryInterface(riid, ppv);
+        return E_FAIL;
     }
 
-    HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
+    auto factory = new CorProfilerClassFactory(dispatcher);
+    if (factory == NULL)
     {
-        Log::Debug("DllCanUnloadNow");
-
-        return dispatcher->DllCanUnloadNow();
+        return E_FAIL;
     }
+
+    return factory->QueryInterface(riid, ppv);
+}
+
+EXTERN_C HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
+{
+    Log::Debug("DllCanUnloadNow");
+
+    return dispatcher->DllCanUnloadNow();
 }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/exported_functions.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/exported_functions.cpp
@@ -2,14 +2,14 @@
 #include "cor_profiler.h"
 
 // This function is exported for interoperability with native libraries (e.g.: Profiler)
-extern "C" const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain)
+EXTERN_C const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain)
 {
     return datadog::shared::nativeloader::CorProfiler::GetRuntimeId(appDomain);
 }
 
 // This function is exported mainly for interoperability with managed libraries (e.g.: Tracer managed code)
 // This method must be called by a managed thread
-extern "C" const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId()
+EXTERN_C const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId()
 {
     auto appDomain = datadog::shared::nativeloader::CorProfiler::GetCurrentAppDomainId();
     return GetRuntimeId(appDomain);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/exported_functions.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/exported_functions.h
@@ -3,5 +3,10 @@
 #include <corhlpr.h>
 #include <corprof.h>
 
-extern "C" const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId();
-extern "C" const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain);
+#ifndef _WIN32
+#undef EXTERN_C
+#define EXTERN_C extern "C" __attribute__((visibility("default")))
+#endif
+
+EXTERN_C const char* STDMETHODCALLTYPE GetCurrentAppDomainRuntimeId();
+EXTERN_C const char* STDMETHODCALLTYPE GetRuntimeId(AppDomainID appDomain);

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -100,7 +100,7 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OUTPUT_BIN_DIR})
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 
 # Sets compiler options
-add_compile_options(-std=c++17 -fPIC -fms-extensions)
+add_compile_options(-std=c++17 -fPIC -fms-extensions -fvisibility=hidden)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
 add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined)
 if (ISMACOS)

--- a/tracer/src/Datadog.Tracer.Native/dllmain.cpp
+++ b/tracer/src/Datadog.Tracer.Native/dllmain.cpp
@@ -5,45 +5,47 @@
 #include "dllmain.h"
 #include "class_factory.h"
 
+#ifndef _WIN32
+#undef EXTERN_C
+#define EXTERN_C extern "C" __attribute__((visibility("default")))
+#endif
+
 const IID IID_IUnknown = {0x00000000, 0x0000, 0x0000, {0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}};
 
 const IID IID_IClassFactory = {0x00000001, 0x0000, 0x0000, {0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46}};
 
 HINSTANCE DllHandle;
 
-extern "C"
+EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
-    BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+    DllHandle = hModule;
+    return TRUE;
+}
+
+EXTERN_C HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+{
+    // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+    const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
+
+    // {50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5}
+    const GUID CLSID_New_CorProfiler = {0x50da5eed, 0xf1ed, 0xb00b, {0x10, 0x55, 0x5a, 0xfe, 0x55, 0xa1, 0xad, 0xe5}};
+
+    if (ppv == NULL || (rclsid != CLSID_CorProfiler && rclsid != CLSID_New_CorProfiler))
     {
-        DllHandle = hModule;
-        return TRUE;
+        return E_FAIL;
     }
 
-    HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+    auto factory = new ClassFactory;
+
+    if (factory == NULL)
     {
-        // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-        const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
-
-        // {50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5}
-        const GUID CLSID_New_CorProfiler = {0x50da5eed, 0xf1ed, 0xb00b, {0x10, 0x55, 0x5a, 0xfe, 0x55, 0xa1, 0xad, 0xe5}};
-
-        if (ppv == NULL || (rclsid != CLSID_CorProfiler && rclsid != CLSID_New_CorProfiler))
-        {
-            return E_FAIL;
-        }
-
-        auto factory = new ClassFactory;
-
-        if (factory == NULL)
-        {
-            return E_FAIL;
-        }
-
-        return factory->QueryInterface(riid, ppv);
+        return E_FAIL;
     }
 
-    HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
-    {
-        return S_OK;
-    }
+    return factory->QueryInterface(riid, ppv);
+}
+
+EXTERN_C HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
+{
+    return S_OK;
 }

--- a/tracer/src/Datadog.Tracer.Native/dllmain.h
+++ b/tracer/src/Datadog.Tracer.Native/dllmain.h
@@ -3,6 +3,12 @@
 
 #include "class_factory.h"
 
-extern HINSTANCE DllHandle;
+#ifdef _WIN32
+#define EXTERN extern
+#else
+#define EXTERN extern __attribute__((visibility("default")))
+#endif
+
+EXTERN HINSTANCE DllHandle;
 
 #endif // DD_CLR_PROFILER_DLLMAIN_H_

--- a/tracer/src/Datadog.Tracer.Native/interop.cpp
+++ b/tracer/src/Datadog.Tracer.Native/interop.cpp
@@ -10,6 +10,8 @@
 
 #ifndef _WIN32
 #include <dlfcn.h>
+#undef EXTERN_C
+#define EXTERN_C extern "C" __attribute__((visibility("default")))
 #endif
 
 EXTERN_C BOOL STDAPICALLTYPE IsProfilerAttached()


### PR DESCRIPTION
## Summary of changes

This PR changes the `CMakeList.txt` build options to avoid exporting all symbols by default, and marks each method we need to export individually.

## Reason for change

Latest `dd-trace` tool release on MacOS always fails with the following:

```
x ~/.dotnet/tools/dd-trace ci run -- dotnet test
Running: dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  HeavyTests -> /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll
Test run for /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.3.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Testhost process exited with error: Unhandled exception. System.EntryPointNotFoundException: Unable to find an entry point named 'GetAssemblyAndSymbolsBytes' in shared library '/Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib'.
   at __DDVoidMethodType__.GetAssemblyAndSymbolsBytes(IntPtr& , Int32& , IntPtr& , Int32& )
   at __DDVoidMethodType__.__DDVoidMethodCall__()
   at Microsoft.VisualStudio.TestPlatform.TestHost.Program.Main(String[] args)
. Please check the diagnostic logs for more information.

Test Run Aborted.
```

**And the problem is that the runtime is trying to find `GetAssemblyAndSymbolsBytes` in `Datadog.Trace.ClrProfiler.Native.dylib` which is the loader, and not in `Datadog.Tracer.Native.dylib` instead.**

It's weird because when we inject the loader we explicitly call [`shared::GetCurrentModuleFileName()`](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp#L2666-L2668) so the ModuleName should be the Tracer's shared library and not the Native Loader.

By adding more information to check the output of the `shared::GetCurrentModuleFileName()` library function, we can see that function is failing to give us the current module, and always returns the Native Loader shared library.

```
x ~/.dotnet/tools/dd-trace ci run -- dotnet test
Running: dotnet test
MODULE PTR: 4350517092
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
  Determining projects to restore...
  All projects are up-to-date for restore.
  HeavyTests -> /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll
Test run for /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll (.NETCoreApp,Version=v6.0)
MODULE PTR: 4357807972
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
Microsoft (R) Test Execution Command Line Tool Version 17.3.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
MODULE PTR: 4391018340
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
MODULE PTR: 4391018340
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
MODULE PTR: 4391018340
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
Testhost process exited with error: Unhandled exception. System.EntryPointNotFoundException: Unable to find an entry point named 'GetAssemblyAndSymbolsBytes' in shared library '/Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib'.
   at __DDVoidMethodType__.GetAssemblyAndSymbolsBytes(IntPtr& , Int32& , IntPtr& , Int32& )
   at __DDVoidMethodType__.__DDVoidMethodCall__()
   at Microsoft.VisualStudio.TestPlatform.TestHost.Program.Main(String[] args)
. Please check the diagnostic logs for more information.

Test Run Aborted.
```

So there's a problem with the function but if we check the code it's really straightforward:
https://github.com/DataDog/dd-trace-dotnet/blob/5bbf2b2672647586c52d3ac5913ea079ade4623e/shared/src/native-src/pal.h#L142-L174

Just getting the module info from the address of the method, and the method is defined in that shared library.

By printing the stacktraces we can see...

```
> ~/.dotnet/tools/dd-trace ci run -- dotnet test
Running: dotnet test
MODULE PTR: 4392977744
0   Datadog.Trace.ClrProfiler.Native.dy 0x0000000105b0dd5c _ZN6shared24GetCurrentModuleFileNameEv + 276
1   Datadog.Trace.ClrProfiler.Native.dy 0x0000000105b0d0a8 _ZN7datadog6shared12nativeloader21DynamicDispatcherImpl17LoadConfigurationEONSt3__14__fs10filesystem4pathE + 56
2   Datadog.Trace.ClrProfiler.Native.dy 0x0000000105ac40b8 DllMain + 480
3   libcoreclr.dylib                    0x0000000105335b0c _ZL19LOADCallDllMainSafeP10_MODSTRUCTjPv + 136
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
  Determining projects to restore...
  All projects are up-to-date for restore.
  HeavyTests -> /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll
Test run for /Users/tony.redondo/repos/github/tonyredondo/HeavyTest/HeavyTests/bin/Debug/net6.0/HeavyTests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.3.0 (arm64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
MODULE PTR: 4353852752
0   Datadog.Trace.ClrProfiler.Native.dy 0x00000001035bdd5c _ZN6shared24GetCurrentModuleFileNameEv + 276
1   Datadog.Trace.ClrProfiler.Native.dy 0x00000001035bd0a8 _ZN7datadog6shared12nativeloader21DynamicDispatcherImpl17LoadConfigurationEONSt3__14__fs10filesystem4pathE + 56
2   Datadog.Trace.ClrProfiler.Native.dy 0x00000001035740b8 DllMain + 480
3   libcoreclr.dylib                    0x0000000102de5b0c _ZL19LOADCallDllMainSafeP10_MODSTRUCTjPv + 136
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib

MODULE PTR: 4353852752
0   Datadog.Trace.ClrProfiler.Native.dy 0x00000001035bdd5c _ZN6shared24GetCurrentModuleFileNameEv + 276
1   Datadog.Tracer.Native.dylib         0x000000010493f00c _ZN5trace11CorProfiler10InitializeEP8IUnknown + 30708
2   Datadog.Trace.ClrProfiler.Native.dy 0x000000010347997c _ZN7datadog6shared12nativeloader11CorProfiler10InitializeEP8IUnknown + 1264
3   libcoreclr.dylib                    0x0000000102f69b38 _ZN21EEToProfInterfaceImpl10InitializeEv + 156
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib

MODULE PTR: 4353852752
0   Datadog.Trace.ClrProfiler.Native.dy 0x00000001035bdd5c _ZN6shared24GetCurrentModuleFileNameEv + 276
1   Datadog.Tracer.Native.dylib         0x000000010494154c _ZN5trace11CorProfiler20RewritingPInvokeMapsERKNS_14ModuleMetadataERKNSt3__112basic_stringIDsNS4_11char_traitsIDsEENS4_9allocatorIDsEEEESC_ + 228
2   Datadog.Tracer.Native.dylib         0x0000000104943228 _ZN5trace11CorProfiler14TryRejitModuleEm + 3036
3   Datadog.Tracer.Native.dylib         0x0000000104942198 _ZN5trace11CorProfiler18ModuleLoadFinishedEmi + 268
4   Datadog.Trace.ClrProfiler.Native.dy 0x000000010347d490 _ZN7datadog6shared12nativeloader11CorProfiler18ModuleLoadFinishedEmi + 864
5   libcoreclr.dylib                    0x0000000102f6ace0 _ZN21EEToProfInterfaceImpl18ModuleLoadFinishedEmi + 112
Module Name: /Users/tony.redondo/.dotnet/tools/.store/dd-trace/2.18.0/dd-trace/2.18.0/home/osx-arm64/Datadog.Trace.ClrProfiler.Native.dylib
```

As we can see there's a problem, when calling `shared::GetCurrentModuleFileName()` instead of calling the one defined in the `Datadog.Tracer.Native.dylib` module, the one that gets called is the one defined in `Datadog.Trace.ClrProfiler.Native.dylib` being the two modules totally separated from each one.

Is not clear that this is an undefined behaviour, Linker options, or a problem in the Apple CLang compiler. 

The problem is that both libraries have the same function symbols being exported and loaded in the same process. This get's fixed when we avoid exporting all function symbols, in this case the Tracer module cannot see or execute the functions defined in the Loader module. That seems to be a good default as follows the same behavior of the Windows build (with the .def file).

The fix is applied on both Linux and macOS builds.

## Implementation details

- Avoid exporting all symbols by default with -fvisibility=hidden
- Mark each function we need to export individually.

