### PR TITLE
Add Instrumentation Verification to AspNetCoreMinimalApisTests

### DIFF
--- a/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGenerator.cs
+++ b/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGenerator.cs
@@ -251,6 +251,10 @@ namespace Datadog.InstrumentedAssemblyGenerator
                         continue;
                     }
 
+                    if (module.Name == "DataDog.Trace.dll") // We don't instrument ourselves
+                    {
+                        continue;
+                    }
                     using (var memoryStream = new MemoryStream())
                     {
                         // in order to read the final and up-to-date representation of the assembly,

--- a/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGenerator.cs
+++ b/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGenerator.cs
@@ -251,7 +251,7 @@ namespace Datadog.InstrumentedAssemblyGenerator
                         continue;
                     }
 
-                    if (module.Name == "DataDog.Trace.dll") // We don't instrument ourselves
+                    if (module.Name == "Datadog.Trace.dll") // We don't instrument ourselves
                     {
                         continue;
                     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -45,9 +45,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("SupportsInstrumentationVerification", "True")]
         [MemberData(nameof(Data))]
         public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
         {
+            SetInstrumentationVerification();
+
             await Fixture.TryStartApp(this);
 
             var spans = await Fixture.WaitForSpans(path);
@@ -61,6 +64,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             await Verifier.Verify(spans, settings)
                           .UseMethodName("_")
                           .UseTypeName(_testName);
+
+            VerifyInstrumentation(Fixture.Process);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Add support for running the instrumentation verification tooling on `AspNetCoreMinimalApisTests`

## Reason for change
This test has been failing randomly with an `AccessViolationException`. By running Instrumentation Verification on it, I was able to prove that the bytecode we generate for them is 100% valid and passed all verifications (`ILVerify`, `ILSpy`, `PrepareMethod`). So, by elimination, we now have one less dead end to chase down :) 