### PR TITLE
[Tracer] Versions conflicts tests are back

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -19,11 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
         }
 
-#if NET7_0
-        [SkippableFact(Skip = "Flaky in .NET 7 on linux")]
-#else
         [SkippableFact]
-#endif
         public void SubmitTraces()
         {
             // 1 manual span + 2 http spans

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  
+
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.255.246" />
+    <PackageReference Include="Datadog.Trace" Version="255.1.4-dev2.20.0-build01-net7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

Uploaded a new nuget from master. 

## Reason for change

Test all the things

## Implementation details

As a reminder the procedure is written [here](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2258142437/CI+Devops#Add-a-new-nuget-version-to-the-public-feed)

## Test coverage
It's been run in the associated pipeline, as you can see in this wonderful [CI Visibility app](https://ddstaging.datadoghq.com/ci/test-commit/github.com%2FDataDog%2Fdd-trace-dotnet/dd-trace-dotnet/pierre%2Fversion-conflict-net7/0273adf7ab567c447c9ebe9fd3190ff1ea05ff0d?query=env%3Aci%20%40git.repository.id%3A%22github.com%2FDataDog%2Fdd-trace-dotnet%22%20%40test.service%3Add-trace-dotnet%20%40git.branch%3A%22pierre%2Fversion-conflict-net7%22%20%40git.commit.sha%3A0273adf7ab567c447c9ebe9fd3190ff1ea05ff0d%20test_level%3Atest%20%40test.suite%3ADatadog.Trace.ClrProfiler.IntegrationTests.VersionConflict.VersionConflict2xTests&currentTab=trace&env=ci&index=citest&spanViewType=metadata&start=1666646566778&end=1669238566778&paused=false)

## Other details
<!-- Fixes #{issue} -->
