### PR TITLE
Avoid monitoring the dd-trace tool as it causes a crash on start-up

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3232,7 +3232,83 @@ stages:
         build: true
         baseImage: alpine
         command: "CheckSmokeTestsForErrors"
-        
+
+- stage: dotnet_tool_self_instrument_smoke_tests_linux
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux]
+
+  - job: linux
+    timeoutInMinutes: 45 # should take ~5 mins
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      publishFramework: net6.0
+      platformSuffix: linux-x64
+      dockerTag: debian_net6
+      runtimeImage: "mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim"
+      installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb"
+      linuxArtifacts: "linux-packages-centos7"
+    pool:
+      vmImage: ubuntu-20.04
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download artifacts to smoke test directory
+      inputs:
+        artifact: $(linuxArtifacts)
+        path: $(smokeTestAppDir)/artifacts
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tool runner-standalone-$(platformSuffix)
+      inputs:
+        artifact: runner-standalone-$(platformSuffix)
+        patterns: "*.tar.gz"
+        path: $(Agent.TempDirectory)
+
+    - script: |
+        mkdir -p tracer/build_data/snapshots
+        mkdir -p tracer/build_data/logs
+        tar -xf $(Agent.TempDirectory)/dd-trace-$(platformSuffix).tar.gz -C $(smokeTestAppDir)/artifacts
+        chmod +x $(smokeTestAppDir)/artifacts/dd-trace
+      displayName: create test data directories and extract tool
+
+    - script: |
+        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg INSTALL_CMD="$(installCmd)" \
+          dotnet-tool-self-instrument-smoke-tests
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build dotnet-tool-self-instrument-smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dotnet-tool-self-instrument-smoke-tests'
+        snapshotPrefix: "smoke_test"
+
+    - publish: tracer/build_data
+      artifact: dotnet-tool-smoke-test-self-instrument-logs_$(dockerTag)_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: alpine
+        command: "CheckSmokeTestsForErrors"
+
 - stage: installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [package_arm64, generate_variables, master_commit_id]
@@ -3718,6 +3794,7 @@ stages:
     - nuget_installer_smoke_tests_windows
     - dotnet_tool_nuget_smoke_tests_linux
     - dotnet_tool_smoke_tests_linux
+    - dotnet_tool_self_instrument_smoke_tests_linux
     - dotnet_tool_smoke_tests_arm64
     - dotnet_tool_smoke_tests_windows
     - msi_installer_smoke_tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -730,6 +730,26 @@ services:
     depends_on:
     - test-agent
 
+  dotnet-tool-self-instrument-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - INSTALL_CMD=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-self-instrument-tester
+    volumes:
+    - ./:/project
+    - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+    - dockerTag=${dockerTag:-unset}
+    - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+    - test-agent
+
   dotnet-tool-nuget-smoke-tests:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2,6 +2,7 @@
 #include "log.h"
 #include "dynamic_dispatcher.h"
 #include "util.h"
+#include "../../../shared/src/native-src/pal.h"
 #include "instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_function_control.h"
 #include "instrumented_assembly_generator/instrumented_assembly_generator_cor_profiler_info.h"
 #include "instrumented_assembly_generator/instrumented_assembly_generator_helper.h"
@@ -109,6 +110,15 @@ namespace datadog::shared::nativeloader
     {
         Log::Debug("CorProfiler::Initialize");
         InspectRuntimeCompatibility(pICorProfilerInfoUnk);
+
+        const auto process_name = ::shared::GetCurrentProcessName();
+        Log::Debug("ProcessName: ", process_name);
+
+        if (process_name == WStr("dd-trace") || process_name == WStr("dd-trace.exe"))
+        {
+            Log::Info("Profiler disabled - monitoring the dd-trace tool is not supported.");
+            return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+        }
 
         //
         // Get and set profiler pointers

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -38,6 +38,9 @@ ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
 ENV ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -1,0 +1,50 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY --from=builder /src/artifacts /app/install
+
+ARG INSTALL_CMD
+RUN mkdir -p /opt/datadog \
+    && mkdir -p /var/log/datadog \
+    && mkdir -p /tool \
+    && cd /app/install \
+    && $INSTALL_CMD \
+    && cp /app/install/* /tool \
+    && rm -rf /app/install
+
+# Set the required env vars (for self-instrumenting)
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+ENV LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
+
+# Set the optional env vars
+ENV DD_PROFILING_ENABLED=1
+ENV DD_APPSEC_ENABLED=1
+ENV DD_TRACE_DEBUG=1
+ENV ASPNETCORE_URLS=http://localhost:5000
+ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
+
+# see https://github.com/dotnet/runtime/issues/77973
+ENV COMPlus_TieredCompilation=0
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["/tool/dd-trace", "dotnet", "/app/AspNetCoreSmokeTest.dll"]

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -68,6 +68,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto process_command_line = shared::GetCurrentProcessCommandLine();
     Logger::Info("Process CommandLine: ", process_command_line);
 
+    if (process_name == WStr("dd-trace") || process_name == WStr("dd-trace.exe"))
+    {
+        Logger::Info("Profiler disabled - monitoring the dd-trace tool is not supported.");
+        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
+    }
+
     // CI visibility checks
     if (!process_command_line.empty())
     {


### PR DESCRIPTION
## Summary of changes

Added a hardcoded check to avoid initiating our CLR-Profiler on the [dd-trace tool](https://docs.datadoghq.com/tracing/troubleshooting/dotnet_diagnostic_tool/).

## Reason for change

If our Client Library is enabled machine-wide, it may attempt to monitor the dd-trace tool itself, which causes it to crash on startup with the following error:

```
sh-4.2$ ./dd-trace check process 1
2Unhandled exception. System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
3---> System.TypeInitializationException: The type initializer for 'Datadog.Trace.ClrProfiler.Managed.Loader.Startup' threw an exception.
4---> System.TypeLoadException: Could not load type 'System.ResolveEventHandler' from assembly 'System.Runtime.Extensions, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```

## Implementation details

Added a check to the native loader and to the native tracer.

## Test coverage
Added a new smoke test which installs _both_ the installer and then traces using the dd-trace tool. Ran a test without this fix first to confirm that it crashes (it does) and that it works fine with the fix (it does)