### PR TITLE
UDS is a variant, not a scenario in system tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3218,7 +3218,7 @@ stages:
       - publish: system-tests/logs
         condition: always()
         displayName: System tests logs
-        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)_$WEBLOG_VARIANT
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
         
       - script: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
         workingDirectory: system-tests
@@ -3229,7 +3229,7 @@ stages:
       - publish: system-tests/logs_remote_config_mocked_backend_live_debugging
         condition: always()
         displayName: RCM tests logs
-        artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)_$WEBLOG_VARIANT
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)
 
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3181,6 +3181,13 @@ stages:
     pool:
       vmImage: ubuntu-20.04
 
+    strategy:
+      matrix:
+        poc:
+          WEBLOG_VARIANT: "poc"
+        uds:
+          WEBLOG_VARIANT: "uds"
+
     steps:
       - checkout: none
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
@@ -3211,18 +3218,7 @@ stages:
       - publish: system-tests/logs
         condition: always()
         displayName: System tests logs
-        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
-
-      - script: ./run.sh UDS
-        workingDirectory: system-tests
-        displayName: Run tests over UDS
-        env:
-          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
-        
-      - publish: system-tests/logs_uds
-        condition: always()
-        displayName: System tests UDS logs
-        artifact: _$(System.StageName)_$(Agent.JobName)_logs_uds_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)_$WEBLOG_VARIANT
         
       - script: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
         workingDirectory: system-tests
@@ -3233,7 +3229,7 @@ stages:
       - publish: system-tests/logs_remote_config_mocked_backend_live_debugging
         condition: always()
         displayName: RCM tests logs
-        artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)
+        artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)_$WEBLOG_VARIANT
 
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))


### PR DESCRIPTION
## Summary of changes

Previously, UDS was a scenario. Actually, it was a special scenario, as it runs the default scenario, but modifies the tracers to use UDS rather than HTTP to communicate to the agent.

I changed that this week as this setup was not too complex for the added value: UDS is now a different weblog.

* it simplify the overall complexity of system tests, using the weblog dimension to handle this, and removing the hack for UDS weblog modifier
* it allows to test UDS on all scenarios, offering a better testing coverage
* For the con, it recquires a little more effort to set-up UDS for a given weblog. But it's mostly Dockerfile copypasta

In this PR, I've removed the `run.sh UDS`, and added the weblog called `UDS`

## Reason for change

Simplify CI, better coverage

## Implementation details

N/A

## Test coverage

Test the test !
