### PR TITLE
[DRAFT] [Tracer] `SpanContext` refactor part 1: remove `Span.Context` property

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace.MSBuild
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
                 _buildSpan.SetMetric(Tags.Analytics, 1.0d);
 
-                if (_buildSpan.Context.TraceContext is { } traceContext)
+                if (_buildSpan.TraceContext is { } traceContext)
                 {
                     traceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
                     traceContext.Origin = TestTags.CIAppTestOriginName;
@@ -184,14 +184,14 @@ namespace Datadog.Trace.MSBuild
                 string projectName = Path.GetFileName(e.ProjectFile);
 
                 string targetName = string.IsNullOrEmpty(e.TargetNames) ? "build" : e.TargetNames?.ToLowerInvariant();
-                Span projectSpan = _tracer.StartSpan($"msbuild.{targetName}", parent: parentSpan.Context);
+                Span projectSpan = _tracer.StartSpan($"msbuild.{targetName}", parent: parentSpan.GetContext());
 
                 if (projectName != null)
                 {
                     projectSpan.ServiceName = projectName;
                 }
 
-                projectSpan.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
+                projectSpan.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
                 projectSpan.Type = SpanTypes.Build;
 
                 string targetFramework = null;
@@ -358,7 +358,7 @@ namespace Datadog.Trace.MSBuild
                     var traceId = span.GetTraceIdStringForLogs();
                     var spanId = span.SpanId.ToString(CultureInfo.InvariantCulture);
 
-                    _context = new Context(traceId, spanId, span.Context.Origin);
+                    _context = new Context(traceId, spanId, span.TraceContext.Origin);
                 }
             }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                         Span span = tracer.StartSpan("crank.test", startTime: minTimeStamp, serviceName: "crank");
 
-                        span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
+                        span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
                         span.Type = SpanTypes.Test;
                         span.ResourceName = $"{fileName}/{jobItem.Key}";
                         CIEnvironmentValues.Instance.DecorateSpan(span);

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Activity.Handlers
                     {
                         if (ActivityMappingById.TryGetValue(activityTraceId + parentSpanId, out ActivityMapping mapping))
                         {
-                            parent = mapping.Scope.Span.Context;
+                            parent = mapping.Scope.Span.GetContext();
                         }
                         else
                         {
@@ -95,7 +95,7 @@ namespace Datadog.Trace.Activity.Handlers
                         // we have a ParentSpanId/ParentId, but no TraceId/SpanId, so default to use the ParentId for lookup
                         if (ActivityMappingById.TryGetValue(parentId, out ActivityMapping mapping))
                         {
-                            parent = mapping.Scope.Span.Context;
+                            parent = mapping.Scope.Span.GetContext();
                         }
                     }
                 }
@@ -108,10 +108,10 @@ namespace Datadog.Trace.Activity.Handlers
                     if (activity.Parent is null || activity.Parent.StartTimeUtc < activeSpan.StartTime.UtcDateTime)
                     {
                         // TraceId (always 32 chars long even when using 64-bit ids)
-                        w3cActivity.TraceId = activeSpan.Context.RawTraceId;
+                        w3cActivity.TraceId = activeSpan.RawTraceId;
 
                         // SpanId (always 16 chars long)
-                        w3cActivity.ParentSpanId = activeSpan.Context.RawSpanId;
+                        w3cActivity.ParentSpanId = activeSpan.RawSpanId;
 
                         // We clear internals Id and ParentId values to force recalculation.
                         w3cActivity.RawId = null;

--- a/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Activity.Handlers
                         payloadSize ?? 0,
                         0);
 
-                    dataStreamsManager.InjectPathwayContextAsBase64String(span.Context.PathwayContext, new ServiceBusHeadersCollectionAdapter(applicationProperties));
+                    dataStreamsManager.InjectPathwayContextAsBase64String(span.PathwayContext, new ServiceBusHeadersCollectionAdapter(applicationProperties));
 
                     // Close the scope and return so we bypass the common code path
                     span.Finish(activity.StartTimeUtc.Add(activity.Duration));

--- a/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
@@ -99,10 +99,10 @@ namespace Datadog.Trace.Activity.Handlers
                     // in the context propagation, and we will keep the entire trace.
 
                     // TraceId (always 32 chars long even when using 64-bit ids)
-                    w3cActivity.TraceId = span.Context.RawTraceId;
+                    w3cActivity.TraceId = span.RawTraceId;
 
                     // SpanId (always 16 chars long)
-                    w3cActivity.ParentSpanId = span.Context.RawSpanId;
+                    w3cActivity.ParentSpanId = span.RawSpanId;
 
                     // We clear internals Id and ParentId values to force recalculation.
                     w3cActivity.RawId = null;

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Activity
 
             // Fixup "version" tag
             // Fallback to static instance if no tracer associated with the trace
-            var tracer = span.Context.TraceContext?.Tracer ?? Tracer.Instance;
+            var tracer = span.TraceContext?.Tracer ?? Tracer.Instance;
             if (tracer.Settings.ServiceVersionInternal is null
              && span.GetTag("service.version") is { Length: > 1 } otelServiceVersion)
             {
@@ -112,7 +112,7 @@ namespace Datadog.Trace.Activity
             // TODO: Add container tags from attributes if the tag isn't already in the span
 
             // Fixup "env" tag
-            if (span.Context.TraceContext?.Environment is null
+            if (span.TraceContext?.Environment is null
                 && span.GetTag("deployment.environment") is { Length: > 0 } otelServiceEnv)
             {
                 span.SetTag(Tags.Env, otelServiceEnv);

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -447,7 +447,7 @@ namespace Datadog.Trace.Agent
             }
 
             // Add the current keep rate to the root span
-            var rootSpan = spans.Array![spans.Offset].Context.TraceContext?.RootSpan;
+            var rootSpan = spans.Array![spans.Offset].TraceContext?.RootSpan;
 
             if (rootSpan is not null)
             {

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -127,7 +127,10 @@ namespace Datadog.Trace.Agent.MessagePack
             // It should be the number of members of the object to be serialized.
             var len = 8;
 
-            if (span.Context.ParentIdInternal > 0)
+            // TODO: use span.ParentIdInternal
+            var parentId = span.GetContext().ParentIdInternal;
+
+            if (parentId > 0)
             {
                 len++;
             }
@@ -145,10 +148,10 @@ namespace Datadog.Trace.Agent.MessagePack
 
             // trace_id field is 64-bits, truncate by using TraceId128.Lower
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
-            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.TraceId128.Lower);
+            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.TraceId128.Lower);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
-            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.SpanId);
+            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.SpanId);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.OperationName);
@@ -168,10 +171,10 @@ namespace Datadog.Trace.Agent.MessagePack
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, span.Duration.ToNanoseconds());
 
-            if (span.Context.ParentIdInternal > 0)
+            if (parentId > 0)
             {
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
-                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)span.Context.ParentIdInternal);
+                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)parentId);
             }
 
             if (span.Error)
@@ -181,7 +184,7 @@ namespace Datadog.Trace.Agent.MessagePack
             }
 
             ITagProcessor[] tagProcessors = null;
-            if (span.Context.TraceContext?.Tracer is Tracer tracer)
+            if (span.TraceContext?.Tracer is Tracer tracer)
             {
                 tagProcessors = tracer.TracerManager?.TagProcessors;
             }
@@ -271,7 +274,8 @@ namespace Datadog.Trace.Agent.MessagePack
             }
 
             // add "version" tags to all spans whose service name is the default service name
-            if (string.Equals(span.Context.ServiceNameInternal, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
+            // TODO: use span.ServiceNameInternal
+            if (string.Equals(span.GetContext().ServiceNameInternal, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
             {
                 var versionRawBytes = MessagePackStringCache.GetVersionBytes(model.TraceChunk.ServiceVersion);
 

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -112,7 +112,8 @@ internal readonly struct TraceChunkModel
             // skip the HashSet to avoid initializing it yet, always iterate the array of spans.
             ContainsLocalRootSpan = IndexOf(localRootSpanId, spans.Count - 1) >= 0;
 
-            HasUpstreamService = localRootSpan.Context.ParentIdInternal is not (null or 0);
+            // TODO: use span.ParentIdInternal
+            HasUpstreamService = localRootSpan.GetContext().ParentIdInternal is not (null or 0);
         }
     }
 
@@ -125,7 +126,7 @@ internal readonly struct TraceChunkModel
     {
         if (spans.Count > 0)
         {
-            return spans.Array![spans.Offset].Context.TraceContext;
+            return spans.Array![spans.Offset].TraceContext;
         }
 
         return null;
@@ -139,7 +140,8 @@ internal readonly struct TraceChunkModel
         }
 
         var span = _spans.Array![_spans.Offset + spanIndex];
-        var parentId = span.Context.ParentIdInternal ?? 0;
+        // TODO: use span.ParentIdInternal
+        var parentId = span.GetContext().ParentIdInternal ?? 0;
         bool isLocalRoot = parentId is 0 || span.SpanId == LocalRootSpanId;
         bool isFirstSpan = spanIndex == 0;
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.Context.Origin == "synthetics");
+                span.TraceContext.Origin == "synthetics");
         }
 
         internal async Task Flush()

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.TraceContext.Origin == "synthetics");
+                span.TraceContext?.Origin == "synthetics");
         }
 
         internal async Task Flush()

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -111,7 +111,7 @@ internal readonly partial struct SecurityCoordinator
 
         var addressesDictionary = new Dictionary<string, object> { { AddressesConstants.RequestMethod, request.Method }, { AddressesConstants.ResponseStatus, request.HttpContext.Response.StatusCode.ToString() }, { AddressesConstants.RequestUriRaw, request.GetUrlForWaf() }, { AddressesConstants.RequestClientIp, _localRootSpan.GetTag(Tags.HttpClientIp) } };
 
