### PR TITLE
[CI Visibility] - Add validation for git metadata env vars

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -8,6 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Newtonsoft.Json;
@@ -40,6 +41,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 var jsonObject = JsonConvert.DeserializeObject<Dictionary<string, string>[][]>(content);
                 yield return new object[] { new JsonDataItem(name, jsonObject) };
             }
+        }
+
+        [InlineData("git@github.com:DataDog/dd-trace-dotnet.git", true)]
+        [InlineData("git@git@hub.com:DataDog/dd-trace-dotnet.git", false)]
+        [InlineData("git@git/hub.com:DataDog/dd-trace-dotnet.git", false)]
+        [InlineData("git@git$hub.com:DataDog/dd-trace-dotnet.git", false)]
+        [InlineData("github.com:DataDog/dd-trace-dotnet.git", false)]
+        [InlineData("https://github.com/DataDog/dd-trace-dotnet.git", true)]
+        [InlineData("https://github.com/DataDog/dd-trace-dotnet.dit", false)]
+        [InlineData("https://github.com/DataDog/dd-trace-dotnet.git123", false)]
+        [InlineData("git@gitlab.com:gitlab-org/gitlab.git", true)]
+        [InlineData("https://gitlab.com/gitlab-org/gitlab.git", true)]
+        [SkippableTheory]
+        public void RepositoryPattern(string value, bool expected)
+        {
+            Assert.Equal(expected, Regex.Match(value, CIEnvironmentValues.RepositoryUrlPattern).Length != value.Length);
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/usersupplied.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/usersupplied.json
@@ -9,8 +9,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
       "git.branch": "usersupplied-branch",
@@ -21,8 +21,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -35,8 +35,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
       "git.branch": "usersupplied-branch",
@@ -47,8 +47,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -61,8 +61,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
       "git.branch": "usersupplied-branch",
@@ -73,8 +73,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo"
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
     }
   ],
   [
@@ -87,8 +87,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
       "git.commit.author.date": "usersupplied-authordate",
@@ -98,8 +98,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -113,8 +113,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo"
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
     },
     {
       "git.commit.author.date": "usersupplied-authordate",
@@ -124,8 +124,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.1.0"
     }
   ],
@@ -138,8 +138,8 @@
       "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
       "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
       "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
-      "DD_GIT_COMMIT_SHA": "usersupplied-commit",
-      "DD_GIT_REPOSITORY_URL": "usersupplied-repo",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
       "DD_GIT_TAG": "0.0.2"
     },
     {
@@ -150,8 +150,8 @@
       "git.commit.committer.email": "usersupplied-comitteremail",
       "git.commit.committer.name": "usersupplied-comittername",
       "git.commit.message": "usersupplied-message",
-      "git.commit.sha": "usersupplied-commit",
-      "git.repository_url": "usersupplied-repo",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e000",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
       "git.tag": "0.0.2"
     }
   ]


### PR DESCRIPTION
## Summary of changes

This PR adds validation to both `DD_GIT_REPOSITORY_URL` and `DD_GIT_COMMIT_SHA`.

## Reason for change

Jira ticket: https://datadoghq.atlassian.net/browse/CIAPP-5374
