### PR TITLE
[tracer] W3C Trace Context part 2: `dd` values in `tracestate` header

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -27,19 +27,17 @@ namespace Datadog.Trace.Propagators
 
             return default;
         }
-#else
+#endif
+
         public static ulong ParseFromHexOrDefault(string value)
         {
-            try
+            if (ulong.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             {
-                return Convert.ToUInt64(value, 16);
+                return result;
             }
-            catch
-            {
-                return default;
-            }
+
+            return default;
         }
-#endif
 
         public static ulong? ParseUInt64<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter getter, string headerName)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>

--- a/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
+++ b/tracer/src/Datadog.Trace/Propagators/ParseUtility.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace.Propagators
 #if NETCOREAPP
         public static ulong ParseFromHexOrDefault(ReadOnlySpan<char> value)
         {
+            // we use ulong.TryParse() here instead of Convert.ToUInt64() like we do in ParseFromHexOrDefault(string)
+            // because benchmarks show it has better performance in .NET Core
             if (ulong.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
             {
                 return result;
@@ -27,17 +29,21 @@ namespace Datadog.Trace.Propagators
 
             return default;
         }
-#endif
-
+#else
         public static ulong ParseFromHexOrDefault(string value)
         {
-            if (ulong.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var result))
+            try
             {
-                return result;
+                // we use Convert.ToUInt64() here instead of ulong.TryParse() like we do in ParseFromHexOrDefault(ReadOnlySpan<char>)
+                // because benchmarks show it has better performance in .NET Framework
+                return Convert.ToUInt64(value, 16);
             }
-
-            return default;
+            catch
+            {
+                return default;
+            }
         }
+#endif
 
         public static ulong? ParseUInt64<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter getter, string headerName)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagatorFactory.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagatorFactory.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Propagators
 
         public static IEnumerable<TPropagator> GetPropagators<TPropagator>(string[] headerStyles)
         {
-            if (headerStyles == null)
+            if (headerStyles is null or { Length: 0 })
             {
                 yield break;
             }

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -11,6 +11,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Propagators
@@ -80,7 +81,7 @@ namespace Datadog.Trace.Propagators
                 {
                     foreach (var tag in tags)
                     {
-                        if (tag.Key.StartsWith("_dd.p.", StringComparison.Ordinal))
+                        if (tag.Key.StartsWith(TagPropagation.PropagatedTagPrefix, StringComparison.Ordinal))
                         {
 #if NETCOREAPP
                             var key = tag.Key.AsSpan(start: 6);
@@ -316,7 +317,7 @@ namespace Datadog.Trace.Propagators
                     }
                     else if (name.StartsWith("t.", StringComparison.Ordinal))
                     {
-                        propagatedTagsBuilder.Append("_dd.p.").Append(name[2..]).Append('=').Append(value).Append(',');
+                        propagatedTagsBuilder.Append(TagPropagation.PropagatedTagPrefix).Append(name[2..]).Append('=').Append(value).Append(',');
                     }
 #else
                     var name = header.Substring(startIndex, colonIndex - startIndex);
@@ -333,7 +334,7 @@ namespace Datadog.Trace.Propagators
                     }
                     else if (name.StartsWith("t.", StringComparison.Ordinal))
                     {
-                        propagatedTagsBuilder.Append("_dd.p.").Append(name.Substring(2)).Append('=').Append(value).Append(',');
+                        propagatedTagsBuilder.Append(TagPropagation.PropagatedTagPrefix).Append(name.Substring(2)).Append('=').Append(value).Append(',');
                     }
 #endif
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -407,13 +407,13 @@ namespace Datadog.Trace.Propagators
                                         SamplingPriorityValues.AutoReject);
 
             spanContext = new SpanContext(
-                traceParent.TraceId,
-                traceParent.ParentId,
-                samplingPriority,
+                traceId: traceParent.TraceId,
+                spanId: traceParent.ParentId,
+                samplingPriority: samplingPriority,
                 serviceName: null,
                 origin: traceState.Origin,
-                traceParent.RawTraceId,
-                traceParent.RawParentId);
+                rawTraceId: traceParent.RawTraceId,
+                rawSpanId: traceParent.RawParentId);
 
             spanContext.PropagatedTags = traceState.PropagatedTags;
             return true;

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.Propagators
                        "1" => 1,
                        "0" => 0,
                        "-1" => 1,
-                       null => null,
+                       null or "" => null,
                        not null => int.TryParse(samplingPriority, out var result) ? result : null
                    };
         }

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -300,6 +300,8 @@ namespace Datadog.Trace.Propagators
 
                 if (propagatedTagsBuilder.Length > 0)
                 {
+                    // we can't use [^1] in .NET Framework without access to the Index and Range types
+                    // ReSharper disable once UseIndexFromEndExpression
                     if (propagatedTagsBuilder[propagatedTagsBuilder.Length - 1] == ',')
                     {
                         propagatedTagsBuilder.Length--;

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Propagators
                     sb.Length--;
                 }
 
-                return StringBuilderCache.GetStringAndRelease(sb);
+                return sb.ToString();
             }
             finally
             {
@@ -307,7 +307,7 @@ namespace Datadog.Trace.Propagators
                         propagatedTagsBuilder.Length--;
                     }
 
