### PR TITLE
Move maximum possible tasks from `Datadog.Trace.proj` to `Nuke`

### DIFF
--- a/tracer/Datadog.Trace.proj
+++ b/tracer/Datadog.Trace.proj
@@ -5,70 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <CsharpProject Include="src\**\*.csproj" Exclude="src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj;src/Datadog.Trace.Tools.Runner/*.csproj;src\**\Datadog.InstrumentedAssembly*.csproj" />
-    <CsharpUnitTestProject Include="test\**\*.Tests.csproj"/>
-    <CsharpInstrumentationVerificationLibrary Include="src\**\Datadog.InstrumentedAssembly*.csproj"/>
-    <CsharpIntegrationTestProject Include="test\*.IntegrationTests\*.IntegrationTests.csproj" />
-    <CsharpIntegrationTestProject Remove="test\Datadog.Trace.Tools.Runner.IntegrationTests\Datadog.Trace.Tools.Runner.IntegrationTests.csproj" Condition="$(TargetFramework.StartsWith('net4'))" />
-    <CsharpIntegrationTestRegressionProject Include="test\tests-applications\regression\*.IntegrationTests.csproj" />
-    <CsharpIntegrationTestDebuggerProject Include="test\Datadog.Trace.Debugger.IntegrationTests\Datadog.Trace.Debugger.IntegrationTests.csproj" />
-    <RazorPagesProject Include="test/test-applications/**/Samples.AspNetCoreRazorPages.csproj" />
-    <ExcludeExpenseItDemoProject Remove="test/test-applications/regression/**/ExpenseItDemo*.csproj" />
-    <ExcludeLegacyRedisProject Remove="test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj" />
-    <CsharpTestHelperProject Include="test\**\*.TestHelpers.csproj;test\**\*.TestHelpers.AutoInstrumentation.csproj"/>
     <CppProject Include="src\**\*.vcxproj"/>
     <CppTestProject Include="test\**\*.vcxproj"/>
-    <VbSampleLibProject Include="test\test-applications\integrations\**\*.vbproj" />
-    <SampleLibProject Include="test\test-applications\integrations\dependency-libs\**\*.csproj" />
-    <RegressionSampleLibProject Include="test\test-applications\regression\dependency-libs\**\Datadog.StackExchange.Redis*.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <FrameworkReproduction Include="test\test-applications\regression\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj" />
   </ItemGroup>
-
-  <!--  Used by CompileManagedSrc-->
-  <Target Name="BuildCsharpSrc">
-    <MSBuild Targets="Build" Projects="@(CsharpProject)" Properties="Platform=AnyCPU">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!--  Used by CompileManagedTestHelpers-->
-  <Target Name="BuildInstrumentationVerificationLibrary">
-    <MSBuild Targets="Build" Projects="@(CsharpInstrumentationVerificationLibrary)">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!--  Used by CompileManagedTestHelpers-->
-  <Target Name="BuildCsharpTestHelpers">
-    <MSBuild Targets="Build" Projects="@(CsharpTestHelperProject)">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!--  Used by CompileManagedUnitTests-->
-  <Target Name="BuildCsharpUnitTests">
-    <MSBuild Targets="Build" Projects="@(CsharpTestHelperProject);@(CsharpUnitTestProject)">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!-- Used by CompileIntegrationTests-->
-  <Target Name="BuildCsharpIntegrationTests">
-
-    <!-- Filter the sample projects by TargetFramework -->
-    <ItemGroup>
-      <IntegrationTestProjects Include="@(RazorPagesProject)" Condition="!$(TargetFramework.StartsWith('net4'))" />
-      <IntegrationTestProjects Include="@(CsharpIntegrationTestProject);@(CsharpIntegrationTestRegressionProject);@(ExcludeExpenseItDemoProject);@(ExcludeLegacyRedisProject)" />
-      <IntegrationTestProjects Remove="@(CsharpIntegrationTestDebuggerProject)" />
-    </ItemGroup>
-
-    <MSBuild Targets="Build" Projects="@(CsharpTestHelperProject);@(IntegrationTestProjects)">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
 
   <!--  Used by CompileNativeSrcWindows-->
   <Target Name="BuildCppSrc">
@@ -77,16 +17,9 @@
     </MSBuild>
   </Target>
 
-  <!--  Used by CompileDependencyLibs-->
-  <Target Name="BuildDependencyLibs">
-    <MSBuild Targets="Build" Projects="@(SampleLibProject);@(VbSampleLibProject);">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!--  Used by CompileRegressionDependencyLibs-->
-  <Target Name="BuildRegressionDependencyLibs">
-    <MSBuild Targets="Build" Projects="@(RegressionSampleLibProject)">
+  <!--  Used by CompileNativeTestsWindows-->
+  <Target Name="BuildCppTests">
+    <MSBuild Targets="Build" Projects="@(CppTestProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
@@ -94,13 +27,6 @@
   <!--  Used by CompileFrameworkReproductions-->
   <Target Name="BuildFrameworkReproductions">
     <MSBuild Targets="Build" Projects="@(FrameworkReproduction)">
