### PR TITLE
[CI Visibility] Include Intelligent Test Runner stats tags in TestSession

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestModuleSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestModuleSpanTags.cs
@@ -55,7 +55,4 @@ internal partial class TestModuleSpanTags : TestSessionSpanTags
 
     [Tag(CommonTags.OSVersion)]
     public string OSVersion { get; set; }
-
-    [Tag(CommonTags.TestsSkipped)]
-    public string TestsSkipped { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSessionSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSessionSpanTags.cs
@@ -101,6 +101,9 @@ internal partial class TestSessionSpanTags : Trace.Tagging.CommonTags
     [Tag(CommonTags.CiEnvVars)]
     public string CiEnvVars { get; set; }
 
+    [Tag(CommonTags.TestsSkipped)]
+    public string TestsSkipped { get; set; }
+
     public void SetCIEnvironmentValues(CIEnvironmentValues environmentValues)
     {
         if (environmentValues is not null)

--- a/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
@@ -159,5 +159,15 @@ namespace Datadog.Trace.Ci.Tags
         /// Intelligent Test Runner tests skipped flag
         /// </summary>
         public const string TestsSkipped = "_dd.ci.itr.tests_skipped";
+
+        /// <summary>
+        /// Intelligent Test Runner tests skipping is enabled flag
+        /// </summary>
+        public const string TestsSkippingEnabled = "itr.tests_skipping.enabled";
+
+        /// <summary>
+        /// Code Coverage is enabled flag
+        /// </summary>
+        public const string CodeCoverageEnabled = "code_coverage.enabled";
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -132,11 +132,8 @@ public sealed class TestModule
             }
         }
 
