### PR TITLE
Removes Task.Delay dependency on TaskContinuation tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskAsyncContinuationGeneratorTests.cs
@@ -105,9 +105,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state);
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -116,9 +119,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async Task GetPreviousTask()
+            async Task GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
             }
         }
 
@@ -208,9 +211,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state);
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -219,9 +225,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async Task<bool> GetPreviousTask()
+            async Task<bool> GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
                 return true;
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/TaskContinuationGeneratorTests.cs
@@ -104,9 +104,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state);
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -115,9 +118,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async Task GetPreviousTask()
+            async Task GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
             }
         }
 
@@ -207,9 +210,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state);
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state);
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -218,9 +224,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async Task<bool> GetPreviousTask()
+            async Task<bool> GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
                 return true;
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/ValueTaskAsyncContinuationGeneratorTests.cs
@@ -108,9 +108,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state).AsTask();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state).AsTask();
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -119,9 +122,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async ValueTask GetPreviousTask()
+            async ValueTask GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
             }
         }
 
@@ -213,9 +216,12 @@ namespace Datadog.Trace.Tests.CallTarget
             var synchronizationContext = new CustomSynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
 
+            var tcs = new TaskCompletionSource<bool>();
             var state = CallTargetState.GetDefault();
-            var cTask = tcg.SetContinuation(this, GetPreviousTask(), null, in state).AsTask();
+            var cTask = tcg.SetContinuation(this, GetPreviousTask(tcs.Task), null, in state).AsTask();
 
+            // After setting the continuation, we resolve the task completion source.
+            tcs.TrySetResult(true);
             Task.WaitAny(cTask, synchronizationContext.Task);
 
             // If preserving context, the continuation should be posted to the synchronization context and cTask should never complete
@@ -224,9 +230,9 @@ namespace Datadog.Trace.Tests.CallTarget
 
             Assert.False(notCompletedTask.IsCompleted);
 
-            async ValueTask<bool> GetPreviousTask()
+            async ValueTask<bool> GetPreviousTask(Task task)
             {
-                await Task.Delay(1000).ConfigureAwait(false);
+                await task.ConfigureAwait(false);
                 return true;
             }
         }


### PR DESCRIPTION
## Summary of changes

This PR removes the `Task.Delay` dependency on TaskContinuation's preserve context tests.

## Reason for change

We have seen a flaky test caused by the `Task.Delay()` resolving before the continuation is set