-                    propagatedTags = StringBuilderCache.GetStringAndRelease(propagatedTagsBuilder);
+                    propagatedTags = propagatedTagsBuilder.ToString();
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -21,12 +21,31 @@ namespace Datadog.Trace.Propagators
     {
         private const string TraceStateHeaderValuesSeparator = ",";
 
-        private const char LowerBound = (char)0x20;
-        private const char UpperBound = (char)0x7E;
-        private const char InvalidCharacterReplacement = '_';
-        private const string InvalidOriginCharacters = ",;=";
-        private const string InvalidPropagatedTagKeyCharacters = " ,=";
-        private const string InvalidPropagatedTagValueCharacters = " ,=";
+        private const char LowerBound = '\u0020'; // decimal: 32, ' ' (space)
+        private const char UpperBound = '\u007e'; // decimal: 126, '~' (tilde)
+        private const char OutOfBoundsReplacement = '_';
+
+        private static readonly KeyValuePair<char, char>[] OriginReplacements =
+        {
+            new(',', '_'),
+            new(';', '_'),
+            new('=', '_'),
+        };
+
+        private static readonly KeyValuePair<char, char>[] PropagatedTagKeyReplacements =
+        {
+            new(' ', '_'),
+            new(',', '_'),
+            new('=', '_'),
+        };
+
+        private static readonly KeyValuePair<char, char>[] PropagatedTagValueReplacements =
+        {
+            new(',', '_'),
+            new(';', '_'),
+            new('~', '_'),
+            new('=', '~'), // note '=' is encoded as '~' when injecting, then back to '=' then extracting
+        };
 
         /// <summary>
         /// W3C traceparent header name
@@ -81,7 +100,7 @@ namespace Datadog.Trace.Propagators
 
                 if (!string.IsNullOrWhiteSpace(context.Origin))
                 {
-                    var origin = ReplaceInvalidCharacters(context.Origin, LowerBound, UpperBound, InvalidOriginCharacters, InvalidCharacterReplacement);
+                    var origin = ReplaceInvalidCharacters(context.Origin, LowerBound, UpperBound, OutOfBoundsReplacement, OriginReplacements);
                     sb.Append("o:").Append(origin).Append(';');
                 }
 
@@ -97,8 +116,8 @@ namespace Datadog.Trace.Propagators
                             var key = tag.Key.Substring(startIndex: 6);
 #endif
 
-                            var tagKey = ReplaceInvalidCharacters(key, LowerBound, UpperBound, InvalidPropagatedTagKeyCharacters, InvalidCharacterReplacement);
-                            var tagValue = ReplaceInvalidCharacters(tag.Value, LowerBound, UpperBound, InvalidPropagatedTagValueCharacters, InvalidCharacterReplacement);
+                            var tagKey = ReplaceInvalidCharacters(key, LowerBound, UpperBound, OutOfBoundsReplacement, PropagatedTagKeyReplacements);
+                            var tagValue = ReplaceInvalidCharacters(tag.Value, LowerBound, UpperBound, OutOfBoundsReplacement, PropagatedTagValueReplacements);
                             sb.Append("t.").Append(tagKey).Append(':').Append(tagValue).Append(';');
                         }
                     }
@@ -581,9 +600,9 @@ namespace Datadog.Trace.Propagators
         }
 
 #if NETCOREAPP
-        public static string ReplaceInvalidCharacters(ReadOnlySpan<char> value, char lowerBound, char upperBound, string invalidChars, char replacement)
+        public static string ReplaceInvalidCharacters(ReadOnlySpan<char> value, char lowerBound, char upperBound, char outOfBoundsReplacement, KeyValuePair<char, char>[] replacements)
 #else
