### PR TITLE
Add integration tests for OWIN apps hosted on Microsoft.Owin.Host.SystemWeb

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -504,6 +504,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes.TestRuns", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OpenTelemetrySdk", "tracer\test\test-applications\integrations\Samples.OpenTelemetrySdk\Samples.OpenTelemetrySdk.csproj", "{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Owin.Iis.WebApi2", "tracer\test\test-applications\aspnet\Samples.Owin.Iis.WebApi2\Samples.Owin.Iis.WebApi2.csproj", "{B417E258-A21F-4546-B78F-8A7A4879472A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -2532,6 +2534,18 @@ Global
 		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Release|x64.Build.0 = Release|x64
 		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Release|x86.ActiveCfg = Release|x86
 		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Release|x86.Build.0 = Release|x86
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|x64.ActiveCfg = Debug|x64
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|x64.Build.0 = Debug|x64
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|x86.ActiveCfg = Debug|x86
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Debug|x86.Build.0 = Debug|x86
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|x64.ActiveCfg = Release|x64
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|x64.Build.0 = Release|x64
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|x86.ActiveCfg = Release|x86
+		{B417E258-A21F-4546-B78F-8A7A4879472A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2724,6 +2738,7 @@ Global
 		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{4F377216-3D76-4169-BE2B-8DA3A653DD5E} = {0884B566-D22E-498C-BAA9-26D50ABCAE3A}
 		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{B417E258-A21F-4546-B78F-8A7A4879472A} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -215,7 +215,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Overriding the method name to _
             // Overriding the parameters to remove the expectedSpanCount parameter, which is necessary for operation but unnecessary for the filename
             await Verifier.Verify(spans, settings)
-                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}");
+                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}")
+                          .DisableRequireUniquePrefix(); // sharing snapshots between web api and owin
         }
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
@@ -1,0 +1,150 @@
+// <copyright file="OwinIisWebApi2Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class OwinIisWebApi2TestsCallTarget : OwinIisWebApi2Tests
+    {
+        public OwinIisWebApi2TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class OwinIisWebApi2TestsCallTargetWithFeatureFlag : OwinIisWebApi2Tests
+    {
+        public OwinIisWebApi2TestsCallTargetWithFeatureFlag(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class OwinIisWebApi2TestsCallTargetWithRouteTemplateExpansion : OwinIisWebApi2Tests
+    {
+        public OwinIisWebApi2TestsCallTargetWithRouteTemplateExpansion(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableRouteTemplateResourceNames: true, enableRouteTemplateExpansion: true)
+        {
+        }
+    }
+
+    [UsesVerify]
+    public abstract class OwinIisWebApi2Tests : TracingIntegrationTest, IClassFixture<IisFixture>
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        public OwinIisWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableRouteTemplateResourceNames, bool enableRouteTemplateExpansion = false)
+            : base("Owin.Iis.WebApi2", @"test\test-applications\aspnet", output)
+        {
+            SetServiceVersion("1.0.0");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, enableRouteTemplateResourceNames.ToString());
+            SetEnvironmentVariable(ConfigurationKeys.ExpandRouteTemplatesEnabled, enableRouteTemplateExpansion.ToString());
+
+            _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/shutdown";
+
+            // OWIN can only run in integrated mode
+            _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
+
+            _iisFixture = iisFixture;
+            _testName = nameof(AspNetWebApi2Tests) // Note that these spans are identical to the non-owin webapi2 version
+                      + ".Integrated"
+                      + (enableRouteTemplateExpansion ? ".WithExpansion" :
+                        (enableRouteTemplateResourceNames ?  ".WithFF" : ".NoFF"));
+        }
+
+        public static TheoryData<string, int, int> Data() => new()
+        {
+            { "/api/environment", 200, 2 },
+            { "/api/absolute-route", 200, 2 },
+            { "/api/delay/0", 200, 2 },
+            { "/api/delay-optional", 200, 2 },
+            { "/api/delay-optional/1", 200, 2 },
+            { "/api/delay-async/0", 200, 2 },
+            { "/api/transient-failure/true", 200, 2 },
+            { "/api/transient-failure/false", 500, 3 },
+            { "/api/statuscode/201", 201, 2 },
+            { "/api/statuscode/503", 503, 2 },
+            { "/api/constraints", 200, 2 },
+            { "/api/constraints/201", 201, 2 },
+            // { "/api/TransferRequest/401", 401, 4 },
+            // { "/api/TransferRequest/503", 503, 4 },
+            { "/api2/delay/0", 200, 2 },
+            { "/api2/optional", 200, 2 },
+            { "/api2/optional/1", 200, 2 },
+            { "/api2/delayAsync/0", 200, 2 },
+            { "/api2/transientfailure/true", 200, 2 },
+            { "/api2/transientfailure/false", 500, 3 },
+            { "/api2/statuscode/201", 201, 2 },
+            { "/api2/statuscode/503", 503, 3 },
+
+            // The global message handler will fail when ps=false
+            // The per-route message handler is not invoked with the route /api2, so ts=true|false has no effect
+            { "/api2/statuscode/201?ps=true&ts=true", 201, 2 },
+            { "/api2/statuscode/201?ps=true&ts=false", 201, 2 },
+            { "/api2/statuscode/201?ps=false&ts=true", 500, 2 },
+            { "/api2/statuscode/201?ps=false&ts=false", 500, 2 },
+
+            // The global message handler will fail when ps=false
+            // The global and per-route message handler is invoked with the route /handler-api, so ts=false will also fail the request
+            // { "/handler-api/api?ps=true&ts=true", 200, 1 }, // I'm not sure why, but this one doesnt seem to work
+            { "/handler-api/api?ps=true&ts=false", 500, 2 },
+            { "/handler-api/api?ps=false&ts=true", 500, 2 },
+            { "/handler-api/api?ps=false&ts=false", 500, 2 },
+        };
+
+        public override Result ValidateIntegrationSpan(MockSpan span) =>
+            span.Name switch
+            {
+                "aspnet.request" => span.IsAspNet(),
+                "aspnet-webapi.request" => span.IsAspNetWebApi2(),
+                _ => Result.DefaultSuccess,
+            };
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
+        [MemberData(nameof(Data))]
+        public async Task SubmitsTraces(string path, HttpStatusCode statusCode, int expectedSpanCount)
+        {
+            // Append virtual directory to the actual request
+            var spans = await GetWebServerSpans(_iisFixture.VirtualApplicationPath + path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount);
+            ValidateIntegrationSpans(spans, expectedServiceName: "sample", isExternalSpan: false);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Overriding the method name to _
+            // Overriding the parameters to remove the expectedSpanCount parameter, which is necessary for operation but unnecessary for the filename
+            await Verifier.Verify(spans, settings)
+                          .UseFileName($"{_testName}.__path={sanitisedPath}_statusCode={(int)statusCode}")
+                          .DisableRequireUniquePrefix(); // sharing snapshots between web api and owin
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
@@ -90,6 +90,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/api/statuscode/503", 503, 2 },
             { "/api/constraints", 200, 2 },
             { "/api/constraints/201", 201, 2 },
+            // Transfer request doesn't work as expected with OWIN, but I'm not sure whether they should work, and seems relatively niche so ignoring them for now
             // { "/api/TransferRequest/401", 401, 4 },
             // { "/api/TransferRequest/503", 503, 4 },
             { "/api2/delay/0", 200, 2 },

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Controllers/HomeController.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Web.Http;
+
+namespace Samples.Owin.WebApi2.Controllers
+{
+    [RoutePrefix("")]
+    public class HomeController : System.Web.Http.ApiController
+    {
+        [HttpGet]
+        [Route("alive-check")]
+        public string IsAlive()
+        {
+            return "Yes";
+        }
+
+        [HttpGet]
+        [Route("shutdown")]
+        public string Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
+
+            return "Code coverage data has been flushed";
+        }
+    }
+}

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Properties/AssemblyInfo.cs
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Samples.Owin.Iis.WebApi2")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Samples.Owin.Iis.WebApi2")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b417e258-a21f-4546-b78f-8a7a4879472a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Samples.Owin.Iis.WebApi2.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Samples.Owin.Iis.WebApi2.csproj
@@ -1,0 +1,193 @@
+﻿<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{B417E258-A21F-4546-B78F-8A7A4879472A}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Samples.Owin.Iis.WebApi2</RootNamespace>
+    <AssemblyName>Samples.Owin.Iis.WebApi2</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.Owin.Host.SystemWeb.4.2.2\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.9\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Web.Http, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.9\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.9.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.9\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Samples.AspNetMvc5\Handlers\CustomTracingExceptionHandler.cs">
+      <Link>Handlers\CustomTracingExceptionHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.AspNetMvc5\Handlers\PassThroughQuerySuccessMessageHandler.cs">
+      <Link>Handlers\PassThroughQuerySuccessMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.AspNetMvc5\Handlers\TerminatingQuerySuccessMessageHandler.cs">
+      <Link>Handlers\TerminatingQuerySuccessMessageHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Samples.AspNetMvc5\Controllers\ApiController.cs" Link="Controllers\ApiController.cs" />
+    <Compile Include="..\Samples.AspNetMvc5\Controllers\ConventionsController.cs" Link="Controllers\ConventionsController.cs" />
+    <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>49631</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:49631/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Import Project="..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.3.6.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Startup.cs
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Startup.cs
@@ -1,0 +1,55 @@
+using System.Web;
+using System.IO;
+using System.Web.Http;
+using System.Web.Http.ExceptionHandling;
+using Microsoft.Owin;
+using Owin;
+using Microsoft.Owin.Extensions;
+using Samples.AspNetMvc5.Handlers;
+using Samples.Owin.WebApi2;
+
+[assembly: OwinStartup(typeof(Startup))]
+
+namespace Samples.Owin.WebApi2
+{
+    public class Startup
+    {
+        public static void Configuration(IAppBuilder appBuilder)
+        {
+            var config = new HttpConfiguration();
+
+            // Attribute routing.
+            config.MapHttpAttributeRoutes();
+
+            // Replace default exception handler
+            config.Services.Replace(typeof(IExceptionHandler), new CustomTracingExceptionHandler());
+
+            // Add global message handler
+            config.MessageHandlers.Add(new PassThroughQuerySuccessMessageHandler());
+
+            // Convention-based routing.
+            config.Routes.MapHttpRoute( 
+                name: "ApiConventions", 
+                routeTemplate: "api2/{action}/{value}",
+                defaults: new
+                {
+                    controller = "Conventions",
+                    value = RouteParameter.Optional
+                });
+
+            // Add a new /handler-api base path that will be handled by a per-route message handler
+            config.Routes.MapHttpRoute(
+                name: "Route2",
+                routeTemplate: "handler-api/{controller}/{id}",
+                defaults: new
+                {
+                    id = RouteParameter.Optional
+                },
+                constraints: null,
+                handler: new TerminatingQuerySuccessMessageHandler()  // per-route message handler
+            );
+
+            appBuilder.UseWebApi(config);
+        }
+    }
+}

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.Debug.config
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.Release.config
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/Web.config
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  https://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.6.2" />
+    <httpRuntime targetFramework="4.6.2" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.2.0" newVersion="4.2.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <system.codedom>
+    <compilers>
+      <compiler extension=".cs" language="c#;cs;csharp" warningLevel="4" compilerOptions="/langversion:7.0 /nowarn:1659;1699;1701;612;618" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+      <compiler extension=".vb" language="vb;vbs;visualbasic;vbscript" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008,40000,40008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
+    </compilers>
+  </system.codedom>
+</configuration>