-        var userId = _localRootSpan.Context?.TraceContext?.Tags.GetTag(Tags.User.Id);
+        var userId = _localRootSpan.TraceContext?.Tags.GetTag(Tags.User.Id);
         if (!string.IsNullOrEmpty(userId))
         {
             addressesDictionary.Add(AddressesConstants.UserId, userId!);

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -73,7 +73,7 @@ internal readonly partial struct SecurityCoordinator
         {
             span = TryGetRoot(span);
             security.WafInitResult.Reported = true;
-            span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+            span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             span.SetMetric(Metrics.AppSecWafInitRulesLoaded, security.WafInitResult.LoadedRules);
             span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, security.WafInitResult.FailedToLoadRules);
             if (security.WafInitResult.HasErrors)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -68,7 +68,7 @@ internal readonly partial struct SecurityCoordinator
             var isApiSecurityProcessed = _security.ApiSecurity.TryTellWafToAnalyzeSchema(args);
             if (isApiSecurityProcessed)
             {
-                _localRootSpan.Context.TraceContext.MarkApiSecurity();
+                _localRootSpan.TraceContext.MarkApiSecurity();
             }
         }
 
@@ -149,5 +149,5 @@ internal readonly partial struct SecurityCoordinator
         _httpTransport.DisposeAdditiveContext();
     }
 
-    private static Span TryGetRoot(Span span) => span.Context.TraceContext?.RootSpan ?? span;
+    private static Span TryGetRoot(Span span) => span.TraceContext?.RootSpan ?? span;
 }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -467,11 +467,11 @@ namespace Datadog.Trace.AppSec
             {
                 // NOTE: setting DD_APPSEC_KEEP_TRACES=false means "drop all traces by setting AutoReject".
                 // It does _not_ mean "stop setting UserKeep (do nothing)". It should only be used for testing.
-                span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoReject, SamplingMechanism.Asm);
+                span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoReject, SamplingMechanism.Asm);
             }
             else if (_rateLimiter?.Allowed(span) ?? false)
             {
-                span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+                span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -171,7 +171,7 @@ namespace Datadog.Trace.AspNet
                 // (e.g. WCF being hosted in IIS)
                 if (HttpRuntime.UsingIntegratedPipeline)
                 {
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, httpRequest.Headers.Wrap());
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), httpRequest.Headers.Wrap());
                 }
 
                 httpContext.Items[_httpContextScopeKey] = scope;
@@ -201,7 +201,7 @@ namespace Datadog.Trace.AspNet
                 var iastInstance = Iast.Iast.Instance;
                 if (iastInstance.Settings.Enabled && iastInstance.OverheadController.AcquireRequest())
                 {
-                    var traceContext = scope.Span?.Context?.TraceContext;
+                    var traceContext = scope.Span?.TraceContext;
                     traceContext?.EnableIastInRequest();
                     traceContext?.IastRequestContext?.AddRequestData(httpRequest);
                 }

--- a/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace
             var scope = new Scope(newParent, span, this, finishOnClose);
 
             Active = scope;
-            DistributedTracer.Instance.SetSpanContext(scope.Span.Context);
+            DistributedTracer.Instance.SetSpanContext(scope.Span.GetContext());
 
             return scope;
         }
@@ -52,7 +52,8 @@ namespace Datadog.Trace
             Active = scope.Parent;
 
             // scope.Parent is null for distributed traces, so use scope.Span.Context.Parent
-            DistributedTracer.Instance.SetSpanContext(scope.Span.Context.ParentInternal as SpanContext);
+            // TODO: use span.ParentIdInternal
+            DistributedTracer.Instance.SetSpanContext(scope.Span.GetContext().ParentInternal as SpanContext);
         }
 
         private static AsyncLocal<Scope> CreateScope()

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
         public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
         {
-            var context = value.Context;
+            var context = value.GetContext();
             var testSessionTags = value.Tags as TestSessionSpanTags;
             var testModuleTags = value.Tags as TestModuleSpanTags;
             var testSuiteTags = value.Tags as TestSuiteSpanTags;
@@ -216,7 +216,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
         private int WriteTags(ref byte[] bytes, int offset, Span span, ITags tags, ITagProcessor[] tagProcessors)
         {
             int originalOffset = offset;
-            var traceContext = span.Context.TraceContext;
+            var traceContext = span.TraceContext;
 
             // Start of "meta" dictionary. Do not add any string tags before this line.
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaBytes);
@@ -271,7 +271,8 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             }
 
             // add "version" tags to all spans whose service name is the default service name
