### PR TITLE
[tracer] W3C Trace Context part 3: include additional vendor values in `tracestate` header

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -687,7 +687,7 @@ namespace Datadog.Trace.Propagators
 
         private static string TrimAndJoinStringsRare(IEnumerable<string?> values)
         {
-            static void AppendIfNullOrWhiteSpace(StringBuilder sb, string? value)
+            static void AppendIfNotNullOrWhiteSpace(StringBuilder sb, string? value)
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
@@ -703,7 +703,7 @@ namespace Datadog.Trace.Propagators
                     // converts into a `for` loop
                     foreach (var value in array)
                     {
-                        AppendIfNullOrWhiteSpace(sb, value);
+                        AppendIfNotNullOrWhiteSpace(sb, value);
                     }
 
                     break;
@@ -712,7 +712,7 @@ namespace Datadog.Trace.Propagators
                     // uses List<T>'s struct enumerator
                     foreach (var value in list)
                     {
-                        AppendIfNullOrWhiteSpace(sb, value);
+                        AppendIfNotNullOrWhiteSpace(sb, value);
                     }
 
                     break;
@@ -720,7 +720,7 @@ namespace Datadog.Trace.Propagators
                 default:
                     foreach (var value in values)
                     {
-                        AppendIfNullOrWhiteSpace(sb, value);
+                        AppendIfNotNullOrWhiteSpace(sb, value);
                     }
 
                     break;

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -517,17 +517,44 @@ namespace Datadog.Trace.Propagators
             return true;
         }
 
-        private static bool TryGetSingle(IEnumerable<string?> values, out string? value)
+        private static bool TryGetSingle(IEnumerable<string?> values, out string value)
         {
-            var list = values as IReadOnlyList<string?> ?? values.Take(2).ToList();
-
-            if (list.Count == 1)
+            if (values is IReadOnlyList<string?> list)
             {
-                value = list[0];
-                return true;
+                if (list.Count == 1)
+                {
+                    value = list[0] ?? string.Empty;
+                    return true;
+                }
+
+                value = string.Empty;
+                return false;
             }
 
-            value = null;
+            return TryGetSingleRare(values, out value);
+        }
+
+        private static bool TryGetSingleRare(IEnumerable<string?> values, out string value)
+        {
+            value = string.Empty;
+            var hasValue = false;
+
+            foreach (var s in values)
+            {
+                if (!hasValue)
+                {
+                    // save first item
+                    value = s ?? string.Empty;
+                    hasValue = true;
+                }
+                else
+                {
+                    // we already saved the first item and there is a second one
+                    return false;
+                }
+            }
+
+            // there were no items
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -179,7 +179,7 @@ namespace Datadog.Trace.Propagators
                         sb.Append(TraceStateHeaderValuesSeparator);
                     }
 
-                    sb.Append(additionalState!.Trim());
+                    sb.Append(additionalState);
                 }
 
                 return sb.ToString();
@@ -518,8 +518,6 @@ namespace Datadog.Trace.Propagators
                 sb.Append(otherValuesLeft).Append(TraceStateHeaderValuesSeparator).Append(otherValuesRight);
                 additionalValues = StringBuilderCache.GetStringAndRelease(sb);
             }
-
-            additionalValues = additionalValues?.Trim();
         }
 
         [return: NotNullIfNotNull("samplingPriority")]

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -668,20 +668,15 @@ namespace Datadog.Trace.Propagators
         }
 
         private static string TrimAndJoinStrings(IEnumerable<string?> values)
