### PR TITLE
[CI Visibility] - CheckAgentConnectionAsync rewrite to use the DiscoveryService.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tools.Runner
                                 return 1;
                             }
                         }
-                        else if (!Utils.CheckAgentConnectionAsync(options.AgentUrl).GetAwaiter().GetResult())
+                        else if (Utils.CheckAgentConnectionAsync(options.AgentUrl).GetAwaiter().GetResult() is null)
                         {
                             return 1;
                         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.Util;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -90,7 +91,10 @@ namespace Datadog.Trace.Tools.Runner
                     if (!agentless)
                     {
                         // EVP proxy is enabled.
+                        // By setting the environment variables we avoid the usage of the DiscoveryService in each child process
+                        // to ask for EVP proxy support.
                         profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy] = "1";
+                        EnvironmentHelpers.SetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, "1");
                     }
                 }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -13,10 +13,12 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
 using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner
@@ -235,7 +237,7 @@ namespace Datadog.Trace.Tools.Runner
             return defaultValue;
         }
 
-        public static async Task<bool> CheckAgentConnectionAsync(string agentUrl)
+        public static async Task<AgentConfiguration> CheckAgentConnectionAsync(string agentUrl)
         {
             var env = new NameValueCollection();
             if (!string.IsNullOrWhiteSpace(agentUrl))
@@ -251,30 +253,39 @@ namespace Datadog.Trace.Tools.Runner
 
             var tracerSettings = new TracerSettings(configurationSource);
             var settings = tracerSettings.Build();
-            var discoveryService = DiscoveryService.Create(settings.Exporter);
+            var discoveryService = new DiscoveryService(
+                AgentTransportStrategy.Get(
+                    settings.Exporter,
+                    productName: "discovery",
+                    tcpTimeout: TimeSpan.FromSeconds(5),
+                    AgentHttpHeaderNames.MinimalHeaders,
+                    () => new MinimalAgentHeaderHelper(),
+                    uri => uri),
+                10,
+                1000,
+                int.MaxValue);
 
-            var agentWriter = new ApmAgentWriter(settings, new CISampler(), discoveryService);
-
-            try
-            {
-                if (!await agentWriter.Ping().ConfigureAwait(false))
+            var tcs = new TaskCompletionSource<AgentConfiguration>(TaskCreationOptions.RunContinuationsAsynchronously);
+            discoveryService.SubscribeToChanges(
+                aCfg =>
                 {
-                    WriteError($"Error connecting to the Datadog Agent at {tracerSettings.Exporter.AgentUri}.");
-                    return false;
-                }
-            }
-            catch (Exception ex)
-            {
-                WriteError($"Error connecting to the Datadog Agent at {tracerSettings.Exporter.AgentUri}.");
-                AnsiConsole.WriteException(ex);
-                return false;
-            }
-            finally
-            {
-                await agentWriter.FlushAndCloseAsync().ConfigureAwait(false);
-            }
+                    tcs.TrySetResult(aCfg);
+                    discoveryService.DisposeAsync();
+                });
 
-            return true;
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(5000);
+            using (cts.Token.Register(
+                       token =>
+                       {
+                           WriteError($"Error connecting to the Datadog Agent at {tracerSettings.Exporter.AgentUri}.");
+                           tcs.TrySetResult(null);
+                           discoveryService.DisposeAsync();
+                       },
+                       cts.Token))
+            {
+                return await tcs.Task.ConfigureAwait(false);
+            }
         }
 
         internal static void WriteError(string message)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -276,13 +276,12 @@ namespace Datadog.Trace.Tools.Runner
             var cts = new CancellationTokenSource();
             cts.CancelAfter(5000);
             using (cts.Token.Register(
-                       token =>
+                       () =>
                        {
                            WriteError($"Error connecting to the Datadog Agent at {tracerSettings.Exporter.AgentUri}.");
                            tcs.TrySetResult(null);
                            discoveryService.DisposeAsync();
-                       },
-                       cts.Token))
+                       }))
             {
                 return await tcs.Task.ConfigureAwait(false);
             }

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -83,6 +83,10 @@ namespace Datadog.Trace.Ci
                         1000,
                         int.MaxValue);
                 }
+                else
+                {
+                    Log.Information("Using the Event platform proxy through the agent.");
+                }
 
                 eventPlatformProxyEnabled = _settings.ForceAgentsEvpProxy || IsEventPlatformProxySupportedByAgent(discoveryService);
             }


### PR DESCRIPTION
## Summary of changes

This PR improves the agent detections of the runner to include the EVP proxy detection, also removes the `ApmAgentWriter` instance to use only the `DiscoveryService`

## Reason for change

General improvements
