### PR TITLE
Upgrade build to .NET 7

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -7,7 +7,7 @@ pr:
 
 # Global variables
 variables:
-  dotnetCoreSdkLatestVersion: 6.0.100
+  dotnetCoreSdkLatestVersion: 7.0.100
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])] # required by update-github-status
   TargetBranch: $[variables['System.PullRequest.TargetBranch']]
 

--- a/.azure-pipelines/steps/install-dotnet-sdks.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdks.yml
@@ -22,6 +22,10 @@ steps:
 
 - template: install-dotnet-sdk-manually.yml
   parameters:
+    channel: 6.0
+
+- template: install-dotnet-sdk-manually.yml
+  parameters:
     sdkVersion: $(dotnetCoreSdkLatestVersion)
 
 - ${{ if eq(parameters.includeX86, true) }}:
@@ -40,6 +44,10 @@ steps:
     - template: install-dotnet-sdk-manually.yml
       parameters:
         channel: 5.0
+        is64bit: false
+    - template: install-dotnet-sdk-manually.yml
+      parameters:
+        channel: 6.0
         is64bit: false
     - template: install-dotnet-sdk-manually.yml
       parameters:

--- a/.azure-pipelines/steps/install-dotnet.yml
+++ b/.azure-pipelines/steps/install-dotnet.yml
@@ -28,6 +28,13 @@ steps:
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
+  displayName: install dotnet core runtime 6.0
+  inputs:
+    packageType: runtime
+    version: 6.0.x
+  retryCountOnTaskFailure: 5
+
+- task: UseDotNet@2
   displayName: install latest dotnet core sdk
   inputs:
     packageType: sdk

--- a/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
+++ b/.azure-pipelines/steps/install-latest-dotnet-sdk.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: install dotnet core sdk 6
+  displayName: install .NET SDK $(dotnetCoreSdkLatestVersion)
   inputs:
     packageType: sdk
     version: $(dotnetCoreSdkLatestVersion)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -198,7 +198,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -223,7 +223,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -252,7 +252,7 @@ stages:
 
   - job: build
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2019 # profiler doesn't build on windows-2022 currently: "The Windows SDK version 10.0.18362.0 was not found"
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -577,7 +577,7 @@ stages:
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -622,7 +622,7 @@ stages:
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:
@@ -1817,7 +1817,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     # Enable the Datadog Agent service for this job
     services:
@@ -2002,7 +2002,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ Windows ]
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -2075,7 +2075,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -2216,7 +2216,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -2797,7 +2797,7 @@ stages:
       timeoutInMinutes: 30
 
       pool:
-        vmImage: windows-2019
+        vmImage: windows-2022
 
       steps:
       - template: steps/clone-repo.yml
@@ -3443,7 +3443,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -3512,7 +3512,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -3577,7 +3577,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml
@@ -3642,7 +3642,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -95,7 +95,7 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdkLatestVersion: 6.0.100
+  dotnetCoreSdkLatestVersion: 7.0.100
   relativeArtifacts: /tracer/src/bin/artifacts
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts

--- a/.github/actions/run-in-docker/action.yml
+++ b/.github/actions/run-in-docker/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         docker build \
-          --build-arg DOTNETSDK_VERSION=6.0.100 \
+          --build-arg DOTNETSDK_VERSION=7.0.100 \
           --tag dd-trace-dotnet/debian-builder \
           --target builder \
           --file "${GITHUB_WORKSPACE}/tracer/build/_build/docker/debian.dockerfile" \

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Add labels"
         run: ./tracer/build.sh AssignLabelsToPullRequest

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Bump Version"
         id: versions

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Bump Version"
         id: versions

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -346,6 +346,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
+            7.0.100
         
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -393,6 +394,7 @@ jobs:
           dotnet-version: | 
             3.1.x
             6.0.100
+            7.0.100
     
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -471,6 +473,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
+            7.0.100
     
       - name: Install Datadog agent
         continue-on-error: false
@@ -555,7 +558,7 @@ jobs:
       - uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            6.0.100
+            7.0.100
 
       - name: Install Datadog agent
         continue-on-error: false
@@ -667,6 +670,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
+            7.0.100
     
       - name: Install Datadog agent
         continue-on-error: false
@@ -698,6 +702,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
+            7.0.100
 
       - name: Build Monitoring home
         run: .\tracer\build.cmd BuildTracerHome BuildNativeLoader --build-configuration ${{matrix.configuration}} --target-platform ${{matrix.platform}}

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.100'
+          dotnet-version: '7.0.100'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,7 +315,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -361,7 +361,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -496,7 +496,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -564,7 +564,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-6.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/docs/development/CI/RunSmokeTestsLocally.md
+++ b/docs/development/CI/RunSmokeTestsLocally.md
@@ -16,7 +16,7 @@ Then run the following
 docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
 # build the smoke test docker image (using the artifacts)
