### PR TITLE
Fix Single Span Sampling tags to be metrics

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/ISpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ISpanSamplingRule.cs
@@ -29,16 +29,6 @@ namespace Datadog.Trace.Sampling
         float? MaxPerSecond { get; }
 
         /// <summary>
-        ///     Gets the cached <see cref="SamplingRate"/> string for tagging.
-        /// </summary>
-        string SamplingRateString { get; }
-
-        /// <summary>
-        ///     Gets the cached <see cref="MaxPerSecond"/> string for tagging.
-        /// </summary>
-        string MaxPerSecondString { get; }
-
-        /// <summary>
         ///     Checks whether or not the <paramref name="span"/> matches the glob patterns defined by this rule.
         /// </summary>
         /// <param name="span">The <see cref="Span"/> to check.</param>

--- a/tracer/src/Datadog.Trace/Sampling/SpanSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSampler.cs
@@ -15,8 +15,6 @@ namespace Datadog.Trace.Sampling;
 /// </summary>
 internal class SpanSampler : ISpanSampler
 {
-    private static readonly string SamplingMechanismString = SamplingMechanism.SpanSamplingRule.ToString();
-
     private readonly List<ISpanSamplingRule> _rules;
 
     public SpanSampler(IEnumerable<ISpanSamplingRule> rules)
@@ -59,13 +57,13 @@ internal class SpanSampler : ISpanSampler
     /// <param name="rule">The <see cref="ISpanSamplingRule"/> that contains the tag information.</param>
     private static void AddTags(Span span, ISpanSamplingRule rule)
     {
-        span.Tags.SetTag(Tags.SingleSpanSampling.RuleRate, rule.SamplingRateString);
+        span.Tags.SetMetric(Tags.SingleSpanSampling.RuleRate, rule.SamplingRate);
 
         if (rule.MaxPerSecond is not null)
         {
-            span.Tags.SetTag(Tags.SingleSpanSampling.MaxPerSecond, rule.MaxPerSecondString);
+            span.Tags.SetMetric(Tags.SingleSpanSampling.MaxPerSecond, rule.MaxPerSecond);
         }
 
-        span.Tags.SetTag(Tags.SingleSpanSampling.SamplingMechanism, SamplingMechanismString);
+        span.Tags.SetMetric(Tags.SingleSpanSampling.SamplingMechanism, SamplingMechanism.SpanSamplingRule);
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
@@ -58,10 +58,6 @@ namespace Datadog.Trace.Sampling
 
             // null/absent for MaxPerSecond indicates unlimited, which is a negative value in the limiter
             _limiter = MaxPerSecond is null ? new SpanRateLimiter(-1) : new SpanRateLimiter((int?)MaxPerSecond);
-
-            // cache strings for tagging to reduce allocations
-            SamplingRateString = SamplingRate.ToString();
-            MaxPerSecondString = MaxPerSecond?.ToString();
         }
 
         /// <inheritdoc/>
@@ -69,12 +65,6 @@ namespace Datadog.Trace.Sampling
 
         /// <inheritdoc/>
         public float? MaxPerSecond { get; } = null;
-
-        /// <inheritdoc/>
-        public string SamplingRateString { get; }
-
-        /// <inheritdoc/>
-        public string MaxPerSecondString { get; }
 
         /// <summary>
         ///     Creates <see cref="SpanSamplingRule"/>s from the supplied JSON <paramref name="configuration"/>.

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -33,9 +33,9 @@ namespace Datadog.Trace.IntegrationTests
         [Fact]
         public void SpanSampler_ShouldNotAddTags_OnSpanClose_ForKeptTrace()
         {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             using (var scope = _tracer.StartActive("root"))
             {
@@ -46,17 +46,17 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var span = trace[0].Single();
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
 
         [Fact]
         public void SpanSampler_ShouldTag_OnSpanFinish()
         {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             using (var scope = _tracer.StartActive("root"))
             {
@@ -69,17 +69,17 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var span = trace[0].Single();
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
 
         [Fact]
         public void SpanSampler_ShouldTagMultiple_OnSpanFinish()
         {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             using (var rootScope = _tracer.StartActive("root"))
             {
@@ -103,27 +103,27 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
         [Fact]
         public void SpanSampler_ShouldTagMultiple_OnSpanFinish_WhenSamplingPriorityChanges()
         {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             using (var rootScope = _tracer.StartActive("root"))
             {
@@ -150,27 +150,27 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            rootSpan.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-                span.Tags.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
         [Fact]
         public void SpanSampler_ShouldNotTag_WhenSpansAreKept()
         {
-            var ruleRate = "1";
-            var maxPerSecond = "1000";
-            var samplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             using (var rootScope = _tracer.StartActive("root"))
             {
@@ -191,27 +191,27 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, ruleRate);
-            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, maxPerSecond);
-            rootSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, samplingMechanism);
+            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, ruleRate);
-                span.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, maxPerSecond);
-                span.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, samplingMechanism);
+                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
         [Fact]
         public void SpanSampler_ShouldNotTag_WhenSamplingPriority_IsNull()
         {
-            var expectedRuleRate = "1";
-            var expectedMaxPerSecond = "1000";
-            var expectedSamplingMechanism = "8";
+            var expectedRuleRate = 1.0f;
+            var expectedMaxPerSecond = 1000.0f;
+            var expectedSamplingMechanism = 8;
 
             var spanContext = new SpanContext(4, 5, samplingPriority: null, serviceName: "serviceName");
             var span = new Span(spanContext, DateTimeOffset.Now) { OperationName = "test" };
@@ -223,9 +223,9 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var writtenSpan = trace[0].Single();
-            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            writtenSpan.Tags.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
+            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
@@ -37,9 +37,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -52,9 +52,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -71,9 +71,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism.ToString());
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -90,9 +90,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism.ToString());
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -106,9 +106,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -119,9 +119,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -133,9 +133,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().NotBeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().NotBeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().NotBeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().NotBeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().NotBeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().NotBeNull();
         }
 
         [Fact]
@@ -147,9 +147,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -164,9 +164,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism.ToString());
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -182,9 +182,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetTag(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond.ToString());
-            span.Tags.GetTag(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism.ToString());
+            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
@@ -176,33 +176,6 @@ namespace Datadog.Trace.Tests.Sampling
             rule.SamplingRate.Should().Be(1.0f);
         }
 
-        [Fact]
-        public void SampleRateString_ShouldMatch_SampleRate()
-        {
-            var config = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":0.5}]";
-            var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
-
-            rule.SamplingRateString.Should().Be("0.5");
-        }
-
-        [Fact]
-        public void MaxPerSecondString_ShouldMatch_MaxPerSecond()
-        {
-            var config = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":0.5, \"max_per_second\":1000.5}]";
-            var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
-
-            rule.MaxPerSecondString.Should().Be("1000.5");
-        }
-
-        [Fact]
-        public void MaxPerSecondString_ShouldBeNull_WhenMaxPerSecondNull()
-        {
-            var config = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":0.5}]";
-            var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
-
-            rule.MaxPerSecondString.Should().BeNull();
-        }
-
         private void VerifySingleRule(string config, Span span, bool isMatch)
         {
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();


### PR DESCRIPTION
## Summary of changes

The tags that were being added for spans kept by single span sampling were getting added to the `Span.Tags` where they should've been going to the `Span.Metrics` as they are numerical values.

## Reason for change

Tags were going into the wrong dictionary and needed to be in the metrics dictionary and not the meta dictionary.

## Implementation details

- I swapped `SetTag` to be `SetMetric`
- I removed the cached `string` values as those are no longer needed.

## Test coverage

- Tests have been updated to expect the numerical values
- Tests for the cached `string` tags have been removed.

