### PR TITLE
[Tracer] Add OpenTelemetry Resources as span tags

### DIFF
--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -358,6 +358,10 @@ otel.status_code | `STATUS_CODE_UNSET`; `STATUS_CODE_OK`; `STATUS_CODE_ERROR`
 otel.status_description | No
 otel.trace_id | Yes
 span.kind | `internal`; `server`; `client`; `producer`; `consumer`
+### AdditionalTags
+Source | Operation | Required |
+---------|-----------|----------------|
+OTEL Resource Attributes | PassThru | No
 
 ## Oracle
 ### Span properties

--- a/tracer/build/_build/Honeypot/IntegrationGroups.cs
+++ b/tracer/build/_build/Honeypot/IntegrationGroups.cs
@@ -79,6 +79,7 @@ namespace Honeypot
             NugetPackages.Add("Grpc.Core", new string[] { "Grpc" });
             NugetPackages.Add("Microsoft.AspNetCore.Mvc.Core", new [] { "Microsoft.AspNetCore.Mvc.Core" });
             NugetPackages.Add("OpenTelemetry.Api", new [] { "OpenTelemetry.Api" });
+            NugetPackages.Add("OpenTelemetry", new [] { "OpenTelemetry" });
         }
 
         private IntegrationMap()

--- a/tracer/dependabot/Datadog.Dependabot.Integrations.csproj
+++ b/tracer/dependabot/Datadog.Dependabot.Integrations.csproj
@@ -146,6 +146,11 @@
     <!-- Latest package https://www.nuget.org/packages/NUnit/3.13.3 -->
     <PackageReference Include="NUnit" Version="3.13.3" />
 
