### PR TITLE
Fix sending multiple logs via DirectLogSubmission when using sub-loggers

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/AggregateSinkProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/AggregateSinkProxy.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="AggregateSinkProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+
+[DuckCopy]
+internal struct AggregateSinkProxy
+{
+    /// <summary>
+    /// Gets the
+    /// </summary>
+    [DuckField(Name = "_sinks")]
+    public ICollection LogEventSinks;
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/CopyingSinkProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/CopyingSinkProxy.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="CopyingSinkProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+
+#if NETFRAMEWORK
+
+[DuckCopy]
+internal struct CopyingSinkProxy
+{
+    [DuckField(Name = "_copyToSink")]
+    public LoggerProxy Logger;
+}
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
     {
         private readonly IDatadogSink _sink;
         private readonly int _minimumLevel;
+        private bool _isDisabled;
 
         internal DirectSubmissionSerilogSink(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
         {
@@ -31,17 +32,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
         [DuckReverseMethod(ParameterTypeNames = new[] { "Serilog.Events.LogEvent, Serilog" })]
         public void Emit(ILogEvent? logEvent)
         {
-            if (logEvent is null)
-            {
-                return;
-            }
-
-            if ((int)logEvent.Level < _minimumLevel)
+            if (_isDisabled
+                || logEvent is null
+                || (int)logEvent.Level < _minimumLevel)
             {
                 return;
             }
 
             _sink.EnqueueLog(new SerilogDatadogLogEvent(logEvent));
+        }
+
+        internal void Disable()
+        {
+            _isDisabled = true;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerProxy.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="LoggerProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+
+[DuckCopy]
+internal struct LoggerProxy
+{
+    /// <summary>
+    /// Gets the
+    /// </summary>
+    [DuckField(Name = "_sink")]
+    public object Sink;
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SecondaryLoggerSinkProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SecondaryLoggerSinkProxy.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="SecondaryLoggerSinkProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+#nullable enable
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+
+[DuckCopy]
+internal struct SecondaryLoggerSinkProxy
+{
+    [DuckField(Name = "_logger")]
+    public LoggerProxy Logger;
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -125,6 +126,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 logs.Should().Contain(x => x.Message.Contains("Building pipeline")); // these should not be filtered out
             }
+
+            logs.Where(x => !x.Message.Contains("Waiting for app started handling requests"))
+                .Should()
+                .HaveCount(expectedLogCount);
 
             VerifyInstrumentation(processResult.Process);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -184,6 +184,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                    .Where(x => !x.Message.Contains(ExcludeMessagePrefix))
                    .Should()
                    .NotBeEmpty()
+                   // .HaveCount(1) // Currently fails
                    .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
                    .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             logs
                .Where(x => !x.Message.Contains(ExcludeMessagePrefix))
                .Should()
-               .NotBeEmpty()
+               .HaveCount(1)
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             VerifyInstrumentation(processResult.Process);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             logs
                .Where(x => !x.Message.Contains(ExcludeMessagePrefix))
                .Should()
-               .NotBeEmpty()
+               .HaveCount(1)
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             VerifyInstrumentation(processResult.Process);


### PR DESCRIPTION
## Summary of changes

- Add tests that we're only sending a single instance of a log when using DirectLogSubmission
- Fix scenario in Serilog that can lead to sending multiple instances of a log

## Reason for change

A recent escalation flagged that if you configure Serilog using sub-loggers, you'll get duplicate log messages sent to Datadog. For example, the following configuration creates a sublogger for the console sink:

```csharp
Log.Logger = new LoggerConfiguration()
.MinimumLevel.Debug()
.WriteTo.Logger(lc => lc
  .WriteTo.Console())
.WriteTo.Debug()
.CreateLogger();
```

In this case we add the sink twice - once for the sublogger and once for the final logger, leading to every message being sent twice

## Implementation details

Unfortunately, the subloggers really are the same as "outer" loggers, so it's not easy to "avoid" adding the logger. Instead, this PR checks that none of the sinks being added to the configuration are a "SecondaryLoggerSink", and if it is, check the child sinks for our direct log submission sink. Once it's found, we permanently disable the sink, leaving the sink at the "current" level. 

## Test coverage

Initially updated the direct log submission test to check we're only sending the log once:

- NLog ✅ Works as expected
- ILogger ✅ Works as expected
- Serilog ❌ Fixed in this PR - tested with multiple layers of nested loggers
- Log4Net ❌ Out of scope for this PR, so just documented in the test that it's an issue

## Other details
We can fix the Log4Net version in a separate PR
