### PR TITLE
Force English for .NET CLI in build scripts

### DIFF
--- a/tracer/build.ps1
+++ b/tracer/build.ps1
@@ -27,6 +27,11 @@ function ExecSafe([scriptblock] $cmd) {
 # If dotnet CLI is installed globally and it matches requested version, use for execution
 $env:DOTNET_EXE = (Get-Command "dotnet").Path
 
+# Some commands apparently break unless this is set
+# e.g. "/property:Platform=AnyCPU" gives
+# No se reconoce el comando o el argumento "/property:Platform=AnyCPU"
+$env:DOTNET_CLI_UI_LANGUAGE="en"
+
 Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }

--- a/tracer/build.sh
+++ b/tracer/build.sh
@@ -17,6 +17,11 @@ BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build/_build.csproj"
 
 export DOTNET_EXE="$(command -v dotnet)"
 
+# Some commands apparently break unless this is set
+# e.g. "/property:Platform=AnyCPU" gives
+# No se reconoce el comando o el argumento "/property:Platform=AnyCPU"
+export DOTNET_CLI_UI_LANGUAGE="en"
+
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet


### PR DESCRIPTION
## Summary of changes

Sets `DOTNET_CLI_UI_LANGUAGE=en` in Nuke bootstrapping scripts

## Reason for change

If your environment is set to non-english, some Nuke commands _may_ fail. For example, the following fails for Spanish:

```bash
> "C:\Program Files\dotnet\dotnet.exe" test C:\github\DataDog\dd-trace-dotnet\tracer\test\Datadog.Trace.ClrProfiler.Managed.Tests\Datadog.Trace.ClrProfiler.Managed.Tests.csproj --configuration Release --logger trx --no-build --no-restore --results-directory C:\github\DataDog\dd-trace-dotnet\tracer\build_data\results\Datadog.Trace.ClrProfiler.Managed.Tests /property:Platform=AnyCPU
No se reconoce el comando o el argumento "/property:Platform=AnyCPU"
Description:
  Controlador de pruebas de .NET

Usage:
  dotnet test [<PROJECT | SOLUTION>] [options] [[--] <additional arguments>...]]
```

(Though it passes for english)

## Implementation details

Set `DOTNET_CLI_UI_LANGUAGE=en` in the bootstrap scripts used to run Nuke. That should cause child processes to inherit the value.

## Test coverage

@tonyredondo, does it work?! 😄 