### PR TITLE
[Profiler] Improve Linux stackwalk

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -4,7 +4,7 @@ SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunw
 
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
-    GIT_TAG v1.6.2
+    GIT_TAG gleocadie/backtrace2_2
     GIT_PROGRESS true
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -183,7 +183,7 @@ std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
 
         if (count == 0)
         {
-            return S_FALSE;
+            return E_FAIL;
         }
 
         SetFrameCount(count);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
@@ -8,7 +8,7 @@
 
 #include "Log.h"
 #include "ManagedThreadInfo.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 // This method is called from the CLR so we need to use STDMETHODCALLTYPE macro to match the CLR declaration
 HRESULT STDMETHODCALLTYPE StackSnapshotCallbackHandlerImpl(FunctionID funcId, UINT_PTR ip, COR_PRF_FRAME_INFO frameInfo, ULONG32 contextSize, BYTE context[], void* clientData);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
@@ -11,7 +11,7 @@
 #include "Log.h"
 #include "ManagedThreadInfo.h"
 #include "StackSamplerLoopManager.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 #endif // matches the '#ifdef BIT64' above
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -309,7 +309,7 @@
     <ClInclude Include="StackFramesCollectorBase.h" />
     <ClInclude Include="StackSamplerLoop.h" />
     <ClInclude Include="StackSamplerLoopManager.h" />
-    <ClInclude Include="StackSnapshotResultReusableBuffer.h" />
+    <ClInclude Include="StackSnapshotResultBuffer.h" />
     <ClInclude Include="TagsHelper.h" />
     <ClInclude Include="ThreadCpuInfo.h" />
     <ClInclude Include="ThreadsCpuManager.h" />
@@ -359,7 +359,7 @@
     <ClCompile Include="StackFramesCollectorBase.cpp" />
     <ClCompile Include="StackSamplerLoop.cpp" />
     <ClCompile Include="StackSamplerLoopManager.cpp" />
-    <ClCompile Include="StackSnapshotResultReusableBuffer.cpp" />
+    <ClCompile Include="StackSnapshotResultBuffer.cpp" />
     <ClCompile Include="TagsHelper.cpp" />
     <ClCompile Include="ThreadCpuInfo.cpp" />
     <ClCompile Include="ThreadsCpuManager.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -89,7 +89,7 @@
     <ClInclude Include="StackSamplerLoopManager.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
-    <ClInclude Include="StackSnapshotResultReusableBuffer.h">
+    <ClInclude Include="StackSnapshotResultBuffer.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
     <ClInclude Include="ThreadCpuInfo.h">
@@ -328,7 +328,7 @@
     <ClCompile Include="StackSamplerLoopManager.cpp">
       <Filter>Profiler-Driver</Filter>
     </ClCompile>
-    <ClCompile Include="StackSnapshotResultReusableBuffer.cpp">
+    <ClCompile Include="StackSnapshotResultBuffer.cpp">
       <Filter>Profiler-Driver</Filter>
     </ClCompile>
     <ClCompile Include="ThreadCpuInfo.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -11,7 +11,7 @@
 #include "corprof.h"
 #include "GroupSampler.h"
 #include "OsSpecificApi.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 class ExceptionsProvider
     : public CollectorBase<RawExceptionSample>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -12,9 +12,6 @@ namespace shared {
 struct LoaderResourceMonikerIDs;
 }
 
-class StackSnapshotResultReusableBuffer;
-class IManagedThreadList;
-
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
@@ -14,29 +14,29 @@
 StackFramesCollectorBase::StackFramesCollectorBase()
 {
     _isRequestedCollectionAbortSuccessful = false;
-    _pReusableStackSnapshotResult = new StackSnapshotResultReusableBuffer();
+    _pStackSnapshotResult = std::make_unique<StackSnapshotResultBuffer>();
     _pCurrentCollectionThreadInfo = nullptr;
     _isCurrentCollectionAbortRequested.store(false);
 }
 