-        public static string ReplaceInvalidCharacters(string value, char lowerBound, char upperBound, string invalidChars, char replacement)
+        public static string ReplaceInvalidCharacters(string value, char lowerBound, char upperBound, char outOfBoundsReplacement, KeyValuePair<char, char>[] replacements)
 #endif
         {
             var sb = StringBuilderCache.Acquire(value.Length);
@@ -593,9 +612,19 @@ namespace Datadog.Trace.Propagators
             {
                 var c = sb[i];
 
-                if (c < lowerBound || c > upperBound || invalidChars.IndexOf(c) >= 0)
+                if (c < lowerBound || c > upperBound)
                 {
-                    sb[i] = replacement;
+                    sb[i] = outOfBoundsReplacement;
+                }
+                else
+                {
+                    foreach (var replacement in replacements)
+                    {
+                        if (c == replacement.Key)
+                        {
+                            sb[i] = replacement.Value;
+                        }
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -118,6 +118,8 @@ namespace Datadog.Trace.Propagators
                 return false;
             }
 
+            header = header.Trim();
+
             if (header.Length != 55 || header[2] != '-' || header[35] != '-' || header[52] != '-')
             {
                 // validate format
@@ -193,7 +195,7 @@ namespace Datadog.Trace.Propagators
         {
             traceState = default;
 
-            if (string.IsNullOrWhiteSpace(header))
+            if (header == null!)
             {
                 return false;
             }

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -260,12 +260,12 @@ namespace Datadog.Trace.Propagators
                     var name = header.AsSpan(start: startIndex, length: colonIndex - startIndex);
                     var value = header.AsSpan(start: colonIndex + 1, length: endIndex - colonIndex);
 
-                    if (name.SequenceEqual("s"))
+                    if (name.Equals("s", StringComparison.Ordinal))
                     {
                         // SamplingPriorityToInt32(ReadOnlySpan<char>)
                         samplingPriority = SamplingPriorityToInt32(value);
                     }
-                    else if (name.SequenceEqual("o"))
+                    else if (name.Equals("o", StringComparison.Ordinal))
                     {
                         origin = value.ToString();
                     }

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -32,11 +32,7 @@ namespace Datadog.Trace.Propagators
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
             var traceparent = CreateTraceParentHeader(context);
-
-            if (!string.IsNullOrWhiteSpace(traceparent))
-            {
-                carrierSetter.Set(carrier, TraceParentHeaderName, traceparent);
-            }
+            carrierSetter.Set(carrier, TraceParentHeaderName, traceparent);
 
             var tracestate = CreateTraceStateHeader(context);
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -344,7 +344,7 @@ namespace Datadog.Trace.Propagators
                        "2" => 2,
                        "1" => 1,
                        "0" => 0,
-                       "-1" => 1,
+                       "-1" => -1,
                        null or "" => null,
                        not null => int.TryParse(samplingPriority, out var result) ? result : null
                    };

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -361,19 +361,6 @@ namespace Datadog.Trace.Propagators
                    };
         }
 
-        private static int? SamplingPriorityToInt32(string? samplingPriority)
-        {
-            return samplingPriority switch
-                   {
-                       "2" => 2,
-                       "1" => 1,
-                       "0" => 0,
-                       "-1" => -1,
-                       null or "" => null,
-                       not null => int.TryParse(samplingPriority, out var result) ? result : null
-                   };
-        }
-
 #if NETCOREAPP
         private static int? SamplingPriorityToInt32(ReadOnlySpan<char> samplingPriority)
         {
@@ -385,6 +372,19 @@ namespace Datadog.Trace.Propagators
                        "-1" => -1,
                        "" => null,
                        _ => int.TryParse(samplingPriority, out var result) ? result : null
+                   };
+        }
+#else
+        private static int? SamplingPriorityToInt32(string? samplingPriority)
+        {
+            return samplingPriority switch
+                   {
+                       "2" => 2,
+                       "1" => 1,
+                       "0" => 0,
+                       "-1" => -1,
+                       null or "" => null,
+                       not null => int.TryParse(samplingPriority, out var result) ? result : null
                    };
         }
 #endif

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -218,7 +218,7 @@ namespace Datadog.Trace.Propagators
 
         internal static bool TryParseTraceState(string header, out W3CTraceState traceState)
         {
-            // "dd=s:1;o:rum;t.dm:-4;t.usr.id:12345"
+            // "[*,]dd=s:1;o:rum;t.dm:-4;t.usr.id:12345[,*]"
             traceState = default;
 
             if (header == null!)
@@ -230,7 +230,7 @@ namespace Datadog.Trace.Propagators
 
             if (header.Length < 6 || !header.StartsWith("dd=", StringComparison.Ordinal))
             {
-                // shorted valid length is 6: "dd=s:1"
+                // shortest valid length is 6: "dd=s:1"
                 return false;
             }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -353,27 +353,15 @@ namespace Datadog.Trace.Propagators
 #if NETCOREAPP
         private static int? SamplingPriorityToInt32(ReadOnlySpan<char> samplingPriority)
         {
-            if (samplingPriority.Equals("2", StringComparison.Ordinal))
-            {
-                return 2;
-            }
-
-            if (samplingPriority.Equals("1", StringComparison.Ordinal))
-            {
-                return 1;
-            }
-
-            if (samplingPriority.Equals("0", StringComparison.Ordinal))
-            {
-                return 0;
-            }
-
-            if (samplingPriority.Equals("-1", StringComparison.Ordinal))
-            {
-                return -1;
-            }
-
-            return int.TryParse(samplingPriority, out var result) ? result : null;
+            return samplingPriority switch
+                   {
+                       "2" => 2,
+                       "1" => 1,
+                       "0" => 0,
+                       "-1" => -1,
+                       "" => null,
+                       _ => int.TryParse(samplingPriority, out var result) ? result : null
+                   };
         }
 #endif
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Propagators
 
         internal static bool TryParseTraceParent(string header, out W3CTraceParent traceParent)
         {
-            // "{version:2}-{trace-id:32}-{parent-id:16}-{trace-flags:2}
+            // "{version:2}-{trace-id:32}-{parent-id:16}-{trace-flags:2}"
             //             ^ 2           ^ 35           ^ 52            ^ 55
 
             traceParent = default;
@@ -214,6 +214,7 @@ namespace Datadog.Trace.Propagators
 
         internal static bool TryParseTraceState(string header, out W3CTraceState traceState)
         {
+            // "dd=s:1;o:rum;t.dm:-4;t.usr.id:12345"
             traceState = default;
 
             if (header == null!)
@@ -396,6 +397,7 @@ namespace Datadog.Trace.Propagators
         {
             spanContext = null;
 
+            // TODO: reject multiple "traceparent" headers
             // get the "traceparent" header
             var traceParentHeader = ParseUtility.ParseString(carrier, carrierGetter, TraceParentHeaderName)?.Trim();
 
@@ -405,6 +407,7 @@ namespace Datadog.Trace.Propagators
                 return false;
             }
 
+            // TODO: concatenate multiple "tracestate" headers
             var traceStateHeader = ParseUtility.ParseString(carrier, carrierGetter, TraceStateHeaderName)?.Trim();
 
             if (string.IsNullOrEmpty(traceStateHeader) || !TryParseTraceState(traceStateHeader!, out var traceState))

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -377,7 +377,10 @@ namespace Datadog.Trace.Propagators
         }
 #endif
 
-        public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
+        public bool TryExtract<TCarrier, TCarrierGetter>(
+            TCarrier carrier,
+            TCarrierGetter carrierGetter,
+            [NotNullWhen(true)] out SpanContext? spanContext)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {
             spanContext = null;

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceParent.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceParent.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="W3CTraceParent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Propagators;
+
+internal readonly struct W3CTraceParent
+{
+    public readonly ulong TraceId;
+
+    public readonly ulong ParentId;
+
+    public readonly bool Sampled;
+
+    public readonly string? RawTraceId;
+
+    public readonly string? RawParentId;
+
+    public W3CTraceParent(
+        ulong traceId,
+        ulong parentId,
+        bool sampled,
+        string? rawTraceId,
+        string? rawParentId)
+    {
+        TraceId = traceId;
+        ParentId = parentId;
+        Sampled = sampled;
+        RawTraceId = rawTraceId;
+        RawParentId = rawParentId;
+    }
+}

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceState.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceState.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="W3CTraceState.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Propagators;
+
+internal readonly struct W3CTraceState
+{
+    public readonly int? SamplingPriority;
+
+    public readonly string? Origin;
+
+    // format is "_dd.p.key1:value1;_dd.p.key2:value2"
+    public readonly string? PropagatedTags;
+
+    public W3CTraceState(int? samplingPriority, string? origin, string? propagatedTags)
+    {
+        SamplingPriority = samplingPriority;
+        Origin = origin;
+        PropagatedTags = propagatedTags;
+    }
+}

--- a/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
+++ b/tracer/src/Datadog.Trace/Util/StringBuilderCache.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Util
 
         public static void Release(StringBuilder sb)
         {
-            if (sb.Capacity <= MaxBuilderSize)
+            if (sb?.Capacity <= MaxBuilderSize)
             {
                 _cachedInstance = sb;
             }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -3,9 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Reflection;
+using System;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Tagging;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -23,204 +25,284 @@ namespace Datadog.Trace.Tests.Propagators
                 new[] { ContextPropagationHeaderStyle.W3CTraceContext });
         }
 
+        [Theory]
+        [InlineData(123456789, 987654321, null, "00-000000000000000000000000075bcd15-000000003ade68b1-01")]
+        [InlineData(123456789, 987654321, SamplingPriorityValues.UserReject, "00-000000000000000000000000075bcd15-000000003ade68b1-00")]
+        [InlineData(123456789, 987654321, SamplingPriorityValues.AutoReject, "00-000000000000000000000000075bcd15-000000003ade68b1-00")]
+        [InlineData(123456789, 987654321, SamplingPriorityValues.AutoKeep, "00-000000000000000000000000075bcd15-000000003ade68b1-01")]
+        [InlineData(123456789, 987654321, SamplingPriorityValues.UserKeep, "00-000000000000000000000000075bcd15-000000003ade68b1-01")]
+        public void CreateTraceParentHeader(ulong traceId, ulong spanId, int? samplingPriority, string expected)
+        {
+            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, "origin");
+            var traceparent = W3CTraceContextPropagator.CreateTraceParentHeader(context);
+
+            traceparent.Should().Be(expected);
+        }
+
+        [Theory]
+        // null/empty/whitespace
+        [InlineData(null, null, null, "")]
+        [InlineData(null, "", "", "")]
+        [InlineData(null, " ", " ", "")]
+        // sampling priority only
+        [InlineData(SamplingPriorityValues.UserReject, null, null, "dd=s:-1")]
+        [InlineData(SamplingPriorityValues.AutoReject, null, null, "dd=s:0")]
+        [InlineData(SamplingPriorityValues.AutoKeep, null, null, "dd=s:1")]
+        [InlineData(SamplingPriorityValues.UserKeep, null, null, "dd=s:2")]
+        [InlineData(3, null, null, "dd=s:3")]
+        [InlineData(-5, null, null, "dd=s:-5")]
+        // origin only
+        [InlineData(null, "abc", null, "dd=o:abc")]
+        // propagated tags only
+        [InlineData(null, null, "_dd.p.a=1", "dd=t.a:1")]
+        [InlineData(null, null, "_dd.p.a=1,_dd.p.b=2", "dd=t.a:1;t.b:2")]
+        [InlineData(null, null, "_dd.p.a=1,b=2", "dd=t.a:1")]
+        // combined
+        [InlineData(SamplingPriorityValues.UserKeep, "rum", null, "dd=s:2;o:rum")]
+        [InlineData(SamplingPriorityValues.AutoReject, null, "_dd.p.a=b", "dd=s:0;t.a:b")]
+        [InlineData(null, "rum", "_dd.p.a=b", "dd=o:rum;t.a:b")]
+        [InlineData(SamplingPriorityValues.AutoKeep, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345", "dd=s:1;o:rum;t.dm:-4;t.usr.id:12345")]
+        public void CreateTraceStateHeader(int? samplingPriority, string origin, string tags, string expected)
+        {
+            var propagatedTags = TagPropagation.ParseHeader(tags, 100);
+            var traceContext = new TraceContext(tracer: null, propagatedTags) { Origin = origin };
+            traceContext.SetSamplingPriority(samplingPriority, mechanism: null, notifyDistributedTracer: false);
+            var spanContext = new SpanContext(parent: null, traceContext, serviceName: null, traceId: 1, spanId: 2);
+
+            var tracestate = W3CTraceContextPropagator.CreateTraceStateHeader(spanContext);
+
+            tracestate.Should().Be(expected);
+        }
+
+        [Fact]
+        public void CreateTraceStateHeader_WithPublicPropagatedTags()
+        {
+            var traceContext = new TraceContext(tracer: null);
+            var spanContext = new SpanContext(parent: null, traceContext, serviceName: null, traceId: 1, spanId: 2);
+            var span = new Span(spanContext, DateTimeOffset.Now);
+
+            var user = new UserDetails("12345")
+                       {
+                           PropagateId = true,
+                           Email = "user@example.com"
+                       };
+
+            // use public APIs to add propagated tags
+            span.SetTraceSamplingPriority(SamplingPriority.UserKeep); // adds "_dd.p.dm"
+            span.SetUser(user);                                       // adds "_dd.p.usr.id"
+
+            var tracestate = W3CTraceContextPropagator.CreateTraceStateHeader(spanContext);
+
+            tracestate.Should().Be("dd=s:2;t.dm:-4;t.usr.id:MTIzNDU=");
+        }
+
         [Fact]
         public void Inject_IHeadersCollection()
         {
-            ulong traceId = 123456789;
-            ulong spanId = 987654321;
-            var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
+            var context = new SpanContext(
+                traceId: 123456789,
+                spanId: 987654321,
+                SamplingPriorityValues.UserKeep,
+                serviceName: null,
+                "origin");
+
             var headers = new Mock<IHeadersCollection>();
 
             W3CPropagator.Inject(context, headers.Object);
 
             headers.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
+            headers.Verify(h => h.Set("tracestate", "dd=s:2;o:origin"), Times.Once());
             headers.VerifyNoOtherCalls();
-
-            // Extract sampling from trace context
-            var newContext = new SpanContext(null, new TraceContext(null), null, traceId, spanId);
-            var newHeaders = new Mock<IHeadersCollection>();
-            W3CPropagator.Inject(newContext, newHeaders.Object);
-            newHeaders.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-00"), Times.Once());
-            newHeaders.VerifyNoOtherCalls();
-
-            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
-            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
-            newHeaders = new Mock<IHeadersCollection>();
-            W3CPropagator.Inject(newContext, newHeaders.Object);
-            newHeaders.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
-            newHeaders.VerifyNoOtherCalls();
         }
 
         [Fact]
         public void Inject_CarrierAndDelegate()
         {
-            ulong traceId = 123456789;
-            ulong spanId = 987654321;
-            var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, null);
+            var context = new SpanContext(
+                traceId: 123456789,
+                spanId: 987654321,
+                SamplingPriorityValues.UserKeep,
+                serviceName: null,
+                "origin");
 
-            // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();
 
             W3CPropagator.Inject(context, headers.Object, (carrier, name, value) => carrier.Set(name, value));
 
             headers.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
+            headers.Verify(h => h.Set("tracestate", "dd=s:2;o:origin"), Times.Once());
             headers.VerifyNoOtherCalls();
+        }
 
-            // Extract sampling from trace context
-            var newContext = new SpanContext(null, new TraceContext(null), null, traceId, spanId);
-            var newHeaders = new Mock<IHeadersCollection>();
-            W3CPropagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
-            newHeaders.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-00"), Times.Once());
-            newHeaders.VerifyNoOtherCalls();
+        [Theory]
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-00", 123456789, 987654321, false, "000000000000000000000000075bcd15", "000000003ade68b1")]
+        [InlineData("00-0000000000000000000000003ade68b1-00000000075bcd15-01", 987654321, 123456789, true, "0000000000000000000000003ade68b1", "00000000075bcd15")]
+        public void TryParseTraceParent(string header, ulong traceId, ulong spanId, bool sampled, string rawTraceId, string rawParentId)
+        {
+            var expected = new W3CTraceParent(
+                traceId,
+                spanId,
+                sampled,
+                rawTraceId,
+                rawParentId);
 
-            var traceContextSamplingField = typeof(TraceContext).GetField("_samplingPriority", BindingFlags.Instance | BindingFlags.NonPublic);
-            traceContextSamplingField.SetValue(newContext.TraceContext, SamplingPriorityValues.UserKeep);
-            newHeaders = new Mock<IHeadersCollection>();
-            W3CPropagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
-            newHeaders.Verify(h => h.Set("traceparent", "00-000000000000000000000000075bcd15-000000003ade68b1-01"), Times.Once());
-            newHeaders.VerifyNoOtherCalls();
+            W3CTraceContextPropagator.TryParseTraceParent(header, out var traceParent).Should().BeTrue();
+
+            traceParent.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]                                                      // null
+        [InlineData("")]                                                        // empty
+        [InlineData(" ")]                                                       // whitespace
+        [InlineData("01-000000000000000000000000075bcd15-000000003ade68b1-0")]  // too short
+        [InlineData("010-00000000000000000000000075bcd15-000000003ade68b1-00")] // wrong hyphen location #1
+        [InlineData("01-000000000000000000000000075bcd150-00000003ade68b1-00")] // wrong hyphen location #2
+        [InlineData("01-000000000000000000000000075bcd15-000000003ade68b-100")] // wrong hyphen location #3
+        [InlineData("01-000000000000000000000000075bcd15-000000003ade68b1-00")] // bad version value
+        [InlineData("00-000000000000000000000000075bcd1z-000000003ade68b1-00")] // bad trace id value
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68bx-00")] // bad parent id value
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-02")] // bad sampled value
+        public void TryParseTraceParent_Invalid(string header)
+        {
+            W3CTraceContextPropagator.TryParseTraceParent(header, out _).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("dd=s:2", 2, null, null)]
+        [InlineData("dd=o:rum", null, "rum", null)]
+        [InlineData("dd=t.dm:-4;t.usr.id:12345", null, null, "_dd.p.dm=-4,_dd.p.usr.id=12345")]
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345")]
+        // invalid propagated tag (first)
+        [InlineData("dd=s:2;o:rum;:12345;t.dm:-4", 2, "rum", "_dd.p.dm=-4")]    // no key
+        [InlineData("dd=s:2;o:rum;t.usr.id:;t.dm:-4", 2, "rum", "_dd.p.dm=-4")] // no value
+        [InlineData("dd=s:2;o:rum;:;t.dm:-4", 2, "rum", "_dd.p.dm=-4")]         // no key or value
+        [InlineData("dd=s:2;o:rum;t.abc;t.dm:-4", 2, "rum", "_dd.p.dm=-4")]     // no colon
+        // invalid propagated tag (last)
+        [InlineData("dd=s:2;o:rum;t.dm:-4;:12345", 2, "rum", "_dd.p.dm=-4")]    // no key
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:", 2, "rum", "_dd.p.dm=-4")] // no value
+        [InlineData("dd=s:2;o:rum;t.dm:-4;:", 2, "rum", "_dd.p.dm=-4")]         // no key or value
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.abc", 2, "rum", "_dd.p.dm=-4")]     // no colon
+        public void TryParseTraceState(string header, int? samplingPriority, string origin, string propagatedTags)
+        {
+            var expected = new W3CTraceState(samplingPriority, origin, propagatedTags);
+
+            W3CTraceContextPropagator.TryParseTraceState(header, out var traceState).Should().BeTrue();
+
+            traceState.Should().NotBeNull().And.BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]        // null
+        [InlineData("")]          // empty
+        [InlineData(" ")]         // whitespace
+        [InlineData("s:2;o:rum")] // missing "dd=" prefix
+        [InlineData("dd=")]       // "dd=" prefix only
+        public void TryParseTraceState_Invalid(string header)
+        {
+            W3CTraceContextPropagator.TryParseTraceState(header, out _).Should().BeFalse();
         }
 
         [Fact]
         public void Extract_IHeadersCollection()
         {
             var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
             headers.Setup(h => h.GetValues("traceparent"))
                    .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-01" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { "dd=s:2;o:rum;t.dm:-4;t.usr.id:12345" });
 
             var result = W3CPropagator.Extract(headers.Object);
 
             headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
             result.Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
                        new SpanContextMock
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
-                           Origin = null,
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
+                           SamplingPriority = SamplingPriorityValues.UserKeep,
+                           Origin = "rum",
+                           PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",
+                           Parent = null,
+                           ParentId = null,
                        });
         }
 
         [Fact]
         public void Extract_CarrierAndDelegate()
         {
-            // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
             headers.Setup(h => h.GetValues("traceparent"))
                    .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-01" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { "dd=s:2;o:rum;t.dm:-4;t.usr.id:12345" });
 
             var result = W3CPropagator.Extract(headers.Object, (carrier, name) => carrier.GetValues(name));
 
             headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
 
             result.Should()
+                  .NotBeNull()
+                  .And
                   .BeEquivalentTo(
                        new SpanContextMock
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
-                           Origin = null,
-                           SamplingPriority = SamplingPriorityValues.AutoKeep,
+                           SamplingPriority = SamplingPriorityValues.UserKeep,
+                           Origin = "rum",
+                           PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",
+                           Parent = null,
+                           ParentId = null,
                        });
         }
 
         [Fact]
