### PR TITLE
Add environment variable DD_TRACE_OTEL_ENABLED 

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -550,9 +550,9 @@ namespace Datadog.Trace.Configuration
             public const string HeaderTagsNormalizationFixEnabled = "DD_TRACE_HEADER_TAG_NORMALIZATION_FIX_ENABLED";
 
             /// <summary>
-            /// Enables experimental support for activity listener
+            /// Enables beta support for instrumentation via the System.Diagnostics API and the OpenTelemetry SDK.
             /// </summary>
-            public const string ActivityListenerEnabled = "DD_TRACE_ACTIVITY_LISTENER_ENABLED";
+            public const string OpenTelemetryEnabled = "DD_TRACE_OTEL_ENABLED";
         }
 
         internal static class Telemetry

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -175,7 +175,8 @@ namespace Datadog.Trace.Configuration
 
             ObfuscationQueryStringRegexTimeout = source?.GetDouble(ConfigurationKeys.ObfuscationQueryStringRegexTimeout) is { } x and > 0 ? x : 200;
 
-            IsActivityListenerEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.ActivityListenerEnabled) ??
+            IsActivityListenerEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled) ??
+                                        source?.GetBool("DD_TRACE_ACTIVITY_LISTENER_ENABLED") ??
                                         // default value
                                         false;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public TelemetryTests(ITestOutputHelper output)
             : base("Telemetry", output)
         {
-            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.ActivityListenerEnabled, "true");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "true");
             SetServiceVersion(ServiceVersion);
             EnableDebugMode();
         }


### PR DESCRIPTION
## Summary of changes
This environment variable is the preferred configuration for enabling the ActivityListener, which combines OTEL/Activity instrumentation with the Datadog automatic instrumentation.

## Reason for change
Enable standardized configuration for combining OTEL custom instrumentation with Datadog automatic instrumentation

## Implementation details
N/A

## Test coverage
Updated the `TelemetryTests` integration test with the new configuration and observed that the custom span was created in the snapshot.

## Other details
N/A
