### PR TITLE
Fix bug which caused `DD_WRITE_INSTRUMENTATION_TO_DISK` to stop working

### DIFF
--- a/docs/InstrumentationVerification/InstrumentationVerification.md
+++ b/docs/InstrumentationVerification/InstrumentationVerification.md
@@ -26,7 +26,7 @@ To run a verification, simply:
 
 
 
-1. Verify that the environment variable `DD_WRITE_INSTRUMENTATION_TO_DISK` is set to “true” (it should be on by default).
+1. Verify that the environment variable `DD_WRITE_INSTRUMENTATION_TO_DISK` is not set to “false” (it should be on by default).
 2. Run your application. Observe that as we instrument the app, more and more files will appear under [Datadog Logs Folder]/InstrumentationVerification/{ProcessName}_{ProcessID}_{ProcessCreationTime}
 3. In order to run the analysis:
     1. To analyze a running process:

--- a/docs/InstrumentationVerification/InstrumentationVerification.md
+++ b/docs/InstrumentationVerification/InstrumentationVerification.md
@@ -26,7 +26,7 @@ To run a verification, simply:
 
 
 
-1. Verify that the environment variable `DD_WRITE_INSTRUMENTATION_TO_DISK` is not set to “false” (it should be on by default).
+1. Verify that the environment variable `DD_WRITE_INSTRUMENTATION_TO_DISK` is set to “true” (it is "false" by default).
 2. Run your application. Observe that as we instrument the app, more and more files will appear under [Datadog Logs Folder]/InstrumentationVerification/{ProcessName}_{ProcessID}_{ProcessCreationTime}
 3. In order to run the analysis:
     1. To analyze a running process:

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
@@ -119,9 +119,10 @@ inline bool IsInstrumentedAssemblyGeneratorEnabled()
     {
         const auto instrumentationVerificationEnv = shared::GetEnvironmentValue(cfg_instrumentation_verification_env);
         bool isInstrumentedAssemblyGeneratorEnabled;
-        // default is true
-        if (instrumentationVerificationEnv.empty() || shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv, isInstrumentedAssemblyGeneratorEnabled) && isInstrumentedAssemblyGeneratorEnabled)
+        // default is false
+        if (shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv, isInstrumentedAssemblyGeneratorEnabled) && isInstrumentedAssemblyGeneratorEnabled)
         {
+            Log::Info("Entered the if and the value was : ", isInstrumentedAssemblyGeneratorEnabled);
 #if _WIN32
             if (const auto path = GetInstrumentedAssemblyGeneratorCurrentProcessFolder(); !path.empty())
             {

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
@@ -129,7 +129,7 @@ inline bool IsInstrumentedAssemblyGeneratorEnabled()
                 return true;
             }
 #else
-            Log::Warn("Instrumentation Verification is currently only supported on Windows and will be disabled.");
+            Log::Info("Instrumentation Verification is currently only supported on Windows and will be disabled.");
 #endif
         }
     }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
@@ -120,10 +120,7 @@ inline bool IsInstrumentedAssemblyGeneratorEnabled()
         const auto instrumentationVerificationEnv = shared::GetEnvironmentValue(cfg_instrumentation_verification_env);
         bool isInstrumentedAssemblyGeneratorEnabled;
         // default is true