-        public void ExtractAndInject_PreserveOriginalTraceId()
+        public void StringifyAndParse_PreserveOriginalTraceId()
         {
-            var traceId = "0af7651916cd43dd8448eb211c80319c";
-            var spanId = "00f067aa0ba902b7";
-            var expectedTraceParent = $"00-{traceId}-{spanId}-01";
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { expectedTraceParent });
+            const string traceId = "0af7651916cd43dd8448eb211c80319c";
+            const string parentId = "00f067aa0ba902b7";
+            const string traceParentHeader = $"00-{traceId}-{parentId}-01";
 
-            var result = W3CPropagator.Extract(headers.Object);
+            W3CTraceContextPropagator.TryParseTraceParent(traceParentHeader, out var traceParent).Should().BeTrue();
 
             // 64 bits verify
-            var expectedTraceId = 9532127138774266268UL;
-            var expectedSpanId = 67667974448284343UL;
-            Assert.Equal(expectedTraceId, result.TraceId);
-            Assert.Equal(expectedSpanId, result.SpanId);
+            const ulong expectedTraceId = 9532127138774266268UL;
+            const ulong expectedParentId = 67667974448284343UL;
 
-            // Check truncation
-            var truncatedTraceId64 = expectedTraceId.ToString("x16");
-            Assert.Equal(truncatedTraceId64, traceId.Substring(16));
+            traceParent.Should()
+                       .NotBeNull()
+                       .And
+                       .BeEquivalentTo(
+                            new W3CTraceParent(
+                                expectedTraceId,
+                                expectedParentId,
+                                sampled: true,
+                                rawTraceId: traceId,
+                                rawParentId: parentId));
 
