### PR TITLE
Try to fix compiler warning in `ClrEventsParser.cpp`

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -330,7 +330,7 @@ void ClrEventsParser::ResetGC(GCDetails& gc)
     gc.Reason = (GCReason)0;
     gc.Type = (GCType)0;
     gc.IsCompacting = false;
-    gc.PauseDuration;
+    gc.PauseDuration = 0;
     gc.StartTimestamp = 0;
 }
 


### PR DESCRIPTION
Reset `gc.PauseDuration` correctly to fix this build error:
```
/project/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp:333:8: warning: expression result unused [-Wunused-value]
    gc.PauseDuration;
    ~~ ^~~~~~~~~~~~~
```
