### PR TITLE
[Dynamic Instrumentation] Gracefully ignore byref-like types + Added TypeRef to TypeDef resolution functionality

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -571,11 +571,31 @@ struct FunctionInfo
         method_signature(method_signature)
     {
     }
-
+    
     bool IsValid() const
     {
         return id != 0;
     }
+};
+
+struct GenericTypeProps
+{
+private:
+    PCCOR_SIGNATURE pbBase;
+    ULONG len;
+
+public:
+    unsigned char SpecElementType = 0; // Element type of the TypeSpec. e.g GENERICINST, VAR, MVAR, SZARRAY etc.
+    mdToken OpenTypeToken = mdTokenNil; // Token of the open generic type, can be TypeDef or TypeRef. In any case except CLASS or VALUETYPE, this will be mdTokenNil.
+    unsigned char GenericElementType = 0; // Element type of the generic type, can be any valid element type. e.g. OBJECT, CLASS, VALUETYPE etc.
+    unsigned ParamsCount = 0; // Number of generic type args. e.g. GenericClass<T,V> params count will be 2.
+    unsigned IndexOfFirstParam = 0; // Index (the offset in signature) of the first generic parameter type.
+    unsigned ParamPosition = 0; // For VAR and MVAR will be the number in the generic type parameters.
+    std::vector<std::tuple<PCCOR_SIGNATURE, ULONG, unsigned char>> ParamsSignature; // Collection of tuple(signature, length) for each generic parameter type.
+    
+    GenericTypeProps(PCCOR_SIGNATURE pb, ULONG len) : pbBase(pb), len(len){}
+
+    HRESULT TryParse();
 };
 
 RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info);

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -603,6 +603,16 @@ bool FindTypeDefByName(const shared::WSTRING& instrumentationTargetMethodTypeNam
                        const ComPtr<IMetaDataImport2>& metadata_import, mdTypeDef& typeDef);
 
 HRESULT HasAsyncStateMachineAttribute(const ComPtr<IMetaDataImport2>& metadataImport, const mdMethodDef methodDefToken, bool& hasAsyncAttribute);
+HRESULT IsByRefLike(const ComPtr<IMetaDataImport2>& metadataImport, const mdTypeDef typeDefToken, bool& hasByRefLikeAttribute);
+HRESULT ResolveTypeInternal(ICorProfilerInfo4* info, const std::vector<ModuleID>& loadedModules,
+                            const std::vector<WCHAR>& refTypeName,
+                            const mdToken parentToken, const shared::WSTRING& resolutionScopeName,
+                            mdTypeDef& resolvedTypeDefToken, ComPtr<IMetaDataImport2>& resolvedTypeDefMetadataImport);
+HRESULT ResolveType(ICorProfilerInfo4* info, const ComPtr<IMetaDataImport2>& metadata_import,
+                    const ComPtr<IMetaDataAssemblyImport>& assembly_import,
+                    const mdTypeRef typeRefToken, mdTypeDef& resolvedTypeDefToken,
+                    ComPtr<IMetaDataImport2>& resolvedMetadataImport);
+
 } // namespace trace
 
 #endif // DD_CLR_PROFILER_CLR_HELPERS_H_

