### PR TITLE
Small refactor for managed logging

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="ConfigurationKeys.Logging.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.Configuration;
+
+internal static partial class ConfigurationKeys
+{
+        /// <summary>
+        /// Configuration key for enabling or disabling the diagnostic log at startup
+        /// </summary>
+        /// <seealso cref="TracerSettings.StartupDiagnosticLogEnabled"/>
+        public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
+
+        /// <summary>
+        /// Configuration key for setting the approximate maximum size,
+        /// in bytes, for Tracer log files.
+        /// Default value is 10 MB.
+        /// </summary>
+        public const string MaxLogFileSize = "DD_MAX_LOGFILE_SIZE";
+
+        /// <summary>
+        /// Configuration key for setting the number of seconds between,
+        /// identical log messages, for Tracer log files.
+        /// Default value is 60s. Setting to 0 disables rate limiting.
+        /// </summary>
+        public const string LogRateLimit = "DD_TRACE_LOGGING_RATE";
+
+        /// <summary>
+        /// Configuration key for setting the path to the .NET Tracer native log file.
+        /// This also determines the output folder of the .NET Tracer managed log files.
+        /// Overridden by <see cref="LogDirectory"/> if present.
+        /// </summary>
+        [Obsolete(DeprecationMessages.LogPath)]
+        public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
+
+        /// <summary>
+        /// Configuration key for setting the directory of the .NET Tracer logs.
+        /// Overrides the value in <see cref="ProfilerLogPath"/> if present.
+        /// Default value is "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows
+        /// or "/var/log/datadog/dotnet/" on Linux.
+        /// </summary>
+        public const string LogDirectory = "DD_TRACE_LOG_DIRECTORY";
+
+        /// <summary>
+        /// Configuration key for setting in number of days when to delete log files based on their last writetime date.
+        /// </summary>
+        public const string LogFileRetentionDays = "DD_TRACE_LOGFILE_RETENTION_DAYS";
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
@@ -49,4 +49,11 @@ internal static partial class ConfigurationKeys
         /// Configuration key for setting in number of days when to delete log files based on their last writetime date.
         /// </summary>
         public const string LogFileRetentionDays = "DD_TRACE_LOGFILE_RETENTION_DAYS";
+
+        /// <summary>
+        /// Configuration key for locations to write internal diagnostic logs.
+        /// Comma-separated list, containing one of <c>file</c> or <c>datadog</c> e.g. file,datadog
+        /// Defaults to <c>file</c>
+        /// </summary>
+        public const string LogSinks = "DD_TRACE_LOG_SINKS";
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -130,12 +130,6 @@ namespace Datadog.Trace.Configuration
         public const string TraceRateLimit = "DD_TRACE_RATE_LIMIT";
 
         /// <summary>
-        /// Configuration key for enabling or disabling the diagnostic log at startup
-        /// </summary>
-        /// <seealso cref="TracerSettings.StartupDiagnosticLogEnabled"/>
-        public const string StartupDiagnosticLogEnabled = "DD_TRACE_STARTUP_LOGS";
-
-        /// <summary>
         /// Configuration key for setting custom sampling rules based on regular expressions.
         /// Semi-colon separated list of sampling rules.
         /// The rule is matched in order of specification. The first match in a list is used.
@@ -214,36 +208,6 @@ namespace Datadog.Trace.Configuration
         /// Default value is <c>false</c> (disabled).
         /// </summary>
         public const string RuntimeMetricsEnabled = "DD_RUNTIME_METRICS_ENABLED";
-
-        /// <summary>
-        /// Configuration key for setting the approximate maximum size,
-        /// in bytes, for Tracer log files.
-        /// Default value is 10 MB.
-        /// </summary>
-        public const string MaxLogFileSize = "DD_MAX_LOGFILE_SIZE";
-
-        /// <summary>
-        /// Configuration key for setting the number of seconds between,
-        /// identical log messages, for Tracer log files.
-        /// Default value is 60s. Setting to 0 disables rate limiting.
-        /// </summary>
-        public const string LogRateLimit = "DD_TRACE_LOGGING_RATE";
-
-        /// <summary>
-        /// Configuration key for setting the path to the .NET Tracer native log file.
-        /// This also determines the output folder of the .NET Tracer managed log files.
-        /// Overridden by <see cref="LogDirectory"/> if present.
-        /// </summary>
-        [Obsolete(DeprecationMessages.LogPath)]
-        public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
-
-        /// <summary>
-        /// Configuration key for setting the directory of the .NET Tracer logs.
-        /// Overrides the value in <see cref="ProfilerLogPath"/> if present.
-        /// Default value is "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows
-        /// or "/var/log/datadog/dotnet/" on Linux.
-        /// </summary>
-        public const string LogDirectory = "DD_TRACE_LOG_DIRECTORY";
 
         /// <summary>
         /// Configuration key for when a standalone instance of the Trace Agent needs to be started.
@@ -394,11 +358,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="TracerSettings.QueryStringReportingEnabled"/>
         public const string QueryStringReportingEnabled = "DD_HTTP_SERVER_TAG_QUERY_STRING";
-
-        /// <summary>
-        /// Configuration key for setting in number of days when to delete log files based on their last writetime date.
-        /// </summary>
-        public const string LogFileRetentionDays = "DD_TRACE_LOGFILE_RETENTION_DAYS";
 
         /// <summary>
         /// String constants for CI Visibility configuration keys.

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -26,6 +26,7 @@
     the */** trick here ensures that there's at least one subdirectory, which indicates the files comes
     from a source generator as opposed to something that is coming from some other tool. -->
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
+    <Compile Update="Configuration\ConfigurationKeys.*.cs" DependentUpon="ConfigurationKeys.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="DatadogLoggingConfiguration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.Logging.Internal.Configuration;
+
+internal readonly struct DatadogLoggingConfiguration
+{
+    public readonly int RateLimit;
+    public readonly FileLoggingConfiguration? File;
+
+    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file)
+    {
+        RateLimit = rateLimit;
+        File = file;
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/FileLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/FileLoggingConfiguration.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="FileLoggingConfiguration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.Logging.Internal.Configuration;
+
+internal readonly struct FileLoggingConfiguration
+{
+    public readonly long MaxLogFileSizeBytes;
+    public readonly string LogDirectory;
+    public readonly int LogFileRetentionDays;
+
+    public FileLoggingConfiguration(long maxLogFileSizeBytes, string logDirectory, int logFileRetentionDays)
+    {
+        MaxLogFileSizeBytes = maxLogFileSizeBytes;
+        LogDirectory = logDirectory;
+        LogFileRetentionDays = logFileRetentionDays;
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="LogSinkOptions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Logging.Internal.Configuration;
+
+internal static class LogSinkOptions
+{
+    public const string File = "file";
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Logging
         {
             // Initialize the fallback logger right away
             // because some part of the code might produce logs while we initialize the actual logger
-            SharedLogger = new DatadogSerilogLogger(SilentLogger.Instance, new NullLogRateLimiter());
+            SharedLogger = DatadogSerilogLogger.NullLogger;
 
             try
             {

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -4,28 +4,21 @@
 // </copyright>
 
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Util;
-using Datadog.Trace.Vendors.Serilog;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Core.Pipeline;
 using Datadog.Trace.Vendors.Serilog.Events;
-using Datadog.Trace.Vendors.Serilog.Sinks.File;
 
 namespace Datadog.Trace.Logging
 {
     internal static class DatadogLogging
     {
-        internal static readonly LoggingLevelSwitch LoggingLevelSwitch = new LoggingLevelSwitch(DefaultLogLevel);
-        // By default, we don't rate limit log messages;
-        private const int DefaultLogMessageRateLimit = 0;
+        internal static readonly LoggingLevelSwitch LoggingLevelSwitch = new(DefaultLogLevel);
         private const LogEventLevel DefaultLogLevel = LogEventLevel.Information;
-        private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
-        private static readonly IDatadogLogger SharedLogger = null;
+        private static readonly IDatadogLogger SharedLogger;
 
         static DatadogLogging()
         {
@@ -40,81 +33,15 @@ namespace Datadog.Trace.Logging
                     LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 }
 
-                var maxLogSizeVar = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.MaxLogFileSize);
-                if (long.TryParse(maxLogSizeVar, out var maxLogSize))
-                {
-                    // No verbose or debug logs
-                    MaxLogFileSize = maxLogSize;
-                }
+                var config = DatadogLoggingFactory.GetConfiguration(GlobalConfigurationSource.Instance);
 
-                string logDirectory = null;
-                try
+                if (config.File is { LogFileRetentionDays: > 0 } fileConfig)
                 {
-                    logDirectory = GetLogDirectory();
-                }
-                catch
-                {
-                    // Do nothing when an exception is thrown for attempting to access the filesystem
-                }
-
-                Task.Run(() => CleanLogFiles(logDirectory));
-
-                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-                if (logDirectory == null)
-                {
-                    return;
+                    Task.Run(() => CleanLogFiles(fileConfig.LogFileRetentionDays, fileConfig.LogDirectory));
                 }
 
                 var domainMetadata = DomainMetadata.Instance;
-
-                // Ends in a dash because of the date postfix
-                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-.log");
-
-                var loggerConfiguration =
-                    new LoggerConfiguration()
-                       .Enrich.FromLogContext()
-                       .MinimumLevel.ControlledBy(LoggingLevelSwitch)
-                       .WriteTo.File(
-                            managedLogPath,
-                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception} {Properties}{NewLine}",
-                            rollingInterval: RollingInterval.Day,
-                            rollOnFileSizeLimit: true,
-                            fileSizeLimitBytes: MaxLogFileSize,
-                            shared: true);
-
-                try
-                {
-                    loggerConfiguration.Enrich.WithProperty("MachineName", domainMetadata.MachineName);
-                    loggerConfiguration.Enrich.WithProperty("Process", $"[{domainMetadata.ProcessId} {domainMetadata.ProcessName}]");
-                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{domainMetadata.AppDomainId} {domainMetadata.AppDomainName}]");
-#if NETCOREAPP
-                    loggerConfiguration.Enrich.WithProperty("AssemblyLoadContext", System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(DatadogLogging).Assembly)?.ToString());
-#endif
-                    loggerConfiguration.Enrich.WithProperty("TracerVersion", TracerConstants.AssemblyVersion);
-                }
-                catch
-                {
-                    // At all costs, make sure the logger works when possible.
-                }
-
-                var internalLogger = loggerConfiguration.CreateLogger();
-
-                ILogRateLimiter rateLimiter;
-
-                try
-                {
-                    var rate = GetRateLimit();
-
-                    rateLimiter = rate == 0
-                        ? new NullLogRateLimiter()
-                        : new LogRateLimiter(rate);
-                }
-                catch
-                {
-                    rateLimiter = new NullLogRateLimiter();
-                }
-
-                SharedLogger = new DatadogSerilogLogger(internalLogger, rateLimiter);
+                SharedLogger = DatadogLoggingFactory.CreateFromConfiguration(in config, domainMetadata) ?? SharedLogger;
             }
             catch
             {
@@ -154,105 +81,32 @@ namespace Datadog.Trace.Logging
             SetLogLevel(DefaultLogLevel);
         }
 
-        private static int GetRateLimit()
+        internal static void CleanLogFiles(int deleteAfter, string logsDirectory)
         {
-            string rawRateLimit = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.LogRateLimit);
-            if (!string.IsNullOrEmpty(rawRateLimit)
-                && int.TryParse(rawRateLimit, out var rate)
-                && (rate >= 0))
+            var date = DateTime.Now.AddDays(-deleteAfter);
+            var logFormats = new[]
+              {
+                "dotnet-tracer-*.log",
+                "dotnet-native-loader-*.log",
+                "DD-DotNet-Profiler-Native-*.log"
+              };
+
+            try
             {
-                return rate;
-            }
-
-            return DefaultLogMessageRateLimit;
-        }
-
-        internal static string GetLogDirectory()
-        {
-            string logDirectory = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.LogDirectory);
-            if (logDirectory == null)
-            {
-#pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
-                var nativeLogFile = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilerLogPath);
-#pragma warning restore 618
-
-                if (!string.IsNullOrEmpty(nativeLogFile))
+                foreach (var logFormat in logFormats)
                 {
-                    logDirectory = Path.GetDirectoryName(nativeLogFile);
-                }
-            }
-
-            // This entire block may throw a SecurityException if not granted the System.Security.Permissions.FileIOPermission
-            // because of the following API calls
-            //   - Directory.Exists
-            //   - Environment.GetFolderPath
-            //   - Path.GetTempPath
-            if (logDirectory == null)
-            {
-#if NETFRAMEWORK
-                logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
-#else
-                if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
-                {
-                    logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
-                }
-                else
-                {
-                    // Linux
-                    logDirectory = "/var/log/datadog/dotnet";
-                }
-#endif
-            }
-
-            if (!Directory.Exists(logDirectory))
-            {
-                try
-                {
-                    Directory.CreateDirectory(logDirectory);
-                }
-                catch
-                {
-                    // Unable to create the directory meaning that the user
-                    // will have to create it on their own.
-                    // Last effort at writing logs
-                    logDirectory = Path.GetTempPath();
-                }
-            }
-
-            return logDirectory;
-        }
-
-        internal static void CleanLogFiles(string logsDirectory)
-        {
-            var logDaysLimit = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.LogFileRetentionDays) ?? "32";
-
-            if (int.TryParse(logDaysLimit, out var days) && days > 0)
-            {
-                var date = DateTime.Now.AddDays(-days);
-                var logFormats = new[]
-                  {
-                    "dotnet-tracer-*.log",
-                    "dotnet-native-loader-*.log",
-                    "DD-DotNet-Profiler-Native-*.log"
-                  };
-
-                try
-                {
-                    foreach (var logFormat in logFormats)
+                    foreach (var logFile in Directory.EnumerateFiles(logsDirectory, logFormat))
                     {
-                        foreach (var logFile in Directory.EnumerateFiles(logsDirectory, logFormat))
+                        if (File.GetLastWriteTime(logFile) < date)
                         {
-                            if (File.GetLastWriteTime(logFile) < date)
-                            {
-                                File.Delete(logFile);
-                            }
+                            File.Delete(logFile);
                         }
                     }
                 }
-                catch
-                {
-                    // Abort on first catch when doing IO operation for performance reasons.
-                }
+            }
+            catch
+            {
+                // Abort on first catch when doing IO operation for performance reasons.
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -1,0 +1,206 @@
+﻿// <copyright file="DatadogLoggingFactory.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.Internal.Configuration;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog;
+
+namespace Datadog.Trace.Logging;
+
+internal static class DatadogLoggingFactory
+{
+    // By default, we don't rate limit log messages;
+    private const int DefaultRateLimit = 0;
+    private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
+
+    public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource? source)
+    {
+        string? logDirectory = null;
+        try
+        {
+            logDirectory = GetLogDirectory(source);
+        }
+        catch
+        {
+            // Do nothing when an exception is thrown for attempting to access the filesystem
+        }
+
+        if (logDirectory is null)
+        {
+            return new DatadogLoggingConfiguration(rateLimit: DefaultRateLimit, file: null);
+        }
+        
+        // get file details
+        var maxLogSizeVar = source?.GetString(ConfigurationKeys.MaxLogFileSize);
+        var maxLogFileSize = long.TryParse(maxLogSizeVar, out var maxLogSize) ? maxLogSize : DefaultMaxLogFileSize;
+
+        var logFileRetentionDays = source?.GetInt32(ConfigurationKeys.LogFileRetentionDays) switch
+        {
+            >= 0 and var d => d,
+            _ => 32,
+        };
+
+        var fileConfig = new FileLoggingConfiguration(maxLogFileSize, logDirectory, logFileRetentionDays);
+
+        var rateLimit = source?.GetInt32(ConfigurationKeys.LogRateLimit) switch
+        {
+            >= 0 and { } r => r,
+            _ => DefaultRateLimit,
+        };
+
+        return new DatadogLoggingConfiguration(rateLimit, fileConfig);
+    }
+
+    public static IDatadogLogger? CreateFromConfiguration(
+        in DatadogLoggingConfiguration config,
+        DomainMetadata domainMetadata)
+    {
+        if (!config.File.HasValue)
+        {
+            return null;
+        }
+
+        // Ends in a dash because of the date postfix
+        var managedLogPath = Path.Combine(config.File.Value.LogDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-.log");
+
+        var loggerConfiguration =
+            new LoggerConfiguration()
+               .Enrich.FromLogContext()
+               .MinimumLevel.ControlledBy(DatadogLogging.LoggingLevelSwitch)
+               .WriteTo.File(
+                    managedLogPath,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception} {Properties}{NewLine}",
+                    rollingInterval: RollingInterval.Day,
+                    rollOnFileSizeLimit: true,
+                    fileSizeLimitBytes: config.File.Value.MaxLogFileSizeBytes,
+                    shared: true);
+
+        try
+        {
+            loggerConfiguration.Enrich.WithProperty("MachineName", domainMetadata.MachineName);
+            loggerConfiguration.Enrich.WithProperty("Process", $"[{domainMetadata.ProcessId} {domainMetadata.ProcessName}]");
+            loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{domainMetadata.AppDomainId} {domainMetadata.AppDomainName}]");
+#if NETCOREAPP
+            loggerConfiguration.Enrich.WithProperty("AssemblyLoadContext", System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(DatadogLogging).Assembly)?.ToString());
+#endif
+            loggerConfiguration.Enrich.WithProperty("TracerVersion", TracerConstants.AssemblyVersion);
+        }
+        catch
+        {
+            // At all costs, make sure the logger works when possible.
+        }
+
+        var internalLogger = loggerConfiguration.CreateLogger();
+
+        ILogRateLimiter rateLimiter;
+
+        try
+        {
+            rateLimiter = config.RateLimit == 0
+                              ? new NullLogRateLimiter()
+                              : new LogRateLimiter(config.RateLimit);
+        }
+        catch
+        {
+            rateLimiter = new NullLogRateLimiter();
+        }
+
+        return new DatadogSerilogLogger(internalLogger, rateLimiter);
+    }
+
+    // Internal for testing
+    internal static string GetLogDirectory()
+        => GetLogDirectory(GlobalConfigurationSource.CreateDefaultConfigurationSource());
+
+    private static string GetLogDirectory(IConfigurationSource? source)
+    {
+        var logDirectory = source?.GetString(ConfigurationKeys.LogDirectory);
+        if (string.IsNullOrEmpty(logDirectory))
+        {
+#pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
+            var nativeLogFile = source?.GetString(ConfigurationKeys.ProfilerLogPath);
+#pragma warning restore 618
+
+            if (!string.IsNullOrEmpty(nativeLogFile))
+            {
+                logDirectory = Path.GetDirectoryName(nativeLogFile);
+            }
+        }
+
+        // This entire block may throw a SecurityException if not granted the System.Security.Permissions.FileIOPermission
+        // because of the following API calls
+        //   - Directory.Exists
+        //   - Environment.GetFolderPath
+        //   - Path.GetTempPath
+        if (string.IsNullOrEmpty(logDirectory))
+        {
+#if NETFRAMEWORK
+            logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
+#else
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
+            }
+            else
+            {
+                // Linux
+                logDirectory = "/var/log/datadog/dotnet";
+            }
+#endif
+        }
+
+        if (!Directory.Exists(logDirectory))
+        {
+            try
+            {
+                Directory.CreateDirectory(logDirectory);
+            }
+            catch
+            {
+                // Unable to create the directory meaning that the user
+                // will have to create it on their own.
+                // Last effort at writing logs
+                logDirectory = Path.GetTempPath();
+            }
+        }
+
+        return logDirectory!;
+    }
+
+    private static FileLoggingConfiguration? GetFileLoggingConfiguration(IConfigurationSource? source)
+    {
+        string? logDirectory = null;
+        try
+        {
+            logDirectory = GetLogDirectory(source);
+        }
+        catch
+        {
+            // Do nothing when an exception is thrown for attempting to access the filesystem
+        }
+
+        if (logDirectory is null)
+        {
+            return null;
+        }
+
+        // get file details
+        var maxLogSizeVar = source?.GetString(ConfigurationKeys.MaxLogFileSize);
+        var maxLogFileSize = long.TryParse(maxLogSizeVar, out var maxLogSize) ? maxLogSize : DefaultMaxLogFileSize;
+
+        var logFileRetentionDays = source?.GetInt32(ConfigurationKeys.LogFileRetentionDays) switch
+        {
+            >= 0 and var d => d,
+            _ => 32,
+        };
+
+        return new FileLoggingConfiguration(maxLogFileSize, logDirectory, logFileRetentionDays);
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -24,6 +24,8 @@ namespace Datadog.Trace.Logging
             _rateLimiter = rateLimiter;
         }
 
+        public static DatadogSerilogLogger NullLogger { get; } = new(SilentLogger.Instance, new NullLogRateLimiter());
+
         public bool IsEnabled(LogEventLevel level) => _logger.IsEnabled(level);
 
         public void Debug(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -28,7 +28,7 @@ public class RcmBase : AspNetBase
 
     protected TimeSpan LogEntryWatcherTimeout => TimeSpan.FromSeconds(20);
 
-    protected string LogDirectory => Path.Combine(DatadogLogging.GetLogDirectory(), $"{GetTestName()}Logs");
+    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(), $"{GetTestName()}Logs");
 
     internal static void CheckAckState(GetRcmRequest request, string product, uint expectedState, string expectedError, string message)
     {

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.TestHelpers
             _targetFramework = Assembly.GetAssembly(anchorType).GetCustomAttribute<TargetFrameworkAttribute>();
             _output = output;
             MonitoringHome = GetMonitoringHomePath();
-            LogDirectory = DatadogLogging.GetLogDirectory();
+            LogDirectory = DatadogLoggingFactory.GetLogDirectory();
 
             var parts = _targetFramework.FrameworkName.Split(',');
             _runtime = parts[0];

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.TestHelpers;
@@ -20,7 +21,7 @@ public class LogEntryWatcher : IDisposable
 
     public LogEntryWatcher(string logFilePattern, string logDirectory = null)
     {
-        var logPath = logDirectory ?? DatadogLogging.GetLogDirectory();
+        var logPath = logDirectory ?? DatadogLoggingFactory.GetLogDirectory();
         _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
 
         var dir = new DirectoryInfo(logPath);

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -98,4 +98,42 @@ public class DatadogLoggingFactoryTests
             Directory.Exists(logDirectory).Should().BeTrue();
         }
     }
+
+    public class SinkConfiguration
+    {
+        [Fact]
+        public void WhenNoSinksProvided_UsesFileSink()
+        {
+            var source = new NameValueConfigurationSource(new());
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("file")]
+        [InlineData("file,console")]
+        [InlineData("console, file")]
+        [InlineData("unknown,file")]
+        public void WhenFileSinkIsIncluded_UsesFileSink(string sinks)
+        {
+            var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("console")]
+        [InlineData("datadog")]
+        [InlineData("datadog,console")]
+        [InlineData("unknown")]
+        public void WhenFileSinkIsNotIncluded_DoesNotUseFileSink(string sinks)
+        {
+            var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeFalse();
+        }
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="DatadogLoggingFactoryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging;
+
+public class DatadogLoggingFactoryTests
+{
+    public class FileLoggingConfiguration
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("C:/")]
+        [InlineData("/var/root")]
+        public void UsesLogDirectoryWhenItExists(string obsoleteLogDirectory)
+        {
+            // will always exist
+            var logDirectory = Environment.CurrentDirectory;
+
+            var source = new NameValueConfigurationSource(
+                new()
+                {
+                    { ConfigurationKeys.LogDirectory, logDirectory },
+#pragma warning disable CS0618
+                    { ConfigurationKeys.ProfilerLogPath, obsoleteLogDirectory },
+#pragma warning restore CS0618
+                });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+            config.File?.LogDirectory.Should().Be(logDirectory);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void UsesObsoleteLogDirectoryWhenAvailable(string logDirectory)
+        {
+            // will always exist
+            var obsoleteLogDirectory = Environment.CurrentDirectory;
+            var obsoleteLogPath = $"{obsoleteLogDirectory}{Path.DirectorySeparatorChar}{Guid.NewGuid()}.log";
+
+            var source = new NameValueConfigurationSource(
+                new()
+                {
+                    { ConfigurationKeys.LogDirectory, logDirectory },
+#pragma warning disable CS0618
+                    { ConfigurationKeys.ProfilerLogPath, obsoleteLogPath },
+#pragma warning restore CS0618
+                });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+            config.File?.LogDirectory.Should().Be(obsoleteLogDirectory);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        public void UsesEnvironmentFallBackWhenBothNull(string logDirectory, string obsoleteLogDirectory)
+        {
+            var source = new NameValueConfigurationSource(
+                new()
+                {
+                    { ConfigurationKeys.LogDirectory, logDirectory },
+#pragma warning disable CS0618
+                    { ConfigurationKeys.ProfilerLogPath, obsoleteLogDirectory },
+#pragma warning restore CS0618
+                });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+            config.File?.LogDirectory.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreatesLogDirectoryWhenItDoesntExist()
+        {
+            var logDirectory = Path.GetTempPath() + Path.DirectorySeparatorChar + Guid.NewGuid();
+            Directory.Exists(logDirectory).Should().BeFalse();
+
+            var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogDirectory, logDirectory } });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.File.HasValue.Should().BeTrue();
+            config.File?.LogDirectory.Should().Be(logDirectory);
+            Directory.Exists(logDirectory).Should().BeTrue();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -232,7 +232,7 @@ namespace Datadog.Trace.Tests.Logging
             }
 
             // Running method to delete the old files
-            DatadogLogging.CleanLogFiles(tempLogsDir);
+            DatadogLogging.CleanLogFiles(32, tempLogsDir);
 
             var deletedLogFiles = Directory.EnumerateFiles(tempLogsDir, "DD-DotNet-Profiler-Native-*").Count();
             var retainedLogFiles = Directory.EnumerateFiles(tempLogsDir, "dotnet-tracer-*").Count();

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.Internal.Configuration;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 using Datadog.Trace.Vendors.Serilog.Core;
@@ -245,6 +246,54 @@ namespace Datadog.Trace.Tests.Logging
             deletedLogFiles.Should().Be(0);
             retainedLogFiles.Should().Be(2);
             ignoredLogFiles.Should().Be(3);
+        }
+
+        [Fact]
+        public void WritingToAnInvalidPathDoesntCauseErrors()
+        {
+            string directory;
+
+            if (System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                // Windows
+                directory = @"Z:\i-dont-exist";
+            }
+            else
+            {
+                // Linux
+                directory = "/proc/self";
+            }
+
+            // make sure we can't write to it
+            IsDirectoryWritable(directory).Should().BeFalse();
+
+            var config = DatadogLoggingFactory.GetConfiguration(new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.LogDirectory, directory }
+            }));
+            var logger = DatadogLoggingFactory.CreateFromConfiguration(config, DomainMetadata.Instance);
+            logger.Should().NotBeNull();
+
+            logger!.Error("Trying to write an error");
+
+            logger.CloseAndFlush();
+
+            static bool IsDirectoryWritable(string dirPath)
+            {
+                try
+                {
+                    var path = Path.Combine(dirPath, Path.GetRandomFileName());
+                    using (var fs = File.Create(path, bufferSize: 1, FileOptions.DeleteOnClose))
+                    {
+                    }
+
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            }
         }
 
         private void WriteRateLimitedLogMessage(IDatadogLogger logger, string message)


### PR DESCRIPTION
## Summary of changes

- Split the reading of logging configuration from the building of the logger
- Move logging-related config keys to separate (partial) file
- Add `DD_TRACE_LOG_SINK` to control where logs will be written

## Reason for change

This PR is in preparation for follow up PRs that will allow sending the managed logs to other destinations (such as the telemetry backend). It mostly moves things around to make various aspects easier to test

## Implementation details

- Extracted a log of the code in the `DatadogLogging` static constructor to two separate methods in a new `DatadogLoggingFactory` type. This allows us to test both the reading of configuration and the logger that's created, without having to modify the static logger instance
  - `DatadogLoggingFactory.GetConfiguration(IConfigurationSource source)` - reads the configuration keys from the source, and builds an instance of `DatadogLoggingConfiguration` describing the desired config.
  - `DatadogLoggingFactory.CreateFromConfiguration(DatadogLoggingConfiguration)` - creates an instance of `IDatadogLogger` based on the provided configuration.
  - Loading configuration keys from the global `IConfigurationSource`. We were only using env vars, but as far as I can tell, there's no need for that. We were _already_ loading the global `IConfigurationSource` to fetch the `DD_TRACE_DEBUG` variable, so no reason _not_ to use it for the other config values IMO. Plus it makes testing easier.
- Moved the `ConfigurationKeys` into a separate file (and enabled file-folding in VS/Rider)
- Added `DD_TRACE_LOG_SINK` configuration key to control _where_ logs are to be sent. This only has a single valid option currently, `file`, but we'll add additional options soon.
  - The naming is up for discussion. AFAICT, no other languages have a key for this.
- Added a test that confirms we don't crash when writing logs to an unwriteable destination

## Test coverage

Better than it was! Added unit tests for most of the existing, did some manual testing, and will confirm everything looks good in CI.

## Other details
This is a precursor to a PR to send logs to other destinations