-            if (string.Equals(span.Context.ServiceNameInternal, traceContext?.Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
+            // TODO: use span.ServiceNameInternal
+            if (string.Equals(span.GetContext().ServiceNameInternal, traceContext?.Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
             {
                 var version = traceContext?.ServiceVersion;
 
@@ -361,7 +362,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
                 }
 
                 // add "_sampling_priority_v1" tag
-                if (span.Context.TraceContext.SamplingPriority is { } samplingPriority)
+                if (span.TraceContext.SamplingPriority is { } samplingPriority)
                 {
                     count++;
                     offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _samplingPriorityNameBytes);

--- a/tracer/src/Datadog.Trace/Ci/Processors/OriginTagTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Ci/Processors/OriginTagTraceProcessor.cs
@@ -46,7 +46,9 @@ namespace Datadog.Trace.Ci.Processors
                 for (var i = trace.Offset + trace.Count - 1; i >= trace.Offset; i--)
                 {
                     var span = trace.Array![i];
-                    if (span.Context.ParentInternal is null &&
+
+                    // TODO: use span.ParentIdInternal
+                    if (span.GetContext().ParentInternal is null &&
                         span.Type != SpanTypes.Test &&
                         span.Type != SpanTypes.TestSuite &&
                         span.Type != SpanTypes.TestModule &&
@@ -72,7 +74,7 @@ namespace Datadog.Trace.Ci.Processors
             if (!_isCiVisibilityProtocol)
             {
                 // Sets the origin tag on the TraceContext to ensure the CI track.
-                var traceContext = trace.Array![trace.Offset].Context.TraceContext;
+                var traceContext = trace.Array![trace.Offset].TraceContext;
 
                 if (traceContext is not null)
                 {
@@ -86,7 +88,7 @@ namespace Datadog.Trace.Ci.Processors
         public Span Process(Span span)
         {
             // Sets the origin tag on the TraceContext to ensure the CI track.
-            var traceContext = span.Context.TraceContext;
+            var traceContext = span.TraceContext;
 
             if (traceContext is not null)
             {

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -49,8 +49,8 @@ public sealed class Test
 
         scope.Span.Type = SpanTypes.Test;
         scope.Span.ResourceName = $"{suite.Name}.{name}";
-        scope.Span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep, SamplingMechanism.Manual);
-        scope.Span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        scope.Span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep, SamplingMechanism.Manual);
+        scope.Span.TraceContext.Origin = TestTags.CIAppTestOriginName;
         TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.CiAppManual);
 
         _scope = scope;
@@ -339,7 +339,7 @@ public sealed class Test
         var tags = (TestSpanTags)scope.Span.Tags;
 
         // Calculate duration beforehand
-        duration ??= _scope.Span.Context.TraceContext.Clock.ElapsedSince(scope.Span.StartTime);
+        duration ??= _scope.Span.TraceContext.Clock.ElapsedSince(scope.Span.StartTime);
 
         // Set coverage
         if (CIVisibility.Settings.CodeCoverageEnabled == true)

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -166,8 +166,8 @@ public sealed class TestModule
 
         span.Type = SpanTypes.TestModule;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.ModuleId = span.SpanId;
 
@@ -396,7 +396,7 @@ public sealed class TestModule
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.Clock.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.Clock.ElapsedSince(span.StartTime);
 
         var remainingSuites = Array.Empty<TestSuite>();
         lock (_suites)

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -60,8 +60,8 @@ public sealed class TestSession
 
         span.Type = SpanTypes.TestSession;
         span.ResourceName = $"{span.OperationName}.{command}";
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SessionId = span.SpanId;
 
@@ -395,7 +395,7 @@ public sealed class TestSession
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.Clock.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.Clock.ElapsedSince(span.StartTime);
 
         // Set status
         switch (status)
@@ -522,7 +522,7 @@ public sealed class TestSession
         };
 
         SpanContextPropagator.Instance.Inject(
-            span.Context,
+            span.GetContext(),
             (IDictionary)environmentVariables,
             new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
 

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -38,8 +38,8 @@ public sealed class TestSuite
 
         span.Type = SpanTypes.TestSuite;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SuiteId = span.SpanId;
 
@@ -152,7 +152,7 @@ public sealed class TestSuite
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.Clock.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.Clock.ElapsedSince(span.StartTime);
 
         // Update status
         if (Tags.Status is { } status)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
@@ -50,9 +50,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
-            if (scope?.Span.Context != null)
+            if (scope?.Span.GetContext() is { } context)
             {
-                ContextPropagation.InjectTraceIntoData<TPutRecordRequest>(request, scope.Span.Context);
+                ContextPropagation.InjectTraceIntoData<TPutRecordRequest>(request, context);
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
@@ -48,9 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
-            if (scope?.Span.Context != null)
+            if (scope?.Span.GetContext() is { } context)
             {
-                ContextPropagation.InjectTraceIntoData<TPutRecordRequest>(request, scope.Span.Context);
+                ContextPropagation.InjectTraceIntoData<TPutRecordRequest>(request, context);
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
@@ -50,9 +50,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
-            if (scope?.Span.Context != null)
+            if (scope?.Span.GetContext() is { } context)
             {
-                ContextPropagation.InjectTraceIntoRecords<TPutRecordsRequest>(request, scope.Span.Context);
+                ContextPropagation.InjectTraceIntoRecords<TPutRecordsRequest>(request, context);
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
@@ -48,9 +48,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
             var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
-            if (scope?.Span.Context != null)
+            if (scope?.Span.GetContext() is { } context)
             {
-                ContextPropagation.InjectTraceIntoRecords<TPutRecordsRequest>(request, scope.Span.Context);
+                ContextPropagation.InjectTraceIntoRecords<TPutRecordsRequest>(request, context);
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -42,12 +42,12 @@ internal abstract class LambdaCommon
             Log("samplingPriority not found");
 
             var samplingDecision = tracer.CurrentTraceSettings.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-            span.Context.TraceContext?.SetSamplingPriority(samplingDecision);
+            span.TraceContext?.SetSamplingPriority(samplingDecision);
         }
         else
         {
             Log($"setting the placeholder sampling priority to = {samplingPriority}");
-            span.Context.TraceContext?.SetSamplingPriority(Convert.ToInt32(samplingPriority), notifyDistributedTracer: false);
+            span.TraceContext?.SetSamplingPriority(Convert.ToInt32(samplingPriority), notifyDistributedTracer: false);
         }
 
         TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.AwsLambda);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
@@ -47,7 +47,7 @@ internal class LambdaRequestBuilder : ILambdaExtensionRequest
             request.Headers.Set(HttpHeaderNames.TraceId, span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture));
             request.Headers.Set(HttpHeaderNames.SpanId, span.SpanId.ToString(CultureInfo.InvariantCulture));
 
-            if (span.Context.TraceContext?.SamplingPriority is { } samplingPriority)
+            if (span.TraceContext?.SamplingPriority is { } samplingPriority)
             {
                 request.Headers.Set(HttpHeaderNames.SamplingPriority, samplingPriority.ToString());
             }
@@ -82,4 +82,3 @@ internal class LambdaRequestBuilder : ILambdaExtensionRequest
 }
 
 #endif
-

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 tags.TopicName = AwsSnsCommon.GetTopicName(request.TopicArn);
             }
 
-            if (scope?.Span.Context is { } context)
+            if (scope?.Span.GetContext() is { } context)
             {
                 ContextPropagation.InjectHeadersIntoMessage<TTarget, TPublishRequest>(request, context);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -81,12 +81,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                             && tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Service)
                         {
                             _dbCommandCachingLogged = true;
-                            var spanContext = scope.Span.Context;
+                            var span = scope.Span;
                             Log.Warning(
                                 "The {CommandType} IDbCommand instance already contains DBM information. Caching of the command objects is not supported with full DBM mode. [s_id: {SpanId}, t_id: {TraceId}]",
                                 command.CommandType,
-                                spanContext.RawSpanId,
-                                spanContext.RawTraceId);
+                                span.RawSpanId,
+                                span.RawTraceId);
                         }
                     }
                     else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     // Additionally, update the scope so it does not finish the span on close. This allows
                     // us to defer finishing the span later while making sure callers of this method do not
                     // get this scope when calling Tracer.ActiveScope
-                    var now = scope.Span.Context.TraceContext.Clock.UtcNow;
+                    var now = scope.Span.TraceContext.Clock.UtcNow;
                     httpContext.AddOnRequestCompleted(h => OnRequestCompletedAfterException(h, scope, now));
 
                     scope.SetFinishOnClose(false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -171,7 +171,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tags.AspNetArea = areaName;
                     tags.AspNetController = controllerName;
                     tags.AspNetAction = actionName;
-                    var rootspanTags = span.Context.TraceContext?.RootSpan.Tags;
+                    var rootspanTags = span.TraceContext?.RootSpan.Tags;
 
                     // in case of a transfered request, the child request shouldnt set a new http route.
                     if (rootspanTags is AspNetTags rootAspNetTags)
@@ -183,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     }
                     else if (string.IsNullOrEmpty(rootspanTags.GetTag(Tags.HttpRoute)))
                     {
-                        span.Context.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, routeUrl);
+                        span.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, routeUrl);
                     }
 
                     tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -205,13 +205,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tags.AspNetController = controller;
                     tags.AspNetArea = area;
                     tags.AspNetRoute = route;
-                    if (span.Context.TraceContext.RootSpan.Tags is AspNetTags rootAspNetTags)
+                    if (span.TraceContext.RootSpan.Tags is AspNetTags rootAspNetTags)
                     {
                         rootAspNetTags.HttpRoute = route;
                     }
                     else
                     {
-                        span.Context.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, route);
+                        span.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, route);
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     // Additionally, update the scope so it does not finish the span on close. This allows
                     // us to defer finishing the span later while making sure callers of this method do not
                     // get this scope when calling Tracer.ActiveScope
-                    var now = scope.Span.Context.TraceContext.Clock.UtcNow;
+                    var now = scope.Span.TraceContext.Clock.UtcNow;
                     httpContext.AddOnRequestCompleted(h => OnRequestCompletedAfterException(h, scope, now));
 
                     scope.SetFinishOnClose(false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext_SetResult_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/DefaultModelBindingContext_SetResult_Integration.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore
 
                             if (iast.Settings.Enabled)
                             {
-                                span.Context?.TraceContext?.IastRequestContext?.AddRequestBody(defaultModelBindingContext.Result.Model, bodyExtracted);
+                                span.TraceContext?.IastRequestContext?.AddRequestBody(defaultModelBindingContext.Result.Model, bodyExtracted);
                             }
                         }
                         else
@@ -94,7 +94,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore
 
                                         if (iast.Settings.Enabled)
                                         {
-                                            span.Context?.TraceContext?.IastRequestContext?.AddRequestBody(defaultModelBindingContext.Result.Model, bodyExtracted);
+                                            span.TraceContext?.IastRequestContext?.AddRequestBody(defaultModelBindingContext.Result.Model, bodyExtracted);
                                         }
 
                                         break;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -296,7 +296,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                 // in the GRPC http request representation, which is what we're doing here by overwriting all
                 // the existing datadog headers
                 var useNullableHeaders = !string.IsNullOrEmpty(useNullableHeadersCapability);
-                SpanContextPropagator.Instance.Inject(span.Context, new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
+                SpanContextPropagator.Instance.Inject(span.GetContext(), new RpcHttpHeadersCollection<TTarget>(typedData.Http, useNullableHeaders));
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
 
                 // add distributed tracing headers to the HTTP request
                 // These will be overwritten by the HttpClient integration if that is enabled, per the RFC
-                SpanContextPropagator.Instance.Inject(span.Context, new HttpHeadersCollection(requestMessage.Headers));
+                SpanContextPropagator.Instance.Inject(span.GetContext(), new HttpHeadersCollection(requestMessage.Headers));
 
                 // Add the request metadata as tags
                 if (grpcCall.Options.Headers is { Count: > 0 })

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                 tags.HttpClientHandlerType = instance.GetType().FullName;
 
                 // add distributed tracing headers to the HTTP request
-                SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(headers));
+                SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), new HttpHeadersCollection(headers));
 
                 tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
                         // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
                         // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                         HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -60,14 +60,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
                         // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
                         // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                         HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.Context.TraceContext.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
+                            scope.Span.TraceContext.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
                         }
 
                         if (returnValue is HttpWebResponse response)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         startTime: null,
                         addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
@@ -69,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
                         // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
                         // added by us, not the application
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                         HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -73,11 +73,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.Context.TraceContext.SetSamplingPriority(spanContext.SamplingPriority.Value);
+                            scope.Span.TraceContext.SetSamplingPriority(spanContext.SamplingPriority.Value);
                         }
 
                         // add distributed tracing headers to the HTTP request
-                        SpanContextPropagator.Instance.Inject(scope.Span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), request.Headers.Wrap());
 
                         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/GetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/GetIntegration.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.IbmMq
                             pathwayContext);
                         // we need to inject new context, since message objects can theoretically be reused
                         // hence we need to make sure the parent hash changes properly
-                        dataStreams.InjectPathwayContextAsBase64String(scope.Span.Context.PathwayContext, new IbmMqHeadersAdapter(msg));
+                        dataStreams.InjectPathwayContextAsBase64String(scope.Span.PathwayContext, new IbmMqHeadersAdapter(msg));
                     }
 
                     scope.DisposeWithException(exception);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/IbmMqHelper.cs
@@ -50,7 +50,7 @@ internal static class IbmMqHelper
             span.SetTag(Tags.SpanKind, SpanKinds.Producer);
 
             var adapter = new IbmMqHeadersAdapter(message);
-            SpanContextPropagator.Instance.Inject(span.Context, adapter);
+            SpanContextPropagator.Instance.Inject(span.GetContext(), adapter);
         }
         catch (Exception ex)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/PutIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/PutIntegration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.IbmMq
                 {
                     var edgeTags = new[] { "direction:out", $"topic:{instance.Name}", $"type:{IbmMqConstants.QueueType}" };
                     scope.Span.SetDataStreamsCheckpoint(dataStreams, CheckpointKind.Produce, edgeTags, msg.MessageLength, 0);
-                    dataStreams.InjectPathwayContextAsBase64String(scope.Span.Context.PathwayContext, new IbmMqHeadersAdapter(msg));
+                    dataStreams.InjectPathwayContextAsBase64String(scope.Span.PathwayContext, new IbmMqHeadersAdapter(msg));
                 }
 
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -323,7 +323,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
                 var adapter = new KafkaHeadersCollectionAdapter(message.Headers);
 
