### PR TITLE
[Profiler] Disable tiered jit compilation only when Tracer is activated

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -139,9 +139,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         {
             var profilerPath = GetNativeLoaderPath();
 
-            // Temporarily disable tiered compilation
-            environmentVariables["COMPlus_TieredCompilation"] = "0";
-
             environmentVariables["DD_NATIVELOADER_CONFIGFILE"] = GenerateLoaderConfigFile();
 
             if (!File.Exists(profilerPath))
@@ -346,6 +343,9 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
 
         private void AddTracerEnvironmentVariables()
         {
+            // Temporarily disable tiered compilation
+            CustomEnvironmentVariables["COMPlus_TieredCompilation"] = "0";
+
             CustomEnvironmentVariables["DD_TRACE_ENABLED"] = "1";
             CustomEnvironmentVariables["DD_DOTNET_TRACER_HOME"] = GetMonitoringHome();
         }


### PR DESCRIPTION
## Summary of changes

Disable tiered jit compilation when Tracer is activated to prevent profiler specific tests to fail.

## Reason for change

There profiler integration tests where we check the managed callstacks we collected. If we disable tiered jit compilation, the callstack will be different. Today, we want to disable tiered jit compilation only if the Tracer is activated to avoid crashing.

## Implementation details

Set `COMPlus_TieredCompilation= "0"` only when the tracer is activated.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
