### PR TITLE
Disable tiered compilation in integration tests

### DIFF
--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -46,6 +46,9 @@ ENV CORECLR_ENABLE_PROFILING=1 \
     DD_PROFILING_ENABLED=1 \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -50,6 +50,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -189,6 +189,7 @@ namespace Datadog.Trace.TestHelpers
         {
             string profilerEnabled = AutomaticInstrumentationEnabled ? "1" : "0";
             environmentVariables["DD_DOTNET_TRACER_HOME"] = MonitoringHome;
+            environmentVariables["COMPlus_TieredCompilation"] = "0";
 
             // Everything should be using the native loader now
             var nativeLoaderPath = GetNativeLoaderPath();


### PR DESCRIPTION
## Summary of changes

Temporarily disable tiered compilation by setting `COMPlus_TieredCompilation=0`

## Reason for change

We have been seeing flakiness in our integration tests for a long time which we have narrowed down to being related to how tiered JIT handles call-counting for our Rejited methods. This appears to be much more significant in our new Windows-2022 runners. [We have raised an issue with the .NET runtime team](https://github.com/dotnet/runtime/issues/77973). Disabling tiered compilation for now will hopefully significantly reduce flake in the meantime.

## Implementation details

Set `COMPlus_TieredCompilation=0` in integration sample apps. This is not a long-term solution, just a temporary fix for flake 


## Other details
For more details and analysis, see https://github.com/dotnet/runtime/issues/77973
