### PR TITLE
Adds a workaround for the dotnet runtime issue 77973

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -215,6 +215,29 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         return E_FAIL;
     }
 
+    WSTRING runtimeType = runtime_information_.is_core() ? (runtime_information_.major_version > 4 ? WStr(".NET") : WStr(".NET Core")) : WStr(".NET Framework");
+    Logger::Info("Runtime Information: ", runtimeType, " ", runtime_information_.major_version, ".", runtime_information_.minor_version, ".", runtime_information_.build_version);
+
+    // Check if we have to disable tiered compilation (due to https://github.com/dotnet/runtime/issues/77973)
+    bool disableTieredCompilation = false;
+    bool internal_workaround_77973_enabled = true;
+    shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(environment::internal_workaround_77973_enabled), internal_workaround_77973_enabled);
+    if (internal_workaround_77973_enabled)
+    {
+        if (runtime_information_.major_version == 5 ||
+            (runtime_information_.major_version == 6 && runtime_information_.minor_version == 0 && runtime_information_.build_version <= 11) ||
+            (runtime_information_.major_version == 7 && runtime_information_.minor_version == 0 && runtime_information_.build_version == 0))
+        {
+            Logger::Warn("Tiered Compilation was disabled due to https://github.com/dotnet/runtime/issues/77973. This action can be disabled by setting the environment variable DD_INTERNAL_WORKAROUND_77973_ENABLED=false");
+            disableTieredCompilation = true;
+        }
+    }
+
+    if (runtime_information_.major_version == 6 && runtime_information_.minor_version == 0 && runtime_information_.build_version <= 11)
+    {
+        disableTieredCompilation = true;
+    }
+
     auto pInfo = info10 != nullptr ? info10 : this->info_;
     auto work_offloader = std::make_shared<RejitWorkOffloader>(pInfo);
 
@@ -255,8 +278,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         event_mask |= COR_PRF_DISABLE_ALL_NGEN_IMAGES;
     }
 
-    // set event mask to subscribe to events and disable NGEN images
-    hr = this->info_->SetEventMask2(event_mask, COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES);
+    DWORD high_event_mask = COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES;
+    if (disableTieredCompilation)
+    {
+        high_event_mask |= COR_PRF_HIGH_DISABLE_TIERED_COMPILATION;
+    }
+
+    // set event mask to subscribe to events
+    hr = this->info_->SetEventMask2(event_mask, high_event_mask);
     if (FAILED(hr))
     {
         Logger::Warn("DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: unable to set event mask.");

--- a/tracer/src/Datadog.Tracer.Native/environment_variables.h
+++ b/tracer/src/Datadog.Tracer.Native/environment_variables.h
@@ -115,6 +115,9 @@ namespace environment
     // Sets whether the current process must run in CI Visibility mode or not.
     const shared::WSTRING ci_visibility_enabled = WStr("DD_CIVISIBILITY_ENABLED");
 
+    // Enables the workaround for dotnet issue 77973 (https://github.com/dotnet/runtime/issues/77973)
+    const shared::WSTRING internal_workaround_77973_enabled = WStr("DD_INTERNAL_WORKAROUND_77973_ENABLED");
+
 } // namespace environment
 } // namespace trace
 


### PR DESCRIPTION
## Summary of changes

This PR adds a workaround for https://github.com/dotnet/runtime/issues/77973

## Implementation details

The PR disables by default Tiered Compilation for the following cases:
- Runtime version is `.NET 5`
- Runtime version is `>= 6.0.0 && <= 6.0.11` (current version)
- Runtime version is `== 7.0.0`

Microsoft is considering including a fix for the next service release for [.NET 6](https://github.com/dotnet/runtime/pull/78670) and [.NET 7](https://github.com/dotnet/runtime/pull/78669)

**Note**: The workaround can be disabled by setting the environment variable: `DD_INTERNAL_WORKAROUND_77973_ENABLED=false`