### PR TITLE
Pin the fpm version, because latest breaks the pipeline

### DIFF
--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -22,7 +22,7 @@ RUN apk update \
         musl-dbg \
     && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
-    && gem install --minimal-deps --no-document fpm
+    && gem install --version 1.14.2 --minimal-deps --no-document fpm
 
 ENV IsAlpine=true
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -54,7 +54,7 @@ RUN echo "gem: --no-document --no-rdoc --no-ri" > ~/.gemrc && \
     gem install --version 3.2.3  --user-install rexml && \
     gem install backports -v 3.21.0 && \
     gem install --version 2.7.6 dotenv && \
-    gem install --minimal-deps fpm
+    gem install --version 1.14.2 --minimal-deps fpm
 
 
 # Install the .NET SDK

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
         gdb \
     && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
-    && gem install --minimal-deps --no-document fpm \
+    && gem install --version 1.14.2 --minimal-deps --no-document fpm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install the .NET SDK


### PR DESCRIPTION
## Summary of changes

Pins the version of fpm to the previous version

## Reason for change

The latest version of fpm released today broke our packaging 🤦‍♂️ 

## Implementation details

Pinned to the version that we were previously using

## Test coverage

It works so N/A

## Other details

This is quick and dirty but we should probably look at the alternative solutions:
- gem lockfile
- Stop using ruby in a .net build and find a better alternative 🙏  