-        {
-            switch (values)
-            {
-                case IReadOnlyList<string?> { Count: 1 } list:
-                    // fast path for single values
-                    return list[0]?.Trim() ?? string.Empty;
-                case IReadOnlyCollection<string?> { Count: 0 }:
-                case null:
-                    // fast path for null or empty collections
-                    return string.Empty;
-                default:
-                    return TrimAndJoinStringsRare(values);
-            }
-        }
+            => values switch
+               {
+                   // fast path for single value
+                   IReadOnlyList<string?> { Count: 1 } list => list[0]?.Trim() ?? string.Empty,
+                   // fast path for null or empty collections
+                   IReadOnlyCollection<string?> { Count: 0 } or null => string.Empty,
+                   // fallback
+                   _ => TrimAndJoinStringsRare(values),
+               };
 
         private static string TrimAndJoinStringsRare(IEnumerable<string?> values)
         {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -295,20 +295,18 @@ namespace Datadog.Trace.Propagators
 
         internal static W3CTraceState ParseTraceState(string header)
         {
-            var otherHeaderValues = string.Empty;
-
             // header format: "[*,]dd=s:1;o:rum;t.dm:-4;t.usr.id:12345[,*]"
             if (string.IsNullOrWhiteSpace(header))
             {
-                return new W3CTraceState(null, null, null, otherHeaderValues);
+                return default;
             }
 
-            SplitTraceStateValues(header, out var ddValues, out otherHeaderValues);
+            SplitTraceStateValues(header, out var ddValues, out var additionalValues);
 
             if (ddValues.Length < 6)
             {
-                // "dd" section too short, shortest length is 6, "dd=a:b"
-                return new W3CTraceState(null, null, null, otherHeaderValues);
+                // "dd" section too short, shortest valid length is 6 as in "dd=a:b"
+                return new W3CTraceState(null, null, null, additionalValues);
             }
 
             int? samplingPriority = null;
@@ -425,7 +423,7 @@ namespace Datadog.Trace.Propagators
                     propagatedTags = null;
                 }
 
-                return new W3CTraceState(samplingPriority, origin, propagatedTags, otherHeaderValues);
+                return new W3CTraceState(samplingPriority, origin, propagatedTags, additionalValues);
             }
             finally
             {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceState.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceState.cs
@@ -16,10 +16,14 @@ internal readonly struct W3CTraceState
     // format is "_dd.p.key1:value1;_dd.p.key2:value2"
     public readonly string? PropagatedTags;
 
-    public W3CTraceState(int? samplingPriority, string? origin, string? propagatedTags)
+    // the string left in "tracestate" after removing "dd=*"
+    public readonly string? AdditionalValues;
+
+    public W3CTraceState(int? samplingPriority, string? origin, string? propagatedTags, string? additionalValues)
     {
         SamplingPriority = samplingPriority;
         Origin = origin;
         PropagatedTags = propagatedTags;
+        AdditionalValues = additionalValues;
     }
 }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -221,6 +221,13 @@ namespace Datadog.Trace
         /// </summary>
         internal string RawSpanId { get; }
 
+        /// <summary>
+        /// Gets or sets additional key/value pairs from an upstream "tracestate" W3C header that we will propagate downstream.
+        /// This value will _not_ include the "dd" key, which is parsed out into other individual values
+        /// (e.g. sampling priority, origin, propagates tags, etc).
+        /// </summary>
+        internal string AdditionalW3CTraceState { get; set; }
+
         internal PathwayContext? PathwayContext { get; private set; }
 
         /// <inheritdoc/>

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace
         /// <param name="rawTraceId">Raw trace id value</param>
         /// <param name="rawSpanId">Raw span id value</param>
         internal SpanContext(ISpanContext parent, TraceContext traceContext, string serviceName, ulong? traceId = null, ulong? spanId = null, string rawTraceId = null, string rawSpanId = null)
-            : this(parent?.TraceId ?? traceId, serviceName)
+            : this(parent?.TraceId > 0 ? parent.TraceId : traceId, serviceName)
         {
             SpanId = spanId ?? SpanIdGenerator.CreateNew();
             Parent = parent;

--- a/tracer/src/Datadog.Trace/Tagging/TagPropagation.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagPropagation.cs
@@ -32,8 +32,8 @@ internal static class TagPropagation
     public const string PropagatedTagPrefix = "_dd.p.";
 
     // "x-datadog-tags" header format is "key1=value1,key2=value2"
-    private const char TagPairSeparator = ',';
-    private const char KeyValueSeparator = '=';
+    public const char TagPairSeparator = ',';
+    public const char KeyValueSeparator = '=';
 
     private const int PropagatedTagPrefixLength = 6; // "_dd.p.".Length
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -120,10 +120,10 @@ namespace Datadog.Trace
                         }
                     }
 
-                    // if the trace's origin is not set and this span has an origin
-                    // (probably propagated from an upstream service),
-                    // copy the span's origin into the trace
+                    // if these trace attributes are not set yet, copy them from the span context if present
+                    // (probably propagated from an upstream service)
                     Origin ??= span.Context.Origin;
+                    AdditionalW3CTraceState ??= span.Context.AdditionalW3CTraceState;
                 }
 
                 _openSpans++;

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -70,6 +70,13 @@ namespace Datadog.Trace
         public string Origin { get; set; }
 
         /// <summary>
+        /// Gets or sets additional key/value pairs from upstream "tracestate" header that we will propagate downstream.
+        /// This value will _not_ include the "dd" key, which is parsed out into other individual values
+        /// (e.g. sampling priority, origin, propagates tags, etc).
+        /// </summary>
+        internal string AdditionalW3CTraceState { get; set; }
+
+        /// <summary>
         /// Gets the IAST context.
         /// </summary>
         internal IastRequestContext IastRequestContext => _iastRequestContext;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -11,7 +11,6 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -363,6 +363,7 @@ namespace Datadog.Trace
                     var samplingPriority = parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority();
                     traceContext.SetSamplingPriority(samplingPriority);
                     traceContext.Origin = parentSpanContext.Origin;
