### PR TITLE
Reduce number of testing frameworks in PRs (again)

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -159,7 +159,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsLinuxMatrix()
             {
-                var targetFrameworks = TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0, });
+                var targetFrameworks = TestingFrameworks.Except(new [] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0 });
 
                 var baseImages = new[] { "centos7", "alpine" };
 


### PR DESCRIPTION
## Summary of changes

Fixes regression introduced in #3520

## Reason for change

In #3511 we reduced the number of frameworks we test in PRs to reduce the impact of flakiness. In #3520 I accidentally regressed this, and started testing all frameworks for unit tests and linux integration tests.

## Implementation details

Reinstates the previous behaviour

## Test coverage

Less, hopefully.
