### PR TITLE
Add missing entry to VSConfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -45,6 +45,7 @@
     "Microsoft.VisualStudio.Workload.NetWeb",
     "Microsoft.VisualStudio.Component.VC.CoreIde",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    "Microsoft.VisualStudio.Component.Windows10SDK.18362",
     "Microsoft.VisualStudio.Component.Windows10SDK.19041",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",
     "Microsoft.ComponentGroup.Blend",


### PR DESCRIPTION
## Summary of changes

Adds the `Microsoft.VisualStudio.Component.Windows10SDK.18362` entry to vsconfig as it's currently required by the profiler

## Reason for change

We should list the actual required values

## Implementation details

Add missing entry

## Test coverage

None, YOLO

## Other details
Required as part of the .NET 7 upgrade