+                    traceContext.AdditionalW3CTraceState = parentSpanContext.AdditionalW3CTraceState;
                 }
             }
             else

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -32,10 +32,12 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_All_IHeadersCollection()
         {
-            ulong traceId = 123456789;
-            ulong spanId = 987654321;
-            var samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, origin: "rum");
+            var traceContext = new TraceContext(tracer: null);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            traceContext.Origin = "rum";
+
+            var context = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, 123456789, 987654321);
+
             var headers = new Mock<IHeadersCollection>();
 
             Propagator.Inject(context, headers.Object);
@@ -61,10 +63,11 @@ namespace Datadog.Trace.Tests.Propagators
         [Fact]
         public void Inject_All_CarrierAndDelegate()
         {
-            const ulong traceId = 123456789;
-            const ulong spanId = 987654321;
-            const int samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, origin: "rum");
+            var traceContext = new TraceContext(tracer: null);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            traceContext.Origin = "rum";
+
+            var context = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, 123456789, 987654321);
 
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.Agent;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
@@ -487,14 +485,6 @@ namespace Datadog.Trace.Tests.Propagators
                                      .ToString() // NETCOREAPP returns ReadOnlySpan<char>
                                      .Should()
                                      .Be(expected);
-        }
-
-        private static SpanContext CreateSpanContext(ulong traceId, ulong spanId, string rawTraceId, string rawSpanId)
-        {
-            var settings = new TracerSettings();
-            var agentWriter = new Mock<IAgentWriter>();
-            var tracer = new Tracer(settings, agentWriter.Object, sampler: null, scopeManager: null, statsd: null);
-            return tracer.CreateSpanContext(parent: SpanContext.None, serviceName: null, traceId, spanId, rawTraceId, rawSpanId);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -188,33 +188,33 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Theory]
-        // invalid "dd" value
-        [InlineData(null, null, null, null, "")]                 // null
-        [InlineData("", null, null, null, "")]                   // empty
-        [InlineData(" ", null, null, null, "")]                  // whitespace
-        [InlineData("dd=", null, null, null, "")]                // "dd=" prefix only
-        [InlineData("dd=:2", null, null, null, "")]              // no key
-        [InlineData("dd=s:", null, null, null, "")]              // no value
-        [InlineData("dd=s", null, null, null, "")]               // no colon
-        [InlineData("dd=xyz:123", null, null, null, "")]         // unknown key
-        [InlineData("s:2;o:rum", null, null, null, "s:2;o:rum")] // missing "dd=" prefix, interpreted as additional values
         // valid
-        [InlineData("dd=s:2", 2, null, null, "")]                                                                                    // sampling priority
-        [InlineData("dd=o:rum", null, "rum", null, "")]                                                                              // origin
-        [InlineData("dd=t.dm:-4;t.usr.id:12345", null, null, "_dd.p.dm=-4,_dd.p.usr.id=12345", "")]                                  // propagated tags
+        [InlineData("dd=s:2", 2, null, null, null)]                                                                                  // sampling priority
+        [InlineData("dd=s:-1", -1, null, null, null)]                                                                                // sampling priority
+        [InlineData("dd=o:rum", null, "rum", null, null)]                                                                            // origin
+        [InlineData("dd=t.dm:-4;t.usr.id:12345", null, null, "_dd.p.dm=-4,_dd.p.usr.id=12345", null)]                                // propagated tags
         [InlineData("key1=value1,key2=value2", null, null, null, "key1=value1,key2=value2")]                                         // additional values
         [InlineData("key1=value1dd=,key2=value2", null, null, null, "key1=value1dd=,key2=value2")]                                   // additional values, ignore embedded "dd="
         [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345~,key1=value1", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345=", "key1=value1")] // all, and '~' is converted to '='
+        // invalid "dd" value
+        [InlineData(null, null, null, null, null)]         // null
+        [InlineData("", null, null, null, null)]           // empty
+        [InlineData(" ", null, null, null, null)]          // whitespace
+        [InlineData("dd=", null, null, null, null)]        // "dd=" prefix only
+        [InlineData("dd=:2", null, null, null, null)]      // no key
+        [InlineData("dd=s:", null, null, null, null)]      // no value
+        [InlineData("dd=s", null, null, null, null)]       // no colon
+        [InlineData("dd=xyz:123", null, null, null, null)] // unknown key
         // invalid propagated tag (first)
