### PR TITLE
Normalize names of logs and snapshot artifacts for consistency

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -649,7 +649,7 @@ stages:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
       - publish: tracer/build_data
-        artifact: profiler-logs_unit_tests_windows_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
         condition: succeededOrFailed()
         continueOnError: true
 
@@ -711,7 +711,7 @@ stages:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
       - publish: tracer/build_data
-        artifact: profiler-logs_unit_tests_macos_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
         condition: succeededOrFailed()
         continueOnError: true
 
@@ -760,7 +760,7 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - publish: tracer/build_data
-      artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -842,7 +842,7 @@ stages:
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
         - publish: tracer/build_data
-          artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -909,13 +909,13 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows tracer logs
-      artifact: integration_tests_windows_tracer_logs_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_windows_snapshots_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -965,13 +965,13 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
-      artifact: integration_tests_windows_iis_tracer_logs_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_windows_iis_snapshots_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1021,13 +1021,13 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
-      artifact: integration_tests_windows_iis_security_tracer_logs_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_windows_iis_security_snapshots_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1085,13 +1085,13 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading tracer logs
-      artifact: integration_tests_windows_azure_functions_tracer_logs_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_windows_azure_functions__snapshots_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1176,13 +1176,13 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_msi tracer logs
-      artifact: integration_tests_windows_msi_tracer_logs_$(targetPlatform)_$(framework)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_windows_msi_snapshots_$(targetPlatform)_$(framework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1254,7 +1254,7 @@ stages:
       condition: succeededOrFailed()
 
     - publish: tracer/build_data
-      artifact: integration_tests_linux_tracer_logs_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1267,7 +1267,7 @@ stages:
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_linux_snapshots_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1352,7 +1352,7 @@ stages:
       condition: succeededOrFailed()
 
     - publish: tracer/build_data
-      artifact: integration_tests_linux_docker_tracer_logs_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1365,7 +1365,7 @@ stages:
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_linux_docker_snapshots_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1521,7 +1521,7 @@ stages:
       condition: succeededOrFailed()
 
     - publish: tracer/build_data
-      artifact: integration_tests_linux_serverless_tracer_logs_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1534,7 +1534,7 @@ stages:
 
     - publish: tracer/test/snapshots
       displayName: Uploading snapshots
-      artifact: integration_tests_linux_serverless_snapshots_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1620,7 +1620,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - publish: profiler/build_data
-      artifact: continuous-profiler-logs_integration_tests_linux_$(baseImage)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1694,7 +1694,7 @@ stages:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
         - publish: tracer/build_data
-          artifact: integration_tests_linux_tracer_logs_arm64_$(publishTargetFramework)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -1707,7 +1707,7 @@ stages:
 
         - publish: tracer/test/snapshots
           displayName: Uploading snapshots
-          artifact: integration_tests_linux_snapshots_arm64_$(publishTargetFramework)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -1786,7 +1786,7 @@ stages:
           condition: succeededOrFailed()
 
         - publish: tracer/build_data
-          artifact: integration_tests_linux_docker_tracer_logs_arm64_$(publishTargetFramework)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -1799,7 +1799,7 @@ stages:
 
         - publish: tracer/test/snapshots
           displayName: Uploading snapshots
-          artifact: integration_tests_linux_docker_snapshots_arm64_$(publishTargetFramework)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -1859,7 +1859,7 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading exploration_tests_windows tracer logs
-      artifact: exploration_tests_windows_tracer_logs_$(explorationTestUseCase)_$(explorationTestName)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -1957,7 +1957,7 @@ stages:
       condition: succeededOrFailed()
 
     - publish: tracer/build_data
-      artifact: profiler-logs_exploration_tests_linux_$(baseImage)_$(publishTargetFramework)_$(explorationTestUseCase)_$(explorationTestName)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -2964,7 +2964,7 @@ stages:
       - publish: system-tests/logs
         condition: always()
         displayName: System tests logs
-        artifact: system-tests_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
 
       - script: ./run.sh UDS
         workingDirectory: system-tests
@@ -2975,7 +2975,7 @@ stages:
       - publish: system-tests/logs_uds
         condition: always()
         displayName: System tests UDS logs
-        artifact: system-tests-uds_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_uds_$(System.JobAttempt)
         
       - script: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
         workingDirectory: system-tests
@@ -2986,7 +2986,7 @@ stages:
       - publish: system-tests/logs_remote_config_mocked_backend_live_debugging
         condition: always()
         displayName: RCM tests logs
-        artifact: system-tests-rcm_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)
 
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -3041,7 +3041,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: installer-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3112,7 +3112,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: nuget_installer-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3174,7 +3174,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: dotnet-tool-nuget-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3240,7 +3240,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: dotnet-tool-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3316,7 +3316,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: dotnet-tool-smoke-test-self-instrument-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3375,7 +3375,7 @@ stages:
             snapshotPrefix: "smoke_test"
 
         - publish: tracer/build_data
-          artifact: installer-smoke-test-logs_arm64_$(dockerTag)_$(System.JobAttempt)
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
 
@@ -3444,7 +3444,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: nuget_installer-smoke-test-logs_arm64_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3506,7 +3506,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - publish: tracer/build_data
-      artifact: dotnet-tool-smoke-test-logs_arm64_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3577,7 +3577,7 @@ stages:
         isLinux: false
 
     - publish: tracer/build_data
-      artifact: nuget_installer_windows-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3642,7 +3642,7 @@ stages:
         isLinux: false
 
     - publish: tracer/build_data
-      artifact: dotnet-tool-smoke-test-windows-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3707,7 +3707,7 @@ stages:
         isLinux: false
 
     - publish: tracer/build_data
-      artifact: msi-installer-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -3771,7 +3771,7 @@ stages:
         isLinux: false
 
     - publish: tracer/build_data
-      artifact: tracer-home-smoke-test-logs_$(dockerTag)_$(System.JobAttempt)
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 


### PR DESCRIPTION
## Summary of changes

- Normalizes the name of log and snapshot artifacts in Azure Devops to make them easier to find

## Reason for change

I got fed up of scrolling around trying to find the right artifacts

## Implementation details

Every job uses the same pattern: 

- `_$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)`
- `_$(System.StageName)_$(Agent.JobName)_snapshots_$(System.JobAttempt)`

Reasoning:
* Starting with `_` means all the log/snapshot artifacts are grouped together, and all the build artifacts are grouped together. This unfortunately puts the logs at the _start_ of the list (I'd rather they were at the end), but it's still better than being distributed all between each other
* Matches the general hierarchy of the pipeline
* Puts logs and snapshots next to each other

## Test coverage

It works:
![image](https://user-images.githubusercontent.com/18755388/204561693-93742d95-3f1b-47dc-94f5-893e82953bb9.png)