-        if (instrumentationVerificationEnv.empty() ||
-            (shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv,
-                                                    isInstrumentedAssemblyGeneratorEnabled) &&
-            isInstrumentedAssemblyGeneratorEnabled))
+        if (instrumentationVerificationEnv.empty() || shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv, isInstrumentedAssemblyGeneratorEnabled) && isInstrumentedAssemblyGeneratorEnabled)
         {
 #if _WIN32
             if (const auto path = GetInstrumentedAssemblyGeneratorCurrentProcessFolder(); !path.empty())

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/instrumented_assembly_generator/instrumented_assembly_generator_helper.h
@@ -120,10 +120,10 @@ inline bool IsInstrumentedAssemblyGeneratorEnabled()
         const auto instrumentationVerificationEnv = shared::GetEnvironmentValue(cfg_instrumentation_verification_env);
         bool isInstrumentedAssemblyGeneratorEnabled;
         // default is true
-        if (instrumentationVerificationEnv.empty() &&
-            shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv,
+        if (instrumentationVerificationEnv.empty() ||
+            (shared::TryParseBooleanEnvironmentValue(instrumentationVerificationEnv,
                                                     isInstrumentedAssemblyGeneratorEnabled) &&
-            isInstrumentedAssemblyGeneratorEnabled)
+            isInstrumentedAssemblyGeneratorEnabled))
         {
 #if _WIN32
             if (const auto path = GetInstrumentedAssemblyGeneratorCurrentProcessFolder(); !path.empty())

--- a/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGeneration.cs
+++ b/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGeneration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 

--- a/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGeneration.cs
+++ b/tracer/src/Datadog.InstrumentedAssemblyGenerator/InstrumentedAssemblyGeneration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -124,18 +124,22 @@ internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentat
             return dir.FullName;
         }
 
-        var processName = string.IsNullOrEmpty(settings.ProcessName) ? "[A-Z0-9]" : $"({settings.ProcessName})";
+        var processName = string.IsNullOrEmpty(settings.ProcessName) ? "[A-Za-z0-9.]*" : $"({settings.ProcessName})";
         var pid = settings.Pid == null ? "\\d+" : settings.Pid.ToString();
         var pattern = $"^{processName}(_){pid}(_)[0-9-_]+$";
-
         var candidates = dirs.Where(d => Regex.IsMatch(d.Name, pattern)).ToList();
         if (candidates.Count == 1)
         {
             return candidates[0].FullName;
         }
 
+        if (candidates.Count == 0)
+        {
+            AnsiConsole.WriteLine($"No directory was found matching pattern {pattern}");
+        }
+
         AnsiConsole.WriteLine("There is more than one directory that match the argument, taking the last modified directory");
-        return candidates.OrderByDescending(dir => dir.LastWriteTime).FirstOrDefault()?.FullName;
+        return candidates.OrderByDescending(dir => dir.LastWriteTime).First().FullName;
     }
 
     private string GetLogDirectory(int? pid)

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -135,7 +135,8 @@ internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentat
 
         if (candidates.Count == 0)
         {
-            AnsiConsole.WriteLine($"No directory was found matching pattern {pattern}");
+            AnsiConsole.WriteLine($"No directory was found matching pattern {pattern}, make sure {settings.Pid} is right");
+            return null;
         }
 
         AnsiConsole.WriteLine("There is more than one directory that match the argument, taking the last modified directory");

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -82,8 +82,6 @@ internal class AnalyzeInstrumentationErrorsCommand : AsyncCommand<AnalyzeInstrum
                     AnsiConsole.WriteLine($"Instrumented Decompiled Code:{Environment.NewLine}{method.DecompiledCode.Value}");
                 }
             }
-
-            await ReportResult(AnsiConsole.ExportText()).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -92,11 +90,6 @@ internal class AnalyzeInstrumentationErrorsCommand : AsyncCommand<AnalyzeInstrum
         }
 
         return allVerificationsPassed ? 0 : -1;
-    }
-
-    private Task<bool> ReportResult(string result)
-    {
-        return Task.FromResult(true);
     }
 
     /// <param name="tracerLogDir">Tracer logs directory</param>

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -118,10 +118,10 @@ internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentat
             }
             else
             {
-                dir = dirs[0];
+                dir = dirs.FirstOrDefault();
             }
 
-            return dir.FullName;
+            return dir?.FullName;
         }
 
         var processName = string.IsNullOrEmpty(settings.ProcessName) ? "[A-Za-z0-9.]*" : $"({settings.ProcessName})";

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -93,7 +93,7 @@ internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentat
     }
 
     /// <param name="tracerLogDir">Tracer logs directory</param>
-    /// <returns>e.g. C:\ProgramData\Datadog .NET Tracer\logs\InstrumentationVerification\dotnet_12345_dd-mm-yyyy_hh-mm-ss</returns>
+    /// <returns>e.g. C:\ProgramData\Datadog .NET Tracer\logs\InstrumentationVerification\dotnet_12345_dd-mm-yyyy_hh-mm-ss or C:\ProgramData\Datadog-APM\logs\DotNet\dotnet_12345_dd-mm-yyyy_hh-mm-ss</returns>
     private string GetProcessInstrumentationVerificationLogDirectory(string tracerLogDir, AnalyzeInstrumentationErrorsSettings settings)
     {
         var instrumentationVerificationLogs = Path.Combine(tracerLogDir, InstrumentedAssemblyGeneratorConsts.InstrumentedAssemblyGeneratorLogsFolder);

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -16,9 +16,9 @@ using Spectre.Console.Cli;
 
 namespace Datadog.Trace.Tools.Runner;
 
-internal class AnalyzeInstrumentationErrorsCommand : AsyncCommand<AnalyzeInstrumentationErrorsSettings>
+internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentationErrorsSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, AnalyzeInstrumentationErrorsSettings settings)
+    public override int Execute(CommandContext context, AnalyzeInstrumentationErrorsSettings settings)
     {
         var process = $"'{settings.ProcessName ?? "na"}'";
         if (settings.Pid != null)

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -110,7 +110,18 @@ internal class AnalyzeInstrumentationErrorsCommand : AsyncCommand<AnalyzeInstrum
 
         if (string.IsNullOrEmpty(settings.ProcessName) && settings.Pid == null)
         {
-            return dirs.Count == 1 ? dirs[0].FullName : null;
+            DirectoryInfo dir = null;
+            if (dirs.Count > 1)
+            {
+                AnsiConsole.WriteLine($"There is more than one directory in {instrumentationVerificationLogs}, taking the last modified one");
+                dir = dirs.OrderByDescending(dir => dir.LastWriteTime).First();
+            }
+            else
+            {
+                dir = dirs[0];
+            }
+
+            return dir.FullName;
         }
 
         var processName = string.IsNullOrEmpty(settings.ProcessName) ? "[A-Z0-9]" : $"({settings.ProcessName})";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
@@ -22,6 +22,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
     }
 
     [Fact]