-            // Check the injection restoring the 128 bits traceId.
-            var headersForInjection = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headersForInjection.Setup(h => h.Set("traceparent", expectedTraceParent));
+            var spanContext = new SpanContext(
+                traceParent.TraceId,
+                traceParent.ParentId,
+                samplingPriority: SamplingPriorityValues.AutoKeep,
+                serviceName: null,
+                origin: null,
+                traceParent.RawTraceId,
+                traceParent.RawParentId);
 
-            W3CPropagator.Inject(result, headersForInjection.Object);
-
-            headersForInjection.Verify(h => h.Set("traceparent", expectedTraceParent), Times.Once());
-        }
-
-        [Fact]
-        public void Extract_InvalidLength()
-        {
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { "00-1234000000000000000000000000075bcd15-000000003ade68b1-01" });
-
-            var result = W3CPropagator.Extract(headers.Object);
-
-            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void Extract_InvalidFormat()
-        {
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { "00=000000000000000000000000075bcd15=000000003ade68b1=01" });
-
-            var result = W3CPropagator.Extract(headers.Object);
-
-            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void Extract_InvalidSampledFormat()
-        {
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-51" });
-
-            var result = W3CPropagator.Extract(headers.Object);
-
-            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void Extract_EmptyTraceIdStrings()
-        {
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { "00-                                -000000003ade68b1-01" });
-
-            var result = W3CPropagator.Extract(headers.Object);
-
-            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
-            Assert.Null(result);
-        }
-
-        [Fact]
-        public void Extract_EmptyStrings()
-        {
-            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
-            headers.Setup(h => h.GetValues("traceparent"))
-                   .Returns(new[] { "       " });
-
-            var result = W3CPropagator.Extract(headers.Object);
-
-            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
-            Assert.Null(result);
+            W3CTraceContextPropagator.CreateTraceParentHeader(spanContext).Should().Be(traceParentHeader);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -58,6 +58,7 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData(null, null, "_dd.p.a=1", "dd=t.a:1")]
         [InlineData(null, null, "_dd.p.a=1,_dd.p.b=2", "dd=t.a:1;t.b:2")]
         [InlineData(null, null, "_dd.p.a=1,b=2", "dd=t.a:1")]
