### PR TITLE
[Debugger] Temporary disable debugger tests for `x86`, .net 3.1 and .net6.0

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -91,6 +91,12 @@ partial class Build : NukeBuild
                 {
                     foreach (var targetPlatform in targetPlatforms)
                     {
+                        if (targetPlatform == "x86" && (framework.Equals(TargetFramework.NETCOREAPP3_1) || framework.Equals(TargetFramework.NET6_0)))
+                        {
+                            // fails on CI with error "apphost.exe" not found.
+                            continue;
+                        }
+
                         matrix.Add($"{targetPlatform}_{framework}", new { framework = framework, targetPlatform = targetPlatform });
                     }
                 }


### PR DESCRIPTION
## Summary of changes
Temporary disable debugger tests for `x86`, .net 3.1 and .net6.0

## Reason for change
`x86`, .net 3.1 and .net6.0 fails on ci with error `apphost.exe` is not found.
There is possible workaround with setting explicit SDK for build and test, but it's very complicated for implementation.