-StackFramesCollectorBase::~StackFramesCollectorBase()
-{
-    StackSnapshotResultReusableBuffer* pReusableStackSnapshotResult = _pReusableStackSnapshotResult;
-    if (pReusableStackSnapshotResult != nullptr)
-    {
-        delete pReusableStackSnapshotResult;
-        _pReusableStackSnapshotResult = nullptr;
-    }
-}
-
 bool StackFramesCollectorBase::AddFrame(std::uintptr_t ip)
 {
-    return _pReusableStackSnapshotResult->AddFrame(ip);
+    return _pStackSnapshotResult->AddFrame(ip);
 }
 
 void StackFramesCollectorBase::AddFakeFrame()
 {
-    _pReusableStackSnapshotResult->AddFakeFrame();
+    _pStackSnapshotResult->AddFakeFrame();
+}
+
+void StackFramesCollectorBase::SetFrameCount(std::uint16_t count)
+{
+    _pStackSnapshotResult->SetFramesCount(count);
+}
+
+std::pair<uintptr_t*, std::uint16_t> StackFramesCollectorBase::Data()
+{
+    return {_pStackSnapshotResult->Data(), StackSnapshotResultBuffer::MaxSnapshotStackDepth_Limit};
 }
 
 void StackFramesCollectorBase::RequestAbortCurrentCollection(void)
@@ -113,8 +113,8 @@ bool StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThre
         std::uint64_t localRootSpanId = pCurrentCollectionThreadInfo->GetLocalRootSpanId();
         std::uint64_t spanId = pCurrentCollectionThreadInfo->GetSpanId();
 
-        _pReusableStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
-        _pReusableStackSnapshotResult->SetSpanId(spanId);
+        _pStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
+        _pStackSnapshotResult->SetSpanId(spanId);
 
         return true;
     }
@@ -124,7 +124,7 @@ bool StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThre
 
 StackSnapshotResultBuffer* StackFramesCollectorBase::GetStackSnapshotResult()
 {
-    return _pReusableStackSnapshotResult;
+    return _pStackSnapshotResult.get();
 }
 
 // ----------- Inline stubs for APIs that are specific to overriding implementations: -----------
@@ -136,7 +136,7 @@ void StackFramesCollectorBase::PrepareForNextCollection(void)
     // We cannot allocate memory once a thread is suspended.
     // This is because malloc() uses a lock and so if we suspend a thread that was allocating, we will deadlock.
     // So we pre-allocate the memory buffer and reset it before suspending the target thread.
-    _pReusableStackSnapshotResult->Reset();
+    _pStackSnapshotResult->Reset();
 
     // Clear the current collection thread pointer:
     _pCurrentCollectionThreadInfo = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.h
@@ -5,10 +5,11 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 
 #include "ManagedThreadInfo.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 class StackFramesCollectorBase
 {
@@ -18,6 +19,9 @@ protected:
     bool TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot(void);
     bool AddFrame(std::uintptr_t ip);
     void AddFakeFrame();
+    void SetFrameCount(std::uint16_t count);
+
+    std::pair<uintptr_t*, std::uint16_t> Data();
 
     StackSnapshotResultBuffer* GetStackSnapshotResult(void);
     bool IsCurrentCollectionAbortRequested();
@@ -32,7 +36,7 @@ protected:
     virtual StackSnapshotResultBuffer* CollectStackSampleImplementation(ManagedThreadInfo* pThreadInfo, uint32_t* pHR, bool selfCollect);
 
 public:
-    virtual ~StackFramesCollectorBase();
+    virtual ~StackFramesCollectorBase() = default;
     StackFramesCollectorBase(StackFramesCollectorBase const&) = delete;
     StackFramesCollectorBase& operator=(StackFramesCollectorBase const&) = delete;
 
@@ -48,7 +52,7 @@ protected:
     ManagedThreadInfo* _pCurrentCollectionThreadInfo;
 
 private:
-    StackSnapshotResultReusableBuffer* _pReusableStackSnapshotResult;
+    std::unique_ptr<StackSnapshotResultBuffer> _pStackSnapshotResult;
     std::atomic<bool> _isCurrentCollectionAbortRequested;
     std::condition_variable _collectionAbortPerformedSignal;
     std::mutex _collectionAbortNotificationLock;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
@@ -1,19 +1,17 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
-StackSnapshotResultBuffer::StackSnapshotResultBuffer(std::uint16_t initialCapacity) :
+StackSnapshotResultBuffer::StackSnapshotResultBuffer() :
     _unixTimeUtc{0},
     _representedDurationNanoseconds{0},
     _appDomainId{0},
-    _currentCapacity{0},
-    _nextResetCapacity{initialCapacity},
+    _instructionPointers{},
     _currentFramesCount{0},
     _localRootSpanId{0},
     _spanId{0}
 {
-    _instructionPointers.reserve(initialCapacity);
 }
 
 StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
@@ -21,18 +19,13 @@ StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
     _unixTimeUtc = 0;
     _representedDurationNanoseconds = 0;
     _appDomainId = static_cast<AppDomainID>(0);
-    _currentCapacity = 0;
-    _nextResetCapacity = 0;
     _currentFramesCount = 0;
     _localRootSpanId = 0;
     _spanId = 0;
 }
 
