### PR TITLE
[Profiler] Fix Windows Throughput tests

### DIFF
--- a/profiler/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/profiler/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -63,6 +63,24 @@ scenarios:
         serverPort: 5000
         path: /hello
 
+  profiler_walltime:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_PROFILING_ENABLED: 1
+        COMPlus_EnableDiagnostics: 1
+        DD_PROFILING_WALLTIME_ENABLED: 1
+        DD_PROFILING_CPU_ENABLED: 0
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello
+
   profiler_exceptions:
     application:
       job: server
@@ -87,6 +105,7 @@ scenarios:
         COR_ENABLE_PROFILING: 1
         CORECLR_ENABLE_PROFILING: 1
         DD_PROFILING_ENABLED: 1
+        DD_PROFILING_WALLTIME_ENABLED: 0
         DD_PROFILING_CPU_ENABLED: 1
         COMPlus_EnableDiagnostics: 1
     load:

--- a/profiler/build/crank/os.profiles.yml
+++ b/profiler/build/crank/os.profiles.yml
@@ -12,11 +12,10 @@ profiles:
           - "{{ windowsEndpoint }}"
         environmentVariables:
           COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\Datadog.AutoInstrumentation.NativeLoader.x64.dll"
+          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\Datadog.AutoInstrumentation.NativeLoader.x64.dll"
-          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\tracer"
-          DD_DOTNET_PROFILER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\continousprofiler"
+          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\monitoring-home-windows"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_ENABLED: 0
@@ -41,7 +40,6 @@ profiles:
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
           CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/monitoring-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
           DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/monitoring-home-linux"
-          DD_DOTNET_PROFILER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/monitoring-home-linux/linux-x64"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_ENABLED: 0

--- a/profiler/build/crank/run.sh
+++ b/profiler/build/crank/run.sh
@@ -38,6 +38,10 @@ if [ "$1" = "windows" ]; then
     dd-trace --crank-import="profiler_windows.json"
     rm profiler_windows.json
 
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_walltime --profile windows --json profiler_windows_walltime.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_walltime --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="profiler_windows_walltime.json"
+    rm profiler_windows_walltime.json
+
     crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_exceptions_baseline --profile windows --json profiler_exceptions_baseline_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_exceptions_baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="profiler_exceptions_baseline_windows.json"
     rm profiler_exceptions_baseline_windows.json


### PR DESCRIPTION
## Summary of changes

Fix windows throughput tests.

## Reason for change

They are broken: profiler is not correctly attached since the package layout changes.

## Other

I took the opportunity to also adjust cpu test because it was containing walltime too, and I added walltime scenario
