### PR TITLE
[Profiler] Improve CodeHotspots

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Diagnostics;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using BuggyBits.Models;
 using Microsoft.AspNetCore.Http;
@@ -187,20 +186,6 @@ namespace BuggyBits.Controllers
 
             ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
             ViewData["ProductsTable"] = productsTable;
-            return View("Index");
-        }
-
-        // GET: Products on sale
-        [Route("Products/MyRequest")]
-        public IActionResult MyRequest()
-        {
-            var sw = new Stopwatch();
-            sw.Start();
-            Thread.Sleep(TimeSpan.FromMilliseconds(20));
-            sw.Stop();
-
-            ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
-            ViewData["ProductsTable"] = "hello boy";
             return View("Index");
         }
     }

--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuggyBits.Models;
 using Microsoft.AspNetCore.Http;
@@ -186,6 +187,20 @@ namespace BuggyBits.Controllers
 
             ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
             ViewData["ProductsTable"] = productsTable;
+            return View("Index");
+        }
+
+        // GET: Products on sale
+        [Route("Products/MyRequest")]
+        public IActionResult MyRequest()
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+            Thread.Sleep(TimeSpan.FromMilliseconds(20));
+            sw.Stop();
+
+            ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
+            ViewData["ProductsTable"] = "hello boy";
             return View("Index");
         }
     }

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -21,7 +21,8 @@ namespace BuggyBits
         StringBuilder,   // using StringBuilder
         Parallel,        // using parallel code
         Async,           // using async code
-        FormatExceptions // generating FormatExceptions for prices
+        FormatExceptions, // generating FormatExceptions for prices
+        ControlledRequest,
     }
 
     public class Program
@@ -34,7 +35,7 @@ namespace BuggyBits
 
             EnvironmentInfo.PrintDescriptionToConsole();
 
-            ParseCommandLine(args, out var timeout, out var iterations, out var scenario);
+            ParseCommandLine(args, out var timeout, out var iterations, out var scenario, out var nbIdleThreads);
 
             using (var host = CreateHostBuilder(args).Build())
             {
@@ -53,7 +54,7 @@ namespace BuggyBits
                 WriteLine($"Listening to {rootUrl}");
 
                 var cts = new CancellationTokenSource();
-                using (var selfInvoker = new SelfInvoker(cts.Token, scenario))
+                using (var selfInvoker = new SelfInvoker(cts.Token, scenario, nbIdleThreads))
                 {
                     await host.StartAsync();
 
@@ -121,12 +122,13 @@ namespace BuggyBits
                     webBuilder.UseStartup<Startup>();
                 });
 
-        private static void ParseCommandLine(string[] args, out TimeSpan timeout, out int iterations, out Scenario scenario)
+        private static void ParseCommandLine(string[] args, out TimeSpan timeout, out int iterations, out Scenario scenario, out int nbIdleThreads)
         {
             // by default, need interactive action to exit and string.Concat scenario
             timeout = TimeSpan.MinValue;
             iterations = 0;
             scenario = Scenario.StringConcat;
+            nbIdleThreads = 0;
 
             for (int i = 0; i < args.Length; i++)
             {
@@ -170,6 +172,15 @@ namespace BuggyBits
                 if ("--run-infinitely".Equals(arg, StringComparison.OrdinalIgnoreCase))
                 {
                     timeout = Timeout.InfiniteTimeSpan;
+                }
+                else
+                if ("--with-idle-threads".Equals(arg, StringComparison.OrdinalIgnoreCase))
+                {
+                    var nbThreadsArgument = i + 1;
+                    if (nbThreadsArgument >= args.Length || !int.TryParse(args[nbThreadsArgument], out nbIdleThreads))
+                    {
+                        throw new InvalidOperationException($"Invalid or missing count after --with-idle-threads");
+                    }
                 }
             }
 

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -21,8 +21,7 @@ namespace BuggyBits
         StringBuilder,   // using StringBuilder
         Parallel,        // using parallel code
         Async,           // using async code
-        FormatExceptions, // generating FormatExceptions for prices
-        ControlledRequest,
+        FormatExceptions // generating FormatExceptions for prices
     }
 
     public class Program

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -100,8 +100,6 @@ namespace BuggyBits
 
                 case Scenario.FormatExceptions:
                     return $"{rootUrl}/Products/Sales";