-      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
-    </MSBuild>
-  </Target>
-
-  <!--  Used by CompileNativeTestsWindows-->
-  <Target Name="BuildCppTests">
-    <MSBuild Targets="Build" Projects="@(CppTestProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1100,7 +1100,7 @@ partial class Build
                     _ when exclude.Contains(project.Path) => false,
                     _ when !string.IsNullOrWhiteSpace(SampleName) => project.Path.ToString().Contains(SampleName),
                     (_, _, true) => false, // can't use docker on Windows
-                    var (_, targets, _) when targets is not null => targets.Contains(Framework),
+                    (_, { } targets, _) => targets.Contains(Framework),
                     _ => true,
                 }
             );
@@ -1272,7 +1272,7 @@ partial class Build
                     var project = Solution.GetProject(path);
                     return (project, project.TryGetTargetFrameworks(), project.RequiresDockerDependency()) switch
                     {
-                        var (_, targets, _) when targets is not null => targets.Contains(Framework),
+                        (_, { } targets, _) => targets.Contains(Framework),
                         _ => true,
                     };
                 });

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -978,7 +978,7 @@ partial class Build
 
             //// Allow restore here, otherwise things go wonky with runtime identifiers
             //// in some target frameworks. No, I don't know why
-            DotnetBuild(regressionLibs, platform: TargetPlatform, framework: Framework, noRestore: false, setNuget: true);
+            DotnetBuild(regressionLibs, platform: TargetPlatform, framework: Framework, noRestore: false);
         });
 
     Target CompileFrameworkReproductions => _ => _
@@ -1278,7 +1278,7 @@ partial class Build
                 });
 
             
-            DotnetBuild(projects, platform: TargetPlatform, noRestore: false, setNuget: true);
+            DotnetBuild(projects, platform: TargetPlatform, noRestore: false);
         });
 
     Target RunWindowsAzureFunctionsTests => _ => _
@@ -1547,7 +1547,7 @@ partial class Build
 
             // do the build and publish separately to avoid dependency issues
 
-            DotnetBuild(projectsToBuild, framework: Framework, noRestore: false, setNuget: true, setPackages: true);
+            DotnetBuild(projectsToBuild, framework: Framework, noRestore: false);
 
             // Always AnyCPU
             DotNetPublish(x => x
@@ -1625,7 +1625,7 @@ partial class Build
                    .GlobFiles("test/*.IntegrationTests/*.csproj")
                    .Where(path => !((string)path).Contains(Projects.DebuggerIntegrationTests));
 
-            DotnetBuild(integrationTestProjects, framework: Framework, noRestore: false, setNuget: true, setPackages: true);
+            DotnetBuild(integrationTestProjects, framework: Framework, noRestore: false);
 
             IntegrationTestLinuxProfilerDirFudge(Projects.ClrProfilerIntegrationTests);
             IntegrationTestLinuxProfilerDirFudge(Projects.AppSecIntegrationTests);
@@ -2215,7 +2215,7 @@ partial class Build
         bool setPackages = false
         )
     {
-        DotnetBuild(new [] { project.Path }, platform, framework, noRestore, noDependencies, setNuget, setPackages); 
+        DotnetBuild(new [] { project.Path }, platform, framework, noRestore, noDependencies); 
     }
 
     private void DotnetBuild(
@@ -2223,9 +2223,7 @@ partial class Build
         MSBuildTargetPlatform platform = null,
         TargetFramework framework = null,
         bool noRestore = true,
-        bool noDependencies = true,
-        bool setNuget = false,
-        bool setPackages = false
+        bool noDependencies = true
         )
     {
         DotNetBuild(s => s
@@ -2234,9 +2232,9 @@ partial class Build
             .When(noRestore, settings => settings.EnableNoRestore())
             .When(noDependencies, settings => settings.EnableNoDependencies())
             .When(framework is not null, settings => settings.SetFramework(framework))
-            .When(setNuget && !string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
-            .When(setPackages && TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
-            .When(setPackages && IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
+            .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
+            .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
+            .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
             .SetNoWarnDotNetCore3()
             .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701")) //nowarn:NU1701 - Package 'x' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'.
             .CombineWith(projPaths, (settings, projPath) => settings.SetProjectFile(projPath)));        

--- a/tracer/build/_build/Projects.cs
+++ b/tracer/build/_build/Projects.cs
@@ -27,6 +27,7 @@ public static class Projects
     public const string DebuggerSamples = "Samples.Probes";
     public const string DebuggerSamplesTestRuns = "Samples.Probes.TestRuns";
 
+    public const string RazorPages = "Samples.AspNetCoreRazorPages";
 }
 
 public static class FileNames


### PR DESCRIPTION
## Summary of changes
Move maximum possible tasks from `Datadog.Trace.proj` to nuke and use `dotnet build` instead of `msbuild`.

## Reason for change
Simplify CI process.