### PR TITLE
[Tracer] Use GetOriginBytes helper for origin tag

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -221,7 +221,7 @@ namespace Datadog.Trace.Agent.MessagePack
             }
 
             // add "_dd.origin" tag to all spans
-            var originRawBytes = MessagePackStringCache.GetEnvironmentBytes(model.TraceChunk.Origin);
+            var originRawBytes = MessagePackStringCache.GetOriginBytes(model.TraceChunk.Origin);
 
             if (originRawBytes is not null)
             {
@@ -252,7 +252,7 @@ namespace Datadog.Trace.Agent.MessagePack
             // add "version" tags to all spans whose service name is the default service name
             if (string.Equals(span.Context.ServiceName, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
             {
-                var versionRawBytes = MessagePackStringCache.GetEnvironmentBytes(model.TraceChunk.ServiceVersion);
+                var versionRawBytes = MessagePackStringCache.GetVersionBytes(model.TraceChunk.ServiceVersion);
 
                 if (versionRawBytes is not null)
                 {


### PR DESCRIPTION
## Summary of changes

Use `GetOriginBytes` and `GetVersionBytes` helpers for origin and version tags instead of `GetEnvironmentBytes` in `SpanMessagePackFormatter`

## Reason for change

We used the wrong one.