+        [InlineData(null, null, "_dd.p.usr.id=MTIzNDU=", "dd=t.usr.id:MTIzNDU~")] // convert '=' to '~'
         // combined
         [InlineData(SamplingPriorityValues.UserKeep, "rum", null, "dd=s:2;o:rum")]
         [InlineData(SamplingPriorityValues.AutoReject, null, "_dd.p.a=b", "dd=s:0;t.a:b")]
@@ -180,7 +181,7 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData("dd=s:2", 2, null, null)]
         [InlineData("dd=o:rum", null, "rum", null)]
         [InlineData("dd=t.dm:-4;t.usr.id:12345", null, null, "_dd.p.dm=-4,_dd.p.usr.id=12345")]
-        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345")]
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345~", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345=")] // '~' is converted to '='
         // invalid propagated tag (first)
         [InlineData("dd=s:2;o:rum;:12345;t.dm:-4", 2, "rum", "_dd.p.dm=-4")]    // no key
         [InlineData("dd=s:2;o:rum;t.usr.id:;t.dm:-4", 2, "rum", "_dd.p.dm=-4")] // no value
@@ -438,7 +439,10 @@ namespace Datadog.Trace.Tests.Propagators
                 new('=', '_'),
             };
 
-            W3CTraceContextPropagator.ReplaceInvalidCharacters(value, lowerBound, upperBound, outOfBoundsReplacement, invalidCharacterReplacements).Should().Be(expected);
+            W3CTraceContextPropagator.ReplaceCharacters(value, lowerBound, upperBound, outOfBoundsReplacement, invalidCharacterReplacements)
+                                     .ToString() // NETCOREAPP returns ReadOnlySpan<char>
+                                     .Should()
+                                     .Be(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -137,6 +137,9 @@ namespace Datadog.Trace.Tests.Propagators
         [Theory]
         [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-00", 123456789, 987654321, false, "000000000000000000000000075bcd15", "000000003ade68b1")]
         [InlineData("00-0000000000000000000000003ade68b1-00000000075bcd15-01", 987654321, 123456789, true, "0000000000000000000000003ade68b1", "00000000075bcd15")]
+        [InlineData("01-0000000000000000000000003ade68b1-00000000075bcd15-01", 987654321, 123456789, true, "0000000000000000000000003ade68b1", "00000000075bcd15")]  // allow other versions, version=01
+        [InlineData("00-0000000000000000000000003ade68b1-00000000075bcd15-02", 987654321, 123456789, false, "0000000000000000000000003ade68b1", "00000000075bcd15")] // allow unknown flags, trace-flags=02
+        [InlineData("00-0000000000000000000000003ade68b1-00000000075bcd15-03", 987654321, 123456789, true, "0000000000000000000000003ade68b1", "00000000075bcd15")]  // allow unknown flags, trace-flags=03
         public void TryParseTraceParent(string header, ulong traceId, ulong spanId, bool sampled, string rawTraceId, string rawParentId)
         {
             var expected = new W3CTraceParent(

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -419,10 +419,11 @@ namespace Datadog.Trace.Tests.Propagators
         // no replacements
         [InlineData("valid1234567890", false)]
         [InlineData("`~!@#$%^&*(){}[]<>-_+'\"/|\\?.", false)]
-        // explicit replacements
+        // specific replacements
         [InlineData(",foo,bar,", true)]
         [InlineData(";foo;bar;", true)]
         [InlineData("=foo=bar=", true)]
+        [InlineData(",foo;bar=", true)]
         // out of bounds replacements
         [InlineData("\0foo\tbar\u00E7", true)]
         [InlineData("dog🐶", true)]
@@ -433,9 +434,9 @@ namespace Datadog.Trace.Tests.Propagators
 
             KeyValuePair<char, char>[] invalidCharacterReplacements =
             {
-                new(',', '_'),
-                new(';', '_'),
-                new('=', '_'),
+                new(',', '1'),
+                new(';', '2'),
+                new('=', '3'),
             };
 
             W3CTraceContextPropagator.NeedsCharacterReplacement(value, lowerBound, upperBound, invalidCharacterReplacements)
@@ -447,10 +448,11 @@ namespace Datadog.Trace.Tests.Propagators
         // no replacements
         [InlineData("valid1234567890", "valid1234567890")]
         [InlineData("`~!@#$%^&*(){}[]<>-_+'\"/|\\?.", "`~!@#$%^&*(){}[]<>-_+'\"/|\\?.")]
-        // explicit replacements
-        [InlineData(",foo,bar,", "_foo_bar_")]
-        [InlineData(";foo;bar;", "_foo_bar_")]
-        [InlineData("=foo=bar=", "_foo_bar_")]
+        // specific replacements
+        [InlineData(",foo,bar,", "1foo1bar1")]
+        [InlineData(";foo;bar;", "2foo2bar2")]
+        [InlineData("=foo=bar=", "3foo3bar3")]
+        [InlineData(",foo;bar=", "1foo2bar3")]
         // out of bounds replacements
         [InlineData("\0foo\tbar\u00E7", "_foo_bar_")]
         [InlineData("dog🐶", "dog__")] // note that 🐶 is two UTF-16 chars, can also be written as "dog\ud83d\udc36" (UTF-16) or "dog\U0001F436" (UTF-32)
@@ -462,9 +464,9 @@ namespace Datadog.Trace.Tests.Propagators
 
             KeyValuePair<char, char>[] invalidCharacterReplacements =
             {
-                new(',', '_'),
-                new(';', '_'),
-                new('=', '_'),
+                new(',', '1'),
+                new(';', '2'),
+                new('=', '3'),
             };
 
             W3CTraceContextPropagator.ReplaceCharacters(value, lowerBound, upperBound, outOfBoundsReplacement, invalidCharacterReplacements)

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -155,17 +155,20 @@ namespace Datadog.Trace.Tests.Propagators
             traceParent.Should().BeEquivalentTo(expected);
         }
 
+        // "{version:2}-{traceid:32}-{parentid:16}-{traceflags:2}
         [Theory]
         [InlineData(null)]                                                           // null
         [InlineData("")]                                                             // empty
         [InlineData(" ")]                                                            // whitespace
-        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-0")]       // too short
-        [InlineData("000-00000000000000000000000075bcd15-000000003ade68b1-00")]      // wrong hyphen location #1
-        [InlineData("00-000000000000000000000000075bcd150-00000003ade68b1-00")]      // wrong hyphen location #2
-        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b-100")]      // wrong hyphen location #3
-        [InlineData("00-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad trace id value
-        [InlineData("00-000000000000000000000000075bcd15-000000003ade68bx-00")]      // bad parent id value
-        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-00-1234")] // do NOT allow more data after trace-flags if the version is 00
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-0")]       // too short (length => 54)
+        [InlineData("000-00000000000000000000000075bcd15-000000003ade68b1-00")]      // wrong hyphen location (2 => 3)
+        [InlineData("00-000000000000000000000000075bcd150-00000003ade68b1-00")]      // wrong hyphen location (35 => 36)
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b-100")]      // wrong hyphen location (52 => 51)
+        [InlineData("ff-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad version value (ff)
+        [InlineData("xz-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad version value (xz)
+        [InlineData("00-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad trace id value ("z" in hex)
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68bx-00")]      // bad parent id value ("x" in hex)
+        [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-00-1234")] // do NOT allow more data after trace-flags if the version is "00"
         public void TryParseTraceParent_Invalid(string header)
         {
             W3CTraceContextPropagator.TryParseTraceParent(header, out _).Should().BeFalse();

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -417,6 +417,34 @@ namespace Datadog.Trace.Tests.Propagators
 
         [Theory]
         // no replacements
+        [InlineData("valid1234567890", false)]
+        [InlineData("`~!@#$%^&*(){}[]<>-_+'\"/|\\?.", false)]
+        // explicit replacements
+        [InlineData(",foo,bar,", true)]
+        [InlineData(";foo;bar;", true)]
+        [InlineData("=foo=bar=", true)]
+        // out of bounds replacements
+        [InlineData("\0foo\tbar\u00E7", true)]
+        [InlineData("dog🐶", true)]
+        public void NeedsCharacterReplacement(string value, bool expected)
+        {
+            const char lowerBound = '\u0020'; // decimal: 32, ' ' (space)
+            const char upperBound = '\u007e'; // decimal: 126, '~' (tilde)
+
+            KeyValuePair<char, char>[] invalidCharacterReplacements =
+            {
+                new(',', '_'),
+                new(';', '_'),
+                new('=', '_'),
+            };
+
+            W3CTraceContextPropagator.NeedsCharacterReplacement(value, lowerBound, upperBound, invalidCharacterReplacements)
+                                     .Should()
+                                     .Be(expected);
+        }
+
+        [Theory]
+        // no replacements
         [InlineData("valid1234567890", "valid1234567890")]
         [InlineData("`~!@#$%^&*(){}[]<>-_+'\"/|\\?.", "`~!@#$%^&*(){}[]<>-_+'\"/|\\?.")]
         // explicit replacements


### PR DESCRIPTION
## Summary of changes

- implement `tracestate` header in `W3CTraceContextPropagator`
- refactor `W3CTraceContextPropagator` to make more testable

## Reason for change

- improved OpenTelemetry support

## Implementation details

- `W3CTraceContextPropagator` now injects and parses both the W3C `traceparent` and `tracestate` headers (previously we only supported the former)

## Test coverage

- big refactoring of `W3CTraceContextPropagator` to make easier to test
- see `W3CTraceContextPropagatorTests` for all tests

## Other details
Follows #3446.
Internal tracking: AIT-5063.

## To Do
- [x] handle multiple instances of `traceparent` (invalid)
- [x] handle multiple instances of `tracestate` (combine)
- [x] handle invalid characters by replacing them
- [x] encode/decode special characters (`=` to `~` and back)
- [ ] propagate additional `tracestate` from upstream to downstream (other key/value pairs aside from `dd`)
- [ ] if `dd` in `tracestate` is updated, move the whole `dd` section to the front