-                case Scenario.ControlledRequest:
-                    return $"{rootUrl}/Products/MyRequest";
             }
         }
 

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -18,12 +18,14 @@ namespace BuggyBits
         private readonly CancellationToken _exitToken;
         private readonly HttpClient _httpClient;
         private readonly Scenario _scenario;
+        private readonly int _nbIdleThreads;
 
-        public SelfInvoker(CancellationToken token, Scenario scenario)
+        public SelfInvoker(CancellationToken token, Scenario scenario, int nbIdleThreds)
         {
             _exitToken = token;
             _httpClient = new HttpClient();
             _scenario = scenario;
+            _nbIdleThreads = nbIdleThreds;
         }
 
         public void Dispose()
@@ -34,6 +36,8 @@ namespace BuggyBits
         public async Task RunAsync(string rootUrl, int iterations = 0)
         {
             Console.WriteLine($"{this.GetType().Name} started.");
+
+            CreateIdleThreads();
 
             if (_scenario == Scenario.None)
             {
@@ -67,6 +71,16 @@ namespace BuggyBits
             Console.WriteLine($"{this.GetType().Name} stopped.");
         }
 
+        private void CreateIdleThreads()
+        {
+            Console.WriteLine($"----- Creating {_nbIdleThreads} idle threads");
+
+            for (var i = 0; i < _nbIdleThreads; i++)
+            {
+                Task.Factory.StartNew(() => { _exitToken.WaitHandle.WaitOne(); }, TaskCreationOptions.LongRunning);
+            }
+        }
+
         private string GetEndpoint(string rootUrl)
         {
             switch (_scenario)
@@ -86,6 +100,8 @@ namespace BuggyBits
 
                 case Scenario.FormatExceptions:
                     return $"{rootUrl}/Products/Sales";
+                case Scenario.ControlledRequest:
+                    return $"{rootUrl}/Products/MyRequest";
             }
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows32BitStackFramesCollector.cpp
@@ -30,7 +30,6 @@ StackSnapshotResultBuffer* Windows32BitStackFramesCollector::CollectStackSampleI
 {
     // Collect data for TraceContext Tracking:
     bool traceContextDataCollected = this->TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
-    assert(traceContextDataCollected);
 
     // Now walk the stack:
     __try

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Windows64BitStackFramesCollector.cpp
@@ -181,7 +181,6 @@ StackSnapshotResultBuffer* Windows64BitStackFramesCollector::CollectStackSampleI
 {
     // Collect data for TraceContext Tracking:
     bool traceContextDataCollected = this->TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
-    assert(traceContextDataCollected);
 
     // Now walk the stack:
     CONTEXT context;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -59,6 +59,7 @@ Configuration::Configuration()
     _cpuWallTimeSamplingRate = ExtractCpuWallTimeSamplingRate();
     _walltimeThreadsThreshold = ExtractWallTimeThreadsThreshold();
     _cpuThreadsThreshold = ExtractCpuThreadsThreshold();
+    _codeHotspotsThreadsThreshold = ExtractCodeHotspotsThreadsThreshold();
     _minimumCores = GetEnvironmentValue<double>(EnvironmentVariables::CoreMinimumOverride, 1.0);
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
@@ -165,6 +166,11 @@ int32_t Configuration::WalltimeThreadsThreshold() const
 int32_t Configuration::CpuThreadsThreshold() const
 {
     return _cpuThreadsThreshold;
+}
+
+int32_t Configuration::CodeHotspotsThreadsThreshold() const
+{
+    return _codeHotspotsThreadsThreshold;
 }
 
 double Configuration::MinimumCores() const
@@ -363,6 +369,13 @@ int32_t Configuration::ExtractWallTimeThreadsThreshold()
         std::min(
             std::max(GetEnvironmentValue(EnvironmentVariables::WalltimeThreadsThreshold, 5), 5),
             64);
+    return threshold;
+}
+
+int32_t Configuration::ExtractCodeHotspotsThreadsThreshold()
+{
+    // default threads to sample for codehotspots is 20; could be changed via env vars from 5 to 64
+    int32_t threshold = std::max(GetEnvironmentValue(EnvironmentVariables::CodeHotspotsThreadsThreshold, 20), 1);
     return threshold;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -374,8 +374,8 @@ int32_t Configuration::ExtractWallTimeThreadsThreshold()
 
 int32_t Configuration::ExtractCodeHotspotsThreadsThreshold()
 {
-    // default threads to sample for codehotspots is 20; could be changed via env vars from 5 to 64
-    int32_t threshold = std::max(GetEnvironmentValue(EnvironmentVariables::CodeHotspotsThreadsThreshold, 20), 1);
+    // default threads to sample for codehotspots is 10; could be changed via env vars but down to 1ms
+    int32_t threshold = std::max(GetEnvironmentValue(EnvironmentVariables::CodeHotspotsThreadsThreshold, 10), 1);
     return threshold;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -52,6 +52,7 @@ public:
     bool IsTimestampsAsLabelEnabled() const override;
     int32_t WalltimeThreadsThreshold() const override;
     int32_t CpuThreadsThreshold() const override;
+    int32_t CodeHotspotsThreadsThreshold() const override;
     bool IsGarbageCollectionProfilingEnabled() const override;
 
 private:
@@ -72,6 +73,7 @@ private:
     static std::chrono::nanoseconds ExtractCpuWallTimeSamplingRate();
     static int32_t ExtractWallTimeThreadsThreshold();
     static int32_t ExtractCpuThreadsThreshold();
+    static int32_t ExtractCodeHotspotsThreadsThreshold();
     static bool GetContention();
 
 private:
@@ -116,6 +118,7 @@ private:
     std::chrono::nanoseconds _cpuWallTimeSamplingRate;
     int32_t _walltimeThreadsThreshold;
     int32_t _cpuThreadsThreshold;
+    int32_t _codeHotspotsThreadsThreshold;
 
     double _minimumCores;
     std::string _namedPipeName;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1108,12 +1108,14 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
     }
 
     std::shared_ptr<ManagedThreadInfo> pThreadInfo;
+    Log::Debug("Removing thread ", std::hex, threadId, " from the trace context threads list.");
     if (_pCodeHotspotThreadList->UnregisterThread(threadId, pThreadInfo))
     {
         pThreadInfo.reset();
     }
 
     if (_pManagedThreadList->UnregisterThread(threadId, pThreadInfo))
+    Log::Debug("Removing thread ", std::hex, threadId, " from the main managed thread list.");
     {
         // The docs require that we do not allow to destroy a thread while it is being stack-walked.
         // TO ensure this, SetThreadDestroyed(..) acquires the StackWalkLock associated with this ThreadInfo.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -114,6 +114,8 @@ bool CorProfilerCallback::InitializeServices()
 
     _pManagedThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
 
+    _pCodeHotspotThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
+
     auto* pRuntimeIdStore = RegisterService<RuntimeIdStore>();
 
     // Each sample contains a vector of values.
@@ -245,6 +247,7 @@ bool CorProfilerCallback::InitializeServices()
         _pClrLifetime.get(),
         _pThreadsCpuManager,
         _pManagedThreadList,
+        _pCodeHotspotThreadList,
         _pWallTimeProvider,
         _pCpuTimeProvider);
 
@@ -1104,6 +1107,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
     }
 
     std::shared_ptr<ManagedThreadInfo> pThreadInfo;
+    if (_pCodeHotspotThreadList->UnregisterThread(threadId, pThreadInfo))
+    {
+        pThreadInfo.reset();
+    }
+
     if (_pManagedThreadList->UnregisterThread(threadId, pThreadInfo))
     {
         // The docs require that we do not allow to destroy a thread while it is being stack-walked.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1114,8 +1114,8 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
         pThreadInfo.reset();
     }
 
-    if (_pManagedThreadList->UnregisterThread(threadId, pThreadInfo))
     Log::Debug("Removing thread ", std::hex, threadId, " from the main managed thread list.");
+    if (_pManagedThreadList->UnregisterThread(threadId, pThreadInfo))
     {
         // The docs require that we do not allow to destroy a thread while it is being stack-walked.
         // TO ensure this, SetThreadDestroyed(..) acquires the StackWalkLock associated with this ThreadInfo.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -345,6 +345,7 @@ bool CorProfilerCallback::DisposeServices()
     _pThreadsCpuManager = nullptr;
     _pStackSamplerLoopManager = nullptr;
     _pManagedThreadList = nullptr;
+    _pCodeHotspotThreadList = nullptr;
     _pApplicationStore = nullptr;
 
     return result;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -114,7 +114,7 @@ bool CorProfilerCallback::InitializeServices()
 
     _pManagedThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
 
-    _pCodeHotspotThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
+    _pCodeHotspotsThreadList = RegisterService<ManagedThreadList>(_pCorProfilerInfo);
 
     auto* pRuntimeIdStore = RegisterService<RuntimeIdStore>();
 
@@ -247,7 +247,7 @@ bool CorProfilerCallback::InitializeServices()
         _pClrLifetime.get(),
         _pThreadsCpuManager,
         _pManagedThreadList,
-        _pCodeHotspotThreadList,
+        _pCodeHotspotsThreadList,
         _pWallTimeProvider,
         _pCpuTimeProvider);
 
@@ -345,7 +345,7 @@ bool CorProfilerCallback::DisposeServices()
     _pThreadsCpuManager = nullptr;
     _pStackSamplerLoopManager = nullptr;
     _pManagedThreadList = nullptr;
-    _pCodeHotspotThreadList = nullptr;
+    _pCodeHotspotsThreadList = nullptr;
     _pApplicationStore = nullptr;
 
     return result;
@@ -1109,7 +1109,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
 
     std::shared_ptr<ManagedThreadInfo> pThreadInfo;
     Log::Debug("Removing thread ", std::hex, threadId, " from the trace context threads list.");
-    if (_pCodeHotspotThreadList->UnregisterThread(threadId, pThreadInfo))
+    if (_pCodeHotspotsThreadList->UnregisterThread(threadId, pThreadInfo))
     {
         // The docs require that we do not allow to destroy a thread while it is being stack-walked.
         // TO ensure this, SetThreadDestroyed(..) acquires the StackWalkLock associated with this ThreadInfo.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -182,7 +182,7 @@ public:
 public:
     IThreadsCpuManager* GetThreadsCpuManager() { return _pThreadsCpuManager; }
     IManagedThreadList* GetManagedThreadList() { return _pManagedThreadList; }
-    IManagedThreadList* GetCodeHotspotThreadList() { return _pCodeHotspotThreadList; }
+    IManagedThreadList* GetCodeHotspotThreadList() { return _pCodeHotspotsThreadList; }
     IStackSamplerLoopManager* GetStackSamplerLoopManager() { return _pStackSamplerLoopManager; }
     IApplicationStore* GetApplicationStore() { return _pApplicationStore; }
     IExporter* GetExporter() { return _pExporter.get(); }
@@ -205,7 +205,7 @@ private :
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     IStackSamplerLoopManager* _pStackSamplerLoopManager = nullptr;
     IManagedThreadList* _pManagedThreadList = nullptr;
-    IManagedThreadList* _pCodeHotspotThreadList = nullptr;
+    IManagedThreadList* _pCodeHotspotsThreadList = nullptr;
     IApplicationStore* _pApplicationStore = nullptr;
     ExceptionsProvider* _pExceptionsProvider = nullptr;
     WallTimeProvider* _pWallTimeProvider = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -182,6 +182,7 @@ public:
 public:
     IThreadsCpuManager* GetThreadsCpuManager() { return _pThreadsCpuManager; }
     IManagedThreadList* GetManagedThreadList() { return _pManagedThreadList; }
+    IManagedThreadList* GetCodeHotspotThreadList() { return _pCodeHotspotThreadList; }
     IStackSamplerLoopManager* GetStackSamplerLoopManager() { return _pStackSamplerLoopManager; }
     IApplicationStore* GetApplicationStore() { return _pApplicationStore; }
     IExporter* GetExporter() { return _pExporter.get(); }
@@ -204,6 +205,7 @@ private :
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     IStackSamplerLoopManager* _pStackSamplerLoopManager = nullptr;
     IManagedThreadList* _pManagedThreadList = nullptr;
+    IManagedThreadList* _pCodeHotspotThreadList = nullptr;
     IApplicationStore* _pApplicationStore = nullptr;
     ExceptionsProvider* _pExceptionsProvider = nullptr;
     WallTimeProvider* _pWallTimeProvider = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -43,6 +43,7 @@ public:
     inline static const shared::WSTRING CpuWallTimeSamplingRate     = WStr("DD_INTERNAL_PROFILING_SAMPLING_RATE");
     inline static const shared::WSTRING WalltimeThreadsThreshold    = WStr("DD_INTERNAL_PROFILING_WALLTIME_THREADS_THRESHOLD");
     inline static const shared::WSTRING CpuTimeThreadsThreshold     = WStr("DD_INTERNAL_PROFILING_CPUTIME_THREADS_THRESHOLD");
+    inline static const shared::WSTRING CodeHotspotsThreadsThreshold = WStr("DD_INTERNAL_PROFILING_CODEHOTSPOTS_THREADS_THRESHOLD");
     inline static const shared::WSTRING TimestampsAsLabelEnabled    = WStr("DD_INTERNAL_PROFILING_TIMESTAMPS_AS_LABEL_ENABLED");
     inline static const shared::WSTRING ProfilesOutputDir           = WStr("DD_INTERNAL_PROFILING_OUTPUT_DIR");
     inline static const shared::WSTRING DevelopmentConfiguration    = WStr("DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -49,5 +49,6 @@ public:
     virtual bool IsTimestampsAsLabelEnabled() const = 0;
     virtual int32_t WalltimeThreadsThreshold() const = 0;
     virtual int32_t CpuThreadsThreshold() const = 0;
+    virtual int32_t CodeHotspotsThreadsThreshold() const = 0;
     virtual bool IsGarbageCollectionProfilingEnabled() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -14,7 +14,7 @@ class IManagedThreadList : public IService
 {
 public:
     virtual bool GetOrCreateThread(ThreadID clrThreadId) = 0;
-    virtual bool RegisterThread(ManagedThreadInfo* pThreadInfo) = 0;
+    virtual bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) = 0;
     virtual bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
     virtual bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) = 0;
     virtual bool SetThreadName(ThreadID clrThreadId, const shared::WSTRING& threadName) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -14,6 +14,7 @@ class IManagedThreadList : public IService
 {
 public:
     virtual bool GetOrCreateThread(ThreadID clrThreadId) = 0;
+    virtual bool RegisterThread(ManagedThreadInfo* pThreadInfo) = 0;
     virtual bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
     virtual bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) = 0;
     virtual bool SetThreadName(ThreadID clrThreadId, const shared::WSTRING& threadName) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -77,6 +77,7 @@ public:
     inline std::uint64_t GetLocalRootSpanId() const;
     inline std::uint64_t GetSpanId() const;
     inline bool CanReadTraceContext() const;
+    inline bool HasTraceContext() const;
 
     inline std::string GetProfileThreadId();
     inline std::string GetProfileThreadName();
@@ -357,4 +358,16 @@ inline bool ManagedThreadInfo::CanReadTraceContext() const
     // On Arm the __sync_synchronize is generated.
     std::atomic_thread_fence(std::memory_order_acquire);
     return canReadTraceContext == 0;
+}
+
+inline bool ManagedThreadInfo::HasTraceContext() const
+{
+    if (CanReadTraceContext())
+    {
+        std::uint64_t localRootSpanId = GetLocalRootSpanId();
+        std::uint64_t spanId = GetSpanId();
+
+        return localRootSpanId != 0 && spanId != 0;
+    }
+    return false;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -151,7 +151,7 @@ bool ManagedThreadList::UnregisterThread(ThreadID clrThreadId, std::shared_ptr<M
         pos++;
     }
 
-    Log::Error("ManagedThreadList: thread ", std::dec, clrThreadId, "cannot be unregister because not in the list");
+    Log::Debug("ManagedThreadList: thread ", std::dec, clrThreadId, " cannot be unregister because not in the list");
     return false;
 }
 
@@ -374,10 +374,9 @@ std::shared_ptr<ManagedThreadInfo> ManagedThreadList::FindByClrId(ThreadID clrTh
     }
 }
 
-bool ManagedThreadList::RegisterThread(ManagedThreadInfo* pThreadInfo)
+bool ManagedThreadList::RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo)
 {
     std::lock_guard<std::recursive_mutex> lock(_mutex);
-    pThreadInfo->AddRef();
 
     auto it = _lookupByClrThreadId.find(pThreadInfo->GetClrThreadId());
     if (it == _lookupByClrThreadId.cend())
@@ -391,6 +390,5 @@ bool ManagedThreadList::RegisterThread(ManagedThreadInfo* pThreadInfo)
         return true;
     }
 
