### PR TITLE
Add support for filtering `ILogger` for direct log submission

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
     /// <summary>
     /// Duck type for ILoggerProvider
     /// </summary>
+    [Microsoft.Extensions.Logging.ProviderAlias("Datadog")]
     internal class DirectSubmissionLoggerProvider
     {
         private readonly Func<string, DirectSubmissionLogger> _createLoggerFunc;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/ProviderAliasAttribute.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/ProviderAliasAttribute.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ProviderAliasAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.ComponentModel;
+
+// ReSharper disable once CheckNamespace - Must match the expected namespace
+namespace Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Defines alias for ILoggerProvider implementation to be used in filtering rules.
+/// Based on https://github.com/dotnet/runtime/blob/793676e851989ac81291b194d5efbcd5e800b673/src/libraries/Microsoft.Extensions.Logging/src/ProviderAliasAttribute.cs
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+internal class ProviderAliasAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProviderAliasAttribute"/> class.
+    /// </summary>
+    /// <param name="alias">The alias to set.</param>
+    public ProviderAliasAttribute(string alias)
+    {
+        Alias = alias;
+    }
+
+    /// <summary>
+    /// Gets the alias of the provider.
+    /// </summary>
+    public string Alias { get; }
+}

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
@@ -478,4 +478,22 @@ namespace Datadog.Trace.DuckTyping
             throw new DuckTypeReverseProxyMustImplementGenericMethodAsGenericException(implementationMethod, targetMethod);
         }
     }
+
+    /// <summary>
+    /// DuckType property or field not found
+    /// </summary>
+    internal class DuckTypeCustomAttributeHasNamedArgumentsException : DuckTypeException
+    {
+        private DuckTypeCustomAttributeHasNamedArgumentsException(string attributeName, string type)
+            : base($"The attribute '{attributeName}' applied to '{type}' uses named arguments. Named arguments are not supported for custom attributes.")
+        {
+        }
+
+        [DebuggerHidden]
+        [DoesNotReturn]
+        internal static void Throw(Type type, CustomAttributeData attributeData)
+        {
+            throw new DuckTypeCustomAttributeHasNamedArgumentsException(attributeData.AttributeType?.FullName ?? "Null", type?.FullName ?? type?.Name ?? "NULL");
+        }
+    }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -78,17 +78,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        [SkippableFact]
+        [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DirectlyShipsLogs()
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DirectlyShipsLogs(bool filterStartupLogs)
         {
             SetInstrumentationVerification();
             var hostName = "integration_ilogger_tests";
             using var logsIntake = new MockLogsIntake();
 
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.ILogger), hostName);
+            if (filterStartupLogs)
+            {
+                SetEnvironmentVariable("Logging__Datadog__LogLevel__LogsInjection.ILogger.Startup", "Warning");
+            }
 
             var agentPort = TcpPortProvider.GetOpenPort();
             using var agent = MockTracerAgent.Create(Output, agentPort);
@@ -98,9 +104,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var logs = logsIntake.Logs;
 
+            var expectedLogCount = filterStartupLogs ? 7 : 12;
             using var scope = new AssertionScope();
             logs.Should().NotBeNull();
-            logs.Should().HaveCountGreaterOrEqualTo(12); // have an unknown number of "Waiting for app started handling requests"
+            logs.Should().HaveCountGreaterOrEqualTo(expectedLogCount); // have an unknown number of "Waiting for app started handling requests"
             logs.Should()
                 .OnlyContain(x => x.Service == "LogsInjection.ILogger")
                 .And.OnlyContain(x => x.Host == hostName)
@@ -109,6 +116,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 .And.OnlyContain(x => x.Version == "1.0.0")
                 .And.OnlyContain(x => x.Exception == null)
                 .And.OnlyContain(x => x.LogLevel == DirectSubmissionLogLevel.Information);
+
+            if (filterStartupLogs)
+            {
+                logs.Should().NotContain(x => x.Message.Contains("Building pipeline")); // these are filtered out
+            }
+            else
+            {
+                logs.Should().Contain(x => x.Message.Contains("Building pipeline")); // these should not be filtered out
+            }
 
             VerifyInstrumentation(processResult.Process);
         }


### PR DESCRIPTION
## Summary of changes

- Allow adding custom attributes to reverse duck-typed proxies
- Allow filtering of ILogger logs sent using direct log submission using .NET Core's native filtering capabilities

## Reason for change

Seemed like a nice to have, and I wondered if it could be done 🕵️ 

The `Microsoft.Extensions.Logging.LoggerFactory` has [extensive filtering features](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-7.0#configure-logging) you can use to control which log level is the minimum, based on the log category (typically a namespace). You can also set provider-specific rules. For example, the following JSON config sets up:

- The default log level (`Information`)
- The log level for the `Microsoft.AspNetCore` category (`Warning`)
- The default log level for the _console_ provider (`Debug`)
- The log level for the `Microsoft.AspNetCore` category for the console provider only (`Warning`)

```json
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft.AspNetCore": "Warning"
    },
    "Console": {
      "LogLevel": {
        "Default": "Debug",
        "Microsoft.Hosting": "Warning"
      },
    }
  }
}
```

It would be nice if customers could add a `"Datadog"` section to configure the direct log shipping - and now they can!

For example, if users only want to ship Warnings in the `"Microsoft.Hosting"` catgeory to Datadog, they can add the following `"Datadog"` section to their application.json (or use any other configuration provider their app uses)

```json
{
  "Logging": {
    "Datadog": {
      "LogLevel": {
        "Microsoft.Hosting": "Warning"
      },
    }
  }
}
```


## Implementation details

The `Microsoft.Extensions.Logging.LoggerFactory` checks for a `ProviderAliasAttribute` on the logging provider, by name, which has a constructor argument. We leverage this by creating an attribute with the same name and adding it to the generated `ILoggerProvider` implementation.

This required adding a new feature to the duck typing library to add the attribute. I went for a simplistic implementation for now, which only supports attributes that use constructors, not named arguments. We could extend the support relatively easily if needs be, just seemed easier to ignore it for now.



## Test coverage

- Duck typing tests for the adding attributes
- Integration test for the ILogger behaviour
- Manual testing to confirm the filtering works as expected