-                SpanContextPropagator.Instance.Inject(span.Context, adapter);
+                SpanContextPropagator.Instance.Inject(span.GetContext(), adapter);
 
                 if (dataStreamsManager.IsEnabled)
                 {
@@ -332,7 +332,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                         : new[] { "direction:out", $"topic:{topic}", "type:kafka" };
                     // produce is always the start of the edge, so defaultEdgeStartMs is always 0
                     span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, GetMessageSize(message), 0);
-                    dataStreamsManager.InjectPathwayContext(span.Context.PathwayContext, adapter);
+                    dataStreamsManager.InjectPathwayContext(span.PathwayContext, adapter);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                         basicProperties.Headers = new Dictionary<string, object>();
                     }
 
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), basicProperties.Headers, default(ContextPropagation));
                     RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(
                         Tracer.Instance,
                         scope.Span,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -125,7 +125,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                                    new[] { "direction:out", $"topic:{tags.Queue ?? tags.RoutingKey}", "type:rabbitmq" } :
                                    new[] { "direction:out", $"exchange:{tags.Exchange}", $"has_routing_key:{!string.IsNullOrEmpty(tags.RoutingKey)}", "type:rabbitmq" };
                 span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, GetHeadersSize(headers) + messageSize, 0);
-                dataStreamsManager.InjectPathwayContext(span.Context.PathwayContext, headersAdapter);
+                dataStreamsManager.InjectPathwayContext(span.PathwayContext, headersAdapter);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/HttpProcessMessageIntegration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
                     // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                     // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                     // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, requestHeaders, (headers, key, value) => headers[key] = value);
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), requestHeaders, (headers, key, value) => headers[key] = value);
 
                     // "Disable" tracing so that the regular WebRequest instrumentation does not fire for this request
                     requestHeaders["x-datadog-tracing-enabled"] = "false";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/Client/IpcTcpProcessMessageIntegration.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Remoting.Client
             var tracer = Tracer.Instance;
             if (tracer.Settings.IsIntegrationEnabled(RemotingIntegration.IntegrationId) && tracer.InternalActiveScope is var scope)
             {
-                SpanContextPropagator.Instance.Inject(scope.Span.Context, requestHeaders, (headers, key, value) => headers[key] = value);
+                SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), requestHeaders, (headers, key, value) => headers[key] = value);
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/AsyncMethodInvoker_InvokeBegin_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/AsyncMethodInvoker_InvokeBegin_Integration.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
 
                 // First, capture the active scope
                 var activeScope = Tracer.Instance.InternalActiveScope;
-                var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+                var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
 
                 var useWcfWebHttpResourceNames = Tracer.Instance.Settings.WcfWebHttpResourceNamesEnabled;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler
             // This is a compromise: we add an additional asynclocal read for the manual tracer when there is no parent trace,
             // but it allows us to remove the asynclocal write for the automatic tracer when running without manual instrumentation.
 
-            return DistributedTrace.Value ?? Tracer.Instance.InternalActiveScope?.Span?.Context;
+            return DistributedTrace.Value ?? Tracer.Instance.InternalActiveScope?.Span.GetContext();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, arguments));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -15,12 +15,12 @@ namespace Datadog.Trace.ClrProfiler
     {
         public int? GetSamplingPriority()
         {
-            return Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext?.SamplingPriority;
+            return Tracer.Instance.InternalActiveScope?.Span.TraceContext?.SamplingPriority;
         }
 
         public void SetSamplingPriority(int? samplingPriority)
         {
-            Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext
+            Tracer.Instance.InternalActiveScope?.Span.TraceContext
                  ?.SetSamplingPriority(samplingPriority, notifyDistributedTracer: false);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -121,11 +121,11 @@ namespace Datadog.Trace.ClrProfiler
                 tags.SetAnalyticsSampleRate(integrationId, tracer.Settings, enabledWithGlobalSetting: false);
                 tracer.CurrentTraceSettings.Schema.RemapPeerService(tags);
 
-                if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
+                if (!addToTraceContext && span.TraceContext.SamplingPriority == null)
                 {
                     // If we don't add the span to the trace context, then we need to manually call the sampler
                     var samplingDecision = tracer.CurrentTraceSettings.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                    span.Context.TraceContext.SetSamplingPriority(samplingDecision);
+                    span.TraceContext.SetSamplingPriority(samplingDecision);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -564,7 +564,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (Iast.Iast.Instance.Settings.Enabled)
                 {
-                    rootSpan.Context?.TraceContext?.IastRequestContext?.AddRequestData(httpContext.Request, routeValues);
+                    rootSpan.TraceContext?.IastRequestContext?.AddRequestData(httpContext.Request, routeValues);
                 }
             }
         }
@@ -612,7 +612,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (shouldUseIast)
                 {
-                    rootSpan.Context?.TraceContext?.IastRequestContext?.AddRequestData(request, typedArg.RouteData?.Values);
+                    rootSpan.TraceContext?.IastRequestContext?.AddRequestData(request, typedArg.RouteData?.Values);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -139,17 +139,16 @@ namespace Datadog.Trace.ExtensionMethods
                 return span?.TraceId.ToString(CultureInfo.InvariantCulture);
             }
 
-            var context = s.Context;
-            var use128Bits = context.TraceContext?.Tracer?.Settings?.TraceId128BitLoggingEnabled ?? false;
+            var use128Bits = s.TraceContext?.Tracer?.Settings?.TraceId128BitLoggingEnabled ?? false;
 
-            if (use128Bits && context.TraceId128.Upper > 0)
+            if (use128Bits && s.TraceId128.Upper > 0)
             {
                 // encode all 128 bits of the trace id as a hex string
-                return context.RawTraceId;
+                return s.RawTraceId;
             }
 
             // encode only the lower 64 bits of the trace ids as decimal (not hex)
-            return context.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
+            return s.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
         }
 
         private static string ConvertStatusCodeToString(int statusCode)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -469,9 +469,8 @@ internal static class IastModule
             return null;
         }
 
-        var currentSpan = (Tracer.Instance.ActiveScope as Scope)?.Span;
-        var traceContext = currentSpan?.Context?.TraceContext;
-        return traceContext?.IastRequestContext;
+        var scope = Tracer.Instance.ActiveScope as Scope;
+        return scope?.Span?.TraceContext?.IastRequestContext;
     }
 
     internal static VulnerabilityBatch GetVulnerabilityBatch()
@@ -490,7 +489,7 @@ internal static class IastModule
         }
 
         var currentSpan = (tracer.ActiveScope as Scope)?.Span;
-        var traceContext = currentSpan?.Context?.TraceContext;
+        var traceContext = currentSpan?.TraceContext;
 
         if (traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() != true)
         {
@@ -517,7 +516,7 @@ internal static class IastModule
     public static bool AddRequestVulnerabilitiesAllowed()
     {
         var currentSpan = (Tracer.Instance.ActiveScope as Scope)?.Span;
-        var traceContext = currentSpan?.Context?.TraceContext;
+        var traceContext = currentSpan?.TraceContext;
         var isRequest = traceContext?.RootSpan?.Type == SpanTypes.Web;
         return isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() == true;
     }
@@ -533,7 +532,7 @@ internal static class IastModule
 
         var scope = tracer.ActiveScope as Scope;
         var currentSpan = scope?.Span;
-        var traceContext = currentSpan?.Context?.TraceContext;
+        var traceContext = currentSpan?.TraceContext;
         var isRequest = traceContext?.RootSpan?.Type == SpanTypes.Web;
 
         // We do not have, for now, tainted objects in console apps, so further checking is not neccessary.

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.PlatformHelpers
             if (iastInstance.Settings.Enabled && iastInstance.OverheadController.AcquireRequest())
             {
                 // If the overheadController disables the vulnerability detection for this request, we do not initialize the iast context of TraceContext
-                scope.Span.Context?.TraceContext?.EnableIastInRequest();
+                scope.Span.TraceContext?.EnableIastInRequest();
             }
 
             tags.SetAnalyticsSampleRate(_integrationId, tracer.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Processors
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L133-L135
-            var traceContext = trace.Array![trace.Offset].Context.TraceContext;
+            var traceContext = trace.Array![trace.Offset].TraceContext;
 
             if (!string.IsNullOrEmpty(traceContext.Environment))
             {
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Processors
             if (span.StartTime < Year2000Time)
             {
                 Log.Debug("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now(): {Span}", span);
-                var now = span.Context.TraceContext.Clock.UtcNow;
+                var now = span.TraceContext.Clock.UtcNow;
                 var start = now - span.Duration;
                 if (start.ToUnixTimeNanoseconds() < 0)
                 {

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Sampling
                 return defaultRate;
             }
 
-            var env = span.Context.TraceContext.Environment;
+            var env = span.TraceContext.Environment;
             var service = span.ServiceName;
 
             var key = new SampleRateKey(service, env);
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Sampling
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.Context.RawTraceId, _defaultSamplingRate);
+                Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.RawTraceId, _defaultSamplingRate);
             }
 
             defaultRate = _defaultSamplingRate ?? 1;

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Sampling
                                 "Matched on rule {RuleName}. Applying rate of {Rate} to trace id {TraceId}",
                                 rule.RuleName,
                                 sampleRate,
-                                span.Context.RawTraceId);
+                                span.RawTraceId);
                         }
 
                         return MakeSamplingDecision(span, sampleRate, rule.SamplingMechanism);
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Sampling
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("No rules matched for trace {TraceId}", span.Context.RawTraceId);
+                Log.Debug("No rules matched for trace {TraceId}", span.RawTraceId);
             }
 
             return SamplingDecision.Default;

