### PR TITLE
Fix Exploration tests

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -212,22 +212,37 @@ partial class Build
             return;
         }
 
-        DotNetTest(
-            x =>
+        if (Framework == null)
+        {
+            foreach (var targetFramework in testDescription.SupportedFrameworks)
             {
-                x = x
-                   .SetProjectFile(testDescription.GetTestTargetPath(ExplorationTestsDirectory, Framework, BuildConfiguration))
-                   .EnableNoRestore()
-                   .EnableNoBuild()
-                   .SetConfiguration(BuildConfiguration)
-                   .When(Framework != null, settings => settings.SetFramework(Framework))
-                   .SetProcessEnvironmentVariables(envVariables)
-                   .SetIgnoreFilter(testDescription.TestsToIgnore)
-                   .WithMemoryDumpAfter(100)
-                    ;
+                Test(targetFramework);
+            }
+        }
+        else
+        {
+            Test(Framework);
+        }
 
-                return x;
-            });
+        void Test(TargetFramework targetFramework)
+        {
+            DotNetTest(
+                x =>
+                {
+                    x = x
+                       .SetProjectFile(testDescription.GetTestTargetPath(ExplorationTestsDirectory, targetFramework, BuildConfiguration))
+                       .EnableNoRestore()
+                       .EnableNoBuild()
+                       .SetConfiguration(BuildConfiguration)
+                       .SetFramework(targetFramework)
+                       .SetProcessEnvironmentVariables(envVariables)
+                       .SetIgnoreFilter(testDescription.TestsToIgnore)
+                       .WithMemoryDumpAfter(100)
+                        ;
+
+                    return x;
+                });
+        }
     }
 
     void RunExplorationTestAssertions()

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -174,7 +174,7 @@ internal static partial class DotNetSettingsExtensions
             var sb = new StringBuilder();
             foreach (var testToIgnore in testsToIgnore)
             {
-                sb.Append("FullyQualifiedName!~");
+                sb.Append("FullyQualifiedName!=");
                 sb.Append(testToIgnore);
                 sb.Append(value: '&');
             }


### PR DESCRIPTION
## Summary of changes
Run dotnet test for supported frameworks only
Change test filtering from "Not contains" to "Not exact match"

## Reason for change
By default, if `Framework` parameter was not provided, exploration tests were running for all frameworks listed in target project. This PR changes default behavior. Now, only frameworks in the list `SupportedFrameworks` on test description will be used.

Another issue, while using "Not contains" filtering (`FullyQualifiedName!~`) caused exception `Exception filtering tests: Incorrect format for TestCaseFilter Error: Invalid Condition`, and all tests were skipped. This PR changes filtering to "Not exact match" (`!=`)

<!-- Fixes #{issue} -->
