### PR TITLE
[Tracer] Add link to the public doc in the logs

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -151,7 +151,7 @@ namespace Datadog.Trace.Agent
                     if (isFinalTry)
                     {
                         // stop retrying
-                        _log.Error(exception, "An error occurred while sending data to the agent at {AgentEndpoint}", _apiRequestFactory.Info(endpoint));
+                        _log.Error(exception, "An error occurred while sending data to the agent at {AgentEndpoint}. If the error isn't transient, please check https://docs.datadoghq.com/tracing/troubleshooting/connection_errors/?code-lang=dotnet for guidance.", _apiRequestFactory.Info(endpoint));
                         return false;
                     }
                     else if (_log.IsEnabled(LogEventLevel.Debug))


### PR DESCRIPTION
## Summary of changes

I've added a link to the public doc in the docs when the tracer cannot send traces to the agent.

## Reason for change

I hope that can help customers jump to our doc, and check some basics on their end prior to talking to the T2s. It's a bet, and it has pros and cons I believe but I think it doesn't hurt.

## Other details
I'll also update the linked doc to make sure people think about checking their egress rules in a k8s environment as it was an issue during a recent customer call