-    pThreadInfo->Release();
     return false;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -131,7 +131,7 @@ bool ManagedThreadList::UnregisterThread(ThreadID clrThreadId, std::shared_ptr<M
     uint32_t pos = 0;
     for (auto i = _threads.begin(); i != _threads.end(); ++i)
     {
-        auto pInfo = *i;
+        std::shared_ptr<ManagedThreadInfo> pInfo = *i; // make a copy so it can be moved later
         if (pInfo->GetClrThreadId() == clrThreadId)
         {
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -373,3 +373,24 @@ std::shared_ptr<ManagedThreadInfo> ManagedThreadList::FindByClrId(ThreadID clrTh
         return elem->second;
     }
 }
+
+bool ManagedThreadList::RegisterThread(ManagedThreadInfo* pThreadInfo)
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    pThreadInfo->AddRef();
+
+    auto it = _lookupByClrThreadId.find(pThreadInfo->GetClrThreadId());
+    if (it == _lookupByClrThreadId.cend())
+    {
+        // not registered yet
+
+        _threads.push_back(pThreadInfo);
+        _lookupByClrThreadId[pThreadInfo->GetClrThreadId()] = pThreadInfo;
+        _lookupByProfilerThreadInfoId[pThreadInfo->GetProfilerThreadInfoId()] = pThreadInfo;
+
+        return true;
+    }
+
+    pThreadInfo->Release();
+    return false;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -31,7 +31,7 @@ public:
     bool Start() override;
     bool Stop() override;
     bool GetOrCreateThread(ThreadID clrThreadId) override;
-    bool RegisterThread(ManagedThreadInfo* pThreadInfo) override;
+    bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) override;
     bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
     bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) override;
     bool SetThreadName(ThreadID clrThreadId, const shared::WSTRING& threadName) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -31,6 +31,7 @@ public:
     bool Start() override;
     bool Stop() override;
     bool GetOrCreateThread(ThreadID clrThreadId) override;