--- a/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Sampling
 
         public override void OnDisallowed(Span span, int count, int intervalMs, int maxTracesPerInterval)
         {
-            Log.Warning<string, int, int>("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.Context.RawTraceId, count, intervalMs);
+            Log.Warning<string, int, int>("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.RawTraceId, count, intervalMs);
         }
 
         public override void OnFinally(Span span)

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ServiceFabric
                     if (messageHeaders != null)
                     {
                         SpanContextPropagator.Instance.Inject(
-                            span.Context,
+                            span.GetContext(),
                             messageHeaders,
                             default(ServiceRemotingRequestMessageHeaderSetter));
                     }

--- a/tracer/src/Datadog.Trace/Span.ISpan.cs
+++ b/tracer/src/Datadog.Trace/Span.ISpan.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace
         ulong ISpan.SpanId => SpanId;
 
         /// <inheritdoc />
-        ISpanContext ISpan.Context => Context;
+        ISpanContext ISpan.Context => _context;
 
         /// <inheritdoc />
         ISpan ISpan.SetTag(string key, string value) => SetTag(key, value);

--- a/tracer/src/Datadog.Trace/Span.ISpan.cs
+++ b/tracer/src/Datadog.Trace/Span.ISpan.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace
         }
 
         /// <inheritdoc />
-        // this public API always returns the lower 64-bits, truncate using TraceId128.Lower
+        // this public API always returns the lower 64-bits, truncate using TraceId.Lower
         ulong ISpan.TraceId => TraceId128.Lower;
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -110,13 +110,13 @@ namespace Datadog.Trace
         /// </summary>
         internal ulong SpanId => _context.SpanId;
 
-        internal ulong? ParentId => _context.Parent?.SpanId;
+        internal ulong? ParentId => _context.ParentInternal?.SpanId;
 
         internal string RawTraceId => _context.RawTraceId;
 
         internal string RawSpanId => _context.RawSpanId;
 
-        internal ISpanContext Parent => _context.Parent;
+        internal ISpanContext Parent => _context.ParentInternal;
 
         /// <summary>
         /// Gets <i>local root span id</i>, i.e. the <c>SpanId</c> of the span that is the root of the local, non-reentrant
@@ -514,8 +514,10 @@ namespace Datadog.Trace
         /// <param name="manager">The <see cref="DataStreamsManager"/> to use</param>
         /// <param name="checkpointKind">The type of the checkpoint</param>
         /// <param name="edgeTags">The edge tags for this checkpoint. NOTE: These MUST be sorted alphabetically</param>
-        internal void SetCheckpoint(DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags) =>
-            _context.SetCheckpoint(manager, checkpointKind, edgeTags);
+        /// <param name="payloadSizeBytes">Payload size in bytes</param>
+        /// <param name="timeInQueueMs">Edge start time extracted from the message metadata. Used only if this is start of the pathway</param>
+        internal void SetCheckpoint(DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags, long payloadSizeBytes, long timeInQueueMs) =>
+            _context.SetCheckpoint(manager, checkpointKind, edgeTags, payloadSizeBytes, timeInQueueMs);
 
         /// <summary>
         /// Merges two DataStreams <see cref="PathwayContext"/>

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -131,8 +131,6 @@ namespace Datadog.Trace
 
         internal ITags Tags { get; set; }
 
-        internal SpanContext Context => _context;
-
         internal DateTimeOffset StartTime { get; private set; }
 
         internal TimeSpan Duration { get; private set; }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Span>();
         private static readonly bool IsLogLevelDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
 
+        private readonly SpanContext _context;
         private int _isFinished;
         private bool _baseServiceTagSet;
 
@@ -40,9 +41,9 @@ namespace Datadog.Trace
 
         internal Span(SpanContext context, DateTimeOffset? start, ITags tags)
         {
-            Tags = tags ?? new CommonTags();
-            Context = context;
+            _context = context;
             StartTime = start ?? Context.TraceContext.Clock.UtcNow;
+            Tags = tags ?? new CommonTags();
 
             if (IsLogLevelDebugEnabled)
             {
@@ -119,7 +120,7 @@ namespace Datadog.Trace
 
         internal ITags Tags { get; set; }
 
-        internal SpanContext Context { get; }
+        internal SpanContext Context => _context;
 
         internal DateTimeOffset StartTime { get; private set; }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -131,6 +131,9 @@ namespace Datadog.Trace
 
         internal ITags Tags { get; set; }
 
+        // do not remove this property, it is accessed via reflection from older versions of the tracer
+        private SpanContext Context => _context;
+
         internal DateTimeOffset StartTime { get; private set; }
 
         internal TimeSpan Duration { get; private set; }

--- a/tracer/src/Datadog.Trace/TaggingUtils.cs
+++ b/tracer/src/Datadog.Trace/TaggingUtils.cs
@@ -20,7 +20,7 @@ internal class TaggingUtils
         if (span is Span spanClassTemp)
         {
             spanClass = spanClassTemp;
-            traceContext = spanClass.Context.TraceContext;
+            traceContext = spanClass.TraceContext;
         }
         else
         {

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -198,7 +198,7 @@ namespace Datadog.Trace
                     Log.Debug<ulong, string, int>(
                         "Closing span {SpanId} triggered a partial flush of trace {TraceId} with {SpanCount} pending spans",
                         span.SpanId,
-                        span.Context.RawTraceId,
+                        span.RawTraceId,
                         _spans.Count);
 
                     spansToWrite = _spans.GetArray();
@@ -275,7 +275,7 @@ namespace Datadog.Trace
                 return;
             }
 
-            if (spans.Array![spans.Offset].Context.TraceContext?.SamplingPriority <= 0)
+            if (spans.Array![spans.Offset].TraceContext?.SamplingPriority <= 0)
             {
                 for (int i = 0; i < spans.Count; i++)
                 {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -196,7 +196,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the active span context dictionary by consulting DistributedTracer.Instance
         /// </summary>
-        internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.Context;
+        internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.GetContext();
 
         /// <summary>
         /// Gets the active scope
@@ -248,7 +248,7 @@ namespace Datadog.Trace
         {
             get
             {
-                if (InternalActiveScope?.Span?.Context?.TraceContext is { } context)
+                if (InternalActiveScope?.Span?.TraceContext is { } context)
                 {
                     return context.CurrentTraceSettings;
                 }
@@ -406,7 +406,7 @@ namespace Datadog.Trace
         internal SpanContext CreateSpanContext(ISpanContext parent = null, string serviceName = null, TraceId traceId = default, ulong spanId = 0, string rawTraceId = null, string rawSpanId = null)
         {
             // null parent means use the currently active span
-            parent ??= DistributedTracer.Instance.GetSpanContext() ?? TracerManager.ScopeManager.Active?.Span?.Context;
+            parent ??= DistributedTracer.Instance.GetSpanContext() ?? TracerManager.ScopeManager.Active?.Span?.GetContext();
 
             TraceContext traceContext;
 

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -36,6 +36,6 @@ namespace Datadog.Trace.Util
             ((id * KnuthFactor) % Modulo) <= (rate * Modulo);
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace) =>
-            trace.Array![trace.Offset].Context.TraceContext?.SamplingPriority > 0;
+            trace.Array![trace.Offset].TraceContext?.SamplingPriority > 0;
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.IntegrationTests
 
             using (var scope = (Scope)_tracer.StartActive("root"))
             {
-                scope.Span.Context.TraceContext.Origin = originValue;
+                scope.Span.TraceContext.Origin = originValue;
 
                 using (_ = _tracer.StartActive("child"))
                 {

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
@@ -84,7 +84,7 @@ public class AASTagsTests
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
 
             using (var scope11 = tracer.StartActive("1.1"))
             {

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
@@ -38,7 +38,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
 
         using (var scope1 = _tracer.StartActive("1", settings))
         {
-            ((Span)scope1.Span).Context.TraceContext.SetSamplingPriority(SamplingPriorityValue);
+            ((Span)scope1.Span).TraceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (_ = _tracer.StartActive("1.1"))
             {
@@ -89,7 +89,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -163,7 +163,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -236,7 +236,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -309,7 +309,7 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithoutUpstreamService.cs
@@ -35,7 +35,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
     {
         using (var rootScope = _tracer.StartActive("1"))
         {
-            ((Span)rootScope.Span).Context.TraceContext.SetSamplingPriority(SamplingPriorityValue);
+            ((Span)rootScope.Span).TraceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (_ = _tracer.StartActive("1.1"))
             {
@@ -83,7 +83,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -154,7 +154,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -224,7 +224,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))
@@ -294,7 +294,7 @@ public class SamplingPriorityTests_MultipleChunksWithoutUpstreamService
         {
             span1 = scope1.Span;
 
-            var traceContext = ((Scope)scope1).Span.Context.TraceContext;
+            var traceContext = ((Scope)scope1).Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValue);
 
             using (var scope11 = _tracer.StartActive("1.1"))

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceContextPropertyTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceContextPropertyTests.cs
@@ -39,7 +39,7 @@ public class TraceContextPropertyTests
     {
         using (var scope = CreateTrace(_tracer))
         {
-            scope.Span.Context.TraceContext.SetSamplingPriority(samplingPriority);
+            scope.Span.TraceContext.SetSamplingPriority(samplingPriority);
         }
 
         await _tracer.FlushAsync();
@@ -67,7 +67,7 @@ public class TraceContextPropertyTests
     {
         using (var scope = CreateTrace(_tracer))
         {
-            scope.Span.Context.TraceContext.Environment = before;
+            scope.Span.TraceContext.Environment = before;
         }
 
         await AssertTag("env", after);
@@ -83,7 +83,7 @@ public class TraceContextPropertyTests
     {
         using (var scope = CreateTrace(_tracer))
         {
-            scope.Span.Context.TraceContext.ServiceVersion = before;
+            scope.Span.TraceContext.ServiceVersion = before;
         }
 
         await AssertTag("version", after);
@@ -99,7 +99,7 @@ public class TraceContextPropertyTests
     {
         using (var scope = CreateTrace(_tracer))
         {
-            scope.Span.Context.TraceContext.Origin = before;
+            scope.Span.TraceContext.Origin = before;
         }
 
         await AssertTag("_dd.origin", after);

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
@@ -41,7 +41,7 @@ public class TraceTags
     {
         using (var scope = _tracer.StartActiveInternal("root"))
         {
-            var traceContext = scope.Span.Context.TraceContext;
+            var traceContext = scope.Span.TraceContext;
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, samplingMechanism);
         }
 

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -61,8 +61,8 @@ namespace Datadog.Trace.OpenTracing.Tests
                                                 .AsChildOf(root)
                                                 .Start();
 
-            var rootParentId = ((Span)root.Span).Context.ParentId;
-            var childParentId = ((Span)child.Span).Context.ParentId;
+            var rootParentId = ((Span)root.Span).ParentId;
+            var childParentId = ((Span)child.Span).ParentId;
 
             Assert.Null(rootParentId);
             Assert.NotEqual<ulong>(0, root.DDSpan.Context.SpanId);
@@ -80,8 +80,8 @@ namespace Datadog.Trace.OpenTracing.Tests
                                                 .AsChildOf(root.Context)
                                                 .Start();
 
-            var rootParentId = ((Span)root.Span).Context.ParentId;
-            var childParentId = ((Span)child.Span).Context.ParentId;
+            var rootParentId = ((Span)root.Span).ParentId;
+            var childParentId = ((Span)child.Span).ParentId;
 
             Assert.Null(rootParentId);
             Assert.NotEqual<ulong>(0, root.DDSpan.Context.SpanId);
@@ -99,8 +99,8 @@ namespace Datadog.Trace.OpenTracing.Tests
                                                 .AddReference(References.ChildOf, root.Context)
                                                 .Start();
 
-            var rootParentId = ((Span)root.Span).Context.ParentId;
-            var childParentId = ((Span)child.Span).Context.ParentId;
+            var rootParentId = ((Span)root.Span).ParentId;
+            var childParentId = ((Span)child.Span).ParentId;
 
             Assert.Null(rootParentId);
             Assert.NotEqual<ulong>(0, root.DDSpan.Context.SpanId);

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -55,8 +55,8 @@ namespace Datadog.Trace.OpenTracing.Tests
             Span rootDatadogSpan = (Span)((OpenTracingSpan)root.Span).Span;
             Span childDatadogSpan = (Span)((OpenTracingSpan)child.Span).Span;
 
-            Assert.Equal(rootDatadogSpan.Context.TraceContext, childDatadogSpan.Context.TraceContext);
-            Assert.Equal(rootDatadogSpan.Context.SpanId, childDatadogSpan.Context.ParentId);
+            Assert.Equal(rootDatadogSpan.TraceContext, childDatadogSpan.TraceContext);
+            Assert.Equal(rootDatadogSpan.SpanId, childDatadogSpan.ParentId);
         }
 
         [Fact]
@@ -80,10 +80,10 @@ namespace Datadog.Trace.OpenTracing.Tests
             Span child1DatadogSpan = (Span)((OpenTracingSpan)child1.Span).Span;
             Span child2DatadogSpan = (Span)((OpenTracingSpan)child2.Span).Span;
 
-            Assert.Same(rootDatadogSpan.Context.TraceContext, child1DatadogSpan.Context.TraceContext);
-            Assert.Equal(rootDatadogSpan.Context.SpanId, child1DatadogSpan.Context.ParentId);
-            Assert.Same(rootDatadogSpan.Context.TraceContext, child2DatadogSpan.Context.TraceContext);
-            Assert.Equal(rootDatadogSpan.Context.SpanId, child2DatadogSpan.Context.ParentId);
+            Assert.Same(rootDatadogSpan.TraceContext, child1DatadogSpan.TraceContext);
+            Assert.Equal(rootDatadogSpan.SpanId, child1DatadogSpan.ParentId);
+            Assert.Same(rootDatadogSpan.TraceContext, child2DatadogSpan.TraceContext);
+            Assert.Equal(rootDatadogSpan.SpanId, child2DatadogSpan.ParentId);
         }
 
         [Fact]
@@ -103,10 +103,10 @@ namespace Datadog.Trace.OpenTracing.Tests
             Span child1DatadogSpan = (Span)((OpenTracingSpan)child1.Span).Span;
             Span child2DatadogSpan = (Span)((OpenTracingSpan)child2.Span).Span;
 
-            Assert.Same(rootDatadogSpan.Context.TraceContext, child1DatadogSpan.Context.TraceContext);
-            Assert.Equal(rootDatadogSpan.Context.SpanId, child1DatadogSpan.Context.ParentId);
-            Assert.Same(rootDatadogSpan.Context.TraceContext, child2DatadogSpan.Context.TraceContext);
-            Assert.Equal(child1DatadogSpan.Context.SpanId, child2DatadogSpan.Context.ParentId);
+            Assert.Same(rootDatadogSpan.TraceContext, child1DatadogSpan.TraceContext);
+            Assert.Equal(rootDatadogSpan.SpanId, child1DatadogSpan.ParentId);
+            Assert.Same(rootDatadogSpan.TraceContext, child2DatadogSpan.TraceContext);
+            Assert.Equal(child1DatadogSpan.SpanId, child2DatadogSpan.ParentId);
         }
 
         [Fact]
@@ -118,28 +118,28 @@ namespace Datadog.Trace.OpenTracing.Tests
                          .BuildSpan("Root")
                          .StartActive(finishSpanOnDispose: true);
 
-            Func<OpenTracingTracer, Task<OpenTracingSpan>> createSpanAsync = async (t) =>
+            Func<OpenTracingTracer, Task<OpenTracingSpan>> createSpanAsync = async _ =>
             {
                 await tcs.Task;
                 return (OpenTracingSpan)_tracer.BuildSpan("AsyncChild").Start();
             };
-            var tasks = Enumerable.Range(0, 10).Select(x => createSpanAsync(_tracer)).ToArray();
+            var tasks = Enumerable.Range(0, 10).Select(_ => createSpanAsync(_tracer)).ToArray();
 
             var syncChild = (OpenTracingSpan)_tracer.BuildSpan("SyncChild").Start();
-            var syncChildSpanContext = ((Span)syncChild.Span).Context;
+            var syncChildSpan = (Span)syncChild.Span;
             tcs.SetResult(true);
 
             Span rootDatadogSpan = (Span)((OpenTracingSpan)root.Span).Span;
 
-            Assert.Equal(rootDatadogSpan.Context.TraceContext, syncChildSpanContext.TraceContext);
-            Assert.Equal(rootDatadogSpan.Context.SpanId, syncChildSpanContext.ParentId);
+            Assert.Equal(rootDatadogSpan.TraceContext, syncChildSpan.TraceContext);
+            Assert.Equal(rootDatadogSpan.SpanId, syncChildSpan.ParentId);
 
             foreach (var task in tasks)
             {
                 var span = await task;
-                var spanContext = ((Span)syncChild.Span).Context;
-                Assert.Equal(rootDatadogSpan.Context.TraceContext, spanContext.TraceContext);
-                Assert.Equal(rootDatadogSpan.Context.SpanId, spanContext.ParentId);
+                var ddSpan = (Span)syncChild.Span;
+                Assert.Equal(rootDatadogSpan.TraceContext, ddSpan.TraceContext);
+                Assert.Equal(rootDatadogSpan.SpanId, ddSpan.ParentId);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EventTrackingSdkTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EventTrackingSdkTests.cs
@@ -36,7 +36,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackUserLoginSuccessEvent(id, null, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessTrack));
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessSdkSource));
         Assert.Equal(id, traceContext.Tags.GetTag(Tags.User.Id));
@@ -67,7 +67,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackUserLoginSuccessEvent(id, meta, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessTrack));
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.SuccessSdkSource));
 
@@ -98,7 +98,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackUserLoginFailureEvent(id, true, null, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal(id, traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserId));
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureTrack));
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists));
@@ -130,7 +130,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackUserLoginFailureEvent(id, false, meta, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureTrack));
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureSdkSource));
         Assert.Equal("false", traceContext.Tags.GetTag(Tags.AppSec.EventsUsers.LoginEvent.FailureUserExists));
@@ -161,7 +161,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackCustomEvent(eventName, null, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.Track(eventName)));
         Assert.Equal("true", traceContext.Tags.GetTag($"_dd.{Tags.AppSec.Events}{eventName}.sdk"));
     }