-void StackSnapshotResultReusableBuffer::Reset(void)
+void StackSnapshotResultBuffer::Reset(void)
 {
-    _instructionPointers.clear();
-    _instructionPointers.reserve(_nextResetCapacity);
-
     _localRootSpanId = 0;
     _spanId = 0;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
@@ -8,6 +8,7 @@
 #include "corprof.h"
 // end
 
+#include <array>
 #include <vector>
 #include <cstdint>
 
@@ -20,7 +21,7 @@
 class StackSnapshotResultBuffer
 {
 public:
-    StackSnapshotResultBuffer() = delete;
+    static constexpr std::uint16_t MaxSnapshotStackDepth_Limit = 2049;
 
     inline std::uint64_t GetUnixTimeUtc(void) const;
     inline std::uint64_t SetUnixTimeUtc(std::uint64_t value);
@@ -38,22 +39,27 @@ public:
     inline std::uint64_t SetSpanId(std::uint64_t value);
 
     inline std::size_t GetFramesCount(void) const;
+    inline void SetFramesCount(std::uint16_t count);
     inline void CopyInstructionPointers(std::vector<std::uintptr_t>& ips) const;
 
     inline void DetermineAppDomain(ThreadID threadId, ICorProfilerInfo4* pCorProfilerInfo);
 
-protected:
-    explicit StackSnapshotResultBuffer(std::uint16_t initialCapacity);
-    virtual ~StackSnapshotResultBuffer();
+    void Reset(void);
+
+    inline bool AddFrame(std::uintptr_t ip);
+    inline bool AddFakeFrame();
+
+    inline uintptr_t* Data();
+
+    StackSnapshotResultBuffer();
+    ~StackSnapshotResultBuffer();
 
 protected:
 
     std::uint64_t _unixTimeUtc;
     std::uint64_t _representedDurationNanoseconds;
     AppDomainID _appDomainId;
-    std::vector<uintptr_t> _instructionPointers;
-    std::uint16_t _currentCapacity;
-    std::uint16_t _nextResetCapacity;
+    std::array<uintptr_t, MaxSnapshotStackDepth_Limit> _instructionPointers;
     std::uint16_t _currentFramesCount;
 
     std::uint64_t _localRootSpanId;
@@ -62,26 +68,7 @@ protected:
 
 // ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
 
-class StackSnapshotResultReusableBuffer : public StackSnapshotResultBuffer
-{
-    static constexpr std::uint16_t MaxSnapshotStackDepth_Limit = 2049;
-
-public:
-    StackSnapshotResultReusableBuffer() :
-        StackSnapshotResultBuffer(MaxSnapshotStackDepth_Limit)
-    {
-    }
-    ~StackSnapshotResultReusableBuffer() override = default;
-
-    void Reset(void);
-
-    inline bool AddFrame(std::uintptr_t ip);
-    inline bool AddFakeFrame();
-};
-
-// ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
-
-inline std::uint64_t StackSnapshotResultBuffer::GetUnixTimeUtc(void) const
+inline std::uint64_t StackSnapshotResultBuffer::GetUnixTimeUtc() const
 {
     return _unixTimeUtc;
 }
@@ -93,7 +80,7 @@ inline std::uint64_t StackSnapshotResultBuffer::SetUnixTimeUtc(std::uint64_t val
     return prevValue;
 }
 
-inline std::uint64_t StackSnapshotResultBuffer::GetRepresentedDurationNanoseconds(void) const
+inline std::uint64_t StackSnapshotResultBuffer::GetRepresentedDurationNanoseconds() const
 {
     return _representedDurationNanoseconds;
 }
@@ -105,7 +92,7 @@ inline std::uint64_t StackSnapshotResultBuffer::SetRepresentedDurationNanosecond
     return prevValue;
 }
 
-inline AppDomainID StackSnapshotResultBuffer::GetAppDomainId(void) const
+inline AppDomainID StackSnapshotResultBuffer::GetAppDomainId() const
 {
     return _appDomainId;
 }
@@ -143,15 +130,20 @@ inline std::uint64_t StackSnapshotResultBuffer::SetSpanId(std::uint64_t value)
 
 inline std::size_t StackSnapshotResultBuffer::GetFramesCount(void) const
 {
-    return _instructionPointers.size();
+    return _currentFramesCount;
+}
+
+inline void StackSnapshotResultBuffer::SetFramesCount(std::uint16_t count)
+{
+    _currentFramesCount = count;
 }
 
 inline void StackSnapshotResultBuffer::CopyInstructionPointers(std::vector<std::uintptr_t>& ips) const
 {
-    ips.reserve(_instructionPointers.size());
+    ips.reserve(_currentFramesCount);
 
     // copy the instruction pointer to the out-parameter
-    ips = _instructionPointers;
+    ips.insert(ips.end(), _instructionPointers.begin(), _instructionPointers.begin() + _currentFramesCount);
 }
 
 inline void StackSnapshotResultBuffer::DetermineAppDomain(ThreadID threadId, ICorProfilerInfo4* pCorProfilerInfo)
@@ -185,27 +177,29 @@ inline void StackSnapshotResultBuffer::DetermineAppDomain(ThreadID threadId, ICo
 
 // ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------
 
-inline bool StackSnapshotResultReusableBuffer::AddFrame(std::uintptr_t ip)
+inline bool StackSnapshotResultBuffer::AddFrame(std::uintptr_t ip)
 {
-    const auto nextIdx = _instructionPointers.size();
-
-    if (nextIdx >= MaxSnapshotStackDepth_Limit)
+    if (_currentFramesCount >= MaxSnapshotStackDepth_Limit)
     {
         return false;
     }
 
-    const auto lastIdx = MaxSnapshotStackDepth_Limit - 1;
-    if (nextIdx == lastIdx)
+    if (_currentFramesCount == MaxSnapshotStackDepth_Limit - 1)
     {
-        _instructionPointers.push_back(0);
+        _instructionPointers[_currentFramesCount++] = 0;
         return false;
     }
 
-    _instructionPointers.push_back(ip);
+    _instructionPointers[_currentFramesCount++] = ip;
     return true;
 }
 
-inline bool StackSnapshotResultReusableBuffer::AddFakeFrame()
+inline bool StackSnapshotResultBuffer::AddFakeFrame()
 {
     return AddFrame(0);
+}
+
+inline uintptr_t* StackSnapshotResultBuffer::Data()
+{
+    return _instructionPointers.data();
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -59,7 +59,7 @@
     <ClCompile Include="RuntimeIdTest.cpp" />
     <ClCompile Include="RuntimeInfoHelper.cpp" />
     <ClCompile Include="SamplesCollectorTest.cpp" />
-    <ClCompile Include="StackSnapshotResultReusableBufferTest.cpp" />
+    <ClCompile Include="StackSnapshotResultBufferTest.cpp" />
     <ClCompile Include="TagsHelperTest.cpp" />
     <ClCompile Include="ProviderTest.cpp" />
     <ClCompile Include="ThreadsCpuManagerHelper.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -77,7 +77,7 @@
     <ClCompile Include="ManagedThreadListTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="StackSnapshotResultReusableBufferTest.cpp">
+    <ClCompile Include="StackSnapshotResultBufferTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
     <ClCompile Include="RuntimeIdTest.cpp">

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -7,7 +7,7 @@
 #include "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h"
 #include "ManagedThreadInfo.h"
 #include "OpSysTools.h"
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
 #include "gtest/gtest-death-test.h"
 #include "gtest/gtest.h"

--- a/profiler/test/Datadog.Profiler.Native.Tests/StackSnapshotResultBufferTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/StackSnapshotResultBufferTest.cpp
@@ -3,11 +3,11 @@
 
 #include "gtest/gtest.h"
 
-#include "StackSnapshotResultReusableBuffer.h"
+#include "StackSnapshotResultBuffer.h"
 
-TEST(StackSnapshotResultReusableBufferTest, CheckAddedFrames)
+TEST(StackSnapshotResultBufferTest, CheckAddedFrames)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     std::vector<std::uintptr_t> expectedIps = {42, 21, 11, 4};
     for (auto ip : expectedIps)
@@ -23,9 +23,9 @@ TEST(StackSnapshotResultReusableBufferTest, CheckAddedFrames)
     ASSERT_EQ(expectedIps, ips);
 }
 
-TEST(StackSnapshotResultReusableBufferTest, CheckAddedFakeFrame)
+TEST(StackSnapshotResultBufferTest, CheckAddedFakeFrame)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     std::vector<std::uintptr_t> expectedIps = {42, 21, 11, 4};
 
@@ -46,9 +46,9 @@ TEST(StackSnapshotResultReusableBufferTest, CheckAddedFakeFrame)
     ASSERT_EQ(expectedIps, ips);
 }
 
-TEST(StackSnapshotResultReusableBufferTest, CheckIfWeReachTheBufferLimitTheLastFrameIsFake)
+TEST(StackSnapshotResultBufferTest, CheckIfWeReachTheBufferLimitTheLastFrameIsFake)
 {
-    auto buffer = StackSnapshotResultReusableBuffer();
+    auto buffer = StackSnapshotResultBuffer();
 
     for (auto i = 1; i < 2049; i++)
     {


### PR DESCRIPTION
## Summary of changes

Improvement linux stackwalk process.

## Reason for change

We got feedback from customer having 2 issues with the .NET Linux profiler:
- Overhead: The unwind process has a noticeable CPU overhead (in the best day 10%, in the worst ones 40%)
- Latency issue: They had some latency peaks  when the profiler was activated. Managed threads are hijacked to unwind their callstack and collect the frames. We use the `generic unwind` approach (The one we see in all examples. See below benchmark screen shot) and this approach does no caching so every time it recomputes everything.

There is another libunwind API `unw_backtrace` also known as `fast backtrace/unwind` which caches things and improves the performance of stack unwinding. Here is the benchmark:
![image](https://user-images.githubusercontent.com/17292193/206468479-e1aa27cd-6752-4c0a-9362-9694cf21fc56.png)

In master, we use the `generic unwind` approach and as you can see the `fast unwind` case is the one we should use :)

This feature requires:
- Having a `unw_backtrace2` which starts unwinding from the context  passed by the signal handler ( + a bug fix): done in  https://github.com/DataDog/libunwind/tree/gleocadie/backtrace2_2. A PR is currently in review in the libunwind repository to add the `unw_backtrace2`. 
- For sure, updating our code to benefit from it

From this PR we can now see the improvement in our benchmark:
![image](https://user-images.githubusercontent.com/17292193/206520303-f0fae1d4-d982-4c24-bbb1-7ca375113a04.png)

## Implementation details

- Expose a function that allows the stackwalker to access the inner buffer to store instruction pointers.
- Use `unw_backtrace2` to collect instruction pointers
- + little bit of cleanup

## Test coverage
The current test we have

## Other details
<!-- Fixes #{issue} -->
