### PR TITLE
Temporarily ignore error in logs from CI app

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1887,6 +1887,7 @@ partial class Build
                new (@".*DD_GIT_REPOSITORY_URL is set with.*", RegexOptions.Compiled),
                new (@".*The Git commit sha couldn't be automatically extracted.*", RegexOptions.Compiled),
                new (@".*DD_GIT_COMMIT_SHA must be a full-length git SHA.*", RegexOptions.Compiled),
+               new (@".*Timeout occurred when flushing spans.*", RegexOptions.Compiled),
                // This one is annoying but we _think_ due to a dodgy named pipes implementation, so ignoring for now
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\trace-.*The operation has timed out.*", RegexOptions.Compiled),
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\metrics-.*The operation has timed out.*", RegexOptions.Compiled),


### PR DESCRIPTION
## Summary of changes

Temporarily ignores the `Timeout occurred when flushing spans.` error causing flakiness in CI

## Reason for change

The ARM64 integration tests in particular have become very flaky recently (I'm done 6 retries in [this unrelated PR](https://github.com/DataDog/dd-trace-dotnet/pull/3567)!). We think #3555 should fix it, but as it's blocking merges, this PR ignores the error temporarily.

## Implementation details

Ignore the error in the `CheckBuildLogs` step

## Test coverage

N/A

## Other details

This is only meant to be temporary, we should remove it again later