@@ -184,7 +184,7 @@ public class EventTrackingSdkTests
 
         EventTrackingSdk.TrackCustomEvent(eventName, meta, tracer);
 
-        var traceContext = rootTestScope.Span.Context.TraceContext;
+        var traceContext = rootTestScope.Span.TraceContext;
         Assert.Equal("true", traceContext.Tags.GetTag(Tags.AppSec.Track(eventName)));
         Assert.Equal("true", traceContext.Tags.GetTag($"_dd.{Tags.AppSec.Events}{eventName}.sdk"));
 

--- a/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
                 scopeFromActivity = Tracer.Instance.ActiveScope;
                 scopeFromActivity.Span.TraceId.Should().Be(traceIdInULong);
                 scopeFromActivity.Span.SpanId.Should().Be(spanIdInULong);
-                ((Span)scopeFromActivity.Span).Context.RawTraceId.Should().Be(traceId);
+                ((Span)scopeFromActivity.Span).RawTraceId.Should().Be(traceId);
                 scopeFromActivity.Span.OperationName.Should().Be("Custom activity");
 
                 // Create datadog span as a child
@@ -76,8 +76,8 @@ namespace Datadog.Trace.Tests
                 {
                     // Assert TraceId and parent span id
                     scope.Span.TraceId.Should().Be(traceIdInULong);
-                    ((Span)scope.Span).Context.ParentId.Should().Be(spanIdInULong);
-                    ((Span)scope.Span).Context.RawTraceId.Should().Be(traceId);
+                    ((Span)scope.Span).ParentId.Should().Be(spanIdInULong);
+                    ((Span)scope.Span).RawTraceId.Should().Be(traceId);
 
                     // Create a new child activity as child of span
                     SD.Activity childActivity = null;
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Tests
                         scopeFromChildActivity.Span.TraceId.Should().Be(traceIdInULong);
                         HexString.TryParseUInt64(childActivity.SpanId.ToString(), out var childActivitySpanId);
                         scopeFromChildActivity.Span.SpanId.Should().Be(childActivitySpanId);
-                        ((Span)scopeFromChildActivity.Span).Context.RawTraceId.Should().Be(traceId);
+                        ((Span)scopeFromChildActivity.Span).RawTraceId.Should().Be(traceId);
                         scopeFromChildActivity.Span.OperationName.Should().Be("Child activity");
 
                         Tracer.Instance.ActiveScope.Should().NotBe(scope);
@@ -171,7 +171,7 @@ namespace Datadog.Trace.Tests
                     var scopeFromChildActivity = Tracer.Instance.ActiveScope;
                     scopeFromChildActivity.Span.TraceId.Should().Be(traceId);
                     scopeFromChildActivity.Span.SpanId.Should().Be(spanIdInULong);
-                    ((Span)scopeFromChildActivity.Span).Context.RawTraceId.Should().Be(traceId128);
+                    ((Span)scopeFromChildActivity.Span).RawTraceId.Should().Be(traceId128);
                     scopeFromChildActivity.Span.OperationName.Should().Be("Child activity");
 
                     // Create datadog span as a child
@@ -179,8 +179,8 @@ namespace Datadog.Trace.Tests
                     {
                         // Assert TraceId and parent span id
                         childScope.Span.TraceId.Should().Be(traceId);
-                        ((Span)childScope.Span).Context.ParentId.Should().Be(spanIdInULong);
-                        ((Span)childScope.Span).Context.RawTraceId.Should().Be(traceId128);
+                        ((Span)childScope.Span).ParentId.Should().Be(spanIdInULong);
+                        ((Span)childScope.Span).RawTraceId.Should().Be(traceId128);
                     }
                 }
                 finally

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Tests.Agent
                 span.OperationName = operationName;
                 span.Type = type;
                 span.SetTag(Tags.HttpStatusCode, httpStatusCode);
