### PR TITLE
Upload crank throughput results to AzDo artifacts

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2909,6 +2909,7 @@ stages:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
     # By default all throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
     runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true'))]
+    CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
   pool: Throughput
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -2933,7 +2934,7 @@ stages:
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        cd $(System.DefaultWorkingDirectory)/tracer/build/crank
+        cd $(CrankDir)
         chmod +x ./run.sh
         ./run.sh "linux" "$(runExtendedThroughputTests)"
       displayName: Crank
@@ -2942,6 +2943,19 @@ stages:
         DD_ENV: CI
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
         DD_API_KEY: $(ddApiKey)
+
+    - script: |
+        mkdir -p $(CrankDir)/results
+        cp $(CrankDir)/*.json $(CrankDir)/results
+      displayName: Copy the results to results dir
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - publish: "$(CrankDir)/results"
+      displayName: Publish results
+      artifact: crank_linux_x64_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
   - job: Windows64
     timeoutInMinutes: 60
@@ -2960,7 +2974,7 @@ stages:
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
-        cd $(System.DefaultWorkingDirectory)/tracer/build/crank
+        cd $(CrankDir)
         chmod +x ./run.sh
         ./run.sh "windows" "$(runExtendedThroughputTests)"
       displayName: Crank
@@ -2969,6 +2983,19 @@ stages:
         DD_ENV: CI
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
         DD_API_KEY: $(ddApiKey)
+
+    - script: |
+        mkdir -p $(CrankDir)/results
+        cp $(CrankDir)/*.json $(CrankDir)/results
+      displayName: Copy the results to results dir
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - publish: "$(CrankDir)/results"
+      displayName: Publish results
+      artifact: crank_windows_x64_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
   - job: LinuxArm64
     timeoutInMinutes: 60
@@ -2996,6 +3023,19 @@ stages:
         DD_ENV: CI
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
         DD_API_KEY: $(ddApiKey)
+
+    - script: |
+        mkdir -p $(CrankDir)/results
+        cp $(CrankDir)/*.json $(CrankDir)/results
+      displayName: Copy the results to results dir
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - publish: "$(CrankDir)/results"
+      displayName: Publish results
+      artifact: crank_linux_arm64_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
 - stage: throughput_appsec
   condition: and(succeeded(), eq(variables.isMainRepository, true))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3042,6 +3042,7 @@ stages:
   dependsOn: [package_linux, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+    CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
   pool: Throughput-AppSec
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -3066,13 +3067,26 @@ stages:
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        cd $(System.DefaultWorkingDirectory)/tracer/build/crank
+        cd $(CrankDir)
         chmod +x ./run-appsec.sh
         ./run-appsec.sh "linux"
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
         DD_ENV: CI
+
+    - script: |
+        mkdir -p $(CrankDir)/results
+        cp $(CrankDir)/*.json $(CrankDir)/results
+      displayName: Copy the results to results dir
+      condition: succeededOrFailed()
+      continueOnError: true
+
+    - publish: "$(CrankDir)/results"
+      displayName: Publish results
+      artifact: crank_linux_x64_asm_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))

--- a/tracer/build/crank/run-appsec.sh
+++ b/tracer/build/crank/run-appsec.sh
@@ -27,21 +27,22 @@ commit="--application.source.branchOrCommit #$commit_sha"
 if [ "$1" = "linux" ]; then
     echo "Running Linux  x64 throughput tests"
 
+    rm -f appsec_baseline.json
+    rm -f appsec_noattack.json
+    rm -f appsec_attack_noblocking.json
+    rm -f appsec_attack_blocking.json
+
     crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_baseline --profile linux --json appsec_baseline.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="appsec_baseline.json"
-    rm appsec_baseline.json
 
     crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noattack --profile linux --json appsec_noattack.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noattack --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="appsec_noattack.json"
-    rm appsec_noattack.json
 
     crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_noblocking --profile linux --json appsec_attack_noblocking.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_noblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="appsec_attack_noblocking.json"
-    rm appsec_attack_noblocking.json
 
     crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_blocking --profile linux --json appsec_attack_blocking.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_blocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="appsec_attack_blocking.json"
-    rm appsec_attack_blocking.json
 
 else
     echo "Unknown argument $1"

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -29,55 +29,58 @@ commit="--application.source.branchOrCommit #$commit_sha"
 if [ "$1" = "windows" ]; then
     echo "Running windows throughput tests"
 
+    rm -f baseline_windows.json
+    rm -f calltarget_ngen_windows.json
+    rm -f trace_stats_windows.json
+
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_windows.json"
-    rm baseline_windows.json
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="calltarget_ngen_windows.json"
-    rm calltarget_ngen_windows.json
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile windows --json trace_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_windows.json"
-      rm trace_stats_windows.json
     fi
 
 elif [ "$1" = "linux" ]; then
     echo "Running Linux  x64 throughput tests"
 
+    rm -f baseline_linux.json
+    rm -f calltarget_ngen_linux.json
+    rm -f trace_stats_linux.json
+
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_linux.json"
-    rm baseline_linux.json
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="calltarget_ngen_linux.json"
-    rm calltarget_ngen_linux.json
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux --json trace_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux.json"
-      rm trace_stats_linux.json
     fi
 
 elif [ "$1" = "linux_arm64" ]; then
     echo "Running Linux arm64 throughput tests"
 
+    rm -f baseline_linux_arm64.json
+    rm -f calltarget_ngen_linux_arm64.json
+    rm -f trace_stats_linux_arm64.json
+
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_linux_arm64.json"
-    rm baseline_linux_arm64.json
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux_arm64 --json calltarget_ngen_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="calltarget_ngen_linux_arm64.json"
-    rm calltarget_ngen_linux_arm64.json
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux_arm64.json"
-      rm trace_stats_linux_arm64.json
     fi
 
 else


### PR DESCRIPTION
## Summary of changes

Uploads the results of the crank throughput test runs to AzureDevops

## Reason for change

We can pull down these results and report them on a PR, similar to the way we do for the benchmarks

## Implementation details

Just upload the artifacts

## Test coverage

Hopefully it'll work on this PR

## Other details
I'll merge this, make sure it works, and then work on the comparison/reporting side
