### PR TITLE
Set QUIC_LTTng=0 in docker images

### DIFF
--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -15,7 +15,7 @@ ENV \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
     # Disable LTTng tracing with QUIC
     QUIC_LTTng=0
     

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -16,6 +16,8 @@ ENV \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
+    # Disable LTTng tracing with QUIC
+    QUIC_LTTng=0
     
 RUN apk update \
         && apk upgrade \

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -14,7 +14,7 @@ ENV \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
     # Disable LTTng tracing with QUIC
     QUIC_LTTng=0
 

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -15,6 +15,8 @@ ENV \
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
+    # Disable LTTng tracing with QUIC
+    QUIC_LTTng=0
 
 RUN yum update -y \
     && yum install -y centos-release-scl \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -14,7 +14,9 @@ ENV \
     # Enable correct mode for dotnet watch (only mode supported in a container)
     DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
+    NUGET_XMLDOC_MODE=skip \
+    # Disable LTTng tracing with QUIC
+    QUIC_LTTng=0
 
 RUN apt-get update \
     && apt-get -y upgrade \


### PR DESCRIPTION
## Summary of changes

Set QUIC_LTTng=0 in docker images

## Reason for change

Since updating to .NET 7, the build randomly fails with the error:

```
╬══════════════════════════
║ CompileDependencyLibs
╬═════════════════

Process terminated. Error while reaping child. errno = 10
   at System.Environment.FailFast(System.String)
   at System.Diagnostics.ProcessWaitState.TryReapChild(Boolean)
   at System.Diagnostics.ProcessWaitState.CheckChildren(Boolean, Boolean)
   at System.Diagnostics.Process.OnSigChild(Int32, Int32)
##[error]Bash exited with code '139'.
```

There is a possibility that we're running into https://github.com/dotnet/runtime/issues/74795, which would be caused by an issue in LTTng. In that case, disabling LTTng tracing in QUIC might help.

## Implementation details

Setting QUIC_LTTng in all docker images.

https://github.com/microsoft/msquic/blob/3e7f404a319c9d534639ff9b6065077a2c628d76/src/platform/platform_posix.c#L125