-                span.Context.Origin = origin;
+                span.TraceContext.Origin = origin;
 
                 return span;
             }
@@ -201,15 +201,15 @@ namespace Datadog.Trace.Tests.Agent
                 parentSpan.SetDuration(TimeSpan.FromMilliseconds(100));
 
                 // childSpan shouldn't be recorded, because it's not top-level and doesn't have the Measured tag
-                var childSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                var childSpan = new Span(new SpanContext(parentSpan.GetContext(), new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
                 childSpan.SetDuration(TimeSpan.FromMilliseconds(100));
 
-                var measuredChildSpan1 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                var measuredChildSpan1 = new Span(new SpanContext(parentSpan.GetContext(), new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
                 measuredChildSpan1.OperationName = "child.op1";
                 measuredChildSpan1.SetTag(Tags.Measured, "1");
                 measuredChildSpan1.SetDuration(TimeSpan.FromMilliseconds(100));
 
-                var measuredChildSpan2 = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
+                var measuredChildSpan2 = new Span(new SpanContext(parentSpan.GetContext(), new TraceContext(Mock.Of<IDatadogTracer>()), "service"), start);
                 measuredChildSpan2.OperationName = "child.op2";
                 measuredChildSpan2.SetTag(Tags.Measured, "1");
                 measuredChildSpan2.SetDuration(TimeSpan.FromMilliseconds(100));
@@ -271,7 +271,7 @@ namespace Datadog.Trace.Tests.Agent
                 snapshotSpan.SetDuration(TimeSpan.FromMilliseconds(300));
 
                 // Create a new child span that is a service entry span, which means it will have stats computed for it
-                var httpClientServiceSpan = new Span(new SpanContext(parentSpan.Context, new TraceContext(Mock.Of<IDatadogTracer>()), "service-http-client"), start);
+                var httpClientServiceSpan = new Span(new SpanContext(parentSpan.GetContext(), new TraceContext(Mock.Of<IDatadogTracer>()), "service-http-client"), start);
                 httpClientServiceSpan.SetDuration(TimeSpan.FromMilliseconds(400));
 
                 aggregator.Add(simpleSpan, parentSpan, snapshotSpan, httpClientServiceSpan);

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -175,7 +174,11 @@ namespace Datadog.Trace.Tests.Agent
                 span.OperationName = operationName;
                 span.Type = type;
                 span.SetTag(Tags.HttpStatusCode, httpStatusCode);
-                span.TraceContext.Origin = origin;
+
+                if (span.TraceContext is { } traceContext)
+                {
+                    traceContext.Origin = origin;
+                }
 
                 return span;
             }

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -71,8 +71,8 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         public void ExpectedTagsInjected(string expectedComment, string env = null, string version = null)
         {
             var span = _v0Tracer.StartSpan(operationName: "mysql.query", parent: SpanContext.None, serviceName: "Test.Service-mysql", traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
-            span.Context.TraceContext.Environment = env;
-            span.Context.TraceContext.ServiceVersion = version;
+            span.TraceContext.Environment = env;
+            span.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
             var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, "Test.Service", span, IntegrationId.MySql, out bool traceParentInjected);
@@ -90,8 +90,8 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         public void ExpectedTagsEncoded(string expectedComment, string service, string env, string version)
         {
             var span = _v0Tracer.StartSpan(operationName: "mysql.query", parent: SpanContext.None, serviceName: $"{service}-mysql", traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
-            span.Context.TraceContext.Environment = env;
-            span.Context.TraceContext.ServiceVersion = version;
+            span.TraceContext.Environment = env;
+            span.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
             var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, service, span, IntegrationId.MySql, out bool traceParentInjected);

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             commonTracer.SetSamplingPriority(expectedSamplingPriority);
 
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
+            scope.Span.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
         }
 
         private class CommonTracerImpl : CommonTracer

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
             distributedTracer.Verify(t => t.GetSpanContext(), Times.Exactly(2));
             scope.Span.TraceId128.Should().Be(spanContext.TraceId128);
             ((ISpan)scope.Span).TraceId.Should().Be(spanContext.TraceId);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(spanContext.SamplingPriority);
+            scope.Span.TraceContext.SamplingPriority.Should().Be(spanContext.SamplingPriority);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             using (var scope = (Scope)Tracer.Instance.StartActive("Test"))
             {
-                distributedTracer.Verify(t => t.SetSpanContext(scope.Span.Context), Times.Once);
+                distributedTracer.Verify(t => t.SetSpanContext(scope.Span.GetContext()), Times.Once);
             }
 
             distributedTracer.Verify(t => t.SetSpanContext(null), Times.Once);

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Tests
             scope.Span.TraceId128.Should().BeGreaterThan(TraceId.Zero);
             ((ISpan)scope.Span).TraceId.Should().BeGreaterThan(0);
             scope.Span.SpanId.Should().BeGreaterThan(0);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
+            scope.Span.TraceContext.SamplingPriority.Should().Be(-1);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests
             scope.Span.TraceId128.Should().Be((TraceId)1234);
             ((ISpan)scope.Span).TraceId.Should().Be(1234);
             scope.Span.SpanId.Should().BeGreaterThan(0);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
+            scope.Span.TraceContext.SamplingPriority.Should().Be(-1);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests.Sampling
             var settings = new TracerSettings { ServiceName = expectedService };
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
             using var scope = (Scope)tracer.StartActive("root");
-            scope.Span.Context.TraceContext.Environment = expectedEnv;
+            scope.Span.TraceContext.Environment = expectedEnv;
 
             // create sampling rule
             var rule = new DefaultSamplingRule();
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests.Sampling
             var firstScope = (Scope)tracer.StartActive("first");
             var firstSpan = firstScope.Span;
             firstSpan.ServiceName = configuredService;
-            firstSpan.Context.TraceContext.Environment = configuredEnv;
+            firstSpan.TraceContext.Environment = configuredEnv;
 
             var secondScope = (Scope)tracer.StartActive("second");
             var secondSpan = secondScope.Span;

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
@@ -22,13 +22,13 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
             var trace1 = new[] { tracer.StartSpan("1"), tracer.StartSpan("1") };
-            trace1[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            trace1[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             var trace2 = new[] { tracer.StartSpan("2"), tracer.StartSpan("1") };
-            trace2[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            trace2[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             var trace3 = new[] { tracer.StartSpan("1"), tracer.StartSpan("1") };
-            trace3[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            trace3[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             sampler.Sample(new(trace1)).Should().BeTrue();
             sampler.Sample(new(trace2)).Should().BeTrue();
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
             var trace = new[] { tracer.StartSpan("1") };
-            trace[0].Context.TraceContext.SetSamplingPriority(priority);
+            trace[0].TraceContext.SetSamplingPriority(priority);
 
             sampler.Sample(new(trace)).Should().Be(expected);
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
             var trace = new[] { Tracer.Instance.StartSpan("1") };
-            trace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            trace[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             sampler.Sample(new(trace)).Should().BeFalse();
             trace.Single().GetMetric(Metrics.RareSpan).Should().Be(null);
@@ -105,13 +105,13 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
             var knownTrace = new[] { tracer.StartSpan("1") };
-            knownTrace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            knownTrace[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             // Show span "1" to the RareSampler
             sampler.Sample(new(knownTrace)).Should().BeTrue();
 
             using var scope1 = tracer.StartActiveInternal("1");
-            scope1.Span.Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            scope1.Span.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             using var scope2 = tracer.StartActiveInternal("2");
 
@@ -131,7 +131,7 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
             var knownTrace = new[] { tracer.StartSpan("1") };
-            knownTrace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            knownTrace[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             // Show span "1" to the RareSampler
             sampler.Sample(new(knownTrace)).Should().BeTrue();
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             // Create a trace with the interesting span ("2") as a child
             var trace = new[] { scope1.Span, scope2.Span };
-            trace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
+            trace[0].TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             sampler.Sample(new(trace)).Should().BeTrue();
         }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling
 {
-    [Collection(nameof(Datadog.Trace.Tests.Sampling))]
+    [Collection(nameof(Sampling))]
     public class TraceSamplerTests
     {
         private const float FallbackRate = 0.25f;
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Tests.Sampling
             var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
 
             using var scope = (Scope)tracer.StartActive(OperationName);
-            scope.Span.Context.TraceContext.Environment = Env;
+            scope.Span.TraceContext.Environment = Env;
 
             var span = scope.Span;
             var sampler = new TraceSampler(new NoLimits());

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -252,8 +252,8 @@ namespace Datadog.Trace.Tests
             SpanContext remoteParentSpanCtx = new SpanContext(traceId: null, spanId: remoteParentSpanId);
 
             using (Span span1 = _tracer.StartSpan(operationName: "Operation Root", parent: remoteParentSpanCtx))
-            using (Span span2 = _tracer.StartSpan(operationName: "Operation Middle", parent: span1.Context))
-            using (Span span3 = _tracer.StartSpan(operationName: "Operation Leaf", parent: span2.Context))
+            using (Span span2 = _tracer.StartSpan(operationName: "Operation Middle", parent: span1.GetContext()))
+            using (Span span3 = _tracer.StartSpan(operationName: "Operation Leaf", parent: span2.GetContext()))
             {
                 span1.SpanId.Should().NotBe(0);
                 span2.SpanId.Should().NotBe(0);
@@ -310,15 +310,15 @@ namespace Datadog.Trace.Tests
                 span3.SpanId.Should().NotBe(0);
                 span4.SpanId.Should().NotBe(0);
 
-                span1.SpanId.Should().NotBe(remoteParentSpanId);          // There is an expected 1 in 2^64 chance of this line failing
-                span2.SpanId.Should().NotBe(remoteParentSpanId);                // There is an expected 1 in 2^64 chance of this line failing
-                span3.SpanId.Should().NotBe(remoteParentSpanId);          // There is an expected 1 in 2^64 chance of this line failing
-                span4.SpanId.Should().NotBe(remoteParentSpanId);                // There is an expected 1 in 2^64 chance of this line failing
+                span1.SpanId.Should().NotBe(remoteParentSpanId); // There is an expected 1 in 2^64 chance of this line failing
+                span2.SpanId.Should().NotBe(remoteParentSpanId); // There is an expected 1 in 2^64 chance of this line failing
+                span3.SpanId.Should().NotBe(remoteParentSpanId); // There is an expected 1 in 2^64 chance of this line failing
+                span4.SpanId.Should().NotBe(remoteParentSpanId); // There is an expected 1 in 2^64 chance of this line failing
 
-                span1.Context.ParentId.Should().Be(remoteParentSpanId);   // Parent (not root) of S1 is remote
-                span2.Context.ParentId.Should().Be(scope1.Span.SpanId);         // Parent of S2 is S1: it was created in an active S1-scope
-                span3.Context.ParentId.Should().Be(scope1.Span.SpanId);   // Parent of S3 is also S1: it was created in an active S1 scope, S2 is not a scope
-                span4.Context.ParentId.Should().Be(scope3.Span.SpanId);         // Parent of S4 is S3: it was created in an active S3-scope
+                span1.ParentId.Should().Be(remoteParentSpanId); // Parent (not root) of S1 is remote
+                span2.ParentId.Should().Be(scope1.Span.SpanId); // Parent of S2 is S1: it was created in an active S1-scope
+                span3.ParentId.Should().Be(scope1.Span.SpanId); // Parent of S3 is also S1: it was created in an active S1 scope, S2 is not a scope
+                span4.ParentId.Should().Be(scope3.Span.SpanId); // Parent of S4 is S3: it was created in an active S3-scope
 
                 span1.RootSpanId.Should().Be(scope1.Span.SpanId);
                 span2.RootSpanId.Should().Be(scope1.Span.SpanId);

--- a/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Tests.Tagging
             const int customTagCount = 15;
             SetupForSerializationTest(span, customTagCount);
 
-            span.Context.TraceContext.Environment.Should().Be("Overridden Environment");
+            span.TraceContext.Environment.Should().Be("Overridden Environment");
             span.GetTag(Tags.Env).Should().Be("Overridden Environment");
             span.GetMetric(Metrics.SamplingLimitDecision).Should().Be(0.75);
 
@@ -274,7 +274,7 @@ namespace Datadog.Trace.Tests.Tagging
             var tags = (CommonTags)span.Tags;
             tags.SamplingLimitDecision = 0.5;
 
-            span.Context.TraceContext.Environment = "Test";
+            span.TraceContext.Environment = "Test";
 
             // Override the properties
             span.SetTag(Tags.Env, "Overridden Environment");

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -44,7 +44,7 @@ public class StringAspectsBenchmark
             IastModule.OnWeakRandomness("fake"); // Add fake span
             var tracer = Tracer.Instance;
             var currentSpan = (tracer.ActiveScope as Scope)?.Span;
-            var traceContext = currentSpan?.Context?.TraceContext;
+            var traceContext = currentSpan?.TraceContext;
             traceContext.EnableIastInRequest();
             var context = traceContext?.IastRequestContext;
             taintedObjects = context.GetTaintedObjects();


### PR DESCRIPTION
## Summary of changes

This is the first step in removing the `SpanContext` instance we create for each `Span`. It adds `Span` members that delegate to a private `SpanContext` field. Old and new code can start using these members and avoid using `Span.Context`, while we continue with the refactor in separate PRs.

- convert property `Span.Context` to `private` field `_context`
- add `internal` members to `Span` which delegate to `_context`
- replace most uses of `Span.Context` with the new `Span` properties
- where a `SpanContext` is required (mostly for propagation), replace `Span.Context` with `Span.GetContext()`

## Reason for change

The goal here is to stop creating a `SpanContext` instance for every `Span` and to have a better separation between the concepts of "local span" and "propagated context." This should make it easier to work with these core tracer types and, as a bonus, reduce the amount of heap allocations per span.

We are breaking this refactoring project into several PRs:

1. (this PR) #3599
2. Refactor `Span` creation so it does not require a `SpanContext` anymore, but can optionally use one as its parent (this is public API and can't be removed for now). Remove the private `Span._context` field.
3. Add a new `internal readonly struct PropagatedSpanContext` alternative to `SpanContext`, used to hold values during trace propagation. Update `Span.GetContext()` and propagators to use this type instead of the now deprecated `SpanContext`.

...

10. (breaking change) flag type `ISpanContext` and `SpanContext` as deprecated (v3?) and remove them (v4?)

## Implementation details

Change the following `Span` members:
```diff
// new temporary backing field for Span.Context property
+ private SpanContext _context;

// temporary access to SpanContext when we still need it (e.g. propagation),
// all other access changes to Span properties
+ internal SpanContext GetContext() => _context;

// make this private but keep it around because it's used for version-conflict via reflection
- internal SpanContext Context { get; }
+ private SpanContext Context => _context;

+ internal TraceContext TraceContext => _context.TraceContext;

+ internal ulong? ParentId => _context.Parent?.SpanId;

+ internal string RawTraceId => _context.RawTraceId;

+ internal string RawSpanId => _context.RawSpanId;

+ internal ISpanContext Parent => _context.Parent;

+ internal PathwayContext? PathwayContext => _context.PathwayContext;

+ internal void SetCheckpoint(...) =>  _context.SetCheckpoint(...)

+ internal void MergePathwayContext(...) => _context.MergePathwayContext(...)
```

## Test coverage

All tests were updated to use the new members on `Span` instead of `SpanContext`.

## Other details
N/A