+    <!-- Integration: OpenTelemetry -->
+    <!-- Assembly: OpenTelemetry -->
+    <!-- Latest package https://www.nuget.org/packages/OpenTelemetry/1.3.2 -->
+    <PackageReference Include="OpenTelemetry" Version="1.3.2" />
+
     <!-- Integration: OpenTelemetry.Api -->
     <!-- Assembly: OpenTelemetry.Api -->
     <!-- Latest package https://www.nuget.org/packages/OpenTelemetry.Api/1.3.2 -->

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Activity.Handlers
     internal class DefaultActivityHandler : IActivityHandler
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DefaultActivityHandler));
-        private static readonly ConcurrentDictionary<string, ActivityMapping> ActivityMappingById = new();
+        internal static readonly ConcurrentDictionary<string, ActivityMapping> ActivityMappingById = new();
         private static readonly IntegrationId IntegrationId = IntegrationId.OpenTelemetry;
 
         public bool ShouldListenTo(string sourceName, string? version)

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -90,8 +90,7 @@ namespace Datadog.Trace.Activity
 
             // Fixup "env" tag
             if (span.Context.TraceContext?.Environment is null
-                && span.GetTag("deployment.environment") is string otelServiceEnv
-                && !string.IsNullOrEmpty(otelServiceEnv))
+                && span.GetTag("deployment.environment") is { Length: > 1 } otelServiceEnv)
             {
                 span.SetTag(Tags.Env, otelServiceEnv);
             }

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Activity
 
             // Fixup "env" tag
             if (span.Context.TraceContext?.Environment is null
-                && span.GetTag("deployment.environment") is { Length: > 1 } otelServiceEnv)
+                && span.GetTag("deployment.environment") is { Length: > 0 } otelServiceEnv)
             {
                 span.SetTag(Tags.Env, otelServiceEnv);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/BaseProcessorStruct.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/BaseProcessorStruct.cs
@@ -9,6 +9,9 @@ using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
 {
+    /// <summary>
+    /// Ducktype for type OpenTelemetry.BaseProcessor`1
+    /// </summary>
     [DuckCopy]
     internal struct BaseProcessorStruct
     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/BaseProcessorStruct.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/BaseProcessorStruct.cs
@@ -1,0 +1,17 @@
+// <copyright file="BaseProcessorStruct.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
+{
+    [DuckCopy]
+    internal struct BaseProcessorStruct
+    {
+        public object? ParentProvider;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/IResource.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/IResource.cs
@@ -1,0 +1,16 @@
+// <copyright file="IResource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
+{
+    internal interface IResource
+    {
+        IEnumerable<KeyValuePair<string, object>> Attributes { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/IResource.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/IResource.cs
@@ -9,6 +9,9 @@ using System.Collections.Generic;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
 {
+    /// <summary>
+    /// Ducktype for type OpenTelemetry.Resources.Resource
+    /// </summary>
     internal interface IResource
     {
         IEnumerable<KeyValuePair<string, object>> Attributes { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -41,18 +41,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
                         var span = activityMapping.Scope.Span;
                         foreach (var attribute in resource.Attributes)
                         {
+                            span.SetTag(attribute.Key, attribute.Value?.ToString());
+
                             // In addition to copying the attribute as a tag, update span fields for specific keys
-                            if (attribute.Key == "service.name")
+                            if (attribute.Value is not null)
                             {
-                                span.ServiceName = attribute.Value.ToString();
-                            }
-                            else if (attribute.Key == "service.version")
-                            {
-                                span.SetTag(Tags.Version, attribute.Value.ToString());
-                            }
-                            else
-                            {
-                                span.SetTag(attribute.Key, attribute.Value.ToString());
+                                if (attribute.Key == "service.name")
+                                {
+                                    span.ServiceName = attribute.Value.ToString();
+                                }
+                                else if (attribute.Key == "service.version")
+                                {
+                                    span.SetTag(Tags.Version, attribute.Value.ToString());
+                                }
                             }
                         }
                     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -6,7 +6,6 @@
 #nullable enable
 
 using System;
-using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Activity.Handlers;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -1,0 +1,97 @@
+// <copyright file="ResourceAttributeProcessorHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.Activity.Handlers;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
+{
+    internal static class ResourceAttributeProcessorHelper
+    {
+        private static Func<object, object>? _getResourceDelegate;
+
+        static ResourceAttributeProcessorHelper()
+        {
+            _getResourceDelegate = CreateGetResourceDelegate();
+        }
+
+        public static void OnStart(object processor, object activityData)
+        {
+            if (_getResourceDelegate is null
+                || !activityData.TryDuckCast<IActivity>(out var activity)
+                || !processor.TryDuckCast<BaseProcessorStruct>(out var baseProcessor))
+            {
+                return;
+            }
+
+            if (DefaultActivityHandler.ActivityMappingById.TryGetValue(activity.Id, out var activityMapping))
+            {
+                if (baseProcessor.ParentProvider is not null)
+                {
+                    var resourceObject = _getResourceDelegate(baseProcessor.ParentProvider);
+                    if (resourceObject.TryDuckCast<IResource>(out var resource))
+                    {
+                        var span = activityMapping.Scope.Span;
+                        foreach (var attribute in resource.Attributes)
+                        {
+                            // Set additional span fields for specific keys
+                            if (attribute.Key == "service.name")
+                            {
+                                span.ServiceName = attribute.Value.ToString();
+                            }
+                            else if (attribute.Key == "service.version")
+                            {
+                                span.SetTag(Tags.Version, attribute.Value.ToString());
+                            }
+
+                            span.SetTag(attribute.Key, attribute.Value.ToString());
+                        }
+                    }
+                }
+            }
+        }
+
+        private static Func<object, object>? CreateGetResourceDelegate()
+        {
+            Type? providerExtensionsType = Type.GetType("OpenTelemetry.ProviderExtensions, OpenTelemetry", throwOnError: false);
+            Type? baseProviderType = Type.GetType("OpenTelemetry.BaseProvider, OpenTelemetry.Api", throwOnError: false);
+
+            if (providerExtensionsType is null || baseProviderType is null)
+            {
+                return null;
+            }
+
+            // Get actual extension method from the API
+            var targetGetResourceMethod = providerExtensionsType?.GetMethod("GetResource", new[] { baseProviderType });
+            if (targetGetResourceMethod is null)
+            {
+                return null;
+            }
+
+            // Create a Delegate that accepts its inputs and outputs as object
+            // and will handle converting to/from object
+            DynamicMethod dynMethod = new DynamicMethod(
+                     $"{nameof(ResourceAttributeProcessorHelper)}.GetResource",
+                     typeof(object),
+                     new Type[] { typeof(object) },
+                     typeof(ResourceAttributeProcessorHelper).Module,
+                     true);
+            ILGenerator ilWriter = dynMethod.GetILGenerator();
+            ilWriter.Emit(OpCodes.Ldarg_0);
+            ilWriter.Emit(OpCodes.Castclass, baseProviderType); // Cast to OpenTelemetry.BaseProvider
+
+            ilWriter.EmitCall(OpCodes.Call, targetGetResourceMethod, null);
+            ilWriter.Emit(OpCodes.Ret);
+
+            return (Func<object, object>)dynMethod.CreateDelegate(typeof(Func<object, object>));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
                         var span = activityMapping.Scope.Span;
                         foreach (var attribute in resource.Attributes)
                         {
-                            // Set additional span fields for specific keys
+                            // In addition to copying the attribute as a tag, update span fields for specific keys
                             if (attribute.Key == "service.name")
                             {
                                 span.ServiceName = attribute.Value.ToString();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -50,8 +50,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
                             {
                                 span.SetTag(Tags.Version, attribute.Value.ToString());
                             }
-
-                            span.SetTag(attribute.Key, attribute.Value.ToString());
+                            else
+                            {
+                                span.SetTag(attribute.Key, attribute.Value.ToString());
+                            }
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
@@ -14,7 +14,8 @@ using Datadog.Trace.DuckTyping;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
 {
     /// <summary>
-    /// Msmq calltarget instrumentation
+    /// OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build calltarget instrumentation,
+    /// aka Sdk.CreateTracerProviderBuilder().Build()
     /// </summary>
     [InstrumentMethod(
         AssemblyName = "OpenTelemetry",

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
@@ -1,0 +1,139 @@
+// <copyright file="TracerProviderBuilderIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+using System.Reflection.Emit;
+using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
+{
+    /// <summary>
+    /// Msmq calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "OpenTelemetry",
+        TypeName = "OpenTelemetry.Trace.TracerProviderBuilderExtensions",
+        MethodName = "Build",
+        ReturnTypeName = "OpenTelemetry.Trace.TracerProvider",
+        ParameterTypeNames = new[] { "OpenTelemetry.Trace.TracerProviderBuilder" },
+        MinimumVersion = "1.0.0",
+        MaximumVersion = "1.0.0",
+        IntegrationName = IntegrationName)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TracerProviderBuilderIntegration
+    {
+        internal const string IntegrationName = nameof(Configuration.IntegrationId.OpenTelemetry);
+        internal const IntegrationId IntegrationId = Configuration.IntegrationId.OpenTelemetry;
+        private static Func<object, object, object> _cachedAddProcessorDelegate;
+        private static Type _cachedProcessorType;
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TTracerProviderBuilder">Type of the span kind</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="tracerProviderBuilder">The TracerProviderBuilder instance.</param>
+        /// <returns>Calltarget state value</returns>
+        internal static CallTargetState OnMethodBegin<TTarget, TTracerProviderBuilder>(TTarget instance, TTracerProviderBuilder tracerProviderBuilder)
+        {
+            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            {
+                _cachedAddProcessorDelegate ??= (Func<object, object, object>)CreateAddProcessorDelegate();
+                _cachedProcessorType ??= CreateProcessorType();
+
+                if (_cachedAddProcessorDelegate is not null
+                    && _cachedProcessorType is not null)
+                {
+                    _cachedAddProcessorDelegate(tracerProviderBuilder, Activator.CreateInstance(_cachedProcessorType));
+                }
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        private static Func<object, object, object> CreateAddProcessorDelegate()
+        {
+            Type builderExtensionsType = Type.GetType("OpenTelemetry.Trace.TracerProviderBuilderExtensions, OpenTelemetry", throwOnError: false);
+            Type builderType = Type.GetType("OpenTelemetry.Trace.TracerProviderBuilder, OpenTelemetry.Api", throwOnError: false);
+            Type baseProcessorType = Type.GetType("OpenTelemetry.BaseProcessor`1, OpenTelemetry", throwOnError: false);
+            Type activityType = Type.GetType("System.Diagnostics.Activity, System.Diagnostics.DiagnosticSource", throwOnError: false);
+
+            if (builderExtensionsType is null || builderType is null || baseProcessorType is null || activityType is null)
+            {
+                return null;
+            }
+
+            // Get actual extension method from the API
+            Type baseProcessorOfActivityType = baseProcessorType.MakeGenericType(activityType);
+            var targetAddProcessorMethod = builderExtensionsType?.GetMethod("AddProcessor", new Type[] { builderType, baseProcessorOfActivityType });
+
+            // Create a Delegate that accepts its inputs and outputs as object
+            // and will handle converting to/from object
+            DynamicMethod dynMethod = new DynamicMethod(
+                     $"{nameof(TracerProviderBuilderIntegration)}.AddProcessor",
+                     typeof(object),
+                     new Type[] { typeof(object), typeof(object) },
+                     typeof(TracerProviderBuilderIntegration).Module,
+                     true);
+            ILGenerator ilWriter = dynMethod.GetILGenerator();
+            ilWriter.Emit(OpCodes.Ldarg_0);
+            ilWriter.Emit(OpCodes.Castclass, builderType); // Cast to OpenTelemetry.Trace.TracerProviderBuilder
+
+            ilWriter.Emit(OpCodes.Ldarg_1);
+            ilWriter.Emit(OpCodes.Castclass, baseProcessorOfActivityType); // Cast to OpenTelemetry.BaseProcessor<System.Diagnostics.Activity>
+
+            ilWriter.EmitCall(OpCodes.Call, targetAddProcessorMethod, null);
+            ilWriter.Emit(OpCodes.Ret);
+
+            return (Func<object, object, object>)dynMethod.CreateDelegate(typeof(Func<object, object, object>));
+        }
+
+        private static Type CreateProcessorType()
+        {
+            Type activityType = Type.GetType("System.Diagnostics.Activity, System.Diagnostics.DiagnosticSource", throwOnError: false);
+            Type baseProcessorType = Type.GetType("OpenTelemetry.BaseProcessor`1, OpenTelemetry", throwOnError: false);
+
+            if (activityType is null || baseProcessorType is null)
+            {
+                return null;
+            }
+
+            Type baseProcessorOfActivityType = baseProcessorType.MakeGenericType(activityType);
+
+            var assemblyName = new AssemblyName("Datadog.OpenTelemetry.Dynamic");
+            assemblyName.Version = typeof(TracerProviderBuilderIntegration).Assembly.GetName().Version;
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+
+            DuckType.EnsureTypeVisibility(moduleBuilder, typeof(TracerProviderBuilderIntegration));
+
+            var typeBuilder = moduleBuilder.DefineType(
+                "ResourceAttributeProcessor",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit | TypeAttributes.AutoLayout | TypeAttributes.Sealed,
+                parent: baseProcessorOfActivityType,
+                interfaces: null);
+
+            var methodAttributes = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig;
+
+            // OnStart
+            var onSetListenerMethodInfo = typeof(ResourceAttributeProcessorHelper).GetMethod(nameof(ResourceAttributeProcessorHelper.OnStart), BindingFlags.Static | BindingFlags.Public)!;
+            var onStartMethod = typeBuilder.DefineMethod("OnStart", methodAttributes, typeof(void), new[] { activityType });
+            var onStartMethodIl = onStartMethod.GetILGenerator();
+            onStartMethodIl.Emit(OpCodes.Ldarg_0);
+            onStartMethodIl.Emit(OpCodes.Ldarg_1);
+            onStartMethodIl.EmitCall(OpCodes.Call, onSetListenerMethodInfo, null);
+            onStartMethodIl.Emit(OpCodes.Ret);
+
+            return typeBuilder.CreateTypeInfo()?.AsType();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
 
         static TracerProviderBuilderIntegration()
         {
-            _cachedAddProcessorDelegate = (Func<object, object, object>)CreateAddProcessorDelegate();
+            _cachedAddProcessorDelegate = CreateAddProcessorDelegate();
             _cachedProcessorType = CreateProcessorType();
         }
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -270,6 +270,7 @@ namespace Datadog.Trace.ClrProfiler
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
                 // OpenTelemetry
+               new ("OpenTelemetry", "OpenTelemetry.Trace.TracerProviderBuilderExtensions", "Build",  new[] { "OpenTelemetry.Trace.TracerProvider", "OpenTelemetry.Trace.TracerProviderBuilder" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartRootSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanContext&", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"),
 
@@ -729,7 +730,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.NUnit,
-                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.OpenTelemetry,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Process.ProcessStartIntegration"

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -271,6 +271,7 @@ namespace Datadog.Trace.ClrProfiler
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
                 // OpenTelemetry
+               new ("OpenTelemetry", "OpenTelemetry.Trace.TracerProviderBuilderExtensions", "Build",  new[] { "OpenTelemetry.Trace.TracerProvider", "OpenTelemetry.Trace.TracerProviderBuilder" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartRootSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanContext&", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"),
 
@@ -748,7 +749,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.NUnit,
-                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.OpenTelemetry,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Process.ProcessStartIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -271,6 +271,7 @@ namespace Datadog.Trace.ClrProfiler
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
                 // OpenTelemetry
+               new ("OpenTelemetry", "OpenTelemetry.Trace.TracerProviderBuilderExtensions", "Build",  new[] { "OpenTelemetry.Trace.TracerProvider", "OpenTelemetry.Trace.TracerProviderBuilder" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartRootSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanContext&", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"),
 
@@ -748,7 +749,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.NUnit,
-                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.OpenTelemetry,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Process.ProcessStartIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -271,6 +271,7 @@ namespace Datadog.Trace.ClrProfiler
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
                 // OpenTelemetry
+               new ("OpenTelemetry", "OpenTelemetry.Trace.TracerProviderBuilderExtensions", "Build",  new[] { "OpenTelemetry.Trace.TracerProvider", "OpenTelemetry.Trace.TracerProviderBuilder" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartRootSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"),
                new ("OpenTelemetry.Api", "OpenTelemetry.Trace.Tracer", "StartSpan",  new[] { "OpenTelemetry.Trace.TelemetrySpan", "System.String", "OpenTelemetry.Trace.SpanKind", "OpenTelemetry.Trace.SpanContext&", "OpenTelemetry.Trace.SpanAttributes", "System.Collections.Generic.IEnumerable`1[OpenTelemetry.Trace.Link]", "System.DateTimeOffset" }, 1, 0, 0, 1, 0, 0, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"),
 
@@ -748,7 +749,8 @@ namespace Datadog.Trace.ClrProfiler
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.NUnit,
-                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
+                "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.TracerProviderBuilderIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartRootSpanIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry.StartSpanIntegration"
                     => Datadog.Trace.Configuration.IntegrationId.OpenTelemetry,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Process.ProcessStartIntegration"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -29,21 +29,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span) =>
-            span.IsOpenTelemetry(excludeTags: new HashSet<string>
-            {
-                "attribute-string",
-                "attribute-int",
-                "attribute-bool",
-                "attribute-double",
-                "attribute-stringArray",
-                "attribute-stringArrayEmpty",
-                "attribute-intArray",
-                "attribute-intArrayEmpty",
-                "attribute-boolArray",
-                "attribute-boolArrayEmpty",
-                "attribute-doubleArray",
-                "attribute-doubleArrayEmpty",
-            });
+            span.IsOpenTelemetry(
+                resources: new HashSet<string>
+                {
+                    "service.instance.id",
+                    "service.name",
+                    "service.version"
+                },
+                excludeTags: new HashSet<string>
+                {
+                    "attribute-string",
+                    "attribute-int",
+                    "attribute-bool",
+                    "attribute-double",
+                    "attribute-stringArray",
+                    "attribute-stringArrayEmpty",
+                    "attribute-intArray",
+                    "attribute-intArrayEmpty",
+                    "attribute-boolArray",
+                    "attribute-boolArrayEmpty",
+                    "attribute-doubleArray",
+                    "attribute-doubleArrayEmpty",
+                });
 
         [SkippableTheory]
         [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -69,12 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var s = new AssertionScope();
                 spans.Count.Should().Be(expectedSpanCount);
-
-                var myServiceNameSpans = spans.Where(s => s.Service == "MyServiceName");
-                var otherLibrarySpans = spans.Where(s => s.Service != "MyServiceName");
-
-                ValidateIntegrationSpans(myServiceNameSpans, expectedServiceName: "MyServiceName");
-                ValidateIntegrationSpans(otherLibrarySpans, expectedServiceName: "OtherLibrary");
+                ValidateIntegrationSpans(spans, expectedServiceName: "MyServiceName");
 
                 // there's a bug in < 1.2.0 where they get the span parenting wrong
                 // so use a separate snapshot

--- a/tracer/test/Datadog.Trace.TestHelpers/Result.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Result.cs
@@ -61,6 +61,13 @@ namespace Datadog.Trace.TestHelpers
             return this;
         }
 
+        public Result AdditionalTags(Action<SpanAdditionalTagsAssertion> tagAssertions)
+        {
+            var t = new SpanAdditionalTagsAssertion(this, this.Span.Tags);
+            tagAssertions(t);
+            return this;
+        }
+
         public override string ToString()
         {
             string errorMessage = string.Concat(Errors.Select(s => $"{Environment.NewLine}- {s}"));

--- a/tracer/test/Datadog.Trace.TestHelpers/Result.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Result.cs
@@ -13,6 +13,11 @@ namespace Datadog.Trace.TestHelpers
     {
         public static readonly Result DefaultSuccess = FromSpan(null);
 
+        private bool _propertiesInvoked;
+        private bool _additionalTagsInvoked;
+        private bool _tagsInvoked;
+        private Action<SpanAdditionalTagsAssertion> _additionalTagAssertions;
+
         private Result(MockSpan span, ISet<string> excludeTags)
         {
             Span = span;
@@ -46,6 +51,12 @@ namespace Datadog.Trace.TestHelpers
 
         public Result Properties(Action<SpanPropertyAssertion> propertyAssertions)
         {
+            if (_propertiesInvoked)
+            {
+                throw new InvalidOperationException("Result.Properties() may only be invoked once per integration");
+            }
+
+            _propertiesInvoked = true;
             var p = new SpanPropertyAssertion(this);
             propertyAssertions(p);
             return this;
@@ -53,8 +64,21 @@ namespace Datadog.Trace.TestHelpers
 
         public Result Tags(Action<SpanTagAssertion> tagAssertions)
         {
-            var t = new SpanTagAssertion(this, this.Span.Tags);
+            if (_tagsInvoked)
+            {
+                throw new InvalidOperationException("Result.Tags() may only be invoked once per integration");
+            }
+
+            _tagsInvoked = true;
+            var tags = new Dictionary<string, string>(this.Span.Tags);
+            var t = new SpanTagAssertion(this, tags);
             tagAssertions(t);
+
+            if (_additionalTagAssertions is not null)
+            {
+                var at = new SpanAdditionalTagsAssertion(this, tags);
+                _additionalTagAssertions(at);
+            }
 
             SpanTagAssertion.DefaultTagAssertions(t);
             SpanTagAssertion.AssertNoRemainingTags(t);
@@ -63,8 +87,17 @@ namespace Datadog.Trace.TestHelpers
 
         public Result AdditionalTags(Action<SpanAdditionalTagsAssertion> tagAssertions)
         {
-            var t = new SpanAdditionalTagsAssertion(this, this.Span.Tags);
-            tagAssertions(t);
+            if (_additionalTagsInvoked)
+            {
+                throw new InvalidOperationException("Result.AdditionalTags() may only be invoked once per integration");
+            }
+            else if (_tagsInvoked)
+            {
+                throw new InvalidOperationException("Result.AdditionalTags() must be invoked before Result.Tags()");
+            }
+
+            _additionalTagsInvoked = true;
+            _additionalTagAssertions = tagAssertions;
             return this;
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanAdditionalTagsAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanAdditionalTagsAssertion.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.TestHelpers
         internal SpanAdditionalTagsAssertion(Result result, IDictionary<string, string> tags)
         {
             _result = result;
-            _tags = new Dictionary<string, string>(tags);
+            _tags = tags;
         }
 
         public SpanAdditionalTagsAssertion PassesThroughSource(string description, ISet<string> tagNames)

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanAdditionalTagsAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanAdditionalTagsAssertion.cs
@@ -1,0 +1,31 @@
+// <copyright file="SpanAdditionalTagsAssertion.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class SpanAdditionalTagsAssertion : SpanAssertion
+    {
+        private readonly Result _result;
+        private readonly IDictionary<string, string> _tags;
+
+        internal SpanAdditionalTagsAssertion(Result result, IDictionary<string, string> tags)
+        {
+            _result = result;
+            _tags = new Dictionary<string, string>(tags);
+        }
+
+        public SpanAdditionalTagsAssertion PassesThroughSource(string description, ISet<string> tagNames)
+        {
+            foreach (var tag in tagNames)
+            {
+                _tags.Remove(tag);
+            }
+
+            return this;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -297,11 +297,9 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("otel.trace_id")
                 .MatchesOneOf("otel.status_code", "STATUS_CODE_UNSET", "STATUS_CODE_OK", "STATUS_CODE_ERROR")
                 .IsOptional("otel.status_description")
-                .PassesThroughMetadata("OTEL Resource Attributes", resources)
-                .MatchesOneOf("span.kind", "internal", "server", "client", "producer", "consumer"));
-                // .IsPresent("service.instance.id") // a "resource" attribute that may be set in code
-                // .IsPresent("service.name") // a "resource" attribute that may be set in code
-                // .IsPresent("service.version")); // a "resource" attribute that may be set in code
+                .MatchesOneOf("span.kind", "internal", "server", "client", "producer", "consumer"))
+            .AdditionalTags(s => s
+                .PassesThroughSource("OTEL Resource Attributes", resources));
 
         public static Result IsOracle(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -288,7 +288,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "Npgsql")
                 .Matches("span.kind", "client"));
 
-        public static Result IsOpenTelemetry(this MockSpan span, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
+        public static Result IsOpenTelemetry(this MockSpan span, ISet<string> resources, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
             .Properties(s => { })
             .Tags(s => s
                 // .IsOptional("events") // aka span events, added by the trace agent when the OTLP span is populated with events
@@ -297,6 +297,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("otel.trace_id")
                 .MatchesOneOf("otel.status_code", "STATUS_CODE_UNSET", "STATUS_CODE_OK", "STATUS_CODE_ERROR")
                 .IsOptional("otel.status_description")
+                .PassesThroughMetadata("OTEL Resource Attributes", resources)
                 .MatchesOneOf("span.kind", "internal", "server", "client", "producer", "consumer"));
                 // .IsPresent("service.instance.id") // a "resource" attribute that may be set in code
                 // .IsPresent("service.name") // a "resource" attribute that may be set in code

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -290,6 +290,8 @@ namespace Datadog.Trace.TestHelpers
 
         public static Result IsOpenTelemetry(this MockSpan span, ISet<string> resources, ISet<string> excludeTags = null) => Result.FromSpan(span, excludeTags)
             .Properties(s => { })
+            .AdditionalTags(s => s
+                .PassesThroughSource("OTEL Resource Attributes", resources))
             .Tags(s => s
                 // .IsOptional("events") // aka span events, added by the trace agent when the OTLP span is populated with events
                 .IsPresent("otel.library.name")
@@ -297,9 +299,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("otel.trace_id")
                 .MatchesOneOf("otel.status_code", "STATUS_CODE_UNSET", "STATUS_CODE_OK", "STATUS_CODE_ERROR")
                 .IsOptional("otel.status_description")
-                .MatchesOneOf("span.kind", "internal", "server", "client", "producer", "consumer"))
-            .AdditionalTags(s => s
-                .PassesThroughSource("OTEL Resource Attributes", resources));
+                .MatchesOneOf("span.kind", "internal", "server", "client", "producer", "consumer"));
 
         public static Result IsOracle(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -102,6 +100,16 @@ namespace Datadog.Trace.TestHelpers
                              + "]";
 
                 _result.WithFailure(GenerateMatchesOneOfFailureString("tag", tagName, expectedValueString, value));
+            }
+
+            return this;
+        }
+
+        public SpanTagAssertion PassesThroughMetadata(string description, ISet<string> tagNames)
+        {
+            foreach (var tag in tagNames)
+            {
+                _tags.Remove(tag);
             }
 
             return this;

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.TestHelpers
         internal SpanTagAssertion(Result result, IDictionary<string, string> tags)
         {
             _result = result;
-            _tags = new Dictionary<string, string>(tags);
+            _tags = tags;
         }
 
         public static void DefaultTagAssertions(SpanTagAssertion s) => s

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -104,15 +104,5 @@ namespace Datadog.Trace.TestHelpers
 
             return this;
         }
-
-        public SpanTagAssertion PassesThroughMetadata(string description, ISet<string> tagNames)
-        {
-            foreach (var tag in tagNames)
-            {
-                _tags.Remove(tag);
-            }
-
-            return this;
-        }
     }
 }

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -23,6 +23,9 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },
@@ -50,6 +53,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -67,6 +73,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -84,6 +93,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -101,6 +113,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_OK,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -121,6 +136,9 @@
       otel.status_code: STATUS_CODE_ERROR,
       otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -138,6 +156,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -146,7 +167,7 @@
     SpanId: Id_9,
     Name: OtherLibrary.internal,
     Resource: Response,
-    Service: OtherLibrary,
+    Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
     Tags: {
@@ -156,11 +177,10 @@
       otel.library.version: 4.0.0,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
-      runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
-    },
-    Metrics: {
-      _dd.top_level: 1.0
     }
   },
   {
@@ -177,6 +197,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -192,8 +215,11 @@
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },
@@ -217,8 +243,11 @@
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -23,6 +23,9 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },
@@ -50,6 +53,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -67,6 +73,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -84,6 +93,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -101,6 +113,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -118,6 +133,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_OK,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -138,6 +156,9 @@
       otel.status_code: STATUS_CODE_ERROR,
       otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -155,6 +176,9 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
     }
   },
@@ -163,7 +187,7 @@
     SpanId: Id_10,
     Name: OtherLibrary.internal,
     Resource: Response,
-    Service: OtherLibrary,
+    Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
     Tags: {
@@ -173,11 +197,10 @@
       otel.library.version: 4.0.0,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
-      runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal
-    },
-    Metrics: {
-      _dd.top_level: 1.0
     }
   },
   {
@@ -192,8 +215,11 @@
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },
@@ -217,8 +243,11 @@
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },


### PR DESCRIPTION
## Summary of changes
Adds new automatic instrumentation to insert a new Processor into the OpenTelemetry TracerProvider to ensure OpenTelemetry resource attributes are copied to Datadog spans.

## Reason for change
The changes in #3556 correctly map OpenTelemetry Span attributes to the corresponding Datadog spans, but it does not have support for OpenTelemetry [Resources](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md). TL;DR Resource attributes are a set of attributes at the application level that identify a single application deployment, including attributes like `service.name`, `service.version`, etc.

In the .NET OpenTelemetry SDK, the resource attributes are never copied into the individual Activity objects themselves, they are only available to processors (e.g. exporters) who can then process them. For example, the OTLP exporter adds these to the [resource field](https://github.com/open-telemetry/opentelemetry-proto/blob/d8729d40f629dba12694b44c4c32c1eab109b00a/opentelemetry/proto/trace/v1/trace.proto#L53) which accompanies a batch of spans (similar to a TraceChunk in Datadog), and the Datadog trace agent copies each resource attribute one-by-one to the Datadog spans as tags.

To simulate the Datadog trace agent logic of copying over resource attributes to Datadog span tags, we need to add a Processor into the OpenTelemetry SDK pipeline.

## Implementation details

### Automatic instrumentation
We use our automatic instrumentation infrastructure to rewrite the extension method `OpenTelemetry.Trace.TracerProviderBuilderExtensions.Build(this OpenTelemetry.Trace.TracerProviderBuilder tracerProviderBuilder)`. This is a common entrypoint among all `1.x` versions of the `OpenTelemetry.dll` so this method made the most sense to instrument, even though it is static and therefore we can't ducktype the `TracerProviderBuilderExtensions` type. Using a bunch of reflection and System.Reflection.Emit, we try to create a new Processor that derives from `OpenTelemetry.BaseProcessor<T>` (where T=System.Diagnostics.Activity) to respond to span events from the SDK and, if successful, add it into the pipeline at the very last moment.

### Activity Processor
Since the base type for the processor is `OpenTelemetry.BaseProcessor<T>`, we can't easily proxy this using our own class that we write in C#. Instead, we dynamically create a new type that implements `OpenTelemetry.BaseProcessor<System.Diagnostics.Activity>` and override the virtual `void OnStart(Activity data)` (using System.Reflection.Emit) to invoke a static helper method where we store our logic.

The invoked method has the signature `void OnStart(object processor, object activity)`. Since we have the processor instance (which has access to the resources) and we have the Activity (which we can map to an active Span), we can easily iterate over the resource attributes and set them as tags on the Datadog spans.

### Miscellaneous
In addition to setting tags, this updates the corresponding Datadog spans with the following logic:
- `service.version` => sets tag `version`
- `service.name` => updates `span.ServiceName`
  - Note: The big change here is that (in alignment with pure OTEL SDK manual spans), other libraries that create their own tracer using `tracerProvider.GetTracer(libraryName, libraryVersion)` will generate spans with the service name coming from the `service.name` resource. They will still have `tags["otel.library.name"] = libraryName` and `tags["otel.library.version"] = libraryVersion`

## Test coverage
- No changes were made to the `Samples.OpenTelemetrySdk` application, but the snapshot has been updated so now all spans carry the (previously defined) attributes `service.instance.id`, `service.name`, and `service.version`
- Updates the span metadata rules to check for the new tags. Since we copy *all* resource attributes and set them as span tags, this PR introduces a new concept `AdditionalTags` which indicates from what sources we pass through arbitrary information. This will help to audit other places in the future where we may be passing arbitrary data into our spans.

## Other details
N/A