--- a/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.Owin.Iis.WebApi2/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.9" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.9" targetFramework="net462" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.9" targetFramework="net462" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="3.6.0" targetFramework="net462" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net462" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.2.2" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net462" />
+  <package id="Owin" version="1.0" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
## Summary of changes

Adds sample and integration tests for OWIN WebApi2 app hosted using Microsoft.Owin.Host.SystemWeb

## Reason for change

As part of a recent escalation, we identified we weren't testing this setup. This testing seems to confirm we're instrumenting correctly (with a couple of small caveats described below)

## Implementation details

Created an OWIN app that uses WebApi2 and hosts in IIS using Microsoft.Owin.Host.SystemWeb. The app is like a combination between the existing `Samples.Owin.WebApi2`app and the `Samples.AspNet5Mvc` sample. The main difference is the hosting mechanism (IIS/System.Web instead of self-hosted).

## Test coverage

Add `OwinwebApi2Tests` based on existing Owin/WebApi2 samples. Rather than create hundreds of new snapshots, I re-used the WebApi2 snapshots, as these should be identical, with 2 caveats:

- I remove the transfer-request requests. These don't work with OWIN, but I'm not sure whether they _should_ work, and seems relatively niche so removed them for now
- The combination of terminating handling and global handler doesn't seems to work in the new app, as we don't get a span for the handler. I'm not sure why, but again, seems niche, so removed for now

## Other Info
I tested locally using 
- `.\tracer\build.ps1 BuildTracerHome`
- `.\tracer\build.ps1 BuildAspNetIntegrationTests  -framework net462 -sampleName "Samples.Owin.Iis.WebApi2" -filter "OwinIisWebApi2"`
- Then, from elevated prompt, `.\tracer\build.ps1 RunWindowsTracerIisIntegrationTests -framework net462 -sampleName "Samples.Owin.Iis.WebApi2" -filter "OwinIisWebApi2"`