### PR TITLE
Keep single sampled spans when stats enabled

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -405,11 +405,12 @@ namespace Datadog.Trace.Agent
                 _statsAggregator?.AddRange(spans);
                 var singleSpanSamplingSpans = new List<Span>(); // TODO maybe we can store this from above?
 
-                for (var i = spans.Offset; i < spans.Count; i++)
+                for (var i = 0; i < spans.Count; i++)
                 {
-                    if (spans.Array![i].GetMetric(Metrics.SingleSpanSampling.SamplingMechanism) is not null)
+                    var index = i + spans.Offset;
+                    if (spans.Array![index].GetMetric(Metrics.SingleSpanSampling.SamplingMechanism) is not null)
                     {
-                        singleSpanSamplingSpans.Add(spans.Array![i]);
+                        singleSpanSamplingSpans.Add(spans.Array![index]);
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -414,22 +414,25 @@ namespace Datadog.Trace.Agent
                     }
                 }
 
-                // If stats computation determined that we can drop the P0 Trace,
-                // skip all other processing
-                if (!shouldSendTrace && singleSpanSamplingSpans.Count == 0)
+                if (!shouldSendTrace)
                 {
-                    Interlocked.Increment(ref _droppedP0Traces);
-                    Interlocked.Add(ref _droppedP0Spans, spans.Count);
-                    return;
-                }
-                else if (!shouldSendTrace && singleSpanSamplingSpans.Count > 0)
-                {
-                    // we need to set the sampling priority of the chunk to be user keep so the agent handles it correctly
-                    // this will override the TraceContext sampling priority when we do a SpanBuffer.TryWrite
-                    chunkSamplingPriority = SamplingPriorityValues.UserKeep;
-                    Interlocked.Increment(ref _droppedP0Traces); // increment since we are sampling out the entire trace
-                    Interlocked.Add(ref _droppedP0Spans, spans.Count - singleSpanSamplingSpans.Count);
-                    spans = new ArraySegment<Span>(singleSpanSamplingSpans.ToArray());
+                    // If stats computation determined that we can drop the P0 Trace,
+                    // skip all other processing
+                    if (singleSpanSamplingSpans.Count == 0)
+                    {
+                        Interlocked.Increment(ref _droppedP0Traces);
+                        Interlocked.Add(ref _droppedP0Spans, spans.Count);
+                        return;
+                    }
+                    else
+                    {
+                        // we need to set the sampling priority of the chunk to be user keep so the agent handles it correctly
+                        // this will override the TraceContext sampling priority when we do a SpanBuffer.TryWrite
+                        chunkSamplingPriority = SamplingPriorityValues.UserKeep;
+                        Interlocked.Increment(ref _droppedP0Traces); // increment since we are sampling out the entire trace
+                        Interlocked.Add(ref _droppedP0Spans, spans.Count - singleSpanSamplingSpans.Count);
+                        spans = new ArraySegment<Span>(singleSpanSamplingSpans.ToArray());
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -426,7 +426,7 @@ namespace Datadog.Trace.Agent
                     // we need to set the sampling priority of the chunk to be user keep so the agent handles it correctly
                     // this will override the TraceContext sampling priority when we do a SpanBuffer.TryWrite
                     chunkSamplingPriority = SamplingPriorityValues.UserKeep;
-                    // note that we aren't incrementing _droppedP0Traces as we aren't dropping the trace entirely
+                    Interlocked.Increment(ref _droppedP0Traces); // increment since we are sampling out the entire trace
                     Interlocked.Add(ref _droppedP0Spans, spans.Count - singleSpanSamplingSpans.Count);
                     spans = new ArraySegment<Span>(singleSpanSamplingSpans.ToArray());
                 }

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -70,10 +70,12 @@ internal readonly struct TraceChunkModel
     private TraceChunkModel(in ArraySegment<Span> spans, TraceContext? traceContext, int? samplingPriority)
         : this(spans, traceContext?.RootSpan)
     {
+        SamplingPriority = samplingPriority;
+
         if (traceContext is not null)
         {
             DefaultServiceName = traceContext.Tracer?.DefaultServiceName;
-            SamplingPriority = samplingPriority ?? traceContext.SamplingPriority;
+            SamplingPriority ??= traceContext.SamplingPriority;
             Environment = traceContext.Environment;
             ServiceVersion = traceContext.ServiceVersion;
             Origin = traceContext.Origin;

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -52,8 +52,13 @@ internal readonly struct TraceChunkModel
 
     public readonly ImmutableAzureAppServiceSettings? AzureAppServiceSettings = null;
 
-    public TraceChunkModel(in ArraySegment<Span> spans)
-        : this(spans, GetTraceContext(spans))
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="TraceChunkModel"/> struct.
+    /// </summary>
+    /// <param name="spans">The spans that will be within this <see cref="TraceChunkModel"/>.</param>
+    /// <param name="samplingPriority">Optional sampling priority to override the <see cref="TraceContext"/> sampling priority.</param>
+    public TraceChunkModel(in ArraySegment<Span> spans, int? samplingPriority = null)
+        : this(spans, GetTraceContext(spans), samplingPriority)
     {
         // since all we have is an array of spans, use the trace context from the first span
         // to get the other values we need (sampling priority, origin, trace tags, etc) for now.
@@ -62,13 +67,13 @@ internal readonly struct TraceChunkModel
     }
 
     // used only to chain constructors
-    private TraceChunkModel(in ArraySegment<Span> spans, TraceContext? traceContext)
+    private TraceChunkModel(in ArraySegment<Span> spans, TraceContext? traceContext, int? samplingPriority)
         : this(spans, traceContext?.RootSpan)
     {
         if (traceContext is not null)
         {
             DefaultServiceName = traceContext.Tracer?.DefaultServiceName;
-            SamplingPriority = traceContext.SamplingPriority;
+            SamplingPriority = samplingPriority ?? traceContext.SamplingPriority;
             Environment = traceContext.Environment;
             ServiceVersion = traceContext.ServiceVersion;
             Origin = traceContext.Origin;

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Agent
         // For tests only
         internal bool IsEmpty => !_locked && !IsFull && TraceCount == 0 && SpanCount == 0 && _offset == HeaderSize;
 
-        public bool TryWrite(ArraySegment<Span> spans, ref byte[] temporaryBuffer)
+        public bool TryWrite(ArraySegment<Span> spans, ref byte[] temporaryBuffer, int? samplingPriority = null)
         {
             bool lockTaken = false;
 
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Agent
                 // to get the other values we need (sampling priority, origin, trace tags, etc) for now.
                 // the idea is that as we refactor further, we can pass more than just the spans,
                 // and these values can come directly from the trace context.
-                var traceChunk = new TraceChunkModel(spans);
+                var traceChunk = new TraceChunkModel(spans, samplingPriority);
 
                 // We don't know what the serialized size of the payload will be,
                 // so we need to write to a temporary buffer first

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -4,12 +4,15 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
 using Moq;
@@ -26,6 +29,159 @@ namespace Datadog.Trace.Tests.Agent
         {
             _api = new Mock<IApi>();
             _agentWriter = new AgentWriter(_api.Object, statsAggregator: null, statsd: null, spanSampler: null);
+        }
+
+        [Fact]
+        public async Task SpanSampling_CanComputeStats_ShouldNotSend_WhenSpanSamplingDoesNotMatch()
+        {
+            var api = new Mock<IApi>();
+            var rules = new List<SpanSamplingRule>() { new SpanSamplingRule("*", "*", 0.0f) }; // don't sample any rule
+            var spanSampler = new SpanSampler(rules);
+            var statsAggregator = new Mock<IStatsAggregator>();
+            statsAggregator.Setup(x => x.CanComputeStats).Returns(true);
+            statsAggregator.Setup(x => x.ProcessTrace(It.IsAny<ArraySegment<Span>>())).Returns<ArraySegment<Span>>(x => x);
+            statsAggregator.Setup(x => x.ShouldKeepTrace(It.IsAny<ArraySegment<Span>>())).Returns(false);
+            var agent = new AgentWriter(api.Object, statsAggregator.Object, statsd: null, spanSampler: spanSampler, automaticFlush: false);
+            var tracer = new Tracer(new TracerSettings(), agent, sampler: null, scopeManager: null, statsd: null);
+
+            var traceContext = new TraceContext(tracer);
+            var spanContext = new SpanContext(null, traceContext, "service");
+            var span = new Span(spanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
+            traceContext.AddSpan(span);
+            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            span.Finish(); // triggers the span sampler to run
+            var traceChunk = new ArraySegment<Span>(new[] { span });
+
+            agent.WriteTrace(traceChunk);
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            api.Verify(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()), Times.Never);
+
+            // validate that we have not updated the sampling priority)
+            traceContext.SamplingPriority.Should().Be(-1);
+
+            await _agentWriter.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task SpanSampling_ShouldSend_SingleMatchedSpan_WhenStatsDrops()
+        {
+            var api = new Mock<IApi>();
+            var statsAggregator = new Mock<IStatsAggregator>();
+            statsAggregator.Setup(x => x.CanComputeStats).Returns(true);
+            statsAggregator.Setup(x => x.ProcessTrace(It.IsAny<ArraySegment<Span>>())).Returns<ArraySegment<Span>>(x => x);
+            statsAggregator.Setup(x => x.ShouldKeepTrace(It.IsAny<ArraySegment<Span>>())).Returns(false);
+            var rules = new List<SpanSamplingRule>() { new SpanSamplingRule("*", "*") };
+            var spanSampler = new SpanSampler(rules);
+            var agent = new AgentWriter(api.Object, statsAggregator.Object, statsd: null, spanSampler: spanSampler, automaticFlush: false);
+            var tracer = new Tracer(new TracerSettings(), agent, sampler: null, scopeManager: null, statsd: null);
+
+            var traceContext = new TraceContext(tracer);
+            var spanContext = new SpanContext(null, traceContext, "service");
+            var span = new Span(spanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
+            traceContext.AddSpan(span);
+            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            span.Finish();
+            var traceChunk = new ArraySegment<Span>(new[] { span });
+            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(traceChunk), SpanFormatterResolver.Instance);
+
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Spans = 0;
+
+            api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);
+
+            // validate that we have updated the sampling priority to 2 (manual keep)
+            traceContext.SamplingPriority.Should().Be(2);
+
+            await _agentWriter.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task SpanSampling_ShouldSend_MultipleMatchedSpans_WhenStatsDrops()
+        {
+            var api = new Mock<IApi>();
+            var statsAggregator = new Mock<IStatsAggregator>();
+            statsAggregator.Setup(x => x.CanComputeStats).Returns(true);
+            statsAggregator.Setup(x => x.ProcessTrace(It.IsAny<ArraySegment<Span>>())).Returns<ArraySegment<Span>>(x => x);
+            statsAggregator.Setup(x => x.ShouldKeepTrace(It.IsAny<ArraySegment<Span>>())).Returns(false);
+            var rules = new List<SpanSamplingRule>() { new SpanSamplingRule("*", "*") };
+            var spanSampler = new SpanSampler(rules);
+            var agent = new AgentWriter(api.Object, statsAggregator.Object, statsd: null, spanSampler: spanSampler, automaticFlush: false);
+            var tracer = new Tracer(new TracerSettings(), agent, sampler: null, scopeManager: null, statsd: null);
+
+            var traceContext = new TraceContext(tracer);
+            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            var rootSpanContext = new SpanContext(null, traceContext, "service");
+            var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
+            var keptChildSpan = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "operation" };
+            traceContext.AddSpan(rootSpan); // IS single span sampled
+            traceContext.AddSpan(keptChildSpan); // IS single span sampled
+
+            rootSpan.Finish();
+            keptChildSpan.Finish();
+
+            var expectedChunk = new ArraySegment<Span>(new[] { rootSpan, keptChildSpan });
+            var size = ComputeSize(expectedChunk);
+            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(expectedChunk), SpanFormatterResolver.Instance);
+
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Spans = 0;
+            api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);
+
+            // validate that we have updated the sampling priority to 2 (manual keep)
+            traceContext.SamplingPriority.Should().Be(2);
+
+            await _agentWriter.FlushAndCloseAsync();
+        }
+
+        [Fact]
+        public async Task SpanSampling_ShouldSend_MultipleMatchedSpans_WhenStatsDropsOne()
+        {
+            var api = new Mock<IApi>();
+            var statsAggregator = new Mock<IStatsAggregator>();
+            statsAggregator.Setup(x => x.CanComputeStats).Returns(true);
+            statsAggregator.Setup(x => x.ProcessTrace(It.IsAny<ArraySegment<Span>>())).Returns<ArraySegment<Span>>(x => x);
+            statsAggregator.Setup(x => x.ShouldKeepTrace(It.IsAny<ArraySegment<Span>>())).Returns(false);
+            var rules = new List<SpanSamplingRule>() { new SpanSamplingRule("*", "operation") };
+            var spanSampler = new SpanSampler(rules);
+            var agent = new AgentWriter(api.Object, statsAggregator.Object, statsd: null, spanSampler: spanSampler, automaticFlush: false);
+            var tracer = new Tracer(new TracerSettings(), agent, sampler: null, scopeManager: null, statsd: null);
+
+            var traceContext = new TraceContext(tracer);
+            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            var rootSpanContext = new SpanContext(null, traceContext, "service");
+            var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
+            var droppedChildSpan = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "drop_me" };
+            var droppedChildSpan2 = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "drop_me_also" };
+            var keptChildSpan = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "operation" };
+            traceContext.AddSpan(rootSpan); // IS single span sampled
+            traceContext.AddSpan(droppedChildSpan); // is NOT single span sampled
+            traceContext.AddSpan(droppedChildSpan2); // is NOT single span sampled
+            traceContext.AddSpan(keptChildSpan); // IS single span sampled
+
+            rootSpan.Finish();
+            droppedChildSpan.Finish();
+            droppedChildSpan2.Finish();
+            keptChildSpan.Finish();
+
+            var traceChunk = new ArraySegment<Span>(new[] { rootSpan, droppedChildSpan, droppedChildSpan2, keptChildSpan });
+            var expectedChunk = new ArraySegment<Span>(new[] { rootSpan, keptChildSpan });
+            var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(expectedChunk), SpanFormatterResolver.Instance);
+
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Spans = 2;
+            // expecting a single trace, but there should have been two spans
+            api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);
+
+            // validate that we have updated the sampling priority to 2 (manual keep)
+            traceContext.SamplingPriority.Should().Be(2);
+            await _agentWriter.FlushAndCloseAsync();
         }
 
         [Fact]
