### PR TITLE
Add support for CallTarget async continuations (`OnAsyncMethodEnd` returning a Task)

### DIFF
--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.BenchmarkDotNet
 
                 // Ensure all the spans gets flushed before we report the success.
                 // In some cases the process finishes without sending the traces in the buffer.
-                CIVisibility.FlushSpans();
+                CIVisibility.Flush();
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -246,7 +246,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                     // Ensure all the spans gets flushed before we report the success.
                     // In some cases the process finishes without sending the traces in the buffer.
-                    CIVisibility.FlushSpans();
+                    CIVisibility.Flush();
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci.Tagging;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ExtensionMethods;
@@ -280,9 +281,47 @@ public sealed class TestModule
     /// <param name="duration">Duration of the test module</param>
     public void Close(TimeSpan? duration)
     {
+        if (InternalClose(duration))
+        {
+            CIVisibility.Log.Debug("### Test Module Flushing after close: {name}", Name);
+            CIVisibility.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Close test module
+    /// </summary>
+    /// <returns>Task instance </returns>
+    public Task CloseAsync()
+    {
+        return CloseAsync(null);
+    }
+
+    /// <summary>
+    /// Close test module
+    /// </summary>
+    /// <param name="duration">Duration of the test module</param>
+    /// <returns>Task instance </returns>
+    public Task CloseAsync(TimeSpan? duration)
+    {
+        if (InternalClose(duration))
+        {
+            CIVisibility.Log.Debug("### Test Module Flushing after close: {name}", Name);
+            return CIVisibility.FlushAsync();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Close test module
+    /// </summary>
+    /// <param name="duration">Duration of the test module</param>
+    private bool InternalClose(TimeSpan? duration)
+    {
         if (Interlocked.Exchange(ref _finished, 1) == 1)
         {
-            return;
+            return false;
         }
 
         var span = _span;
@@ -311,7 +350,7 @@ public sealed class TestModule
 
         Current = null;
         CIVisibility.Log.Debug("### Test Module Closed: {name}", Name);
-        CIVisibility.FlushSpans();
+        return true;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
@@ -16,14 +16,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
     {
         internal static readonly IDatadogLogger Log = Ci.CIVisibility.Log;
 
-        internal static void FlushSpans(IntegrationId integrationInfo)
+        internal static void Flush(IntegrationId integrationInfo)
         {
             if (!Tracer.Instance.Settings.IsIntegrationEnabled(integrationInfo))
             {
                 return;
             }
 
-            CIVisibility.FlushSpans();
+            CIVisibility.Flush();
         }
 
         internal static string GetParametersValueData(object paramValue)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitTestAdapterUnloadIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitTestAdapterUnloadIntegration.cs
@@ -34,7 +34,7 @@ public static class NUnitTestAdapterUnloadIntegration
     /// <returns>Return value of the method</returns>
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
     {
-        Common.FlushSpans(NUnitIntegration.IntegrationId);
+        Common.Flush(NUnitIntegration.IntegrationId);
         return CallTargetReturn.GetDefault();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunAsyncIntegration.cs
@@ -7,6 +7,7 @@
 using System;
 using System.ComponentModel;
 using System.Reflection;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
@@ -102,11 +103,11 @@ public static class XUnitTestAssemblyRunnerRunAsyncIntegration
     /// <param name="exception">Exception instance in case the original code threw an exception.</param>
     /// <param name="state">Calltarget state value</param>
     /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-    internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+    internal static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
     {
         if (state.State is TestModule testModule)
         {
-            testModule.Close();
+            await testModule.CloseAsync().ConfigureAwait(false);
         }
 
         return returnValue;

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
@@ -37,19 +37,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
             }
 
             var previousTask = returnValue == null ? null : FromTReturn<Task>(returnValue);
-            if (_continuation is not null)
+            if (_continuation is not null &&
+                (exception != null || returnValue == null || previousTask.Status == TaskStatus.RanToCompletion))
             {
-                if (exception != null || returnValue == null)
-                {
-                    _continuation(instance, default, exception, in state);
-                    return returnValue;
-                }
-
-                if (previousTask.Status == TaskStatus.RanToCompletion)
-                {
-                    _continuation(instance, default, null, in state);
-                    return returnValue;
-                }
+                _continuation(instance, returnValue, exception, in state);
+                return returnValue;
             }
 
             return ToTReturn(ContinuationAction(previousTask, instance, state));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
@@ -11,39 +11,70 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 {
     internal class ValueTaskContinuationGenerator<TIntegration, TTarget, TReturn> : ContinuationGenerator<TTarget, TReturn>
     {
-        private static readonly ContinuationMethodDelegate _continuation;
-        private static readonly bool _preserveContext;
+        private static readonly ContinuationResolver Resolver;
 
         static ValueTaskContinuationGenerator()
         {
             var result = IntegrationMapper.CreateAsyncEndMethodDelegate(typeof(TIntegration), typeof(TTarget), typeof(object));
-            if (result.Method != null)
+            if (result.Method is not null)
             {
-                _continuation = (ContinuationMethodDelegate)result.Method.CreateDelegate(typeof(ContinuationMethodDelegate));
-                _preserveContext = result.PreserveContext;
+                if (result.Method.ReturnType == typeof(Task) ||
+                    (result.Method.ReturnType.IsGenericType && typeof(Task).IsAssignableFrom(result.Method.ReturnType)))
+                {
+                    var asyncContinuation = (AsyncContinuationMethodDelegate)result.Method.CreateDelegate(typeof(AsyncContinuationMethodDelegate));
+                    Resolver = new AsyncContinuationResolver(asyncContinuation, result.PreserveContext);
+                }
+                else
+                {
+                    var continuation = (ContinuationMethodDelegate)result.Method.CreateDelegate(typeof(ContinuationMethodDelegate));
+                    Resolver = new SyncContinuationResolver(continuation, result.PreserveContext);
+                }
             }
+
+            Resolver ??= new ContinuationResolver();
         }
 
         internal delegate object ContinuationMethodDelegate(TTarget target, object returnValue, Exception exception, in CallTargetState state);
 
+        internal delegate Task<object> AsyncContinuationMethodDelegate(TTarget target, object returnValue, Exception exception, in CallTargetState state);
+
         public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
         {
-            if (_continuation is null)
+            return Resolver.SetContinuation(instance, returnValue, exception, in state);
+        }
+
+        private class ContinuationResolver
+        {
+            public virtual TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
             {
                 return returnValue;
             }
+        }
 
-            if (exception != null)
+        private class SyncContinuationResolver : ContinuationResolver
+        {
+            private readonly ContinuationMethodDelegate _continuation;
+            private readonly bool _preserveContext;
+
+            public SyncContinuationResolver(ContinuationMethodDelegate continuation, bool preserveContext)
             {
-                _continuation(instance, default, exception, in state);
-                return returnValue;
+                _continuation = continuation;
+                _preserveContext = preserveContext;
             }
 
-            ValueTask previousValueTask = FromTReturn<ValueTask>(returnValue);
+            public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            {
+                if (exception != null)
+                {
+                    _continuation(instance, default, exception, in state);
+                    return returnValue;
+                }
 
-            return ToTReturn(InnerSetValueTaskContinuation(instance, previousValueTask, state));
+                var previousValueTask = FromTReturn<ValueTask>(returnValue);
+                return ToTReturn(ContinuationAction(previousValueTask, instance, state));
+            }
 
-            static async ValueTask InnerSetValueTaskContinuation(TTarget instance, ValueTask previousValueTask, CallTargetState state)
+            private async ValueTask ContinuationAction(ValueTask previousValueTask, TTarget target, CallTargetState state)
             {
                 try
                 {
@@ -56,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                         // *
                         // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
                         // *
-                        _continuation(instance, default, ex, in state);
+                        _continuation(target, default, ex, in state);
                     }
                     catch (Exception contEx)
                     {
@@ -71,7 +102,66 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     // *
                     // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
                     // *
-                    _continuation(instance, default, default, in state);
+                    _continuation(target, default, default, in state);
+                }
+                catch (Exception contEx)
+                {
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                }
+            }
+        }
+
+        private class AsyncContinuationResolver : ContinuationResolver
+        {
+            private readonly AsyncContinuationMethodDelegate _asyncContinuation;
+            private readonly bool _preserveContext;
+
+            public AsyncContinuationResolver(AsyncContinuationMethodDelegate asyncContinuation, bool preserveContext)
+            {
+                _asyncContinuation = asyncContinuation;
+                _preserveContext = preserveContext;
+            }
+
+            public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            {
+                var previousValueTask = returnValue == null ? new ValueTask() : FromTReturn<ValueTask>(returnValue);
+                return ToTReturn(ContinuationAction(previousValueTask, instance, state, exception));
+            }
+
+            private async ValueTask ContinuationAction(ValueTask previousValueTask, TTarget target, CallTargetState state, Exception exception)
+            {
+                if (exception != null)
+                {
+                    await _asyncContinuation(target, default, exception, in state).ConfigureAwait(_preserveContext);
+                }
+
+                try
+                {
+                    await previousValueTask.ConfigureAwait(_preserveContext);
+                }
+                catch (Exception ex)
+                {
+                    try
+                    {
+                        // *
+                        // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                        // *
+                        await _asyncContinuation(target, default, ex, in state).ConfigureAwait(_preserveContext);
+                    }
+                    catch (Exception contEx)
+                    {
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    }
+
+                    throw;
+                }
+
+                try
+                {
+                    // *
+                    // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                    // *
+                    await _asyncContinuation(target, default, default, in state).ConfigureAwait(_preserveContext);
                 }
                 catch (Exception contEx)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
@@ -12,38 +12,70 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 {
     internal class ValueTaskContinuationGenerator<TIntegration, TTarget, TReturn, TResult> : ContinuationGenerator<TTarget, TReturn>
     {
-        private static readonly ContinuationMethodDelegate _continuation;
-        private static readonly bool _preserveContext;
+        private static readonly ContinuationResolver Resolver;
 
         static ValueTaskContinuationGenerator()
         {
             var result = IntegrationMapper.CreateAsyncEndMethodDelegate(typeof(TIntegration), typeof(TTarget), typeof(TResult));
-            if (result.Method != null)
+            if (result.Method is not null)
             {
-                _continuation = (ContinuationMethodDelegate)result.Method.CreateDelegate(typeof(ContinuationMethodDelegate));
-                _preserveContext = result.PreserveContext;
+                if (result.Method.ReturnType == typeof(Task) ||
+                    (result.Method.ReturnType.IsGenericType && typeof(Task).IsAssignableFrom(result.Method.ReturnType)))
+                {
+                    var asyncContinuation = (AsyncContinuationMethodDelegate)result.Method.CreateDelegate(typeof(AsyncContinuationMethodDelegate));
+                    Resolver = new AsyncContinuationResolver(asyncContinuation, result.PreserveContext);
+                }
+                else
+                {
+                    var continuation = (ContinuationMethodDelegate)result.Method.CreateDelegate(typeof(ContinuationMethodDelegate));
+                    Resolver = new SyncContinuationResolver(continuation, result.PreserveContext);
+                }
             }
+
+            Resolver ??= new ContinuationResolver();
         }
 
         internal delegate TResult ContinuationMethodDelegate(TTarget target, TResult returnValue, Exception exception, in CallTargetState state);
 
+        internal delegate Task<TResult> AsyncContinuationMethodDelegate(TTarget target, TResult returnValue, Exception exception, in CallTargetState state);
+
         public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
         {
-            if (_continuation is null)
+            return Resolver.SetContinuation(instance, returnValue, exception, in state);
+        }
+
+        private class ContinuationResolver
+        {
+            public virtual TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
             {
                 return returnValue;
             }
+        }
 
-            if (exception != null)
+        private class SyncContinuationResolver : ContinuationResolver
+        {
+            private readonly ContinuationMethodDelegate _continuation;
+            private readonly bool _preserveContext;
+
+            public SyncContinuationResolver(ContinuationMethodDelegate continuation, bool preserveContext)
             {
-                _continuation(instance, default, exception, in state);
-                return returnValue;
+                _continuation = continuation;
+                _preserveContext = preserveContext;
             }
 
-            ValueTask<TResult> previousValueTask = FromTReturn<ValueTask<TResult>>(returnValue);
-            return ToTReturn(InnerSetValueTaskContinuation(instance, previousValueTask, state));
+            public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            {
+                if (exception != null)
+                {
+                    _continuation(instance, default, exception, in state);
+                    return returnValue;
+                }
 
-            static async ValueTask<TResult> InnerSetValueTaskContinuation(TTarget instance, ValueTask<TResult> previousValueTask, CallTargetState state)
+                var previousValueTask = FromTReturn<ValueTask<TResult>>(returnValue);
+                return ToTReturn(ContinuationAction(previousValueTask, instance, state));
+            }
+
+            private async ValueTask<TResult> ContinuationAction(ValueTask<TResult> previousValueTask, TTarget target, CallTargetState state)
             {
                 TResult result = default;
                 try
@@ -57,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                         // *
                         // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
                         // *
-                        _continuation(instance, result, ex, in state);
+                        _continuation(target, result, ex, in state);
                     }
                     catch (Exception contEx)
                     {
@@ -72,7 +104,69 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     // *
                     // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
                     // *
-                    return _continuation(instance, result, null, in state);
+                    return _continuation(target, result, null, in state);
+                }
+                catch (Exception contEx)
+                {
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                }
+
+                return result;
+            }
+        }
+
+        private class AsyncContinuationResolver : ContinuationResolver
+        {
+            private readonly AsyncContinuationMethodDelegate _asyncContinuation;
+            private readonly bool _preserveContext;
+
+            public AsyncContinuationResolver(AsyncContinuationMethodDelegate asyncContinuation, bool preserveContext)
+            {
+                _asyncContinuation = asyncContinuation;
+                _preserveContext = preserveContext;
+            }
+
+            public override TReturn SetContinuation(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            {
+                var previousValueTask = FromTReturn<ValueTask<TResult>>(returnValue);
+                return ToTReturn(ContinuationAction(previousValueTask, instance, state, exception));
+            }
+
+            private async ValueTask<TResult> ContinuationAction(ValueTask<TResult> previousValueTask, TTarget target, CallTargetState state, Exception exception)
+            {
+                if (exception != null)
+                {
+                    return await _asyncContinuation(target, default, exception, in state).ConfigureAwait(_preserveContext);
+                }
+
+                TResult result = default;
+                try
+                {
+                    result = await previousValueTask.ConfigureAwait(_preserveContext);
+                }
+                catch (Exception ex)
+                {
+                    try
+                    {
+                        // *
+                        // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                        // *
+                        await _asyncContinuation(target, result, ex, in state).ConfigureAwait(_preserveContext);
+                    }
+                    catch (Exception contEx)
+                    {
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    }
+
+                    throw;
+                }
+
+                try
+                {
+                    // *
+                    // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                    // *
+                    return await _asyncContinuation(target, result, null, in state).ConfigureAwait(_preserveContext);
                 }
                 catch (Exception contEx)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Threading.Tasks;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
@@ -769,6 +770,20 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             return (TTo)returnValue.Instance;
         }
+
+        private static async Task<TTo> UnwrapTaskReturnValue<TFrom, TTo>(Task<TFrom> returnValue, bool preserveContext)
+            where TFrom : IDuckType
+        {
+            return (TTo)(await returnValue.ConfigureAwait(preserveContext)).Instance;
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        private static async ValueTask<TTo> UnwrapValueTaskReturnValue<TFrom, TTo>(ValueTask<TFrom> returnValue, bool preserveContext)
+            where TFrom : IDuckType
+        {
+            return (TTo)(await returnValue.ConfigureAwait(preserveContext)).Instance;
+        }
+#endif
 
         private static void WriteIntValue(ILGenerator il, int value)
         {

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
@@ -246,6 +246,23 @@ namespace Datadog.Trace.Tests.CallTarget
             }
         }
 
+        [Fact]
+        public async Task SuccessGenericKnownTypeTest()
+        {
+            var tcg = new TaskContinuationGenerator<IntegrationWithKnownType, TaskAsyncContinuationGeneratorTests, Task<string>, string>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            var rValue = await cTask;
+            Assert.Equal("ReturnValue[Modified]", rValue);
+
+            async Task<string> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return "ReturnValue";
+            }
+        }
+
         internal class CustomException : Exception
         {
             public CustomException(string message)
@@ -308,6 +325,15 @@ namespace Datadog.Trace.Tests.CallTarget
         internal class ReturnValue
         {
             public string Value { get; set; }
+        }
+
+        internal class IntegrationWithKnownType
+        {
+            public static async Task<string> OnAsyncMethodEnd<TTarget>(TTarget instance, string returnValue, Exception exception, CallTargetState state)
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return returnValue + "[Modified]";
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
@@ -1,0 +1,272 @@
+// <copyright file="TaskAsyncContinuationGeneratorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations;
+using Xunit;
+
+namespace Datadog.Trace.Tests.CallTarget
+{
+    public class TaskAsyncContinuationGeneratorTests
+    {
+        public static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            await Task.Delay(1000).ConfigureAwait(false);
+            return returnValue;
+        }
+
+        [Fact]
+        public async Task SuccessTest()
+        {
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            await cTask;
+
+            async Task GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+            }
+        }
+
+        [Fact]
+        public async Task ExceptionTest()
+        {
+            Exception ex = null;
+
+            // Normal
+            ex = await Assert.ThrowsAsync<CustomException>(() => GetPreviousTask());
+            Assert.Equal("Internal Test Exception", ex.Message);
+
+            // Using the continuation
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task>();
+            var state = CallTargetState.GetDefault();
+            ex = await Assert.ThrowsAsync<CustomException>(() => tcg.SetContinuation(this, GetPreviousTask(), null, in state));
+            Assert.Equal("Internal Test Exception", ex.Message);
+
+            async Task GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                throw new CustomException("Internal Test Exception");
+            }
+        }
+
+        [Fact]
+        public async Task CancelledTest()
+        {
+            // Normal
+            var task = GetPreviousTask();
+            await Assert.ThrowsAsync<CustomCancellationException>(() => task);
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+
+            // Using the continuation
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task>();
+            var state = CallTargetState.GetDefault();
+            task = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            await Assert.ThrowsAsync<CustomCancellationException>(() => task);
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+
+            static Task GetPreviousTask()
+            {
+                var cts = new CancellationTokenSource();
+
+                return Task.FromResult(true).ContinueWith(
+                    _ =>
+                    {
+                        cts.Cancel();
+                        throw new CustomCancellationException(cts.Token);
+                    },
+                    cts.Token);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SynchronizationContextTest(bool preserveContext)
+        {
+            ContinuationGenerator<TaskAsyncContinuationGeneratorTests, Task> tcg;
+
+            if (preserveContext)
+            {
+                tcg = new TaskContinuationGenerator<PreserveContextTests, TaskAsyncContinuationGeneratorTests, Task>();
+            }
+            else
+            {
+                tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task>();
+            }
+
+            var synchronizationContext = new CustomSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            Task.WaitAny(cTask, synchronizationContext.Task);
+
+            // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
+            // If not, the cTask should complete without using the synchronization context
+            var notCompletedTask = preserveContext ? cTask : synchronizationContext.Task;
+
+            Assert.False(notCompletedTask.IsCompleted);
+
+            async Task GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+            }
+        }
+
+        [Fact]
+        public async Task SuccessGenericTest()
+        {
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task<bool>, bool>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            await cTask;
+
+            async Task<bool> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return true;
+            }
+        }
+
+        [Fact]
+        public async Task ExceptionGenericTest()
+        {
+            Exception ex = null;
+
+            // Normal
+            ex = await Assert.ThrowsAsync<CustomException>(() => GetPreviousTask());
+            Assert.Equal("Internal Test Exception", ex.Message);
+
+            // Using the continuation
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task<bool>, bool>();
+            var state = CallTargetState.GetDefault();
+            ex = await Assert.ThrowsAsync<CustomException>(() => tcg.SetContinuation(this, GetPreviousTask(), null, in state));
+            Assert.Equal("Internal Test Exception", ex.Message);
+
+            async Task<bool> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                throw new CustomException("Internal Test Exception");
+            }
+        }
+
+        [Fact]
+        public async Task CancelledGenericTest()
+        {
+            // Normal
+            var task = GetPreviousTask();
+            await Assert.ThrowsAsync<CustomCancellationException>(() => task);
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+
+            // Using the continuation
+            var tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task<bool>, bool>();
+            var state = CallTargetState.GetDefault();
+            task = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            await Assert.ThrowsAsync<CustomCancellationException>(() => task);
+            Assert.Equal(TaskStatus.Canceled, task.Status);
+
+            static Task<bool> GetPreviousTask()
+            {
+                var cts = new CancellationTokenSource();
+
+                return Task.FromResult(true).ContinueWith<bool>(
+                    _ =>
+                    {
+                        cts.Cancel();
+                        throw new CustomCancellationException(cts.Token);
+                    },
+                    cts.Token);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void SynchronizationContextGenericTest(bool preserveContext)
+        {
+            ContinuationGenerator<TaskAsyncContinuationGeneratorTests, Task<bool>> tcg;
+
+            if (preserveContext)
+            {
+                tcg = new TaskContinuationGenerator<PreserveContextTests, TaskAsyncContinuationGeneratorTests, Task<bool>, bool>();
+            }
+            else
+            {
+                tcg = new TaskContinuationGenerator<TaskAsyncContinuationGeneratorTests, TaskAsyncContinuationGeneratorTests, Task<bool>, bool>();
+            }
+
+            var synchronizationContext = new CustomSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            Task.WaitAny(cTask, synchronizationContext.Task);
+
+            // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
+            // If not, the cTask should complete without using the synchronization context
+            var notCompletedTask = preserveContext ? cTask : synchronizationContext.Task;
+
+            Assert.False(notCompletedTask.IsCompleted);
+
+            async Task<bool> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return true;
+            }
+        }
+
+        internal class CustomException : Exception
+        {
+            public CustomException(string message)
+                : base(message)
+            {
+            }
+        }
+
+        internal class CustomCancellationException : OperationCanceledException
+        {
+            public CustomCancellationException(CancellationToken token)
+                : base(token)
+            {
+            }
+        }
+
+        internal class CustomSynchronizationContext : SynchronizationContext
+        {
+            private readonly TaskCompletionSource<bool> _tcs = new();
+
+            public Task Task => _tcs.Task;
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                _tcs.TrySetResult(true);
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                _tcs.TrySetResult(true);
+            }
+        }
+
+        internal class PreserveContextTests
+        {
+            [PreserveContext]
+            public static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return returnValue;
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
@@ -245,6 +245,23 @@ namespace Datadog.Trace.Tests.CallTarget
             }
         }
 
+        [Fact]
+        public async Task SuccessGenericKnownTypeTest()
+        {
+            var tcg = new TaskContinuationGenerator<IntegrationWithKnownType, TaskContinuationGeneratorTests, Task<string>, string>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            var rValue = await cTask;
+            Assert.Equal("ReturnValue[Modified]", rValue);
+
+            async Task<string> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return "ReturnValue";
+            }
+        }
+
         internal class CustomException : Exception
         {
             public CustomException(string message)
@@ -305,6 +322,14 @@ namespace Datadog.Trace.Tests.CallTarget
         internal class ReturnValue
         {
             public string Value { get; set; }
+        }
+
+        internal class IntegrationWithKnownType
+        {
+            public static string OnAsyncMethodEnd<TTarget>(TTarget instance, string returnValue, Exception exception, in CallTargetState state)
+            {
+                return returnValue + "[Modified]";
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
@@ -251,6 +251,23 @@ namespace Datadog.Trace.Tests.CallTarget
             }
         }
 
+        [Fact]
+        public async Task SuccessGenericKnownTypeTest()
+        {
+            var tcg = new ValueTaskContinuationGenerator<IntegrationWithKnownType, ValueTaskAsyncContinuationGeneratorTests, ValueTask<string>, string>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            var rValue = await cTask;
+            Assert.Equal("ReturnValue[Modified]", rValue);
+
+            async ValueTask<string> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return "ReturnValue";
+            }
+        }
+
         internal class CustomException : Exception
         {
             public CustomException(string message)
@@ -313,6 +330,15 @@ namespace Datadog.Trace.Tests.CallTarget
         internal class ReturnValue
         {
             public string Value { get; set; }
+        }
+
+        internal class IntegrationWithKnownType
+        {
+            public static async Task<string> OnAsyncMethodEnd<TTarget>(TTarget instance, string returnValue, Exception exception, CallTargetState state)
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return returnValue + "[Modified]";
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="ValueTaskContinuationGeneratorTests.cs" company="Datadog">
+// <copyright file="ValueTaskAsyncContinuationGeneratorTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,17 +13,18 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.CallTarget
 {
-    public class ValueTaskContinuationGeneratorTests
+    public class ValueTaskAsyncContinuationGeneratorTests
     {
-        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+        public static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
+            await Task.Delay(1000).ConfigureAwait(false);
             return returnValue;
         }
 
         [Fact]
         public async ValueTask SuccessTest()
         {
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             var state = CallTargetState.GetDefault();
             var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
 
@@ -45,7 +46,7 @@ namespace Datadog.Trace.Tests.CallTarget
             Assert.Equal("Internal Test Exception", ex.Message);
 
             // Using the continuation
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             var state = CallTargetState.GetDefault();
             ex = await Assert.ThrowsAsync<CustomException>(() => tcg.SetContinuation(this, GetPreviousTask(), null, in state).AsTask());
             Assert.Equal("Internal Test Exception", ex.Message);
@@ -67,7 +68,7 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // Using the continuation
             task = GetPreviousTask();
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             var state = CallTargetState.GetDefault();
             await Assert.ThrowsAsync<CustomCancellationException>(() => tcg.SetContinuation(this, task, null, in state).AsTask());
             Assert.True(task.IsCanceled);
@@ -93,15 +94,15 @@ namespace Datadog.Trace.Tests.CallTarget
         [InlineData(false)]
         public void SynchronizationContextTest(bool preserveContext)
         {
-            ContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTask> tcg;
+            ContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTask> tcg;
 
             if (preserveContext)
             {
-                tcg = new ValueTaskContinuationGenerator<PreserveContextTests, ValueTaskContinuationGeneratorTests, ValueTask>();
+                tcg = new ValueTaskContinuationGenerator<PreserveContextTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             }
             else
             {
-                tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask>();
+                tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask>();
             }
 
             var synchronizationContext = new CustomSynchronizationContext();
@@ -127,7 +128,7 @@ namespace Datadog.Trace.Tests.CallTarget
         [Fact]
         public async Task SuccessGenericTest()
         {
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask<bool>, bool>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>, bool>();
             var state = CallTargetState.GetDefault();
             var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
 
@@ -150,7 +151,7 @@ namespace Datadog.Trace.Tests.CallTarget
             Assert.Equal("Internal Test Exception", ex.Message);
 
             // Using the continuation
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask<bool>, bool>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>, bool>();
             var state = CallTargetState.GetDefault();
             ex = await Assert.ThrowsAsync<CustomException>(() => tcg.SetContinuation(this, GetPreviousTask(), null, in state).AsTask());
             Assert.Equal("Internal Test Exception", ex.Message);
@@ -172,7 +173,7 @@ namespace Datadog.Trace.Tests.CallTarget
 
             // Using the continuation
             task = GetPreviousTask();
-            var tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask<bool>, bool>();
+            var tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>, bool>();
             var state = CallTargetState.GetDefault();
             await Assert.ThrowsAsync<CustomCancellationException>(() => tcg.SetContinuation(this, task, null, in state).AsTask());
             Assert.True(task.IsCanceled);
@@ -198,15 +199,15 @@ namespace Datadog.Trace.Tests.CallTarget
         [InlineData(false)]
         public void SynchronizationContextGenericTest(bool preserveContext)
         {
-            ContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTask<bool>> tcg;
+            ContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>> tcg;
 
             if (preserveContext)
             {
-                tcg = new ValueTaskContinuationGenerator<PreserveContextTests, ValueTaskContinuationGeneratorTests, ValueTask<bool>, bool>();
+                tcg = new ValueTaskContinuationGenerator<PreserveContextTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>, bool>();
             }
             else
             {
-                tcg = new ValueTaskContinuationGenerator<ValueTaskContinuationGeneratorTests, ValueTaskContinuationGeneratorTests, ValueTask<bool>, bool>();
+                tcg = new ValueTaskContinuationGenerator<ValueTaskAsyncContinuationGeneratorTests, ValueTaskAsyncContinuationGeneratorTests, ValueTask<bool>, bool>();
             }
 
             var synchronizationContext = new CustomSynchronizationContext();
@@ -233,7 +234,7 @@ namespace Datadog.Trace.Tests.CallTarget
         [Fact]
         public async Task SuccessGenericDuckTypeTest()
         {
-            var tcg = new ValueTaskContinuationGenerator<IntegrationWithDuckType, ValueTaskContinuationGeneratorTests, ValueTask<ReturnValue>, ReturnValue>();
+            var tcg = new ValueTaskContinuationGenerator<IntegrationWithDuckType, ValueTaskAsyncContinuationGeneratorTests, ValueTask<ReturnValue>, ReturnValue>();
             var state = CallTargetState.GetDefault();
             var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
 
@@ -286,8 +287,9 @@ namespace Datadog.Trace.Tests.CallTarget
         internal class PreserveContextTests
         {
             [PreserveContext]
-            public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            public static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
             {
+                await Task.Delay(1000).ConfigureAwait(false);
                 return returnValue;
             }
         }
@@ -299,9 +301,10 @@ namespace Datadog.Trace.Tests.CallTarget
                 string Value { get; set; }
             }
 
-            public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            public static async Task<TReturn> OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
                 where TReturn : IReturnValue
             {
+                await Task.Delay(1000).ConfigureAwait(false);
                 returnValue.Value += "[Modified]";
                 return returnValue;
             }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskContinuationGeneratorTests.cs
@@ -250,6 +250,23 @@ namespace Datadog.Trace.Tests.CallTarget
             }
         }
 
+        [Fact]
+        public async Task SuccessGenericKnownTypeTest()
+        {
+            var tcg = new ValueTaskContinuationGenerator<IntegrationWithKnownType, ValueTaskContinuationGeneratorTests, ValueTask<string>, string>();
+            var state = CallTargetState.GetDefault();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+
+            var rValue = await cTask;
+            Assert.Equal("ReturnValue[Modified]", rValue);
+
+            async ValueTask<string> GetPreviousTask()
+            {
+                await Task.Delay(1000).ConfigureAwait(false);
+                return "ReturnValue";
+            }
+        }
+
         internal class CustomException : Exception
         {
             public CustomException(string message)
@@ -310,6 +327,14 @@ namespace Datadog.Trace.Tests.CallTarget
         internal class ReturnValue
         {
             public string Value { get; set; }
+        }
+
+        internal class IntegrationWithKnownType
+        {
+            public static string OnAsyncMethodEnd<TTarget>(TTarget instance, string returnValue, Exception exception, in CallTargetState state)
+            {
+                return returnValue + "[Modified]";
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
