### PR TITLE
[CLI] Check if DD_TRACE_ENABLED is set And Log if set to false

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -175,11 +175,12 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
             }
 
-            process.EnvironmentVariables.TryGetValue("DD_TRACE_ENABLED", out var traceEnabledValue);
-
-            if (traceEnabledValue == "false")
+            if (process.EnvironmentVariables.TryGetValue("DD_TRACE_ENABLED", out var traceEnabledValue))
             {
-                Utils.WriteError(TracerEnabled);
+                if (!ParseBooleanConfigurationValue(traceEnabledValue))
+                {
+                    Utils.WriteError(TracerNotEnabled(traceEnabledValue));
+                }
             }
 
             return ok;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -175,6 +175,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
             }
 
+            process.EnvironmentVariables.TryGetValue("DD_TRACE_ENABLED", out var traceEnabledValue);
+
+            if (traceEnabledValue == "false")
+            {
+                Utils.WriteError(TracerEnabled);
+            }
+
             return ok;
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public const string TracerEnabled = "DD_TRACE_ENABLED is set to false, tracing is disabled for this process.";
+        public static string TracerNotEnabled(string value) => $"The value for DD_TRACE_ENABLED is set to {value}, to enable automatic tracing set it to true.";
 
         public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -41,6 +41,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
 
+        public const string TracerEnabled = "DD_TRACE_ENABLED is set to false, tracing is disabled for this process.";
+
         public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 
         public static string WrongLdPreload(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";


### PR DESCRIPTION
## Summary of changes
Added check for the value of the `DD_TRACE_ENABLED` config, if it is set to `false` then logging it in red since this would prevent the service that is being checked from being traced.
## Reason for change
So uses are able to identify if automatic instrumentation is either enabled or not for their service using the CLI Tool.
## Test coverage
Tested locally by disabling the tracer in the registry editor for IIS:
Set to `false`:
![image](https://user-images.githubusercontent.com/28125428/203632754-36216c52-7660-4441-9eb7-9840a917ceac.png)
Set to `true`:
![image](https://user-images.githubusercontent.com/28125428/203632823-b82e075c-ecb4-4d6a-94bd-bab44f5392b7.png)