@@ -373,7 +529,8 @@ namespace Datadog.Trace.Tests.Agent
 
         private static bool Equals(ArraySegment<byte> data, byte[] expectedData)
         {
-            return data.Array!.Skip(data.Offset).Take(data.Count).Skip(SpanBuffer.HeaderSize).SequenceEqual(expectedData);
+            var equals = data.Array!.Skip(data.Offset).Take(data.Count).Skip(SpanBuffer.HeaderSize).SequenceEqual(expectedData);
+            return equals;
         }
 
         private static int ComputeSize(ArraySegment<Span> spans)

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Tests.Agent
 
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Traces = 1;
             var expectedDroppedP0Spans = 0;
 
             api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Tests.Agent
 
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Traces = 1;
             var expectedDroppedP0Spans = 0;
             api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);
 
@@ -165,7 +165,7 @@ namespace Datadog.Trace.Tests.Agent
 
             await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
-            var expectedDroppedP0Traces = 0;
+            var expectedDroppedP0Traces = 1;
             var expectedDroppedP0Spans = 2;
             // expecting a single trace, but there should have been two spans
             api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1), It.IsAny<bool>(), It.Is<long>(i => i == expectedDroppedP0Traces), It.Is<long>(i => i == expectedDroppedP0Spans)), Times.Once);

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/TraceChunkModelTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/TraceChunkModelTests.cs
@@ -466,6 +466,23 @@ public class TraceChunkModelTests
         traceChunk.HashSetInitialized.Should().BeFalse();
     }
 
