### PR TITLE
[Build] Add missing labels to auto labeller

### DIFF
--- a/.github/labeller.yml
+++ b/.github/labeller.yml
@@ -2,6 +2,9 @@ labels:
   - name: "area:ci-visibility"
     title: "^\\[?(?i)civisibility"
 
+  - name: "area:ci-visibility"
+    title: "^\\[?(?i)(ci visibility)"
+
   - name: "area:serverless"
     title: "^\\[?(?i)serverless"
 
@@ -16,6 +19,12 @@ labels:
 
   - name: "area:debugger"
     title: "^\\[?(?i)debugger"
+
+  - name: "area:debugger"
+    title: "^\\[?(?i)(dynamic instrumentation)"
+
+  - name: "area:builds"
+    title: "^\\[?(?i)build"
 
   - name: "area:profiler"
     allFilesIn: "profiler\/.*"


### PR DESCRIPTION
## Summary of changes

Adds detection of common title patterns to auto-labeller

## Reason for change

When I did the last release, many of the PRs weren't labelled, even though people had added auto-labelling prefixes to the PR title

## Implementation details

Added detection of 

- `[CI Visibility]`
- `[Builds]`
- `[Dynamic Instrumentation]`

## Test coverage

Can't test fully until it's released to master AFAIK, but testing this PR