-        [InlineData("dd=s:2;o:rum;:12345;t.dm:-4", 2, "rum", "_dd.p.dm=-4", "")]    // no key
-        [InlineData("dd=s:2;o:rum;t.usr.id:;t.dm:-4", 2, "rum", "_dd.p.dm=-4", "")] // no value
-        [InlineData("dd=s:2;o:rum;:;t.dm:-4", 2, "rum", "_dd.p.dm=-4", "")]         // no key or value
-        [InlineData("dd=s:2;o:rum;t.abc;t.dm:-4", 2, "rum", "_dd.p.dm=-4", "")]     // no colon
+        [InlineData("dd=s:2;o:rum;:12345;t.dm:-4", 2, "rum", "_dd.p.dm=-4", null)]    // no key
+        [InlineData("dd=s:2;o:rum;t.usr.id:;t.dm:-4", 2, "rum", "_dd.p.dm=-4", null)] // no value
+        [InlineData("dd=s:2;o:rum;:;t.dm:-4", 2, "rum", "_dd.p.dm=-4", null)]         // no key or value
+        [InlineData("dd=s:2;o:rum;t.abc;t.dm:-4", 2, "rum", "_dd.p.dm=-4", null)]     // no colon
         // invalid propagated tag (last)
-        [InlineData("dd=s:2;o:rum;t.dm:-4;:12345", 2, "rum", "_dd.p.dm=-4", "")]    // no key
-        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:", 2, "rum", "_dd.p.dm=-4", "")] // no value
-        [InlineData("dd=s:2;o:rum;t.dm:-4;:", 2, "rum", "_dd.p.dm=-4", "")]         // no key or value
-        [InlineData("dd=s:2;o:rum;t.dm:-4;t.abc", 2, "rum", "_dd.p.dm=-4", "")]     // no colon
+        [InlineData("dd=s:2;o:rum;t.dm:-4;:12345", 2, "rum", "_dd.p.dm=-4", null)]    // no key
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:", 2, "rum", "_dd.p.dm=-4", null)] // no value
+        [InlineData("dd=s:2;o:rum;t.dm:-4;:", 2, "rum", "_dd.p.dm=-4", null)]         // no key or value
+        [InlineData("dd=s:2;o:rum;t.dm:-4;t.abc", 2, "rum", "_dd.p.dm=-4", null)]     // no colon
         // multiple top-level key/value pairs
         [InlineData("key1=value1,key2=value2,dd=s:2;o:rum;t.dm:-4;t.usr.id:12345", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345", "key1=value1,key2=value2")]                                                 // before "dd"
         [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345,key3=value3,key4=value4", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345", "key3=value3,key4=value4")]                                                 // after "dd"

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -204,7 +204,8 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData("dd=s:2", 2, null, null, "")]                                                                                    // sampling priority
         [InlineData("dd=o:rum", null, "rum", null, "")]                                                                              // origin
         [InlineData("dd=t.dm:-4;t.usr.id:12345", null, null, "_dd.p.dm=-4,_dd.p.usr.id=12345", "")]                                  // propagated tags
-        [InlineData("key1=value1", null, null, null, "key1=value1")]                                                                 // additional values
+        [InlineData("key1=value1,key2=value2", null, null, null, "key1=value1,key2=value2")]                                         // additional values
+        [InlineData("key1=value1dd=,key2=value2", null, null, null, "key1=value1dd=,key2=value2")]                                   // additional values, ignore embedded "dd="
         [InlineData("dd=s:2;o:rum;t.dm:-4;t.usr.id:12345~,key1=value1", 2, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345=", "key1=value1")] // all, and '~' is converted to '='
         // invalid propagated tag (first)
         [InlineData("dd=s:2;o:rum;:12345;t.dm:-4", 2, "rum", "_dd.p.dm=-4", "")]    // no key


### PR DESCRIPTION
## Summary of changes

If the W3C `tracestate` header extracted from an upstream service contains additional values aside from `dd`, we now propagate them when injecting `tracestate` into downstream services.

## Reason for change

Improve support for standard W3C headers and OpenTelemetry.

## Implementation details

When extracting the `tracestate` header, we parse the `dd` value into sampling priority, origin, propagated tags, etc. The rest of the header (normally data from 3rd party vendors) is returned as a string in the extracted `SpanContext`. This value is persisted in the trace's `TraceContext` and appended back into any `tracestate` header we inject.

## Test coverage

Several tests were added or modified in `W3CTraceContextPropagatorTests` to cover these changes.

## Other details

Follows #3491.
Internal tracking: AIT-5063.

This implementation uses `string.Substring()` even in .NET Core. I plan on making further optimizations to reduce heap allocations in a separate PR. `Substring()` will not be used in the common case where the only value in `tracestate` is `dd`.

Bonus:
- fixed a bug in one of the `SpanContext` constructors when passing a parent with traceId = 0