### PR TITLE
[Profiler] Export tracer native symbols in Github Actions

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -364,7 +364,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Monitoring home
-        run: .\tracer\build.cmd BuildTracerHome BuildNativeLoader BuildProfilerHome CompileProfilerNativeTestsWindows --build-configuration ${{matrix.configuration}}
+        run: .\tracer\build.cmd BuildTracerHome BuildNativeLoader BuildProfilerHome PublishNativeSymbolsWindows CompileProfilerNativeTestsWindows --build-configuration ${{matrix.configuration}}
 
       - name: Run Native Unit tests (x64-${{matrix.configuration}})
         run: .\tracer\build.cmd RunProfilerNativeUnitTestsWindows --build-configuration ${{matrix.configuration}} --TargetPlatform x64


### PR DESCRIPTION
## Summary of changes

Export tracer native symbols.

## Reason for change

Ease when investigating a crash.

## Implementation details

Add `PublishNativeSymbolsWindows` in the yaml file.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
