### PR TITLE
Move SpanSampling tag names to Metrics.cs

### DIFF
--- a/tracer/src/Datadog.Trace/Metrics.cs
+++ b/tracer/src/Datadog.Trace/Metrics.cs
@@ -86,5 +86,29 @@ namespace Datadog.Trace
         /// Float representing the number of rules which failed to load
         /// </summary>
         public const string AppSecWafInitRulesErrorCount = "_dd.appsec.event_rules.error_count";
+
+        /// <summary>
+        /// Contains tag names that are associated with Single Span Sampling.
+        /// </summary>
+        internal static class SingleSpanSampling
+        {
+            /// <summary>
+            /// Contains the <see cref="Sampling.SamplingMechanism"/> by which the individual span was sampled.
+            /// </summary>
+            internal const string SamplingMechanism = "_dd.span_sampling.mechanism";
+
+            /// <summary>
+            /// Contains the configured sampling probability for the <see cref="Sampling.ISpanSamplingRule"/> applied.
+            /// </summary>
+            /// <seealso cref="Sampling.ISpanSamplingRule.SamplingRate"/>
+            internal const string RuleRate = "_dd.span_sampling.rule_rate";
+
+            /// <summary>
+            /// Contains the configured limit of maximum number of sampled spans for the <see cref="Sampling.ISpanSamplingRule"/> applied.
+            /// <para>If there is no configured limit for the matched rule, this tag is omitted.</para>
+            /// </summary>
+            /// <seealso cref="Sampling.ISpanSamplingRule.MaxPerSecond"/>
+            internal const string MaxPerSecond = "_dd.span_sampling.max_per_second";
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/SpanSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSampler.cs
@@ -57,13 +57,13 @@ internal class SpanSampler : ISpanSampler
     /// <param name="rule">The <see cref="ISpanSamplingRule"/> that contains the tag information.</param>
     private static void AddTags(Span span, ISpanSamplingRule rule)
     {
-        span.Tags.SetMetric(Tags.SingleSpanSampling.RuleRate, rule.SamplingRate);
+        span.Tags.SetMetric(Metrics.SingleSpanSampling.RuleRate, rule.SamplingRate);
 
         if (rule.MaxPerSecond is not null)
         {
-            span.Tags.SetMetric(Tags.SingleSpanSampling.MaxPerSecond, rule.MaxPerSecond);
+            span.Tags.SetMetric(Metrics.SingleSpanSampling.MaxPerSecond, rule.MaxPerSecond);
         }
 
-        span.Tags.SetMetric(Tags.SingleSpanSampling.SamplingMechanism, SamplingMechanism.SpanSamplingRule);
+        span.Tags.SetMetric(Metrics.SingleSpanSampling.SamplingMechanism, SamplingMechanism.SpanSamplingRule);
     }
 }

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -529,30 +529,6 @@ namespace Datadog.Trace
 
         internal const string TagPropagationError = "_dd.propagation_error";
 
-        /// <summary>
-        /// Contains tags that are associated with Single Span Sampling.
-        /// </summary>
-        internal static class SingleSpanSampling
-        {
-            /// <summary>
-            /// Contains the <see cref="Sampling.SamplingMechanism"/> by which the individual span was sampled.
-            /// </summary>
-            internal const string SamplingMechanism = "_dd.span_sampling.mechanism";
-
-            /// <summary>
-            /// Contains the configured sampling probability for the <see cref="Sampling.ISpanSamplingRule"/> applied.
-            /// </summary>
-            /// <seealso cref="Sampling.ISpanSamplingRule.SamplingRate"/>
-            internal const string RuleRate = "_dd.span_sampling.rule_rate";
-
-            /// <summary>
-            /// Contains the configured limit of maximum number of sampled spans for the <see cref="Sampling.ISpanSamplingRule"/> applied.
-            /// <para>If there is no configured limit for the matched rule, this tag is omitted.</para>
-            /// </summary>
-            /// <seealso cref="Sampling.ISpanSamplingRule.MaxPerSecond"/>
-            internal const string MaxPerSecond = "_dd.span_sampling.max_per_second";
-        }
-
         internal static class User
         {
             internal const string Email = "usr.email";

--- a/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/SpanTagTests.cs
@@ -46,9 +46,9 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var span = trace[0].Single();
-            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
 
         [Fact]
@@ -69,9 +69,9 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var span = trace[0].Single();
-            span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            span.Metrics.Should().Contain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            span.Metrics.Should().Contain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            span.Metrics.Should().Contain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
 
         [Fact]
@@ -103,18 +103,18 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
@@ -150,18 +150,18 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            rootSpan.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().Contain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-                span.Metrics.Should().Contain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().Contain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
@@ -191,18 +191,18 @@ namespace Datadog.Trace.IntegrationTests
             rootSpan.Should().NotBeNull();
 
             // assert that root span has the span sampling tags
-            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            rootSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            rootSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            rootSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            rootSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
 
             // assert child spans have span sampling tags
             var childSpans = traces[0].Where(s => s.ParentId is not null and not 0);
 
             foreach (var span in childSpans)
             {
-                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-                span.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+                span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+                span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+                span.Metrics.Should().NotContain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
             }
         }
 
@@ -223,9 +223,9 @@ namespace Datadog.Trace.IntegrationTests
             trace[0].Should().HaveCount(1);
 
             var writtenSpan = trace[0].Single();
-            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.RuleRate, expectedRuleRate);
-            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
-            writtenSpan.Metrics.Should().NotContain(Tags.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
+            writtenSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.RuleRate, expectedRuleRate);
+            writtenSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.MaxPerSecond, expectedMaxPerSecond);
+            writtenSpan.Metrics.Should().NotContain(Metrics.SingleSpanSampling.SamplingMechanism, expectedSamplingMechanism);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
@@ -37,9 +37,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -52,9 +52,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -71,9 +71,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -90,9 +90,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -106,9 +106,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -119,9 +119,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -133,9 +133,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().NotBeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().NotBeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().NotBeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().NotBeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().NotBeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().NotBeNull();
         }
 
         [Fact]
@@ -147,9 +147,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeFalse();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().BeNull();
         }
 
         [Fact]
@@ -164,9 +164,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().BeNull();
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().BeNull();
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]
@@ -182,9 +182,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             sampler.MakeSamplingDecision(span).Should().BeTrue();
 
-            span.Tags.GetMetric(Tags.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
-            span.Tags.GetMetric(Tags.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.RuleRate).Should().Be(expectedRuleRate);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.MaxPerSecond).Should().Be(expectedMaxPerSecond);
+            span.Tags.GetMetric(Metrics.SingleSpanSampling.SamplingMechanism).Should().Be(expectedSamplingMechanism);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Moving the single span sampling tag names from `Tags.cs` into `Metrics.cs` as they are metrics.

## Reason for change

Cleanup as the names were moved from the actual tags dict to the metrics dict.

## Test coverage

- Should be covered by existing tests

