### PR TITLE
[Profiler] Remove async call for parallel buggybits

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Models/DataLayer.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Models/DataLayer.cs
@@ -236,8 +236,8 @@ namespace BuggyBits.Models
                 new ParallelOptions() { MaxDegreeOfParallelism = Environment.ProcessorCount * 4 },
                 (id) => // download each product and store them in a common list protected by a lock
                 {
-                    // "sync over async" anti-pattern
-                    var product = GetProductAsync(path, id).GetAwaiter().GetResult();
+                    // don't create too many spans
+                    var product = GetProduct(id);
                     lock (listLock)
                     {
                         products.Add(product);


### PR DESCRIPTION
## Summary of changes
Remove async calls to parallel lock scenario in BuggyBits

## Reason for change
Avoid too many spans and lock events

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
