### PR TITLE
[Build] macOS multitarget build support (x86_64 and arm64) from x64 mac

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -565,6 +565,9 @@ stages:
     - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
       displayName: Checking managed loader in the x64 native binary
 
+    - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
+      displayName: Checking managed loader in the arm64 native binary
+
     - publish: $(monitoringHome)
       displayName: Uploading macos profiler artifact
       artifact: macos-tracer-home

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -563,9 +563,6 @@ stages:
     - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
       displayName: Checking managed loader in the x64 native binary
 
-    - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
-      displayName: Checking managed loader in the arm64 native binary
-
     - publish: $(monitoringHome)
       displayName: Uploading macos profiler artifact
       artifact: macos-tracer-home

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -561,7 +561,10 @@ stages:
       displayName: Build tracer home
 
     - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-x64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
-      displayName: Checking managed loader in the native binary
+      displayName: Checking managed loader in the x64 native binary
+
+    - script: $([[ $(otool -s binary dll $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 50000 ]] && [[ $(otool -s binary pdb $(monitoringHome)/osx-arm64/Datadog.Tracer.Native.dylib | wc -c) -gt 40000 ]])
+      displayName: Checking managed loader in the arm64 native binary
 
     - publish: $(monitoringHome)
       displayName: Uploading macos profiler artifact

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,31 @@ project("Datadog.APM.Native" VERSION 2.18.0)
 # Environment detection
 # ******************************************************
 
+SET(OSX_ARCH ${CMAKE_OSX_ARCHITECTURES})
+
+# Detect architecture
+if (OSX_ARCH STREQUAL x86_64)
+    message(STATUS "Architecture is x64/AMD64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISAMD64 true)
+elseif (OSX_ARCH STREQUAL arm64)
+    message(STATUS "Architecture is ARM64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISARM64 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+    message(STATUS "Architecture is x64/AMD64")
+    SET(ISAMD64 true)
+    SET(OSX_ARCH "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+    message(STATUS "Architecture is x86")
+    SET(ISX86 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    message(STATUS "Architecture is ARM64")
+    SET(ISARM64 true)
+    SET(OSX_ARCH "arm64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
+    message(STATUS "Architecture is ARM")
+    SET(ISARM true)
+endif()
+
 # Detect operating system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(FATAL_ERROR "Windows builds are not supported using CMAKE. Please use Visual Studio")
@@ -31,21 +56,6 @@ endif()
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(STATUS "Setting compilation for 64bits processor")
     SET(BIT64 true)
-endif()
-
-# Detect architecture
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
-    message(STATUS "Architecture is x64/AMD64")
-    SET(ISAMD64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
-    message(STATUS "Architecture is x86")
-    SET(ISX86 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
-    message(STATUS "Architecture is ARM64")
-    SET(ISARM64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
-    message(STATUS "Architecture is ARM")
-    SET(ISARM true)
 endif()
 
 SET(DOTNET_TRACER_REPO_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR})

--- a/build/cmake/FindFmt.cmake
+++ b/build/cmake/FindFmt.cmake
@@ -2,15 +2,27 @@ include(ExternalProject)
 
 SET(FMT_VERSION "5.3.0")
 
-ExternalProject_Add(fmt
-    DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
-    TIMEOUT 5
-    INSTALL_COMMAND ""
-    BUILD_IN_SOURCE TRUE
-    CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-    BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 make -j
-    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
-)
+if (ISMACOS)
+    ExternalProject_Add(fmt
+        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
+        TIMEOUT 5
+        INSTALL_COMMAND ""
+        BUILD_IN_SOURCE TRUE
+        CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=-target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
+    )
+elseif(ISLINUX)
+    ExternalProject_Add(fmt
+        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
+        TIMEOUT 5
+        INSTALL_COMMAND ""
+        BUILD_IN_SOURCE TRUE
+        CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
+    )
+endif()
 
 ExternalProject_Get_property(fmt SOURCE_DIR)
 

--- a/build/cmake/FindFmt.cmake
+++ b/build/cmake/FindFmt.cmake
@@ -3,26 +3,20 @@ include(ExternalProject)
 SET(FMT_VERSION "5.3.0")
 
 if (ISMACOS)
-    ExternalProject_Add(fmt
-        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
-        TIMEOUT 5
-        INSTALL_COMMAND ""
-        BUILD_IN_SOURCE TRUE
-        CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=-target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
-        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
-    )
+	SET(FMT_CXXFLAGS "-target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -D_GLIBCXX_USE_CXX11_ABI=0")
 elseif(ISLINUX)
-    ExternalProject_Add(fmt
-        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
-        TIMEOUT 5
-        INSTALL_COMMAND ""
-        BUILD_IN_SOURCE TRUE
-        CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=-D_GLIBCXX_USE_CXX11_ABI=0 make -j
-        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
-    )
+	SET(FMT_CXXFLAGS "-D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
+
+ExternalProject_Add(fmt
+    DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${FMT_VERSION} --config advice.detachedHead=false https://github.com/DataDog/fmt.git
+    TIMEOUT 5
+    INSTALL_COMMAND ""
+    BUILD_IN_SOURCE TRUE
+    CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_TEST=0 -DFMT_DOC=0
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env CXXFLAGS=${FMT_CXXFLAGS} make -j
+    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/fmt-prefix/src/fmt/libfmt.a
+)
 
 ExternalProject_Get_property(fmt SOURCE_DIR)
 

--- a/build/cmake/FindManagedLoader.cmake
+++ b/build/cmake/FindManagedLoader.cmake
@@ -5,8 +5,8 @@ SET(MANAGED_LOADER_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tracer/src/bin/Profiler
 
 # Set specific custom commands to embed the loader
 if (ISMACOS)
-    SET(PDB_COMMAND touch stub.c && gcc -o stub.o -c stub.c && ld -r -o Datadog.Trace.ClrProfiler.Managed.Loader.pdb.o -sectcreate binary pdb Datadog.Trace.ClrProfiler.Managed.Loader.pdb stub.o)
-    SET(DLL_COMMAND touch stub.c && gcc -o stub.o -c stub.c && ld -r -o Datadog.Trace.ClrProfiler.Managed.Loader.dll.o -sectcreate binary dll Datadog.Trace.ClrProfiler.Managed.Loader.dll stub.o)
+    SET(PDB_COMMAND touch stub.c && gcc -o stub.o -c stub.c -target ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION} && ld -r -o Datadog.Trace.ClrProfiler.Managed.Loader.pdb.o -sectcreate binary pdb Datadog.Trace.ClrProfiler.Managed.Loader.pdb stub.o)
+    SET(DLL_COMMAND touch stub.c && gcc -o stub.o -c stub.c -target ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION} && ld -r -o Datadog.Trace.ClrProfiler.Managed.Loader.dll.o -sectcreate binary dll Datadog.Trace.ClrProfiler.Managed.Loader.dll stub.o)
 elseif(ISLINUX)
     SET(DLL_COMMAND ld -r -b binary -o Datadog.Trace.ClrProfiler.Managed.Loader.dll.o Datadog.Trace.ClrProfiler.Managed.Loader.dll)
     SET(PDB_COMMAND ld -r -b binary -o Datadog.Trace.ClrProfiler.Managed.Loader.pdb.o Datadog.Trace.ClrProfiler.Managed.Loader.pdb)

--- a/build/cmake/FindRe2.cmake
+++ b/build/cmake/FindRe2.cmake
@@ -2,15 +2,27 @@ include(ExternalProject)
 
 SET(RE2_VERSION "2018-10-01")
 
-ExternalProject_Add(re2
-    DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${RE2_VERSION} --config advice.detachedHead=false https://github.com/google/re2.git
-    TIMEOUT 5
-    INSTALL_COMMAND ""
-    CONFIGURE_COMMAND ""
-    BUILD_IN_SOURCE TRUE
-    BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
-    BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
-)
+if (ISMACOS)
+    ExternalProject_Add(re2
+        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${RE2_VERSION} --config advice.detachedHead=false https://github.com/google/re2.git
+        TIMEOUT 5
+        INSTALL_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE TRUE
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ ${OSX_ARCH} ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
+    )
+elseif(ISLINUX)
+    ExternalProject_Add(re2
+        DOWNLOAD_COMMAND git clone --quiet --depth 1 --branch ${RE2_VERSION} --config advice.detachedHead=false https://github.com/google/re2.git
+        TIMEOUT 5
+        INSTALL_COMMAND ""
+        CONFIGURE_COMMAND ""
+        BUILD_IN_SOURCE TRUE
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
+    )
+endif()
 
 ExternalProject_Get_property(re2 SOURCE_DIR)
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -11,6 +11,31 @@ project("Datadog.Trace.ClrProfiler.Native" VERSION 2.20.0)
 # Environment detection
 # ******************************************************
 
+SET(OSX_ARCH ${CMAKE_OSX_ARCHITECTURES})
+
+# Detect architecture
+if (OSX_ARCH STREQUAL x86_64)
+    message(STATUS "Architecture is x64/AMD64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISAMD64 true)
+elseif (OSX_ARCH STREQUAL arm64)
+    message(STATUS "Architecture is ARM64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISARM64 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+    message(STATUS "Architecture is x64/AMD64")
+    SET(ISAMD64 true)
+    SET(OSX_ARCH "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+    message(STATUS "Architecture is x86")
+    SET(ISX86 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    message(STATUS "Architecture is ARM64")
+    SET(ISARM64 true)
+    SET(OSX_ARCH "arm64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
+    message(STATUS "Architecture is ARM")
+    SET(ISARM true)
+endif()
+
 # Detect operating system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(FATAL_ERROR "Windows builds are not supported using CMAKE. Please use Visual Studio")
@@ -23,26 +48,10 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     SET(ISMACOS true)
 endif()
 
-
 # Detect bitness of the build
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(STATUS "Setting compilation for 64bits processor")
     SET(BIT64 true)
-endif()
-
-# Detect architecture
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
-    message(STATUS "Architecture is x64/AMD64")
-    SET(ISAMD64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
-    message(STATUS "Architecture is x86")
-    SET(ISX86 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
-    message(STATUS "Architecture is ARM64")
-    SET(ISARM64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
-    message(STATUS "Architecture is ARM")
-    SET(ISARM true)
 endif()
 
 # ******************************************************

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2009,8 +2009,8 @@ partial class Build
         {
             return new (string Arch, string Folder, string Ext)[]
             {
+                ("arm64", "osx-arm64", "dylib"),
                 ("x86_64", "osx-x64", "dylib"),
-                ("arm64", "osx-arm64", "dylib")
             };
         }
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1998,9 +1998,9 @@ partial class Build
     private (string Arch, string Ext) GetUnixArchitectureAndExtension() =>
         (IsOsx, IsAlpine) switch
         {
+            (true, _) => ($"osx-{UnixArchitectureIdentifier}", "dylib"),
             (false, false) => ($"linux-{UnixArchitectureIdentifier}", "so"),
             (false, true) => ($"linux-musl-{UnixArchitectureIdentifier}", "so"),
-            (_, _) => default,
         };
 
     private (string Arch, string Folder, string Ext)[] GetMacOsArchitectureAndExtension()

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -11,6 +11,31 @@ project("Datadog.Tracer.Native" VERSION 2.20.0)
 # Environment detection
 # ******************************************************
 
+SET(OSX_ARCH ${CMAKE_OSX_ARCHITECTURES})
+
+# Detect architecture
+if (OSX_ARCH STREQUAL x86_64)
+    message(STATUS "Architecture is x64/AMD64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISAMD64 true)
+elseif (OSX_ARCH STREQUAL arm64)
+    message(STATUS "Architecture is ARM64 configured by CMAKE_OSX_ARCHITECTURES")
+    SET(ISARM64 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+    message(STATUS "Architecture is x64/AMD64")
+    SET(ISAMD64 true)
+    SET(OSX_ARCH "x86_64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
+    message(STATUS "Architecture is x86")
+    SET(ISX86 true)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+    message(STATUS "Architecture is ARM64")
+    SET(ISARM64 true)
+    SET(OSX_ARCH "arm64")
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
+    message(STATUS "Architecture is ARM")
+    SET(ISARM true)
+endif()
+
 # Detect operating system
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     message(FATAL_ERROR "Windows builds are not supported using CMAKE. Please use Visual Studio")
@@ -27,21 +52,6 @@ endif()
 if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(STATUS "Setting compilation for 64bits processor")
     SET(BIT64 true)
-endif()
-
-# Detect architecture
-if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
-    message(STATUS "Architecture is x64/AMD64")
-    SET(ISAMD64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86 OR CMAKE_SYSTEM_PROCESSOR STREQUAL i686)
-    message(STATUS "Architecture is x86")
-    SET(ISX86 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
-    message(STATUS "Architecture is ARM64")
-    SET(ISARM64 true)
-elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
-    message(STATUS "Architecture is ARM")
-    SET(ISARM true)
 endif()
 
 # ******************************************************


### PR DESCRIPTION
## Summary of changes

This PR adds support for building the `NativeLoader` and the `Tracer` native binaries in `osx-arm64` in CI. Also changes the mode the build is done to Release mode (previously in Debug).

Note, because we are now building in release mode, the new platform doesn't change the size of the `dd-tool` nuget package.

<img width="450" alt="image" src="https://user-images.githubusercontent.com/69803/201364727-4bb3664d-088b-401e-80e7-032548fe193c.png">


## Reason for change

The `osx-arm64` build was missing in the `dd-trace` tool.

## Implementation details

- CMake files were changes to use the `CMAKE_OSX_ARCHITECTURES` property.
- Nuke build project was modified to produce both arch binaries on macOS.
- Pipeline was modified to include a managed loader check for arm64 binary.