### PR TITLE
Reduce flake by always choosing a random port for `MockTracerAgent`

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.TestHelpers
         /// </summary>
         public bool ShouldDeserializeTraces { get; set; } = true;
 
-        public static TcpUdpAgent Create(ITestOutputHelper output, int port = 8126, int retries = 5, bool useStatsd = false, bool doNotBindPorts = false, int? requestedStatsDPort = null, bool useTelemetry = false, AgentConfiguration agentConfiguration = null)
+        public static TcpUdpAgent Create(ITestOutputHelper output, int? port = null, int retries = 5, bool useStatsd = false, bool doNotBindPorts = false, int? requestedStatsDPort = null, bool useTelemetry = false, AgentConfiguration agentConfiguration = null)
             => new TcpUdpAgent(port, retries, useStatsd, doNotBindPorts, requestedStatsDPort, useTelemetry) { Output = output, Configuration = agentConfiguration ?? new() };
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -870,13 +870,14 @@ namespace Datadog.Trace.TestHelpers
             private readonly Task _tracesListenerTask;
             private readonly Task _statsdTask;
 
-            public TcpUdpAgent(int port, int retries, bool useStatsd, bool doNotBindPorts, int? requestedStatsDPort, bool useTelemetry)
+            public TcpUdpAgent(int? port, int retries, bool useStatsd, bool doNotBindPorts, int? requestedStatsDPort, bool useTelemetry)
                 : base(useTelemetry, TestTransports.Tcp)
             {
+                port ??= TcpPortProvider.GetOpenPort();
                 if (doNotBindPorts)
                 {
                     // This is for any tests that want to use a specific port but never actually bind
-                    Port = port;
+                    Port = port.Value;
                     return;
                 }
 
@@ -938,7 +939,7 @@ namespace Datadog.Trace.TestHelpers
                         listener.Start();
 
                         // successfully listening
-                        Port = port;
+                        Port = port.Value;
                         _listener = listener;
 
                         listeners.Add($"Traces at port {Port}");


### PR DESCRIPTION
## Summary of changes

- Don't default to port 8126 in the `MockTracerAgent`. Always choose a random port (unless an explicit port is requested)

## Reason for change

We've been seeing flakiness in some tests (particularly DSM.TransportTests) where the error is due to a closed connection/socket:

```
[HandleHttpRequests]Error processing web request to http://127.0.0.1:8126/v0.4/traces: System.IO.IOException: Unable to read data from the transport connection: Software caused connection abort.
```

This PR is based on a suspicion that there's some interaction between tests causing one to interfere with the port of another. It's a theory, but I haven't seen flakiness yet while testing this PR, and it shouldn't hurt.

## Implementation details

Don't default to port 8126 when no port is provided - choose a random available port in this case. 

## Test coverage

Did a dedicated azdo run and didn't see any flakiness, but `n=1` so far.
