### PR TITLE
[tracer] W3C Trace Context part 2: `tracestate` header

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -27,19 +27,17 @@ namespace Datadog.Trace.Propagators
 
             return default;
         }
-#else
+#endif
+
         public static ulong ParseFromHexOrDefault(string value)
         {
-            try
+            if (ulong.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             {
-                return Convert.ToUInt64(value, 16);
+                return result;
             }
-            catch
-            {
-                return default;
-            }
+
+            return default;
         }
-#endif
 
         public static ulong? ParseUInt64<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter getter, string headerName)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -63,6 +63,7 @@ namespace Datadog.Trace.Propagators
 
                 if (traceParent!.Length != 55 || traceParent[2] != '-' || traceParent[35] != '-' || traceParent[52] != '-')
                 {
+                    // quick format validation
                     return false;
                 }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -17,6 +17,11 @@ namespace Datadog.Trace.Propagators
         /// </summary>
         public const string TraceParent = "traceparent";
 
+        /// <summary>
+        /// W3C tracestate header
+        /// </summary>
+        public const string TraceState = "tracestate";
+
         public static readonly W3CTraceContextPropagator Instance = new();
 
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Propagators
     internal class W3CTraceContextPropagator : IContextInjector, IContextExtractor
     {
         /// <summary>
-        /// W3C TraceParent header
+        /// W3C traceparent header
         /// </summary>
         public const string TraceParent = "traceparent";
 
@@ -40,15 +40,15 @@ namespace Datadog.Trace.Propagators
                 // We found a trace parent (we are reading from the Http Headers)
 
                 /* (https://www.w3.org/TR/trace-context/)
-                    Valid traceparent when caller sampled this request:
 
+                    Valid traceparent when caller sampled this request:
                     Value = 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01
                     base16(version) = 00
                     base16(trace-id) = 4bf92f3577b34da6a3ce929d0e0e4736
                     base16(parent-id) = 00f067aa0ba902b7
                     base16(trace-flags) = 01  // sampled
-                    Valid traceparent when caller didn’t sample this request:
 
+                    Valid traceparent when caller didn’t sample this request:
                     Value = 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00
                     base16(version) = 00
                     base16(trace-id) = 4bf92f3577b34da6a3ce929d0e0e4736

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -61,6 +61,12 @@ namespace Datadog.Trace.Propagators
                     return false;
                 }
 
+                if (traceParent[0] != '0' || traceParent[1] != '0')
+                {
+                    // we only support traceparent version "00"
+                    return false;
+                }
+
                 char w3cSampled = traceParent[54];
                 if (traceParent[53] != '0' || (w3cSampled != '0' && w3cSampled != '1'))
                 {

--- a/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
+++ b/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Util
 
         public static void Release(StringBuilder sb)
         {
-            if (sb.Capacity <= MaxBuilderSize)
+            if (sb?.Capacity <= MaxBuilderSize)
             {
                 _cachedInstance = sb;
             }


### PR DESCRIPTION
## Summary of changes

- implement `tracestate` header
- misc clean up and refactoring
- TODO

## Reason for change

- improved OpenTelemetry support
- TODO

## Implementation details

TODO

## Test coverage

TODO

## Other details
Follows #3446.
Internal tracking: AIT-5063.