--- a/tracer/src/Datadog.Tracer.Native/debugger_members.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_members.h
@@ -141,7 +141,7 @@ struct ProbeMetadata
 {
     shared::WSTRING probeId;
     std::set<trace::MethodIdentifier> methods;
-    ProbeStatus status;
+    ProbeStatus status = ProbeStatus::RECEIVED;
 
     ProbeMetadata() = default;
     ProbeMetadata(const ProbeMetadata& other) = default;

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -857,7 +857,7 @@ HRESULT DebuggerMethodRewriter::EndAsyncMethodProbe(CorProfiler* corProfiler,
                 rewriterWrapper.LoadNull(); // return value
                 auto emit = module_metadata.metadata_emit;
                 auto returnTypeToken = methodReturnType->GetTypeTok(emit, debuggerTokens->GetCorLibAssemblyRef());
-                if (returnTypeToken == mdTokenNil || !module_metadata.IsTypeSpecTokenSane(returnTypeToken))
+                if (returnTypeToken == mdTokenNil)
                 {
                     Logger::Error("Fail to get return type token. Element type is  ", elementType, " Method is: ", caller->type.name, ".", caller->name);
                     return E_FAIL;
@@ -1273,7 +1273,6 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     bool isStatic = !(caller->method_signature.CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS);
     std::vector<TypeSignature> methodArguments = caller->method_signature.GetMethodArguments();
     int numArgs = caller->method_signature.NumberOfArguments();
-    module_metadata.EnsureInitSanityTypeSpecToken();
 
     if (retTypeFlags & TypeFlagByRef || caller->name == WStr(".ctor") || caller->name == WStr(".cctor"))
     {

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -108,14 +108,13 @@ HRESULT DebuggerMethodRewriter::WriteCallsToLogArgOrLocal(
         bool isTypeIsByRefLike = false;
         const auto argOrLocalTok = argOrLocal.GetTypeTok(emit, debuggerTokens->GetCorLibAssemblyRef());
         HRESULT hr = IsTypeByRefLike(moduleMetadata, argOrLocalTok,isTypeIsByRefLike);
+
         if (FAILED(hr))
         {
             Logger::Warn("DebuggerRewriter: Failed to determine if ", isArgs ? "argument" : "local", " index = ", argOrLocalIndex,
                          " is By-Ref like.");
-            continue;
         }
-
-        if (isTypeIsByRefLike)
+        else if (isTypeIsByRefLike)
         {
             Logger::Warn("DebuggerRewriter: Skipped ", isArgs ? "argument" : "local",
                          " index = ", argOrLocalIndex, " because it's By-Ref like.");
@@ -1385,9 +1384,11 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
         const auto methodReturnTypeTok = methodReturnType.GetTypeTok(emit, debuggerTokens->GetCorLibAssemblyRef());
         hr = IsTypeByRefLike(module_metadata, methodReturnTypeTok, isTypeIsByRefLike);
 
-        IfFailRet(hr);
-
-        if (isTypeIsByRefLike)
+        if (FAILED(hr))
+        {
+            Logger::Warn("DebuggerRewriter: Failed to determine if the return value is By-Ref like.");
+        }
+        else if (isTypeIsByRefLike)
         {
             return E_NOTIMPL;
         }
@@ -1396,9 +1397,11 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     bool isTypeIsByRefLike = false;
     hr = IsTypeByRefLike(module_metadata, caller->type.id, isTypeIsByRefLike);
 
-    IfFailRet(hr);
-
-    if (isTypeIsByRefLike)
+    if (FAILED(hr))
+    {
+        Logger::Warn("DebuggerRewriter: Failed to determine if the type we are instrumenting is By-Ref like.");
+    }
+    else if (isTypeIsByRefLike)
     {
         return E_NOTIMPL;
     }
@@ -1563,8 +1566,9 @@ HRESULT DebuggerMethodRewriter::IsTypeByRefLike(
 
     if (!IsTokenSane(typeDefOrRefOrSpecToken))
     {
+        // Do nothing for now.
         isTypeIsByRefLike = false;
-        return E_FAIL;
+        return S_OK;
     }
 
     // Get open type from type spec
@@ -1590,7 +1594,7 @@ HRESULT DebuggerMethodRewriter::IsTypeByRefLike(
         {
             // For now we ignore issues with resolving types.
             isTypeIsByRefLike = false;
-            return E_FAIL;
+            return S_OK;
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -1373,8 +1373,8 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
 
     if (!isAsyncMethod)
     {
-        // Async methods can't have Task<T> where T is byref like, because byref like can't exist as a generic param.
-        // thus we only perform this check here.
+        // In async methods, the return value can't be byref-like (it can't be Task<T> where T is byref-like, because
+        // byref-like can't exist as a generic param). Therefore, we only need to worry about non-async methods.
         auto emit = module_metadata.metadata_emit;
         bool isTypeIsByRefLike = false;
         const auto methodReturnTypeTok = methodReturnType.GetTypeTok(emit, debuggerTokens->GetCorLibAssemblyRef());

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -87,7 +87,9 @@ private:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
                                                         MethodProbeDefinitions& methodProbes,
                                                         LineProbeDefinitions& lineProbes) const;
-    static HRESULT IsTypeByRefLike(ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
+    static HRESULT IsTypeByRefLike(ModuleMetadata& module_metadata, const TypeSignature& typeSig, const mdAssemblyRef& corLibAssemblyRef,
+                                   bool& isTypeIsByRefLike);
+    static HRESULT IsTypeTokenByRefLike(ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
     static std::vector<ILInstr*> GetBranchTargets(ILRewriter* pRewriter);
     static void AdjustBranchTargets(ILInstr* pFromInstr, ILInstr* pToInstr, const std::vector<ILInstr*>& branchTargets);
     static void AdjustExceptionHandlingClauses(ILInstr* pFromInstr, ILInstr* pToInstr, ILRewriter* pRewriter);

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -17,8 +17,6 @@ class DebuggerMethodRewriter : public MethodRewriter, public shared::Singleton<D
     friend class shared::Singleton<DebuggerMethodRewriter>;
 
 private:
-    const PCCOR_SIGNATURE NullSignature = nullptr;
-
     DebuggerMethodRewriter(){}
 
     // Holds incremental index that is used on the managed side for grabbing an InstrumentedMethodInfo instance (per instrumented method)
@@ -69,7 +67,7 @@ private:
                           ULONG returnValueIndex, mdToken callTargetReturnToken, ILInstr* firstInstruction,
                              int instrumentedMethodIndex, ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
     static HRESULT EndAsyncMethodProbe(CorProfiler* corProfiler, ILRewriterWrapper& rewriterWrapper,
-                                       ModuleMetadata& moduleMetadata,
+                                       ModuleMetadata& module_metadata,
                                        DebuggerTokens* debuggerTokens, FunctionInfo* caller, bool isStatic, TypeSignature* methodReturnType,
                                        const std::vector<TypeSignature>& methodLocals, int numLocals, ULONG callTargetStateIndex,
                                        ULONG callTargetReturnIndex, std::vector<EHClause>& newClauses,
@@ -89,8 +87,7 @@ private:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
                                                         MethodProbeDefinitions& methodProbes,
                                                         LineProbeDefinitions& lineProbes) const;
-    static bool IsTokenSane(mdToken token);
-    static HRESULT IsTypeByRefLike(const ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
+    static HRESULT IsTypeByRefLike(ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
     static std::vector<ILInstr*> GetBranchTargets(ILRewriter* pRewriter);
     static void AdjustBranchTargets(ILInstr* pFromInstr, ILInstr* pToInstr, const std::vector<ILInstr*>& branchTargets);
     static void AdjustExceptionHandlingClauses(ILInstr* pFromInstr, ILInstr* pToInstr, ILRewriter* pRewriter);

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -17,6 +17,8 @@ class DebuggerMethodRewriter : public MethodRewriter, public shared::Singleton<D
     friend class shared::Singleton<DebuggerMethodRewriter>;
 
 private:
+    const PCCOR_SIGNATURE NullSignature = nullptr;
+
     DebuggerMethodRewriter(){}
 
     // Holds incremental index that is used on the managed side for grabbing an InstrumentedMethodInfo instance (per instrumented method)
@@ -29,16 +31,16 @@ private:
                                 const TypeSignature& argument);
     static HRESULT LoadLocal(CorProfiler* corProfiler, const ILRewriterWrapper& rewriterWrapper, int localIndex,
                              const TypeSignature& argument);
-    static HRESULT WriteCallsToLogArgOrLocal(CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
+    static HRESULT WriteCallsToLogArgOrLocal(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
                                         const std::vector<TypeSignature>& methodArgsOrLocals, int numArgsOrLocals,
                                         ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
                                              ILInstr** beginCallInstruction, bool isArgs, ProbeType probeType);
-    static HRESULT WriteCallsToLogArg(CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
+    static HRESULT WriteCallsToLogArg(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
                                 const std::vector<TypeSignature>& args, int numArgs, ILRewriterWrapper& rewriterWrapper,
                                 ULONG callTargetStateIndex,
                                 ILInstr** beginCallInstruction,
                                 ProbeType probeType);
-    static HRESULT WriteCallsToLogLocal(CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
+    static HRESULT WriteCallsToLogLocal(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
                                   const std::vector<TypeSignature>& locals, int numLocals,
                                   ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
                                         ILInstr** beginCallInstruction, ProbeType probeType);
@@ -87,6 +89,8 @@ private:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
                                                         MethodProbeDefinitions& methodProbes,
                                                         LineProbeDefinitions& lineProbes) const;
+    static bool IsTokenSane(mdToken token);
+    static HRESULT IsTypeByRefLike(const ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
     static std::vector<ILInstr*> GetBranchTargets(ILRewriter* pRewriter);
     static void AdjustBranchTargets(ILInstr* pFromInstr, ILInstr* pToInstr, const std::vector<ILInstr*>& branchTargets);
     static void AdjustExceptionHandlingClauses(ILInstr* pFromInstr, ILInstr* pToInstr, ILRewriter* pRewriter);

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.cpp
@@ -776,7 +776,7 @@ bool ILRewriter::IsLoadLocalDirectInstruction(unsigned opcode)
     }
 }
 
-bool ILRewriter::GetLocalIndexFromOpcode(const ILInstr* pInstr)
+int ILRewriter::GetLocalIndexFromOpcode(const ILInstr* pInstr)
 {
     // get the index of the local that represent by the opcode or the operand of the instruction
     const auto localIndex =

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter.h
@@ -145,7 +145,7 @@ public:
 
     static bool IsLoadLocalDirectInstruction(unsigned opcode);
 
-    static bool GetLocalIndexFromOpcode(const ILInstr* pInstr);
+    static int GetLocalIndexFromOpcode(const ILInstr* pInstr);
 
     static bool IsLoadConstantInstruction(unsigned opcode);
 };

--- a/tracer/src/Datadog.Tracer.Native/module_metadata.h
+++ b/tracer/src/Datadog.Tracer.Native/module_metadata.h
@@ -123,27 +123,6 @@ public:
         }
         return debuggerTokens.get();
     }
-
-    void EnsureInitSanityTypeSpecToken()
-    {
-        if (moduleSpecSanityToken == mdTokenNil)
-        {
-            const PCCOR_SIGNATURE NullSignature = nullptr;
-            metadata_emit->GetTokenFromTypeSpec(NullSignature, 0x0, &moduleSpecSanityToken);
-        }
-    }
-
-    bool IsTypeSpecTokenSane(mdTypeSpec typeSpec)
-    {
-        EnsureInitSanityTypeSpecToken();
-
-        if (TypeFromToken(typeSpec) != mdtTypeSpec)
-        {
-            return true;
-        }
-
-        return typeSpec < moduleSpecSanityToken;
-    }
 };
 
 } // namespace trace

--- a/tracer/src/Datadog.Tracer.Native/module_metadata.h
+++ b/tracer/src/Datadog.Tracer.Native/module_metadata.h
@@ -25,6 +25,7 @@ private:
     std::unique_ptr<TracerTokens> tracerTokens = nullptr;
     std::unique_ptr<debugger::DebuggerTokens> debuggerTokens = nullptr;
     std::unique_ptr<std::vector<IntegrationDefinition>> integrations = nullptr;
+    mdTypeSpec moduleSpecSanityToken = mdTypeSpecNil;
 
 public:
     const ComPtr<IMetaDataImport2> metadata_import{};
@@ -121,6 +122,27 @@ public:
             debuggerTokens = std::make_unique<debugger::DebuggerTokens>(this);
         }
         return debuggerTokens.get();
+    }
+
+    void EnsureInitSanityTypeSpecToken()
+    {
+        if (moduleSpecSanityToken == mdTokenNil)
+        {
+            const PCCOR_SIGNATURE NullSignature = nullptr;
+            metadata_emit->GetTokenFromTypeSpec(NullSignature, 0x0, &moduleSpecSanityToken);
+        }
+    }
+
+    bool IsTypeSpecTokenSane(mdTypeSpec typeSpec)
+    {
+        EnsureInitSanityTypeSpecToken();
+
+        if (TypeFromToken(typeSpec) != mdtTypeSpec)
+        {
+            return true;
+        }
+
+        return typeSpec < moduleSpecSanityToken;
     }
 };
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ProbesTests.cs
@@ -107,7 +107,7 @@ public class ProbesTests : TestHelper, IDisposable
         await RunSingleTestWithApprovals(testType, isMultiPhase: true, expectedNumberOfSnapshots, probes.Select(p => p.Probe).ToArray());
     }
 
-    [SkippableFact(Skip = "Flaky in .NET 7 build")]
+    [Fact]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
     public async Task LineProbeEmit100SnapshotsTest()
@@ -294,15 +294,6 @@ public class ProbesTests : TestHelper, IDisposable
     /// </summary>
     private void SkipOverTestIfNeeded(Type testType)
     {
-#if NET7_0
-        if (testType == typeof(Samples.Probes.SmokeTests.HasLocalListOfObjects)
-         || testType.Name == "MethodThrowExceptionTest"
-         || testType.Name == "HasLocalsAndArgumentsInGenericNestedType")
-        {
-            throw new SkipException("Flaky in .NET 7");
-        }
-#endif
-
         if (testType == typeof(AsyncInstanceMethod) && !EnvironmentTools.IsWindows())
         {
             throw new SkipException("Can't use WindowsNamedPipes on non-Windows");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.ByRefLikeTest.verified.txt
@@ -1,0 +1,182 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "18": {
+              "arguments": {
+                "this": {
+                  "type": "ByRefLikeTest",
+                  "value": "ByRefLikeTest"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "ByRefLikeTest.cs",
+            "lines": [
+              18
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "ByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.ByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.ByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ByRefLikeTest.Run(this=ByRefLikeTest)",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "19": {
+              "arguments": {
+                "this": {
+                  "type": "ByRefLikeTest",
+                  "value": "ByRefLikeTest"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "ByRefLikeTest.cs",
+            "lines": [
+              19
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "ByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.ByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.ByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ByRefLikeTest.Run(this=ByRefLikeTest)",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "20": {
+              "arguments": {
+                "this": {
+                  "type": "ByRefLikeTest",
+                  "value": "ByRefLikeTest"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "ByRefLikeTest.cs",
+            "lines": [
+              20
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "ByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.ByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.ByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ByRefLikeTest.Run(this=ByRefLikeTest)",
+    "service": "Probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -1,0 +1,2329 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "26": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "isNull": "true",
+                          "type": "String"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Cottage"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "0"
+                    },
+                    "Street": {
+                      "isNull": "true",
+                      "type": "String"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "isNull": "true",
+                  "type": "List`1"
+                },
+                "person": {
+                  "isNull": "true",
+                  "type": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "isNull": "true",
+                      "type": "String"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              26
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=, person=, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "27": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "isNull": "true",
+                          "type": "String"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Cottage"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "0"
+                    },
+                    "Street": {
+                      "isNull": "true",
+                      "type": "String"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "isNull": "true",
+                  "type": "List`1"
+                },
+                "person": {
+                  "isNull": "true",
+                  "type": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              27
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=, person=, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "28": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "isNull": "true",
+                  "type": "List`1"
+                },
+                "person": {
+                  "isNull": "true",
+                  "type": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              28
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=, person=, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "29": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [],
+                  "type": "List`1",
+                  "value": "count: 0"
+                },
+                "person": {
+                  "isNull": "true",
+                  "type": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              29
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 0, person=, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "30": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "isNull": "true",
+                  "type": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              30
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "32": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              32
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "33": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              33
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "34": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              34
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "35": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              35
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "37": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              37
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "38": {
+              "arguments": {
+                "this": {
+                  "type": "GenericByRefLikeTest",
+                  "value": "GenericByRefLikeTest"
+                }
+              },
+              "locals": {
+                "address": {
+                  "fields": {
+                    "City": {
+                      "fields": {
+                        "Name": {
+                          "type": "String",
+                          "value": "New York"
+                        },
+                        "Type": {
+                          "type": "PlaceType",
+                          "value": "City"
+                        }
+                      },
+                      "type": "Place",
+                      "value": "Place"
+                    },
+                    "HomeType": {
+                      "type": "BuildingType",
+                      "value": "Duplex"
+                    },
+                    "Number": {
+                      "type": "Int32",
+                      "value": "15"
+                    },
+                    "Street": {
+                      "type": "String",
+                      "value": "Harlem"
+                    }
+                  },
+                  "type": "Address",
+                  "value": "Address"
+                },
+                "children": {
+                  "elements": [
+                    {
+                      "fields": {
+                        "_shouldCloned": {
+                          "type": "Int32",
+                          "value": "31"
+                        },
+                        "Address": {
+                          "fields": {
+                            "City": {
+                              "fields": {
+                                "Name": {
+                                  "type": "String",
+                                  "value": "New York"
+                                },
+                                "Type": {
+                                  "type": "PlaceType",
+                                  "value": "City"
+                                }
+                              },
+                              "type": "Place",
+                              "value": "Place"
+                            },
+                            "HomeType": {
+                              "type": "BuildingType",
+                              "value": "Duplex"
+                            },
+                            "Number": {
+                              "type": "Int32",
+                              "value": "15"
+                            },
+                            "Street": {
+                              "type": "String",
+                              "value": "Harlem"
+                            }
+                          },
+                          "type": "Address",
+                          "value": "Address"
+                        },
+                        "Age": {
+                          "type": "Double",
+                          "value": "31"
+                        },
+                        "Children": {
+                          "isNull": "true",
+                          "type": "List`1"
+                        },
+                        "Id": {
+                          "type": "Guid",
+                          "value": "ScrubbedValue"
+                        },
+                        "Name": {
+                          "type": "String",
+                          "value": "Ralph Jr."
+                        }
+                      },
+                      "type": "Person",
+                      "value": "Person"
+                    }
+                  ],
+                  "type": "List`1",
+                  "value": "count: 1"
+                },
+                "person": {
+                  "fields": {
+                    "_shouldCloned": {
+                      "type": "Int32",
+                      "value": "99"
+                    },
+                    "Address": {
+                      "fields": {
+                        "City": {
+                          "fields": {
+                            "Name": {
+                              "type": "String",
+                              "value": "New York"
+                            },
+                            "Type": {
+                              "type": "PlaceType",
+                              "value": "City"
+                            }
+                          },
+                          "type": "Place",
+                          "value": "Place"
+                        },
+                        "HomeType": {
+                          "type": "BuildingType",
+                          "value": "Duplex"
+                        },
+                        "Number": {
+                          "type": "Int32",
+                          "value": "15"
+                        },
+                        "Street": {
+                          "type": "String",
+                          "value": "Harlem"
+                        }
+                      },
+                      "type": "Address",
+                      "value": "Address"
+                    },
+                    "Age": {
+                      "type": "Double",
+                      "value": "99"
+                    },
+                    "Children": {
+                      "elements": [
+                        {
+                          "fields": {
+                            "_shouldCloned": {
+                              "type": "Int32",
+                              "value": "31"
+                            },
+                            "Address": {
+                              "fields": {
+                                "City": {
+                                  "notCapturedReason": "depth",
+                                  "type": "Place",
+                                  "value": "Place"
+                                },
+                                "HomeType": {
+                                  "type": "BuildingType",
+                                  "value": "Duplex"
+                                },
+                                "Number": {
+                                  "type": "Int32",
+                                  "value": "15"
+                                },
+                                "Street": {
+                                  "type": "String",
+                                  "value": "Harlem"
+                                }
+                              },
+                              "type": "Address",
+                              "value": "Address"
+                            },
+                            "Age": {
+                              "type": "Double",
+                              "value": "31"
+                            },
+                            "Children": {
+                              "isNull": "true",
+                              "type": "List`1"
+                            },
+                            "Id": {
+                              "type": "Guid",
+                              "value": "ScrubbedValue"
+                            },
+                            "Name": {
+                              "type": "String",
+                              "value": "Ralph Jr."
+                            }
+                          },
+                          "type": "Person",
+                          "value": "Person"
+                        }
+                      ],
+                      "type": "List`1",
+                      "value": "count: 1"
+                    },
+                    "Id": {
+                      "type": "Guid",
+                      "value": "ScrubbedValue"
+                    },
+                    "Name": {
+                      "type": "String",
+                      "value": "Ralph"
+                    }
+                  },
+                  "type": "Person",
+                  "value": "Person"
+                },
+                "place": {
+                  "fields": {
+                    "Name": {
+                      "type": "String",
+                      "value": "New York"
+                    },
+                    "Type": {
+                      "type": "PlaceType",
+                      "value": "City"
+                    }
+                  },
+                  "type": "Place",
+                  "value": "Place"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "GenericByRefLikeTest.cs",
+            "lines": [
+              38
+            ]
+          }
+        },
+        "stack": [
+          {
+            "fileName": "GenericByRefLikeTest.cs",
+            "function": "Samples.Probes.SmokeTests.GenericByRefLikeTest.Run",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "function": "Program.RunTest",
+            "lineNumber": "ScrubbedValue"
+          },
+          {
+            "fileName": "Program.cs",
+            "function": "Program+<>c__DisplayClass2_0.<Main>b__0",
+            "lineNumber": "ScrubbedValue"
+          }
+        ],
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Run",
+      "name": "Samples.Probes.SmokeTests.GenericByRefLikeTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "GenericByRefLikeTest.Run(this=GenericByRefLikeTest)\r\naddress=Address, children=count: 1, person=Person, place=Place",
+    "service": "Probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.ByRefLikeTest.verified.txt
@@ -1,0 +1,86 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "17c1e39c-e46c-828e-4e02-21be0f3b5358",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "86a95ec1-5bda-bd57-3f8e-e610398f9334",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
+    "service": "Probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -1,0 +1,214 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "03da93fa-95b1-4bbc-89e2-6c29cb8f1744",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 03da93fa-95b1-4bbc-89e2-6c29cb8f1744.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "17c1e39c-e46c-828e-4e02-21be0f3b5358",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": {
+          "Message": null,
+          "StackTrace": null,
+          "Type": null
+        },
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "22df6346-f993-1027-bd1a-f25f3a06ca56",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "23827d5e-fc78-6898-4039-dec54409f8c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 23827d5e-fc78-6898-4039-dec54409f8c4.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "31d232fd-e292-63a1-cfc5-f0e71d98afd1",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 31d232fd-e292-63a1-cfc5-f0e71d98afd1.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "35543785-ac9a-85ea-44af-13938dff3136",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 35543785-ac9a-85ea-44af-13938dff3136.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "86a95ec1-5bda-bd57-3f8e-e610398f9334",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "a48bde4f-873f-cac7-08f6-3404c6ceec6d",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "b16773f7-ded8-a522-43ce-b51d18f9205e",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "b1fd073e-cd92-947d-4b6b-d9bd0380b1f2",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70.",
+    "service": "Probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "Exception": null,
+        "probeId": "f23aa325-ec46-b774-3f32-a89b9879ce7d",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
+    "service": "Probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/ByRefLikeTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/ByRefLikeTest.cs
@@ -29,19 +29,19 @@ namespace Samples.Probes.SmokeTests
                 _whoAmI = whoAmI;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public ref ByRefLike CallMe(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
             {
                 return ref refByRefLike;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public ByRefLike CallMe2(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
             {
                 return byRefLike;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public string CallMe3(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
             {
                 return @in + "Hello World";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/ByRefLikeTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/ByRefLikeTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Samples.Probes.Shared;
+
+namespace Samples.Probes.SmokeTests
+{
+    [LineProbeTestData(18)]
+    [LineProbeTestData(19)]
+    [LineProbeTestData(20)]
+    internal class ByRefLikeTest : IRun
+    {
+        public void Run()
+        {
+            var byRefLike = new ByRefLike(nameof(ByRefLikeTest));
+            byRefLike.CallMe("Hello from the outside 1!", byRefLike, ref byRefLike);
+            byRefLike.CallMe2("Hello from the outside 2!", byRefLike, ref byRefLike);
+            byRefLike.CallMe3("Hello from the outside 3!", byRefLike, ref byRefLike);
+        }
+
+        ref struct ByRefLike
+        {
+            private string _whoAmI;
+
+            public ByRefLike(string whoAmI)
+            {
+                _whoAmI = whoAmI;
+            }
+
+            [MethodProbeTestData]
+            public ref ByRefLike CallMe(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
+            {
+                return ref refByRefLike;
+            }
+
+            [MethodProbeTestData]
+            public ByRefLike CallMe2(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
+            {
+                return byRefLike;
+            }
+
+            [MethodProbeTestData]
+            public string CallMe3(string @in, ByRefLike byRefLike, ref ByRefLike refByRefLike)
+            {
+                return @in + "Hello World";
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/Emit100LineProbeSnapshotsTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/Emit100LineProbeSnapshotsTest.cs
@@ -3,7 +3,7 @@ using Samples.Probes.Shared;
 
 namespace Samples.Probes.SmokeTests;
 
-[LineProbeTestData(lineNumber: 14, unlisted: true, skipOnFramework: new []{ "net6.0", "net7.0" })]
+[LineProbeTestData(lineNumber: 14, unlisted: true)]
 public class Emit100LineProbeSnapshotsTest : IRun
 {
     public void Run()

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/GenericByRefLikeTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/GenericByRefLikeTest.cs
@@ -18,7 +18,7 @@ namespace Samples.Probes.SmokeTests
     [LineProbeTestData(35)]
     [LineProbeTestData(37)]
     [LineProbeTestData(38)]
-    [LineProbeTestData(53)]
+    [LineProbeTestData(53, expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
     public class GenericByRefLikeTest : IRun
     {
         public void Run()
@@ -47,25 +47,25 @@ namespace Samples.Probes.SmokeTests
                 _whoAmI = whoAmI;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public ref GenericByRefLike<T> CallMe(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
             {
                 return ref refByRefLike;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public GenericByRefLike<T> CallMe2(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
             {
                 return byRefLike;
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public string CallMe3(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
             {
                 return @in + "Hello World";
             }
 
-            [MethodProbeTestData]
+            [MethodProbeTestData(expectedNumberOfSnapshots: 0 /* byref-like is not supported for now */)]
             public string CallMe4<K>(string @in, GenericByRefLike<K> byRefLike, ref GenericByRefLike<K> refByRefLike)
             {
                 return @in + "Hello World";

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/GenericByRefLikeTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/GenericByRefLikeTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Samples.Probes.Shared;
+
+namespace Samples.Probes.SmokeTests
+{
+    [LineProbeTestData(26)]
+    [LineProbeTestData(27)]
+    [LineProbeTestData(28)]
+    [LineProbeTestData(29)]
+    [LineProbeTestData(30)]
+    [LineProbeTestData(32)]
+    [LineProbeTestData(33)]
+    [LineProbeTestData(34)]
+    [LineProbeTestData(35)]
+    [LineProbeTestData(37)]
+    [LineProbeTestData(38)]
+    [LineProbeTestData(53)]
+    public class GenericByRefLikeTest : IRun
+    {
+        public void Run()
+        {
+            var place = new Place { @Type = PlaceType.City, Name = "New York" };
+            var address = new Address { City = place, HomeType = BuildingType.Duplex, Number = 15, Street = "Harlem" };
+            var children = new List<Person>();
+            children.Add(new Person("Ralph Jr.", 31, address, Guid.Empty, null));
+            var person = new Person("Ralph", 99, address, Guid.Empty, children);
+
+            var genericByRefLike = new GenericByRefLike<Person>(person);
+            genericByRefLike.CallMe("Hello from the outside 1!", genericByRefLike, ref genericByRefLike);
+            genericByRefLike.CallMe2("Hello from the outside 2!", genericByRefLike, ref genericByRefLike);
+            genericByRefLike.CallMe3("Hello from the outside 3!", genericByRefLike, ref genericByRefLike);
+
+            var genericByRefLike2 = new GenericByRefLike<Address>(address);
+            genericByRefLike.CallMe4<Address>("Hello from the outside 3!", genericByRefLike2, ref genericByRefLike2);
+        }
+        
+        ref struct GenericByRefLike<T>
+        {
+            private T _whoAmI;
+
+            public GenericByRefLike(T whoAmI)
+            {
+                _whoAmI = whoAmI;
+            }
+
+            [MethodProbeTestData]
+            public ref GenericByRefLike<T> CallMe(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
+            {
+                return ref refByRefLike;
+            }
+
+            [MethodProbeTestData]
+            public GenericByRefLike<T> CallMe2(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
+            {
+                return byRefLike;
+            }
+
+            [MethodProbeTestData]
+            public string CallMe3(string @in, GenericByRefLike<T> byRefLike, ref GenericByRefLike<T> refByRefLike)
+            {
+                return @in + "Hello World";
+            }
+
+            [MethodProbeTestData]
+            public string CallMe4<K>(string @in, GenericByRefLike<K> byRefLike, ref GenericByRefLike<K> refByRefLike)
+            {
+                return @in + "Hello World";
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/HasLocalsAndArgumentsInGenericType.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/HasLocalsAndArgumentsInGenericType.cs
@@ -26,7 +26,7 @@ namespace Samples.Probes.SmokeTests
         public class Test<T> where T : new()
         {
             [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-            [MethodProbeTestData("System.String", new[] { "!0", "System.Int32" }, skipOnFramework: new string[]{ "net6.0" })]
+            [MethodProbeTestData("System.String", new[] { "!0", "System.Int32" })]
             public string Method(T genericVar, int age)
             {
                 var genericVarToString = genericVar.ToString();

--- a/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/MethodThrowExceptionTest.cs
+++ b/tracer/test/test-applications/debugger/Samples.Probes/SmokeTests/MethodThrowExceptionTest.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace Samples.Probes.SmokeTests
 {
-    [LineProbeTestData(26, skipOnFramework: new[] { "net6.0" })]
+    [LineProbeTestData(26)]
     internal class MethodThrowExceptionTest : IRun
     {
         public int Number { get; set; }
@@ -15,7 +15,7 @@ namespace Samples.Probes.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
-        [MethodProbeTestData("System.String", new []{ "System.Int32" }, skipOnFramework: new[] { "net6.0" })]
+        [MethodProbeTestData("System.String", new []{ "System.Int32" })]
         public string Method(int toSet)
         {
             Number += 7;


### PR DESCRIPTION
## Summary of changes
Byref-like types (`ref struct`) have many constraints that are enforced by the compiler & runtime. One of these constraints is that they can't be used as a generic param (not as method generic param nor type) due to the fact that they can't live in the managed heap. The Tracer and Dynamic Instrumentation products perform bytecode rewriting that heavily utilize generic params to pass arguments, locals, return values and invocation target instances to our side. Trying to use a local/argument/return value/'this' that is byref-like as a generic param yields `VerificationException` by the CLR that propagates to customer code.

Recent improvements in .NET that specifically related to string optimizations adds byref-like types during compilation time. One example is [DefaultInterpolatedStringHandler](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.defaultinterpolatedstringhandler?view=net-7.0) that is inserted by the compiler from C# 10 & .NET 6 for string optimization purposes ([reference](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/)).

## Reason for change
Stabilizing the instrumentation.

## Implementation details
The way to determine if a type is byref-like is by checking if it's decorated with the attribute [IsByRefLikeAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.isbyreflikeattribute?view=net-7.0) and
the API in use for checking if a type has that attribute is [IMetaDataImport::GetCustomAttributeByName](https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/metadata/imetadataimport-getcustomattributebyname-method).
There is caveat in using this API: You have to have the correct resolution scope where that type is defined (where the type is presented as TypeDef for that scope) as these kind of metadata information is only available using the module where the corresponding type is defined.
When we check types that are defined in the same method we are instrumenting, then it's easy because we have a TypeDef.
On the other hand, if we have a TypeRef in hand (a type that is defined elsewhere, not in the same module of the method that is being instrumented) then we need to resolve that type to TypeDef alongside its scope and only then we can determine if that type is byref-like or not.
As such, this PR also includes a code that resolves TypeRefs to TypeDefs (with support for exported types). It's included in `clr_helpers.cpp` so that it can be easily shared.

As to byref-like improvements, for now our solution is to:
- Avoid passing arguments, locals and the invocation instance (`this`) that are byref-like.
- Avoid instrumenting methods that return byref-like.

In a later PR these types will be marked as Not Captured (instead of skipping them) to better reflect to the customer that these types are not supported for now.

## Test coverage
- [HasLocalsAndArgumentsInGenericType.cs](https://github.com/DataDog/dd-trace-dotnet/compare/matang/by-ref-like-fixes?expand=1#diff-8d1498e8d0eb8ad9ee67517c81c056d6f2ec7309b642bb0dc9e8fb8e33f3b7c9)
- [MethodThrowExceptionTest.cs](https://github.com/DataDog/dd-trace-dotnet/compare/matang/by-ref-like-fixes?expand=1#diff-ab14d2d72888e6bc708ebbc1915337c28608988469a46517f1060d42ac5eeb8f)
- [GenericByRefLikeTest.cs](https://github.com/DataDog/dd-trace-dotnet/compare/matang/by-ref-like-fixes?expand=1#diff-4ab3a45c1ce94f571d262b558e2cad32806e135501ebea597cbbc2ac410c9174)
- [ByRefLikeTest.cs](https://github.com/DataDog/dd-trace-dotnet/compare/matang/by-ref-like-fixes?expand=1#diff-ad28d69465720f4185f18edf638c35fdfade5219155062eb4eebe67a63c0ebc4)
- [Emit100LineProbeSnapshotsTest.cs](https://github.com/DataDog/dd-trace-dotnet/pull/3505/files#diff-1607253a4ea830ef134af5b617c814f53b9fc99b3e2c7a42442b84693f70e4c9)