+    [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
     public void WriteInstrumentationToDisk_IsEnabled_FilesGetWrittenToTheAppropriateFolder()
     {
         // Arrange
@@ -42,6 +43,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
     }
 
     [Fact]
+    [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
     public void WriteInstrumentationToDisk_IsDisabled_NothingGetsWrittenToDisk()
     {
         // Arrange
@@ -58,6 +60,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
     }
 
     [Fact]
+    [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
     public void WriteInstrumentationToDisk_IsNotSpecified_DefaultsToFalseAndNothingGetsWrittenToDisk()
     {
         // Act

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
@@ -1,0 +1,76 @@
+// <copyright file="InstrumentationVerificationSanityCheckTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Specialized;
+using System.IO;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+public class InstrumentationVerificationSanityCheckTests : TestHelper
+{
+    public InstrumentationVerificationSanityCheckTests(ITestOutputHelper output)
+        : base(new EnvironmentHelper("Datadog.Tracer.Native.Checks", typeof(TestHelper), output, Path.Combine("test", "test-applications", "instrumentation"), prependSamplesToAppName: false), output)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, EnvironmentHelper.LogDirectory);
+    }
+
+    [Fact]
+    public void WriteInstrumentationToDisk_IsEnabled_FilesGetWrittenToTheAppropriateFolder()
+    {
+        // Arrange
+        SetEnvironmentVariable(InstrumentationVerification.InstrumentationVerificationEnabled, "true");
+
+        // Act
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        // Assert
+        var folderFullPath = InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory);
+        folderFullPath.Should().NotBeNull();
+        Directory.Exists(folderFullPath).Should().BeTrue();
+        Directory.GetFiles(folderFullPath, "*", SearchOption.AllDirectories).Length.Should().BeGreaterThan(expected: 0);
+        var folderName = Path.GetFileName(folderFullPath);
+        folderName.Should().Contain(processResult.Process.Id.ToString());
+        folderName.Should().Contain(EnvironmentHelper.SampleName);
+    }
+
+    [Fact]
+    public void WriteInstrumentationToDisk_IsDisabled_NothingGetsWrittenToDisk()
+    {
+        // Arrange
+        SetEnvironmentVariable(InstrumentationVerification.InstrumentationVerificationEnabled, "false");
+
+        // Act
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        // Assert
+        InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
+                                   .Should()
+                                   .BeNull();
+    }
+
+    [Fact]
+    public void WriteInstrumentationToDisk_IsNotSpecified_DefaultsToFalseAndNothingGetsWrittenToDisk()
+    {
+        // Act
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var processResult = RunSampleAndWaitForExit(agent);
+
+        // Assert
+        processResult.Process.StartInfo.
+                      EnvironmentVariables.ContainsKey(InstrumentationVerification.InstrumentationVerificationEnabled)
+                     .Should().BeFalse();
+
+        InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
+                                   .Should()
+                                   .BeNull();
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
@@ -33,7 +33,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
         using var processResult = RunSampleAndWaitForExit(agent);
 
         // Assert
-        var folderFullPath = InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory);
+        var folderFullPath = InstrumentationVerification.FindInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory);
         folderFullPath.Should().NotBeNull();
         Directory.Exists(folderFullPath).Should().BeTrue();
         Directory.GetFiles(folderFullPath, "*", SearchOption.AllDirectories).Length.Should().BeGreaterThan(expected: 0);
@@ -54,7 +54,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
         using var processResult = RunSampleAndWaitForExit(agent);
 
         // Assert
-        InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
+        InstrumentationVerification.FindInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
                                    .Should()
                                    .BeNull();
     }
@@ -72,7 +72,7 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
                       EnvironmentVariables.ContainsKey(InstrumentationVerification.InstrumentationVerificationEnabled)
                      .Should().BeFalse();
 
-        InstrumentationVerification.GetInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
+        InstrumentationVerification.FindInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
                                    .Should()
                                    .BeNull();
     }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/InstrumentationVerification.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/InstrumentationVerification.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Datadog.Trace.TestHelpers;
 
