### PR TITLE
[Profiler] Disable tiered compilation in integration tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -139,6 +139,9 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         {
             var profilerPath = GetNativeLoaderPath();
 
+            // Temporarily disable tiered compilation
+            environmentVariables["COMPlus_TieredCompilation"] = "0";
+
             environmentVariables["DD_NATIVELOADER_CONFIGFILE"] = GenerateLoaderConfigFile();
 
             if (!File.Exists(profilerPath))


### PR DESCRIPTION
## Summary of changes

Disable tiered compilation in profiler integration tests.

## Reason for change

We have integration tests where profiler and tracer are running together. Tracer has disable tiered jit compilation for its integration tests (temporally) see https://github.com/DataDog/dd-trace-dotnet/pull/3479

## Implementation details

Set `COMPlus_TieredCompilation=0`.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
