### PR TITLE
Reduce number of frameworks tested in PRs

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -42,6 +42,7 @@ steps:
         --env DD_INSTRUMENTATION_TELEMETRY_ENABLED \
         --env Verify_DisableClipboard=true \
         --env DiffEngine_Disabled=true \
+        --env IncludeAllTestFrameworks \
         --env TestAllPackageVersions=$(TestAllPackageVersions) \
         --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
         --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -120,6 +120,8 @@ variables:
   NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
   DefaultTimeout: 60
   DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
+  # Include all test frameworks when (variable is set) OR ((running on master/release/hotfix) and (NOT scheduled build)),
+  IncludeAllTestFrameworks: $[or(eq(variables['run_all_test_frameworks'], 'true'), and(or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hostfix/')), not(eq(variables['Build.Reason'], 'Schedule'))))]
   # Logger variables
   DD_LOGGER_DD_API_KEY: $(DD_API_KEY)
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -381,6 +381,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
+      - IncludeAllTestFrameworks
       - MONGO_HOST=mongo
       - SERVICESTACK_REDIS_HOST=servicestackredis:6379
       - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
@@ -468,6 +469,7 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - CONTAINER_HOSTNAME=http://integrationtests
+      - IncludeAllTestFrameworks
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -514,6 +516,7 @@ services:
       - explorationTestUseCase=${explorationTestUseCase:-debugger}
       - explorationTestName=${explorationTestName:-eshoponweb}
       - baseImage=${baseImage:-default}
+      - IncludeAllTestFrameworks
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
@@ -587,6 +590,7 @@ services:
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
+      - IncludeAllTestFrameworks
       - MONGO_HOST=mongo_arm64
       - SERVICESTACK_REDIS_HOST=servicestackredis_arm64:6379
       - STACKEXCHANGE_REDIS_HOST=stackexchangeredis_arm64:6379

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -124,9 +124,19 @@ partial class Build
     };
 
     TargetFramework[] TestingFrameworks =>
-        IncludeAllTestFrameworks
+        IncludeAllTestFrameworks || HaveIntegrationsChanged
             ? TargetFramework.GetFrameworks(except: TargetFramework.NETSTANDARD2_0)
             : new[] { TargetFramework.NET461, TargetFramework.NETCOREAPP2_1, TargetFramework.NETCOREAPP3_1, TargetFramework.NET7_0, };
+
+    bool HaveIntegrationsChanged => 
+        GetGitChangedFiles(baseBranch: "origin/master")
+           .Any(s => new []
+            {
+                "tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator",
+                "tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator",
+                "tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator",
+                "tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator",
+            }.Any(s.Contains));
 
     readonly IEnumerable<TargetFramework> TargetFrameworks = new[]
     {

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -861,7 +861,7 @@ partial class Build
                            .SetFramework(targetFramework)
                            .EnableCrashDumps()
                            .SetLogsDirectory(TestLogsDirectory)
-                           .When(CodeCoverage, ConfigureCodeCoverage)
+                           .When(CodeCoverage, x => ConfigureCodeCoverage(x, targetFramework))
                            .When(!string.IsNullOrEmpty(Filter), c => c.SetFilter(Filter))
                            .CombineWith(testProjects, (x, project) => x
                                  .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -2132,9 +2132,17 @@ partial class Build
         }
     }
 
-    private DotNetTestSettings ConfigureCodeCoverage(DotNetTestSettings settings)
+    private DotNetTestSettings ConfigureCodeCoverage(DotNetTestSettings settings) 
+        => ConfigureCodeCoverage(settings, Framework);
+
+    private DotNetTestSettings ConfigureCodeCoverage(DotNetTestSettings settings, TargetFramework framework)
     {
-        if (Framework == TargetFramework.NET461)
+        if(framework is null)
+        {
+            throw new InvalidOperationException("No test framework provided. You must define the framework as code coverage breaks on net461");
+        }
+
+        if (framework == TargetFramework.NET461)
         {
             // Coverlet apparently breaks .NET Framework when running on the .NET 7 SDK.
             // TODO: Fix it

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -53,7 +53,6 @@ partial class Build
     [Solution("Datadog.Profiler.sln")] readonly Solution ProfilerSolution;
     AbsolutePath ProfilerMsBuildProject => ProfilerDirectory / "src" / "ProfilerEngine" / "Datadog.Profiler.Native.Windows" / "Datadog.Profiler.Native.Windows.WithTests.proj";
     AbsolutePath ProfilerOutputDirectory => RootDirectory / "profiler" / "_build";
-    AbsolutePath ProfilerLinuxBuildDirectory => ProfilerOutputDirectory / "cmake";
     AbsolutePath ProfilerBuildDataDirectory => ProfilerDirectory / "build_data";
     AbsolutePath ProfilerTestLogsDirectory => ProfilerBuildDataDirectory / "logs";
 

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -69,9 +69,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsWindowsMatrices()
             {
-                var targetFrameworks = TargetFramework.GetFrameworks(except: new[] { TargetFramework.NETSTANDARD2_0 });
-
-                GenerateIntegrationTestsWindowsMatrix(targetFrameworks);
+                GenerateIntegrationTestsWindowsMatrix(TestingFrameworks);
                 GenerateIntegrationTestsWindowsIISMatrix(TargetFramework.NET461);
                 GenerateIntegrationTestsWindowsMsiMatrix(TargetFramework.NET461);
                 GenerateIntegrationTestsWindowsAzureFunctionsMatrix();
@@ -161,7 +159,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsLinuxMatrix()
             {
-                var targetFrameworks = TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NETSTANDARD2_0, });
+                var targetFrameworks = TestingFrameworks.Except(new [] {TargetFramework.NET461});
 
                 var baseImages = new[] { "centos7", "alpine" };
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -84,6 +84,9 @@ partial class Build : NukeBuild
     [Parameter("Should we build and run tests that require docker. true = only docker integration tests, false = no docker integration tests, null = all", List = false)]
     readonly bool? IncludeTestsRequiringDocker;
 
+    [Parameter("Should we build and run tests against _all_ target frameworks, or just the reduced set. Defaults to true locally, false in PRs, and true in CI on main branch only", List = false)]
+    readonly bool IncludeAllTestFrameworks = true;
+
     Target Info => _ => _
         .Description("Describes the current configuration")
         .Before(Clean, Restore, BuildTracerHome)
@@ -96,6 +99,7 @@ partial class Build : NukeBuild
             Logger.Info($"MonitoringHomeDirectory: {MonitoringHomeDirectory}");
             Logger.Info($"ArtifactsDirectory: {ArtifactsDirectory}");
             Logger.Info($"NugetPackageDirectory: {NugetPackageDirectory}");
+            Logger.Info($"IncludeAllTestFrameworks: {IncludeAllTestFrameworks}");
             Logger.Info($"IsAlpine: {IsAlpine}");
             Logger.Info($"Version: {Version}");
         });

--- a/tracer/build/_build/TargetFramework.cs
+++ b/tracer/build/_build/TargetFramework.cs
@@ -23,7 +23,7 @@ public class TargetFramework : Enumeration
         return framework.Value;
     }
 
-    public static TargetFramework[] GetFrameworks(TargetFramework[] except = null)
+    public static TargetFramework[] GetFrameworks(params TargetFramework[] except)
     {
         return typeof(TargetFramework)
               .GetFields(ReflectionService.Static)

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.ClrProfiler
         static InstrumentationDefinitions()
         {
             Payload payload = default;
+
                 // root types for InstrumentationCategory Tracing
                 payload = new Payload
                 {

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -20,7 +20,6 @@ namespace Datadog.Trace.ClrProfiler
         static InstrumentationDefinitions()
         {
             Payload payload = default;
-
                 // root types for InstrumentationCategory Tracing
                 payload = new Payload
                 {


### PR DESCRIPTION
## Summary of changes

- Reduces the frameworks we test in PRs to reduce impact of flakiness and reduce pressure on CI. 
  - On PRs, reduces the tested frameworks to `net461`, `netcoreapp2.1`, `netcoreapp3.1`, `net7.0`. See below for rationale.
- Fixes a bug introduced in #3482 causing us to skip integration tests on .NET 461

## Reason for change

We have been seeing a lot of flakiness in general, and although we're working to tackle the source of the flakiness, the sheer number of tests we run means even a tiny percentage chance of flake appears more often then not. By reducing the number of test permutations we run, it should reduce the number of times the pipeline errors.

Additionally, we recently added _another_ test framework to our matrix (`net7.0`). As we continue to support out-of-support versions of frameworks (e.g. .NET Core2.1 and .NET Core 3.0), our test matrix will continue to grow. This adds an increasing burden on our CI infrastructure, as we use more and more machines. We need to keep this in check, while not sacrificing reliability. 

Also, we realised that the fix for `net461` code coverage introduced in #3482 was not working for unit tests. This is because the `Framework` variable isn't set in that case and we're calling `dotnet test` instead of `dotnet test --framework {Framework}`.

## Implementation details

This PR takes a simple approach - we simply don't run tests on a subset of target frameworks. 

- For integration tests, we simply don't generate a job for the framework
- For unit tests, we switch to calling `dotnet test` and passing in `--framework`, instead of letting the CLI test all frameworks. Note that this was also necessary to fix the code coverage bug.

Added a parameter to Nuke `IncludeAllTestFrameworks`. When `true` this runs against all frameworks, as we do currently. This is the default if not overridden.

In CI, we set this to `true` for merges to master. For PRs and for scheduled builds, this is `false`. You can override it, and run a full test on a branch by setting `run_all_test_frameworks=true` when scheduling the build in Azure Devops. **Consider doing this whenever you add a new integration, or make a change that you expect to effect different frameworks differently**

> To try to make sure we catch the "modified integrations" case, [in this commit](https://github.com/DataDog/dd-trace-dotnet/pull/3511/commits/d8d5d8210046c71543594b5d5970397806fdb304) we look for changes to integrations, and run on all frameworks if changes are detected

I chose the following test frameworks to be run on every PR, as they test each of the generated dlls we produce for Datadog.Trace:

- `net461` for the .NET FX dll
- `netcoreapp2.1` for the `netstandard2.0` dll
- `netcoreapp3.1` for the `netcoreapp3.1` dll
- `net7.0` for the `net6.0` dll

Which means we no longer test the following:

- `netcoreapp3.0` has been out of support for a long time, and there are only a couple of (pretty obsolete by now) ASP.NET Core paths where it branches differently from the `netcoreapp2.1` behaviour
- `net5.0` is out of support, uses the same dll as `netcoreapp3.1`, and doesn't (AFAIK) have any behaviour not covered by `netcoreapp3.`
- `net6.0` is still in support, but should use the same paths as `net7.0` in general. `net7.0` support is still new, so thought we wanted to keep testing that more intensely, to flush out any issues.

I only removed these stages for integration/unit tests where we test them all. For the smoke tests I continued to test all (as we already run a reduced set in PRs). For benchmark/azure functions/lambda where we already only test a limited set of frameworks, I left them unchanged.

## Test coverage

## Other details

I originally investigated a more detailed approach, dynamically changing the `<TargetFrameworks>` based on the `IncludeAllTestFrameworks` variable. This has the advantage that it can significantly reduce the `Restore` (and some build stages) which speeds up the build. 

Unfortunately, this is made complicated by the complex web of samples and dependency projects we have. Some samples _always_ need building, regardless of the targeted frameworks. And as some stages still use the excluded frameworks (e.g. benchmarks, azure functions), it's all quite confusing. Chose to park this approach for now, and we can revisit later if we see fit (potentially revisiting the whole sample-building process etc).