+    bool RegisterThread(ManagedThreadInfo* pThreadInfo) override;
     bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
     bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) override;
     bool SetThreadName(ThreadID clrThreadId, const shared::WSTRING& threadName) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -384,3 +384,12 @@ bool OpSysTools::IsSafeToStartProfiler(double coresThreshold)
 
 #endif
 }
+
+void OpSysTools::Sleep(std::chrono::nanoseconds duration)
+{
+#ifdef _WINDOWS
+    ::Sleep(static_cast<DWORD>(duration.count() / 1000000));
+#else
+    usleep(duration.count() / 1000);
+#endif
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -72,6 +72,8 @@ public:
     static bool IsSafeToStartProfiler(double coresThreshold);
     static std::int64_t GetHighPrecisionTimestamp();
 
+    static void Sleep(std::chrono::nanoseconds duration);
+
 private:
     static constexpr std::int64_t NanosecondsPerSecond = 1000000000;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/PInvoke.cpp
@@ -71,6 +71,8 @@ extern "C" void* __stdcall GetPointerToNativeTraceContext()
         return nullptr;
     }
 
+    profiler->GetCodeHotspotThreadList()->RegisterThread(pCurrentThreadInfo);
+
     // Get pointers to the relevant fields within the thread info data structure.
     return pCurrentThreadInfo->GetTraceContextPointer();
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -201,6 +201,7 @@ void StackSamplerLoop::WalltimeProfilingIteration()
 
         if (firstThread == _targetThread.get())
         {
+            _targetThread.reset();
             break;
         }
 
