### PR TITLE
[Profiler] Fix little memory leak

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -246,8 +246,9 @@ bool LinuxStackFramesCollector::CanCollect(int32_t threadId, pid_t processId) co
 
 bool LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal, siginfo_t* info, void* context)
 {
-    // Libunwind can overwrite the value of errno - save it beforehand and restore it at the end
+    // Libunwind can overwrite the value of errno - save it beforehand and restore it when leaving
     auto oldErrno = errno;
+    on_leave { errno = oldErrno; };
 
     bool success = false;
 
@@ -279,7 +280,6 @@ bool LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal, sigi
         // no need to release the lock and notify. The sampling thread must wait until its signal is handled correctly
     }
 
-    errno = oldErrno;
     return success;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -6,6 +6,7 @@
 #include <signal.h>
 #include <sys/syscall.h>
 
+#include "ScopeFinalizer.h"
 #include "Log.h"
 #include "OpSysTools.h"
 
@@ -170,6 +171,8 @@ void ProfilerSignalManager::CallOrignalHandler(int32_t signal, siginfo_t* info, 
 
     isExecuting = true;
 
+    on_leave { isExecuting = false; };
+
     try
     {
         if ((_previousAction.sa_flags & SA_SIGINFO) == SA_SIGINFO && _previousAction.sa_sigaction != nullptr)
@@ -187,6 +190,4 @@ void ProfilerSignalManager::CallOrignalHandler(int32_t signal, siginfo_t* info, 
     catch (...)
     {
     }
-
-    isExecuting = false;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -454,6 +454,8 @@ bool LibddprofExporter::Export()
             return false;
         }
 
+        on_leave { ddog_prof_Exporter_drop(exporter); };
+
         Tags additionalTags;
         additionalTags.Add("env", applicationInfo.Environment);
         additionalTags.Add("version", applicationInfo.Version);
@@ -464,6 +466,7 @@ bool LibddprofExporter::Export()
         auto* request = CreateRequest(serializedProfile, exporter, additionalTags);
         if (request != nullptr)
         {
+            on_leave { ddog_prof_Exporter_Request_drop(request); };
             exported &= Send(request, exporter);
         }
         else
@@ -471,7 +474,7 @@ bool LibddprofExporter::Export()
             exported = false;
             Log::Error("Unable to create a request to send the profile.");
         }
-        ddog_prof_Exporter_drop(exporter);
+
     }
     return exported;
 }


### PR DESCRIPTION
## Summary of changes

Rely on RAII to ensure releasing of resources (here we use `on_leave` construct.

While doing that, found a memory leak.

## Implementation details

Use `on_leave` construct + clean up the request object.
