### PR TITLE
[Dynamic Instrumentation] Fixed the lookup of Symbol Method of async methods

### DIFF
--- a/tracer/src/Datadog.Trace/PDBs/DatadogPdbReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogPdbReader.cs
@@ -74,9 +74,9 @@ namespace Datadog.Trace.Pdb
             var stateMachineAttributeFullName = typeof(AsyncStateMachineAttribute).FullName;
             var stateMachineAttributeOfMdMethod = mdMethod.CustomAttributes?.FirstOrDefault(ca => ca.TypeFullName == stateMachineAttributeFullName);
             // Grab the generated inner type state machine from the argument given by the compiler to the AsyncStateMachineAttribute
-            var stateMachineInnerType = (stateMachineAttributeOfMdMethod?.ConstructorArguments.FirstOrDefault().Value as ClassSig)?.TypeDef;
+            var stateMachineInnerTypeTypeDefOrRefSig = (stateMachineAttributeOfMdMethod?.ConstructorArguments.FirstOrDefault().Value as TypeDefOrRefSig);
             // Grab the MoveNext from inside the stateMachine and from there the corresponding debugInfo
-            var moveNextDebugInfo = stateMachineInnerType?.FindMethod("MoveNext")?.CustomDebugInfos.OfType<PdbAsyncMethodCustomDebugInfo>().FirstOrDefault();
+            var moveNextDebugInfo = stateMachineInnerTypeTypeDefOrRefSig?.TypeDefOrRef?.ResolveTypeDef()?.FindMethod("MoveNext")?.CustomDebugInfos.OfType<PdbAsyncMethodCustomDebugInfo>().FirstOrDefault();
             var breakpointMethod = moveNextDebugInfo?.StepInfos.FirstOrDefault();
 
             if (breakpointMethod?.BreakpointMethod == null)


### PR DESCRIPTION
## Summary of changes
Compiling generic async method with the optimized flag generates a state machine that is generic & value type. Our current Symbol Method lookup in the PDB reader fails to perform a cast due to mistype usage (dealing with value type sig instead of class sig).

## Reason for change
Failing to grab the Symbol Method of Async Methods correctly.