@@ -212,6 +213,7 @@ void StackSamplerLoop::WalltimeProfilingIteration()
         // skip thread if it has a trace context
         if (_targetThread->HasTraceContext())
         {
+            _targetThread.reset();
             continue;
         }
 
@@ -221,10 +223,6 @@ void StackSamplerLoop::WalltimeProfilingIteration()
 
         CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, duration, PROFILING_TYPE::WallTime);
 
-        // LoopNext() calls AddRef() on the threadInfo before returning it.
-        // This is because it needs to happen under the managedThreads's internal lock
-        // so that a concurrently dying thread cannot delete our threadInfo while we
-        // are just about to start processing it.
         _targetThread.reset();
         i++;
 
@@ -297,6 +295,7 @@ void StackSamplerLoop::CodeHotspotIteration()
         // keep track of the first seen thread, to avoid infinite loop
         if (firstThread == _targetThread.get())
         {
+            _targetThread.reset();
             break;
         }
 
@@ -308,6 +307,7 @@ void StackSamplerLoop::CodeHotspotIteration()
         // skip if it has no trace context
         if (!_targetThread->HasTraceContext())
         {
+            _targetThread.reset();
             continue;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -50,6 +50,7 @@ public:
         StackSamplerLoopManager* pManager,
         IThreadsCpuManager* pThreadsCpuManager,
         IManagedThreadList* pManagedThreadList,
+        IManagedThreadList* pCodeHotspotThreadList,
         ICollector<RawWallTimeSample>* pWallTimeCollector,
         ICollector<RawCpuSample>* pCpuTimeCollector
         );