-docker-compose build --build-arg DOTNETSDK_VERSION=6.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim --build-arg PUBLISH_FRAMEWORK=net6.0 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
+docker-compose build --build-arg DOTNETSDK_VERSION=7.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim --build-arg PUBLISH_FRAMEWORK=net6.0 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
 
 # start the test-agent (you may get an error on Windows, just ignore it)
 docker-compose run --rm start-test-agent
@@ -43,7 +43,7 @@ To test and update the .NET Core 2.1 snapshots, use the following steps instead
 docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
 # build the .NET Core 2.1 smoke test docker image (using the artifacts)
-docker-compose build --build-arg DOTNETSDK_VERSION=6.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:2.1-bionic --build-arg PUBLISH_FRAMEWORK=netcoreapp2.1 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
+docker-compose build --build-arg DOTNETSDK_VERSION=7.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:2.1-bionic --build-arg PUBLISH_FRAMEWORK=netcoreapp2.1 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
 
 # start the test-agent (you may get an error on Windows, just ignore it)
 docker-compose run --rm start-test-agent

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;SA1652</NoWarn>
     <NukeRootDirectory>..\..\..</NukeRootDirectory>

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,5 +1,5 @@
 ﻿ARG DOTNETSDK_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
 
 RUN apk update \
     && apk upgrade \

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -81,6 +81,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.1 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 5.0 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --channel 6.0 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 # Copy the build project in and build it

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,9 +1,40 @@
-﻿ARG DOTNETSDK_VERSION
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.16 as base
+﻿FROM alpine:3.14 as base
+ARG DOTNETSDK_VERSION
 
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=$DOTNETSDK_VERSION \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip
+    
 RUN apk update \
-    && apk upgrade \
-    && apk add --no-cache --update \
+        && apk upgrade \
+        && apk add --no-cache \
+        ca-certificates \
+        \
+        # .NET Core dependencies
+        krb5-libs \
+        libgcc \
+        libintl \
+        libssl1.1 \
+        libstdc++ \
+        zlib \
+        \
+        # SDK dependencies
+        curl \
+        icu-libs \
+        \
+        # our dependencies
         clang \
         cmake \
         git \
@@ -25,6 +56,14 @@ RUN apk update \
     && gem install --minimal-deps --no-document fpm
 
 ENV IsAlpine=true
+
+# Install the .NET SDK
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh \
+    && chmod +x ./dotnet-install.sh \
+    && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
+    && rm dotnet-install.sh \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    && dotnet help
 
 FROM base as builder
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -60,7 +60,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
     && chmod +x ./dotnet-install.sh \
-    && ./dotnet-install.sh --version 6.0.100 --install-dir /usr/share/dotnet \
+    && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm ./dotnet-install.sh \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
 # Trigger first run experience by running arbitrary cmd

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -91,6 +91,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.1 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 5.0 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --channel 6.0 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -77,6 +77,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.1 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 5.0 --install-dir /usr/share/dotnet --no-path \
+    && ./dotnet-install.sh --runtime aspnetcore --channel 6.0 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
 
 

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -12,7 +12,7 @@ $BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 &docker build `
-   --build-arg DOTNETSDK_VERSION=6.0.100 `
+   --build-arg DOTNETSDK_VERSION=7.0.100 `
    --tag $IMAGE_NAME `
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=6.0.100 \
+   --build-arg DOTNETSDK_VERSION=7.0.100 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Summary of changes

- Updates the SDK we build with to .NET 7
- Does _not_ update the version we test again

## Reason for change

We need to start building and testing against the latest SDK.

## Implementation details

- Bump the SDK version to 7.0.100
- Use a custom alpine base image so we keep building on alpine:3.14 for now, but use the newer SDK
- Switch to Windows 2022 base images (required for MSBuild version)
- Explicitly install .NET 6 runtime/sdk for testing

## Test coverage



## Other details
This won't succeed until
- [ ] Create Windows 2022 VMSS images with .NET 7 installed

Once this is merged, we should 
- [ ] Update the Linux VMSS images to re-cache the new docker images
- [ ] Add tests for .NET 7
- [ ] Fix integrations that are broken in .NET 7 (most of the built-in integrations)
- [ ] Consider if we can stop testing any FX versions