+    [Theory]
+    [InlineData(SamplingPriorityValues.UserReject)]
+    [InlineData(SamplingPriorityValues.UserKeep)]
+    [InlineData(SamplingPriorityValues.AutoReject)]
+    [InlineData(SamplingPriorityValues.AutoKeep)]
+    public void Override_SamplingPriority_WhenPresent(int samplingPriority)
+    {
+        var spans = new[]
+                    {
+                        CreateSpan(traceId: 1, spanId: 10, parentId: 5),
+                    };
+
+        var traceChunk = new TraceChunkModel(new ArraySegment<Span>(spans), samplingPriority);
+
+        traceChunk.SamplingPriority.Should().Be(samplingPriority);
+    }
+
     private static TraceChunkModel CreateTraceChunk(IEnumerable<Span> spans, Span root)
     {
         var spansArray = new ArraySegment<Span>(spans.ToArray());


### PR DESCRIPTION
## Summary of changes

Enables single span sampling when stats are enabled within the tracer.

## Reason for change

When stats are enabled the tracer can drop traces/spans, but if single span sampling is enabled we'd like to keep those sampled spans, this enables that.

## Implementation details

- Added additional checks within `AgentWriter.SerializeTrace` after the span sampler is run
- When stats are enabled and we have kept spans with single span sampling we swap those out
- `_droppedP0Traces` is always incremented, `_droppedP0Spans` is incremented with the amount of kept spans subtracted from it.
- Also needed to alter the sampling priority of the trace context to 2 if any are kept so that the agent will keep them

## Test coverage

- System tests pass on a local version (was just a single test for stats w/ single span sampling)
- Added additional tests
- _I think that the `Datadog-Client-Computed-Stats` header is already set and tested when stats are enabled._