@@ -67,6 +68,7 @@ private:
     IConfiguration* _pConfiguration;
     IThreadsCpuManager* _pThreadsCpuManager;
     IManagedThreadList* _pManagedThreadList;
+    IManagedThreadList* _pCodeHotspotThreadList;
     ICollector<RawWallTimeSample>* _pWallTimeCollector;
     ICollector<RawCpuSample>* _pCpuTimeCollector;
 
@@ -76,6 +78,7 @@ private:
     std::shared_ptr<ManagedThreadInfo> _targetThread;
     uint32_t _iteratorWallTime;
     uint32_t _iteratorCpuTime;
+    uint32_t _iteratorCodeHotspot;
     int32_t _walltimeThreadsThreshold;
     int32_t _cpuThreadsThreshold;
 
@@ -88,11 +91,12 @@ private:
     std::chrono::nanoseconds _samplingPeriod;
 
 private:
-    void MainLoop(void);
-    void WaitOnePeriod(void);
-    void MainLoopIteration(void);
-    void CpuProfilingIteration(void);
-    void WalltimeProfilingIteration(void);
+    void MainLoop();
+    void WaitOnePeriod();
+    void MainLoopIteration();
+    void CpuProfilingIteration();
+    void WalltimeProfilingIteration();
+    void CodeHotspotIteration();
     void CollectOneThreadStackSample(std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
                                      int64_t thisSampleTimestampNanosecs,
                                      int64_t duration,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -68,7 +68,7 @@ private:
     IConfiguration* _pConfiguration;
     IThreadsCpuManager* _pThreadsCpuManager;
     IManagedThreadList* _pManagedThreadList;
-    IManagedThreadList* _pCodeHotspotThreadList;
+    IManagedThreadList* _pCodeHotspotsThreadList;
     ICollector<RawWallTimeSample>* _pWallTimeCollector;
     ICollector<RawCpuSample>* _pCpuTimeCollector;
 
@@ -81,6 +81,7 @@ private:
     uint32_t _iteratorCodeHotspot;
     int32_t _walltimeThreadsThreshold;
     int32_t _cpuThreadsThreshold;
+    int32_t _codeHotspotsThreadsThreshold;
 
 private:
     std::unordered_map<HRESULT, uint64_t> _encounteredStackSnapshotHRs;
@@ -92,7 +93,6 @@ private:
 
 private:
     void MainLoop();
-    void WaitOnePeriod();
     void MainLoopIteration();
     void CpuProfilingIteration();
     void WalltimeProfilingIteration();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -53,7 +53,7 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _pClrLifetime{clrLifetime},
     _pThreadsCpuManager{pThreadsCpuManager},
     _pManagedThreadList{pManagedThreadList},
-    _pCodeHotspotThreadList{pCodeHotspotThreadList},
+    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
     _pWallTimeCollector{pWallTimeCollector},
     _pCpuTimeCollector{pCpuTimeCollector},
     _deadlockInterventionInProgress{0}
@@ -120,7 +120,7 @@ void StackSamplerLoopManager::RunStackSampling()
             this,
             _pThreadsCpuManager,
             _pManagedThreadList,
-            _pCodeHotspotThreadList,
+            _pCodeHotspotsThreadList,
             _pWallTimeCollector,
             _pCpuTimeCollector
             );

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -30,6 +30,7 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     IClrLifetime const* clrLifetime,
     IThreadsCpuManager* pThreadsCpuManager,
     IManagedThreadList* pManagedThreadList,