-        // Check if Intelligent Test Runner has skippable tests
-        if (CIVisibility.HasSkippableTests())
-        {
-            tags.TestsSkipped = "true";
-        }
+        // Check if Intelligent Test Runner has skippable tests and set the flag according to that
+        tags.TestsSkipped = CIVisibility.HasSkippableTests() ? "true" : "false";
 
         var span = Tracer.Instance.StartSpan(
             string.IsNullOrEmpty(framework) ? "test_module" : $"{framework!.ToLowerInvariant()}.test_module",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -30,8 +30,6 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] OSPlatformBytes = new byte[] { 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
         // OSVersionBytes = System.Text.Encoding.UTF8.GetBytes("os.version");
         private static readonly byte[] OSVersionBytes = new byte[] { 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -48,7 +46,6 @@ namespace Datadog.Trace.Ci.Tagging
                 "os.architecture" => OSArchitecture,
                 "os.platform" => OSPlatform,
                 "os.version" => OSVersion,
-                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -86,9 +83,6 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "os.version": 
                     OSVersion = value;
-                    break;
-                case "_dd.ci.itr.tests_skipped": 
-                    TestsSkipped = value;
                     break;
                 case "test.bundle": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
@@ -154,11 +148,6 @@ namespace Datadog.Trace.Ci.Tagging
             if (OSVersion is not null)
             {
                 processor.Process(new TagItem<string>("os.version", OSVersion, OSVersionBytes));
-            }
-
-            if (TestsSkipped is not null)
-            {
-                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -240,13 +229,6 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("os.version (tag):")
                   .Append(OSVersion)
-                  .Append(',');
-            }
-
-            if (TestsSkipped is not null)
-            {
-                sb.Append("_dd.ci.itr.tests_skipped (tag):")
-                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
         // CiEnvVarsBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.env_vars");
         private static readonly byte[] CiEnvVarsBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
+        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
+        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -94,6 +96,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "git.commit.author.date" => GitCommitAuthorDate,
                 "git.commit.committer.date" => GitCommitCommitterDate,
                 "_dd.ci.env_vars" => CiEnvVars,
+                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -179,6 +182,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "_dd.ci.env_vars": 
                     CiEnvVars = value;
+                    break;
+                case "_dd.ci.itr.tests_skipped": 
+                    TestsSkipped = value;
                     break;
                 case "library_version": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestSessionSpanTags));
@@ -324,6 +330,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (CiEnvVars is not null)
             {
                 processor.Process(new TagItem<string>("_dd.ci.env_vars", CiEnvVars, CiEnvVarsBytes));
+            }
+
+            if (TestsSkipped is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -517,6 +528,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("_dd.ci.env_vars (tag):")
                   .Append(CiEnvVars)
+                  .Append(',');
+            }
+
+            if (TestsSkipped is not null)
+            {
+                sb.Append("_dd.ci.itr.tests_skipped (tag):")
+                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -30,8 +30,6 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] OSPlatformBytes = new byte[] { 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
         // OSVersionBytes = System.Text.Encoding.UTF8.GetBytes("os.version");
         private static readonly byte[] OSVersionBytes = new byte[] { 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -48,7 +46,6 @@ namespace Datadog.Trace.Ci.Tagging
                 "os.architecture" => OSArchitecture,
                 "os.platform" => OSPlatform,
                 "os.version" => OSVersion,
-                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -86,9 +83,6 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "os.version": 
                     OSVersion = value;
-                    break;
-                case "_dd.ci.itr.tests_skipped": 
-                    TestsSkipped = value;
                     break;
                 case "test.bundle": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
@@ -154,11 +148,6 @@ namespace Datadog.Trace.Ci.Tagging
             if (OSVersion is not null)
             {
                 processor.Process(new TagItem<string>("os.version", OSVersion, OSVersionBytes));
-            }
-
-            if (TestsSkipped is not null)
-            {
-                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -240,13 +229,6 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("os.version (tag):")
                   .Append(OSVersion)
-                  .Append(',');
-            }
-
-            if (TestsSkipped is not null)
-            {
-                sb.Append("_dd.ci.itr.tests_skipped (tag):")
-                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
         // CiEnvVarsBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.env_vars");
         private static readonly byte[] CiEnvVarsBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
+        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
+        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -94,6 +96,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "git.commit.author.date" => GitCommitAuthorDate,
                 "git.commit.committer.date" => GitCommitCommitterDate,
                 "_dd.ci.env_vars" => CiEnvVars,
+                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -179,6 +182,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "_dd.ci.env_vars": 
                     CiEnvVars = value;
+                    break;
+                case "_dd.ci.itr.tests_skipped": 
+                    TestsSkipped = value;
                     break;
                 case "library_version": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestSessionSpanTags));
@@ -324,6 +330,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (CiEnvVars is not null)
             {
                 processor.Process(new TagItem<string>("_dd.ci.env_vars", CiEnvVars, CiEnvVarsBytes));
+            }
+
+            if (TestsSkipped is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -517,6 +528,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("_dd.ci.env_vars (tag):")
                   .Append(CiEnvVars)
+                  .Append(',');
+            }
+
+            if (TestsSkipped is not null)
+            {
+                sb.Append("_dd.ci.itr.tests_skipped (tag):")
+                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -30,8 +30,6 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] OSPlatformBytes = new byte[] { 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
         // OSVersionBytes = System.Text.Encoding.UTF8.GetBytes("os.version");
         private static readonly byte[] OSVersionBytes = new byte[] { 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -48,7 +46,6 @@ namespace Datadog.Trace.Ci.Tagging
                 "os.architecture" => OSArchitecture,
                 "os.platform" => OSPlatform,
                 "os.version" => OSVersion,
-                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -86,9 +83,6 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "os.version": 
                     OSVersion = value;
-                    break;
-                case "_dd.ci.itr.tests_skipped": 
-                    TestsSkipped = value;
                     break;
                 case "test.bundle": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
@@ -154,11 +148,6 @@ namespace Datadog.Trace.Ci.Tagging
             if (OSVersion is not null)
             {
                 processor.Process(new TagItem<string>("os.version", OSVersion, OSVersionBytes));
-            }
-
-            if (TestsSkipped is not null)
-            {
-                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -240,13 +229,6 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("os.version (tag):")
                   .Append(OSVersion)
-                  .Append(',');
-            }
-
-            if (TestsSkipped is not null)
-            {
-                sb.Append("_dd.ci.itr.tests_skipped (tag):")
-                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
         // CiEnvVarsBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.env_vars");
         private static readonly byte[] CiEnvVarsBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
+        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
+        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -94,6 +96,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "git.commit.author.date" => GitCommitAuthorDate,
                 "git.commit.committer.date" => GitCommitCommitterDate,
                 "_dd.ci.env_vars" => CiEnvVars,
+                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -179,6 +182,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "_dd.ci.env_vars": 
                     CiEnvVars = value;
+                    break;
+                case "_dd.ci.itr.tests_skipped": 
+                    TestsSkipped = value;
                     break;
                 case "library_version": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestSessionSpanTags));
@@ -324,6 +330,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (CiEnvVars is not null)
             {
                 processor.Process(new TagItem<string>("_dd.ci.env_vars", CiEnvVars, CiEnvVarsBytes));
+            }
+
+            if (TestsSkipped is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -517,6 +528,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("_dd.ci.env_vars (tag):")
                   .Append(CiEnvVars)
+                  .Append(',');
+            }
+
+            if (TestsSkipped is not null)
+            {
+                sb.Append("_dd.ci.itr.tests_skipped (tag):")
+                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestModuleSpanTags.g.cs
@@ -30,8 +30,6 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] OSPlatformBytes = new byte[] { 111, 115, 46, 112, 108, 97, 116, 102, 111, 114, 109 };
         // OSVersionBytes = System.Text.Encoding.UTF8.GetBytes("os.version");
         private static readonly byte[] OSVersionBytes = new byte[] { 111, 115, 46, 118, 101, 114, 115, 105, 111, 110 };
-        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
-        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -48,7 +46,6 @@ namespace Datadog.Trace.Ci.Tagging
                 "os.architecture" => OSArchitecture,
                 "os.platform" => OSPlatform,
                 "os.version" => OSVersion,
-                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -86,9 +83,6 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "os.version": 
                     OSVersion = value;
-                    break;
-                case "_dd.ci.itr.tests_skipped": 
-                    TestsSkipped = value;
                     break;
                 case "test.bundle": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestModuleSpanTags));
@@ -154,11 +148,6 @@ namespace Datadog.Trace.Ci.Tagging
             if (OSVersion is not null)
             {
                 processor.Process(new TagItem<string>("os.version", OSVersion, OSVersionBytes));
-            }
-
-            if (TestsSkipped is not null)
-            {
-                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -240,13 +229,6 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("os.version (tag):")
                   .Append(OSVersion)
-                  .Append(',');
-            }
-
-            if (TestsSkipped is not null)
-            {
-                sb.Append("_dd.ci.itr.tests_skipped (tag):")
-                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSessionSpanTags.g.cs
@@ -62,6 +62,8 @@ namespace Datadog.Trace.Ci.Tagging
         private static readonly byte[] GitCommitCommitterDateBytes = new byte[] { 103, 105, 116, 46, 99, 111, 109, 109, 105, 116, 46, 99, 111, 109, 109, 105, 116, 116, 101, 114, 46, 100, 97, 116, 101 };
         // CiEnvVarsBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.env_vars");
         private static readonly byte[] CiEnvVarsBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 101, 110, 118, 95, 118, 97, 114, 115 };
+        // TestsSkippedBytes = System.Text.Encoding.UTF8.GetBytes("_dd.ci.itr.tests_skipped");
+        private static readonly byte[] TestsSkippedBytes = new byte[] { 95, 100, 100, 46, 99, 105, 46, 105, 116, 114, 46, 116, 101, 115, 116, 115, 95, 115, 107, 105, 112, 112, 101, 100 };
 
         public override string? GetTag(string key)
         {
@@ -94,6 +96,7 @@ namespace Datadog.Trace.Ci.Tagging
                 "git.commit.author.date" => GitCommitAuthorDate,
                 "git.commit.committer.date" => GitCommitCommitterDate,
                 "_dd.ci.env_vars" => CiEnvVars,
+                "_dd.ci.itr.tests_skipped" => TestsSkipped,
                 _ => base.GetTag(key),
             };
         }