-internal static class InstrumentationVerification
+public static class InstrumentationVerification
 {
     /// <summary>
     /// Configuration key for enabling or disabling writing the instrumentation changes to disk
@@ -32,6 +32,11 @@ internal static class InstrumentationVerification
     public static void VerifyInstrumentation(Process process, string logDirectory)
     {
         var instrumentedLogsPath = GetInstrumentationLogsFolder(process, logDirectory);
+        if (instrumentedLogsPath == null)
+        {
+            throw new Exception($"Unable to find instrumentation verification directory for process {process.Id}");
+        }
+
         var copyOriginalsModulesToDisk = Environment.GetEnvironmentVariable(InstrumentationVerification.CopyingOriginalModulesEnabled);
         var generatorArgs = new AssemblyGeneratorArgs(instrumentedLogsPath, copyOriginalModulesToDisk: copyOriginalsModulesToDisk?.ToLower() is "true" or "1");
         var generatedModules = InstrumentedAssemblyGeneration.Generate(generatorArgs);
@@ -51,7 +56,7 @@ internal static class InstrumentationVerification
             "Instrumentation verification test failed:" + Environment.NewLine + string.Join(Environment.NewLine, results.Where(r => !r.IsValid).Select(r => r.FailureReason)));
     }
 
-    private static string GetInstrumentationLogsFolder(Process process, string logsFolder)
+    public static string GetInstrumentationLogsFolder(Process process, string logsFolder)
     {
         var processExecutableFileName = Path.GetFileNameWithoutExtension(process.StartInfo.FileName);
         Assert.NotNull(logsFolder);
@@ -59,7 +64,7 @@ internal static class InstrumentationVerification
 
         if (!instrumentationLogsFolder.Exists)
         {
-            throw new Exception($"Unable to find instrumentation verification directory at {instrumentationLogsFolder}");
+            return null;
         }
 
         string pattern = $"{processExecutableFileName}_{process.Id}_*"; // * wildcard matches process start time
@@ -69,11 +74,6 @@ internal static class InstrumentationVerification
                .OrderBy(d => d.CreationTime)
                .LastOrDefault();
 
-        if (processSpecificInstrumentationLogsFolder == null)
-        {
-            throw new Exception($"Unable to find instrumentation verification directory that matches pattern '{pattern}' in {instrumentationLogsFolder}");
-        }
-
-        return processSpecificInstrumentationLogsFolder.FullName;
+        return processSpecificInstrumentationLogsFolder?.FullName;
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/InstrumentationVerification.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/InstrumentationVerification.cs
@@ -31,7 +31,7 @@ public static class InstrumentationVerification
 
     public static void VerifyInstrumentation(Process process, string logDirectory)
     {
-        var instrumentedLogsPath = GetInstrumentationLogsFolder(process, logDirectory);
+        var instrumentedLogsPath = FindInstrumentationLogsFolder(process, logDirectory);
         if (instrumentedLogsPath == null)
         {
             throw new Exception($"Unable to find instrumentation verification directory for process {process.Id}");
@@ -56,7 +56,7 @@ public static class InstrumentationVerification
             "Instrumentation verification test failed:" + Environment.NewLine + string.Join(Environment.NewLine, results.Where(r => !r.IsValid).Select(r => r.FailureReason)));
     }
 
-    public static string GetInstrumentationLogsFolder(Process process, string logsFolder)
+    public static string FindInstrumentationLogsFolder(Process process, string logsFolder)
     {
         var processExecutableFileName = Path.GetFileNameWithoutExtension(process.StartInfo.FileName);
         Assert.NotNull(logsFolder);

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -206,8 +206,6 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["COR_PROFILER_PATH"] = nativeLoaderPath;
             }
 
-            environmentVariables["DD_WRITE_INSTRUMENTATION_TO_DISK"] = profilerEnabled;
-
             if (DebugModeEnabled)
             {
                 environmentVariables["DD_TRACE_DEBUG"] = "1";


### PR DESCRIPTION
In https://github.com/DataDog/dd-trace-dotnet/pull/3408 a last minute merge conflict caused a bit of a snafu. Specifically, the intent in that PR was to change it so that `DD_WRITE_INSTRUMENTATION_TO_DISK` will default to `true` if it was not explicitly specified, but in reality it was **always** inferred to be `false`, even if the environment variable was explicitly set to `true`.

Because we are about to release a new version and want to reduce risk, this PR fixes the issue but changes it back so that the default will be `false` (so that this functionality will remain an opt-in instead of an opt-out for now), and adds the `InstrumentationVerificationSantiyCheckTests` to ensure that we avoid such mix-ups in the future.

Additionally, this PR includes a couple of additional fixes:
1. Fix issue where  `dd-trace analyze-instrumentation` would spit out an error message that was irrelevant and confusing.
2.  Fix regex and paths cases for finding the instrumentations logs folder.