+    IManagedThreadList* pCodeHotspotThreadList,
     ICollector<RawWallTimeSample>* pWallTimeCollector,
     ICollector<RawCpuSample>* pCpuTimeCollector
     ) :
@@ -52,6 +53,7 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _pClrLifetime{clrLifetime},
     _pThreadsCpuManager{pThreadsCpuManager},
     _pManagedThreadList{pManagedThreadList},
+    _pCodeHotspotThreadList{pCodeHotspotThreadList},
     _pWallTimeCollector{pWallTimeCollector},
     _pCpuTimeCollector{pCpuTimeCollector},
     _deadlockInterventionInProgress{0}
@@ -118,6 +120,7 @@ void StackSamplerLoopManager::RunStackSampling()
             this,
             _pThreadsCpuManager,
             _pManagedThreadList,
+            _pCodeHotspotThreadList,
             _pWallTimeCollector,
             _pCpuTimeCollector
             );

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -74,6 +74,7 @@ public:
         IClrLifetime const* clrLifetime,
         IThreadsCpuManager* pThreadsCpuManager,
         IManagedThreadList* pManagedThreadList,
+        IManagedThreadList* pCodeHotspotThreadList,
         ICollector<RawWallTimeSample>* pWallTimeCollector,
         ICollector<RawCpuSample>* pCpuTimeCollector
         );