@@ -179,6 +182,9 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "_dd.ci.env_vars": 
                     CiEnvVars = value;
+                    break;
+                case "_dd.ci.itr.tests_skipped": 
+                    TestsSkipped = value;
                     break;
                 case "library_version": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(TestSessionSpanTags));
@@ -324,6 +330,11 @@ namespace Datadog.Trace.Ci.Tagging
             if (CiEnvVars is not null)
             {
                 processor.Process(new TagItem<string>("_dd.ci.env_vars", CiEnvVars, CiEnvVarsBytes));
+            }
+
+            if (TestsSkipped is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.ci.itr.tests_skipped", TestsSkipped, TestsSkippedBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -517,6 +528,13 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("_dd.ci.env_vars (tag):")
                   .Append(CiEnvVars)
+                  .Append(',');
+            }
+
+            if (TestsSkipped is not null)
+            {
+                sb.Append("_dd.ci.itr.tests_skipped (tag):")
+                  .Append(TestsSkipped)
                   .Append(',');
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -139,6 +139,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // checks code owners
                             AssertTargetSpanExists(targetTest, TestTags.CodeOwners);
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetTest, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetTest);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -95,6 +95,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // checks code owners
                             AssertTargetSpanExists(targetSpan, TestTags.CodeOwners);
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetSpan, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetSpan);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -157,6 +157,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // checks code owners
                             AssertTargetSpanExists(targetTest, TestTags.CodeOwners);
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetTest, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetTest);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -110,6 +110,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // checks code owners
                             AssertTargetSpanExists(targetSpan, TestTags.CodeOwners);
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetSpan, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetSpan);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -140,6 +140,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // check the version
                             AssertTargetSpanEqual(targetTest, "version", "1.0.0");
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetTest, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetTest);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -94,6 +94,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             // check the version
                             AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                            // remove ITR skippeable tags
+                            AssertTargetSpanExists(targetSpan, CommonTags.TestsSkipped);
+
                             // checks the origin tag
                             CheckOriginTag(targetSpan);
 


### PR DESCRIPTION
## Summary of changes

This PR includes `_dd.ci.itr.tests_skipped`, `itr.tests_skipping.enabled` and `code_coverage.enabled` flags in `TestSession`

## Reason for change

- [ITR Statistics](https://docs.google.com/document/d/1BFqLbMeUk31fuydsGo0bZqho60lqpN5Lv0PGhB5vkAw/edit#heading=h.rnd972k0hiye)
- [Jira Ticket](https://datadoghq.atlassian.net/browse/CIAPP-5422)