### PR TITLE
Disable tiered JIT workaround by default

### DIFF
--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -36,6 +36,9 @@ ENV DD_APPSEC_ENABLED=1
 ENV DD_TRACE_DEBUG=1
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 ENV ASPNETCORE_URLS=http://localhost:5000
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -36,7 +36,7 @@ ENV DD_APPSEC_ENABLED=1
 ENV DD_TRACE_DEBUG=1
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 ENV ASPNETCORE_URLS=http://localhost:5000

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -32,7 +32,7 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -32,7 +32,7 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -41,6 +41,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -41,7 +41,7 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -43,7 +43,7 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -43,7 +43,7 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -46,6 +46,9 @@ ENV CORECLR_ENABLE_PROFILING=1 \
     DD_PROFILING_ENABLED=1 \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -46,7 +46,7 @@ ENV CORECLR_ENABLE_PROFILING=1 \
     DD_PROFILING_ENABLED=1 \
     ASPNETCORE_URLS=http://localhost:5000
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -50,6 +50,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# see https://github.com/dotnet/runtime/issues/77973
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -50,7 +50,7 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
-# see https://github.com/dotnet/runtime/issues/77973
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 # Copy the app across

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -220,7 +220,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     // Check if we have to disable tiered compilation (due to https://github.com/dotnet/runtime/issues/77973)
     bool disableTieredCompilation = false;
-    bool internal_workaround_77973_enabled = true;
+    bool internal_workaround_77973_enabled = false;
     shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(environment::internal_workaround_77973_enabled), internal_workaround_77973_enabled);
     if (internal_workaround_77973_enabled)
     {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -219,6 +219,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     Logger::Info("Runtime Information: ", runtimeType, " ", runtime_information_.major_version, ".", runtime_information_.minor_version, ".", runtime_information_.build_version);
 
     // Check if we have to disable tiered compilation (due to https://github.com/dotnet/runtime/issues/77973)
+    // see https://github.com/DataDog/dd-trace-dotnet/pull/3579 for more details
     bool disableTieredCompilation = false;
     bool internal_workaround_77973_enabled = false;
     shared::TryParseBooleanEnvironmentValue(shared::GetEnvironmentValue(environment::internal_workaround_77973_enabled), internal_workaround_77973_enabled);

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -190,7 +190,7 @@ namespace Datadog.Trace.TestHelpers
             string profilerEnabled = AutomaticInstrumentationEnabled ? "1" : "0";
             environmentVariables["DD_DOTNET_TRACER_HOME"] = MonitoringHome;
 
-            // see https://github.com/dotnet/runtime/issues/77973
+            // see https://github.com/DataDog/dd-trace-dotnet/pull/3579
             environmentVariables["DD_INTERNAL_WORKAROUND_77973_ENABLED"] = "1";
 
             // Everything should be using the native loader now

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -190,6 +190,9 @@ namespace Datadog.Trace.TestHelpers
             string profilerEnabled = AutomaticInstrumentationEnabled ? "1" : "0";
             environmentVariables["DD_DOTNET_TRACER_HOME"] = MonitoringHome;
 
+            // see https://github.com/dotnet/runtime/issues/77973
+            environmentVariables["DD_INTERNAL_WORKAROUND_77973_ENABLED"] = "1";
+
             // Everything should be using the native loader now
             var nativeLoaderPath = GetNativeLoaderPath();
 


### PR DESCRIPTION
## Summary of changes

Switches the `DD_INTERNAL_WORKAROUND_77973_ENABLED` flag to be `false` by default

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/3506 we added a workaround for the runtime bug https://github.com/dotnet/runtime/issues/77973, and enabled it by default for affected runtimes.

We noticed a significant impact on throughput tests (45% reduction in throughput) when tiered jit was disabled. Based on [the documentation](https://github.com/dotnet/coreclr/blob/a9f3fc16483eecfc47fb79c362811d870be02249/Documentation/design-docs/tiered-compilation.md), it seems likely due to this:

> **Steady-State** - If code loaded from ReadyToRun images appears hot, the runtime replaces it with jitted code which is typically higher quality. At runtime the JIT is able to observe the exact dependencies that are loaded as well as CPU instruction support which allows it to generate superior code. In the future it may also utilize profile guided feedback but it does not currently do so.

## Implementation details

Switch the flag to `false` by default, so as to not impact customers by default. Customers can then make a reason decision whether to take the throughput hit to workaround the runtime bug https://github.com/dotnet/runtime/issues/77973.

## Test coverage

Enabled the flag in smoke tests and integration tests

## Other details
It is preferable to use the `DD_INTERNAL_WORKAROUND_77973_ENABLED` flag as the workaround, instead of `COMPlus_TieredCompilation`, as that way we _only_ disable tiered JIT on affected runtimes