@@ -194,6 +195,7 @@ private:
     IConfiguration* _pConfiguration = nullptr;
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     IManagedThreadList* _pManagedThreadList = nullptr;
+    IManagedThreadList* _pCodeHotspotThreadList = nullptr;
     ICollector<RawWallTimeSample>* _pWallTimeCollector = nullptr;
     ICollector<RawCpuSample>* _pCpuTimeCollector = nullptr;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -195,7 +195,7 @@ private:
     IConfiguration* _pConfiguration = nullptr;
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     IManagedThreadList* _pManagedThreadList = nullptr;
-    IManagedThreadList* _pCodeHotspotThreadList = nullptr;
+    IManagedThreadList* _pCodeHotspotsThreadList = nullptr;
     ICollector<RawWallTimeSample>* _pWallTimeCollector = nullptr;
     ICollector<RawCpuSample>* _pCpuTimeCollector = nullptr;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -34,7 +34,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
         [TestAppFact("Samples.BuggyBits")]
         public void CheckTraceContextAreAttachedForWalltimeProfilerHumberOfThreads(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 6 --with-idle-threads 1000");
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 6 --with-idle-threads 500");
             // By default, the codehotspot feature is activated
 
             runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "1");

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -54,6 +54,7 @@ public:
     MOCK_METHOD(bool, IsTimestampsAsLabelEnabled, (), (const override));
     MOCK_METHOD(int32_t, WalltimeThreadsThreshold, (), (const override));
     MOCK_METHOD(int32_t, CpuThreadsThreshold, (), (const override));
+    MOCK_METHOD(int32_t, CodeHotspotsThreadsThreshold, (), (const override));
     MOCK_METHOD(bool, IsGarbageCollectionProfilingEnabled, (), (const override));
 };
 


### PR DESCRIPTION
## Summary of changes

Improve Code Hotspots feature.

## Reason for change

We got feedback from customer where spans lasting for 100ms did not have associated callstacks.

## Implementation details

There are 2 main changes:
- Algorithm: we maintain a separate list of threads that has/had a trace context. So each iteration we start collecting threads from this list first (checking that they currently have trace context). By default we will collect 20 threads, this will incur a 4ms-overhead but allows us to reduce the chance to lose 100ms requests.
Then we collect 5 threads (like before) that do not currently have a trace context attached.

- Technical: Before we were using `std::this_thread::sleep_for` but this sleep api does not use a high resolution clock, so we ended up sleeping for longer than expected: For example, we asked to sleep for 9ms, it turned out that we were sleeping for 115ms. Instead we will use `::Sleep` on windows and `usleep` on Linux

## Test coverage

Add a new test where we have only one thread that handles request and 500 idle threads. 

## Other details
<!-- Fixes #{issue} -->
