### PR TITLE
Added DI to the README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ This repository contains the sources for the client-side components of the Datad
 
 This library powers [Distributed Tracing](https://docs.datadoghq.com/tracing/),
 [Application Security Management](https://docs.datadoghq.com/tracing/profiler/connect_traces_and_profiles/),
-[Continuous Integration Visibility](https://docs.datadoghq.com/continuous_integration/) and more.
+[Continuous Integration Visibility](https://docs.datadoghq.com/continuous_integration/),
+[Dynamic Instrumentation](https://www.datadoghq.com/blog/dash-2022-new-feature-roundup/#send-critical-metrics-traces-and-logs-with-no-code-changes-using-dynamic-instrumentation) and more.
 
 **[Datadog .NET Continuous Profiler](https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler)**: Libraries that automatically profile your application. [Documentation](https://docs.datadoghq.com/tracing/profiler/).
 


### PR DESCRIPTION
## Summary of changes
Added a link to the [Dynamic Instrumentation](https://www.datadoghq.com/blog/dash-2022-new-feature-roundup/#send-critical-metrics-traces-and-logs-with-no-code-changes-using-dynamic-instrumentation) product in the repo README.
Soon enough the docs will be published in https://docs.datadoghq.com/, until then we have the Dash announcement link.

## Reason for change
Reflect the development of the Dynamic Instrumentation alongside all other products.