### PR TITLE
Limit the number of jobs to the number of cores when building native code on Linux

### DIFF
--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -66,7 +66,7 @@ partial class Build
                 arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B {NativeBuildDirectory} -S {RootDirectory} -DCMAKE_BUILD_TYPE=Release");
 
             CMake.Value(
-                arguments: $"--build {NativeBuildDirectory} --parallel --target all-profiler");
+                arguments: $"--build {NativeBuildDirectory} --parallel {Environment.ProcessorCount} --target all-profiler");
 
             if (IsAlpine)
             {

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -52,7 +52,7 @@ partial class Build
             CMake.Value(
                 arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B {NativeBuildDirectory} -S {RootDirectory}");
             CMake.Value(
-                arguments: $"--build . --parallel --target {FileNames.NativeLoader}",
+                arguments: $"--build . --parallel {Environment.ProcessorCount} --target {FileNames.NativeLoader}",
                 workingDirectory: NativeBuildDirectory);
         });
 
@@ -75,7 +75,7 @@ partial class Build
                     arguments: $"-B {NativeBuildDirectory} -S {RootDirectory} -DCMAKE_BUILD_TYPE=Release",
                     environmentVariables: envVariables);
                 CMake.Value(
-                    arguments: $"--build {NativeBuildDirectory} --parallel --target {FileNames.NativeLoader}",
+                    arguments: $"--build {NativeBuildDirectory} --parallel {Environment.ProcessorCount} --target {FileNames.NativeLoader}",
                     environmentVariables: envVariables);
 
                 var sourceFile = NativeLoaderProject.Directory / "bin" / $"{NativeLoaderProject.Name}.dylib";

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -202,7 +202,7 @@ partial class Build
             CMake.Value(
                 arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -B {NativeBuildDirectory} -S {RootDirectory} -DCMAKE_BUILD_TYPE=Release");
             CMake.Value(
-                arguments: $"--build {NativeBuildDirectory} --parallel --target {FileNames.NativeTracer}");
+                arguments: $"--build {NativeBuildDirectory} --parallel {Environment.ProcessorCount} --target {FileNames.NativeTracer}");
         });
 
     Target CompileNativeSrcMacOs => _ => _
@@ -225,7 +225,7 @@ partial class Build
                     arguments: $"-B {NativeBuildDirectory} -S {RootDirectory} -DCMAKE_BUILD_TYPE=Release",
                     environmentVariables: envVariables);
                 CMake.Value(
-                    arguments: $"--build {NativeBuildDirectory} --parallel --target {FileNames.NativeTracer}",
+                    arguments: $"--build {NativeBuildDirectory} --parallel {Environment.ProcessorCount} --target {FileNames.NativeTracer}",
                     environmentVariables: envVariables);
 
                 var sourceFile = NativeTracerProject.Directory / "build" / "bin" / $"{NativeTracerProject.Name}.dylib";


### PR DESCRIPTION
## Summary of changes

This PR limits the numbers of jobs to be run to the number of cores available on the machine.

## Reason for change

When this [PR](https://github.com/DataDog/dd-trace-dotnet/pull/3412) was merged, the AzDo CI experienced OOM while compiling the .NET profiler. This PR was reverted until a fix is found.

Currently, when using `--parallel` for CMake, it instructs `Make` to compile with its default parallelism value. According to the [Make documentation](https://www.gnu.org/software/make/manual/html_node/Parallel.html), if no value is provided there is no limit (`[...] If there is nothing looking like an integer after the ‘-j’ option, there is no limit on the number of job slots. `)

## Implementation details

For Native code build on Linux, we limit the number of jobs to the number of cores available.

## Test coverage

- Restored the branch chrisnas/add_garbage_collection_in_profile (a new PR is created from it)
- Rebased it from master
- Cherry-picked the commit from this PR to this branch: https://github.com/DataDog/dd-trace-dotnet/pull/3476/commits/9afb5aedda68a0b5e0519470fd8b865d9a2c0a56
- Run in AzDo and check native linux builds (Tracer, Profiler) https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=118781&view=logs&s=dc3d6e3b-87f7-59bf-8467-39fdfe7458a2

## Other details
<!-- Fixes #{issue} -->
