### PR TITLE
[DRAFT] [Tracing] `SpanContext` refactor part 2: remove `Span.Context`

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.MSBuild
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
                 _buildSpan.SetMetric(Tags.Analytics, 1.0d);
 
-                if (_buildSpan.Context.TraceContext is { } traceContext)
+                if (_buildSpan.TraceContext is { } traceContext)
                 {
                     traceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
                     traceContext.Origin = TestTags.CIAppTestOriginName;
@@ -181,14 +181,14 @@ namespace Datadog.Trace.MSBuild
                 string projectName = Path.GetFileName(e.ProjectFile);
 
                 string targetName = string.IsNullOrEmpty(e.TargetNames) ? "build" : e.TargetNames?.ToLowerInvariant();
-                Span projectSpan = _tracer.StartSpan($"msbuild.{targetName}", parent: parentSpan.Context);
+                Span projectSpan = _tracer.StartSpan($"msbuild.{targetName}", parent: parentSpan);
 
                 if (projectName != null)
                 {
                     projectSpan.ServiceName = projectName;
                 }
 
-                projectSpan.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
+                projectSpan.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
                 projectSpan.Type = SpanTypes.Build;
 
                 string targetFramework = null;

--- a/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
@@ -98,12 +98,12 @@ namespace Datadog.Trace.Activity.Handlers
                     // in the context propagation, and we will keep the entire trace.
 
                     // TraceId
-                    w3cActivity.TraceId = string.IsNullOrWhiteSpace(span.Context.RawTraceId) ?
-                                              span.TraceId.ToString("x32") : span.Context.RawTraceId;
+                    w3cActivity.TraceId = string.IsNullOrWhiteSpace(span.RawTraceId) ?
+                                              span.TraceId.ToString("x32") : span.RawTraceId;
 
                     // SpanId
-                    w3cActivity.ParentSpanId = string.IsNullOrWhiteSpace(span.Context.RawSpanId) ?
-                                                   span.SpanId.ToString("x16") : span.Context.RawSpanId;
+                    w3cActivity.ParentSpanId = string.IsNullOrWhiteSpace(span.RawSpanId) ?
+                                                   span.SpanId.ToString("x16") : span.RawSpanId;
 
                     // We clear internals Id and ParentId values to force recalculation.
                     w3cActivity.RawId = null;

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Activity
             // TODO: Add container tags from attributes if the tag isn't already in the span
 
             // Fixup "env" tag
-            if (span.Context.TraceContext?.Environment is null
+            if (span.TraceContext?.Environment is null
                 && span.GetTag("deployment.environment") is string otelServiceEnv
                 && !string.IsNullOrEmpty(otelServiceEnv))
             {

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -437,7 +437,7 @@ namespace Datadog.Trace.Agent
             }
 
             // Add the current keep rate to the root span
-            var rootSpan = spans.Array![spans.Offset].Context.TraceContext?.RootSpan;
+            var rootSpan = spans.Array![spans.Offset].TraceContext?.RootSpan;
 
             if (rootSpan is not null)
             {
@@ -496,7 +496,7 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
-            if (spans.Array![spans.Offset].Context.TraceContext?.SamplingPriority <= 0)
+            if (spans.Array![spans.Offset].TraceContext?.SamplingPriority <= 0)
             {
                 for (int i = 0; i < spans.Count; i++)
                 {

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -127,7 +127,9 @@ namespace Datadog.Trace.Agent.MessagePack
             // It should be the number of members of the object to be serialized.
             var len = 8;
 
-            if (span.Context.ParentId > 0)
+            var parentId = span.ParentId;
+
+            if (parentId > 0)
             {
                 len++;
             }
@@ -144,10 +146,10 @@ namespace Datadog.Trace.Agent.MessagePack
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, len);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
-            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.TraceId);
+            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.TraceId);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
-            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.Context.SpanId);
+            offset += MessagePackBinary.WriteUInt64(ref bytes, offset, span.SpanId);
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, span.OperationName);
@@ -167,10 +169,10 @@ namespace Datadog.Trace.Agent.MessagePack
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, span.Duration.ToNanoseconds());
 
-            if (span.Context.ParentId > 0)
+            if (parentId > 0)
             {
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
-                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)span.Context.ParentId);
+                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)parentId);
             }
 
             if (span.Error)
@@ -180,7 +182,7 @@ namespace Datadog.Trace.Agent.MessagePack
             }
 
             ITagProcessor[] tagProcessors = null;
-            if (span.Context.TraceContext?.Tracer is Tracer tracer)
+            if (span.TraceContext?.Tracer is Tracer tracer)
             {
                 tagProcessors = tracer.TracerManager?.TagProcessors;
             }
@@ -265,7 +267,7 @@ namespace Datadog.Trace.Agent.MessagePack
             }
 
             // add "version" tags to all spans whose service name is the default service name
-            if (string.Equals(span.Context.ServiceName, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(span.ServiceName, model.TraceChunk.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
             {
                 var versionRawBytes = MessagePackStringCache.GetVersionBytes(model.TraceChunk.ServiceVersion);
 

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -102,7 +102,7 @@ internal readonly struct TraceChunkModel
             // skip the HashSet to avoid initializing it yet, always iterate the array of spans.
             ContainsLocalRootSpan = IndexOf(localRootSpanId, spans.Count - 1) >= 0;
 
-            HasUpstreamService = localRootSpan.Context.ParentId is not (null or 0);
+            HasUpstreamService = localRootSpan.ParentId is not (null or 0);
         }
     }
 
@@ -115,7 +115,7 @@ internal readonly struct TraceChunkModel
     {
         if (spans.Count > 0)
         {
-            return spans.Array![spans.Offset].Context.TraceContext;
+            return spans.Array![spans.Offset].TraceContext;
         }
 
         return null;
@@ -129,7 +129,7 @@ internal readonly struct TraceChunkModel
         }
 
         var span = _spans.Array![_spans.Offset + spanIndex];
-        var parentId = span.Context.ParentId ?? 0;
+        var parentId = span.ParentId ?? 0;
         bool isLocalRoot = parentId is 0 || span.SpanId == LocalRootSpanId;
         bool isFirstSpan = spanIndex == 0;
 

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -167,7 +167,7 @@ namespace Datadog.Trace.Agent
                 span.OperationName,
                 span.Type,
                 httpStatusCode,
-                span.Context.Origin == "synthetics");
+                span.TraceContext.Origin == "synthetics");
         }
 
         internal async Task Flush()

--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.AppSec
 
             if (iastEnabled)
             {
-                scope?.Span?.Context?.TraceContext?.IastRequestContext?.AddRequestData(context.Request, controllerContext.RouteData.Values);
+                scope?.Span?.TraceContext?.IastRequestContext?.AddRequestData(context.Request, controllerContext.RouteData.Values);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -80,7 +80,7 @@ internal readonly partial struct SecurityCoordinator
             _localRootSpan.SetTag(Tags.ActorIp, clientIp);
         }
 
-        if (_localRootSpan.Context.TraceContext is { Origin: null } traceContext)
+        if (_localRootSpan.TraceContext is { Origin: null } traceContext)
         {
             _localRootSpan.SetTag(Tags.Origin, "appsec");
             traceContext.Origin = "appsec";
@@ -106,7 +106,7 @@ internal readonly partial struct SecurityCoordinator
         {
             span = TryGetRoot(span);
             security.WafInitResult.Reported = true;
-            span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+            span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             span.SetMetric(Metrics.AppSecWafInitRulesLoaded, security.WafInitResult.LoadedRules);
             span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, security.WafInitResult.FailedToLoadRules);
             if (security.WafInitResult.HasErrors)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -89,5 +89,5 @@ internal readonly partial struct SecurityCoordinator
         _httpTransport.DisposeAdditiveContext();
     }
 
-    private static Span TryGetRoot(Span span) => span.Context.TraceContext?.RootSpan ?? span;
+    private static Span TryGetRoot(Span span) => span.TraceContext?.RootSpan ?? span;
 }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -368,11 +368,11 @@ namespace Datadog.Trace.AppSec
             {
                 // NOTE: setting DD_APPSEC_KEEP_TRACES=false means "drop all traces by setting AutoReject".
                 // It does _not_ mean "stop setting UserKeep (do nothing)". It should only be used for testing.
-                span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoReject, SamplingMechanism.Asm);
+                span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.AutoReject, SamplingMechanism.Asm);
             }
             else if (_rateLimiter.Allowed(span))
             {
-                span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+                span.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -163,7 +163,7 @@ namespace Datadog.Trace.AspNet
                 // (e.g. WCF being hosted in IIS)
                 if (HttpRuntime.UsingIntegratedPipeline)
                 {
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, httpRequest.Headers.Wrap());
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), httpRequest.Headers.Wrap());
                 }
 
                 httpContext.Items[_httpContextScopeKey] = scope;
@@ -192,7 +192,7 @@ namespace Datadog.Trace.AspNet
 
                 if (Iast.Iast.Instance.Settings.Enabled && OverheadController.Instance.AcquireRequest())
                 {
-                    var traceContext = scope?.Span?.Context?.TraceContext;
+                    var traceContext = scope.Span.TraceContext;
                     traceContext?.EnableIastInRequest();
                     traceContext?.IastRequestContext?.AddRequestData(httpRequest);
                 }

--- a/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/tracer/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace
             var scope = new Scope(newParent, span, this, finishOnClose);
 
             Active = scope;
-            DistributedTracer.Instance.SetSpanContext(scope.Span.Context);
+            DistributedTracer.Instance.SetSpanContext(scope.Span.GetContext());
 
             return scope;
         }
@@ -52,7 +52,7 @@ namespace Datadog.Trace
             Active = scope.Parent;
 
             // scope.Parent is null for distributed traces, so use scope.Span.Context.Parent
-            DistributedTracer.Instance.SetSpanContext(scope.Span.Context.Parent as SpanContext);
+            DistributedTracer.Instance.SetSpanContext(scope.Span.Parent as SpanContext);
         }
 
         private static AsyncLocal<Scope> CreateScope()

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -71,7 +71,6 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
         public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
         {
-            var context = value.Context;
             var testSessionTags = value.Tags as TestSessionSpanTags;
             var testModuleTags = value.Tags as TestModuleSpanTags;
             var testSuiteTags = value.Tags as TestSuiteSpanTags;
@@ -80,7 +79,9 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             // It should be the number of members of the object to be serialized.
             var len = 9;
 
-            if (context.ParentId is not null)
+            var parentId = value.ParentId;
+
+            if (parentId is not null)
             {
                 len++;
             }
@@ -119,10 +120,10 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             if (isSpan)
             {
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
-                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.TraceId);
+                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.TraceId);
 
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
-                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.SpanId);
+                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.SpanId);
             }
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
@@ -143,10 +144,10 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, value.Duration.ToNanoseconds());
 
-            if (context.ParentId is not null)
+            if (parentId is not null)
             {
                 offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
-                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, context.ParentId.Value);
+                offset += MessagePackBinary.WriteUInt64(ref bytes, offset, parentId.Value);
             }
 
             if (testSuiteTags is not null)
@@ -171,7 +172,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             offset += MessagePackBinary.WriteByte(ref bytes, offset, (byte)(value.Error ? 1 : 0));
 
             ITagProcessor[] tagProcessors = null;
-            if (context.TraceContext?.Tracer is Tracer tracer)
+            if (value.TraceContext?.Tracer is Tracer tracer)
             {
                 tagProcessors = tracer.TracerManager.TagProcessors;
             }
@@ -196,7 +197,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
         private int WriteTags(ref byte[] bytes, int offset, Span span, ITags tags, ITagProcessor[] tagProcessors)
         {
             int originalOffset = offset;
-            var traceContext = span.Context.TraceContext;
+            var traceContext = span.TraceContext;
 
             // Start of "meta" dictionary. Do not add any string tags before this line.
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaBytes);
@@ -252,7 +253,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             }
 
             // add "version" tags to all spans whose service name is the default service name
-            if (string.Equals(span.Context.ServiceName, traceContext?.Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(span.ServiceName, traceContext?.Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
             {
                 var version = traceContext?.ServiceVersion;
 
@@ -337,7 +338,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
                 }
 
                 // add "_sampling_priority_v1" tag
-                if (span.Context.TraceContext.SamplingPriority is { } samplingPriority)
+                if (span.TraceContext.SamplingPriority is { } samplingPriority)
                 {
                     count++;
                     offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _samplingPriorityNameBytes);

--- a/tracer/src/Datadog.Trace/Ci/Processors/OriginTagTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Ci/Processors/OriginTagTraceProcessor.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Ci.Processors
                 for (var i = trace.Offset + trace.Count - 1; i >= trace.Offset; i--)
                 {
                     var span = trace.Array![i];
-                    if (span.Context.Parent is null &&
+                    if (span.Parent is null &&
                         span.Type != SpanTypes.Test &&
                         span.Type != SpanTypes.TestSuite &&
                         span.Type != SpanTypes.TestModule &&
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Ci.Processors
             if (!_isCiVisibilityProtocol)
             {
                 // Sets the origin tag on the TraceContext to ensure the CI track.
-                var traceContext = trace.Array![trace.Offset].Context.TraceContext;
+                var traceContext = trace.Array![trace.Offset].TraceContext;
 
                 if (traceContext is not null)
                 {
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Ci.Processors
         public Span Process(Span span)
         {
             // Sets the origin tag on the TraceContext to ensure the CI track.
-            var traceContext = span.Context.TraceContext;
+            var traceContext = span.TraceContext;
 
             if (traceContext is not null)
             {

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -37,8 +37,8 @@ public sealed class Test
 
         scope.Span.Type = SpanTypes.Test;
         scope.Span.ResourceName = $"{suite.Name}.{name}";
-        scope.Span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep, SamplingMechanism.Manual);
-        scope.Span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        scope.Span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep, SamplingMechanism.Manual);
+        scope.Span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         _scope = scope;
 
@@ -215,7 +215,7 @@ public sealed class Test
         var tags = (TestSpanTags)scope.Span.Tags;
 
         // Calculate duration beforehand
-        duration ??= _scope.Span.Context.TraceContext.ElapsedSince(scope.Span.StartTime);
+        duration ??= _scope.Span.TraceContext.ElapsedSince(scope.Span.StartTime);
 
         // Set coverage
         if (CIVisibility.Settings.CodeCoverageEnabled == true && Coverage.CoverageReporter.Handler.EndSession() is Coverage.Models.Tests.TestCoverage testCoverage)

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -159,8 +159,8 @@ public sealed class TestModule
 
         span.Type = SpanTypes.TestModule;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.ModuleId = span.SpanId;
 
@@ -345,7 +345,7 @@ public sealed class TestModule
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.ElapsedSince(span.StartTime);
 
         var remainingSuites = Array.Empty<TestSuite>();
         lock (_suites)

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -56,8 +56,8 @@ public sealed class TestSession
 
         span.Type = SpanTypes.TestSession;
         span.ResourceName = $"{span.OperationName}.{command}";
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SessionId = span.SpanId;
 
@@ -313,7 +313,7 @@ public sealed class TestSession
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.ElapsedSince(span.StartTime);
 
         // Set status
         switch (status)
@@ -391,7 +391,7 @@ public sealed class TestSession
         };
 
         SpanContextPropagator.Instance.Inject(
-            span.Context,
+            span.GetContext(),
             (IDictionary)environmentVariables,
             new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor));
 

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -35,8 +35,8 @@ public sealed class TestSuite
 
         span.Type = SpanTypes.TestSuite;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
-        span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
+        span.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SuiteId = span.SpanId;
 
@@ -146,7 +146,7 @@ public sealed class TestSuite
         var span = _span;
 
         // Calculate duration beforehand
-        duration ??= span.Context.TraceContext.ElapsedSince(span.StartTime);
+        duration ??= span.TraceContext.ElapsedSince(span.StartTime);
 
         // Update status
         if (Tags.Status is { } status)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
@@ -51,9 +51,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = requestProxy.QueueUrl;
 
-            if (scope?.Span.Context != null)
+            if (scope != null)
             {
-                ContextPropagation.InjectHeadersIntoMessage<TSendMessageRequest>(requestProxy, scope.Span.Context);
+                ContextPropagation.InjectHeadersIntoMessage<TSendMessageRequest>(requestProxy, scope.Span.GetContext());
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
@@ -51,12 +51,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = requestProxy.QueueUrl;
 
-            if (scope?.Span?.Context != null && requestProxy.Entries.Count > 0)
+            if (scope != null && requestProxy.Entries.Count > 0)
             {
                 for (int i = 0; i < requestProxy.Entries.Count; i++)
                 {
                     var entry = requestProxy.Entries[i].DuckCast<IContainsMessageAttributes>();
-                    ContextPropagation.InjectHeadersIntoMessage<TSendMessageBatchRequest>(entry, scope.Span.Context);
+                    ContextPropagation.InjectHeadersIntoMessage<TSendMessageBatchRequest>(entry, scope.Span.GetContext());
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
@@ -49,12 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = requestProxy.QueueUrl;
 
-            if (scope?.Span?.Context != null && requestProxy.Entries.Count > 0)
+            if (scope != null && requestProxy.Entries.Count > 0)
             {
                 for (int i = 0; i < requestProxy.Entries.Count; i++)
                 {
                     var entry = requestProxy.Entries[i].DuckCast<IContainsMessageAttributes>();
-                    ContextPropagation.InjectHeadersIntoMessage<TSendMessageBatchRequest>(entry, scope.Span.Context);
+                    ContextPropagation.InjectHeadersIntoMessage<TSendMessageBatchRequest>(entry, scope.Span.GetContext());
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
@@ -49,9 +49,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = requestProxy.QueueUrl;
 
-            if (scope?.Span.Context != null)
+            if (scope != null)
             {
-                ContextPropagation.InjectHeadersIntoMessage<TSendMessageRequest>(requestProxy, scope.Span.Context);
+                ContextPropagation.InjectHeadersIntoMessage<TSendMessageRequest>(requestProxy, scope.Span.GetContext());
             }
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     // Additionally, update the scope so it does not finish the span on close. This allows
                     // us to defer finishing the span later while making sure callers of this method do not
                     // get this scope when calling Tracer.ActiveScope
-                    var now = scope.Span.Context.TraceContext.UtcNow;
+                    var now = scope.Span.TraceContext.UtcNow;
                     httpContext.AddOnRequestCompleted(h => OnRequestCompletedAfterException(h, scope, now));
 
                     scope.SetFinishOnClose(false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -160,12 +160,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tags.AspNetArea = areaName;
                     tags.AspNetController = controllerName;
                     tags.AspNetAction = actionName;
-                    var rootspanTags = span.Context.TraceContext?.RootSpan.Tags;
+                    var rootspanTags = span.TraceContext?.RootSpan.Tags;
 
                     // in case of a transfered request, the child request shouldnt set a new http route.
                     if (string.IsNullOrEmpty(rootspanTags.GetTag(Tags.HttpRoute)))
                     {
-                        span.Context.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, routeUrl);
+                        span.TraceContext?.RootSpan.Tags.SetTag(Tags.HttpRoute, routeUrl);
                     }
 
                     tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -203,7 +203,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     tags.AspNetController = controller;
                     tags.AspNetArea = area;
                     tags.AspNetRoute = route;
-                    span.Context.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, route);
+                    span.TraceContext.RootSpan?.SetTag(Tags.HttpRoute, route);
                 }
 
                 if (newResourceNamesEnabled)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     // Additionally, update the scope so it does not finish the span on close. This allows
                     // us to defer finishing the span later while making sure callers of this method do not
                     // get this scope when calling Tracer.ActiveScope
-                    var now = scope.Span.Context.TraceContext.UtcNow;
+                    var now = scope.Span.TraceContext.UtcNow;
                     httpContext.AddOnRequestCompleted(h => OnRequestCompletedAfterException(h, scope, now));
 
                     scope.SetFinishOnClose(false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
 
                 // add distributed tracing headers to the HTTP request
                 // These will be overwritten by the HttpClient integration if that is enabled, per the RFC
-                SpanContextPropagator.Instance.Inject(span.Context, new HttpHeadersCollection(requestMessage.Headers));
+                SpanContextPropagator.Instance.Inject(span.GetContext(), new HttpHeadersCollection(requestMessage.Headers));
 
                 // Add the request metadata as tags
                 if (grpcCall.Options.Headers is { Count: > 0 })

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
 
                 if (setSamplingPriority && existingSpanContext?.SamplingPriority is not null)
                 {
-                    span.Context.TraceContext?.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
+                    span.TraceContext?.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
                 }
 
                 GrpcCommon.RecordFinalStatus(span, receivedStatus.StatusCode, receivedStatus.Detail, receivedStatus.DebugException);
@@ -137,10 +137,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
                     methodName: method.Name,
                     serviceName: method.ServiceName,
                     startTime: span.StartTime,
-                    parentContext: span.Context.Parent);
+                    parentContext: span.Parent);
 
                 // Add the propagation headers
-                SpanContextPropagator.Instance.Inject(span.Context, collection);
+                SpanContextPropagator.Instance.Inject(span.GetContext(), collection);
             }
             catch (Exception ex)
             {
@@ -208,11 +208,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             span.Type = SpanTypes.Grpc;
             span.ResourceName = methodFullName;
 
-            if (span.Context.TraceContext.SamplingPriority == null)
+            if (span.TraceContext.SamplingPriority == null)
             {
                 // If we don't add the span to the trace context, then we need to manually call the sampler
                 var samplingDecision = tracer.TracerManager.Sampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                span.Context.TraceContext.SetSamplingPriority(samplingDecision);
+                span.TraceContext.SetSamplingPriority(samplingDecision);
             }
 
             return span;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(requestMessage.Headers));
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), new HttpHeadersCollection(requestMessage.Headers));
 
                     tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(implementationIntegrationId ?? integrationId);
                     return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -57,13 +57,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 {
                     var span = ScopeFactory.CreateInactiveOutboundHttpSpan(tracer, request.Method, request.RequestUri, WebRequestCommon.IntegrationId, out _, traceId: null, spanId: null, startTime: null, addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                         // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -51,12 +51,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 {
                     var span = ScopeFactory.CreateInactiveOutboundHttpSpan(tracer, request.Method, request.RequestUri, WebRequestCommon.IntegrationId, out _, traceId: null, spanId: null, startTime: null, addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.Context.TraceContext.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
+                            scope.Span.TraceContext.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
                         }
 
                         if (returnValue is HttpWebResponse response)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
@@ -52,13 +52,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 {
                     var span = ScopeFactory.CreateInactiveOutboundHttpSpan(tracer, request.Method, request.RequestUri, WebRequestCommon.IntegrationId, out _, traceId: null, spanId: null, startTime: null, addToTraceContext: false);
 
-                    if (span?.Context != null)
+                    if (span != null)
                     {
                         // Add distributed tracing headers to the HTTP request.
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                         // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
-                        SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(span.GetContext(), request.Headers.Wrap());
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -58,11 +58,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.Context.TraceContext.SetSamplingPriority(spanContext.SamplingPriority.Value);
+                            scope.Span.TraceContext.SetSamplingPriority(spanContext.SamplingPriority.Value);
                         }
 
                         // add distributed tracing headers to the HTTP request
-                        SpanContextPropagator.Instance.Inject(scope.Span.Context, request.Headers.Wrap());
+                        SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), request.Headers.Wrap());
 
                         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -208,7 +208,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     }
                     else
                     {
-                        span.Context.MergePathwayContext(pathwayContext);
+                        span.MergePathwayContext(pathwayContext);
 
                         // TODO: we could pool these arrays to reduce allocations
                         // NOTE: the tags must be sorted in alphabetical order
@@ -216,7 +216,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                                            ? new[] { "direction:in", $"group:{groupId}", "type:kafka" }
                                            : new[] { "direction:in", $"group:{groupId}", $"topic:{topic}", "type:kafka" };
 
-                        span.Context.SetCheckpoint(dataStreamsManager, edgeTags);
+                        span.SetCheckpoint(dataStreamsManager, edgeTags);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             if (scope is not null)
             {
                 KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
-                    scope.Span.Context,
+                    scope.Span.GetContext(),
                     Tracer.Instance.TracerManager.DataStreamsManager,
                     partition?.Topic,
                     message);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             if (scope is not null)
             {
                 KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
-                    scope.Span.Context,
+                    scope.Span.GetContext(),
                     Tracer.Instance.TracerManager.DataStreamsManager,
                     partition?.Topic,
                     message);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                         basicProperties.Headers = new Dictionary<string, object>();
                     }
 
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
+                    SpanContextPropagator.Instance.Inject(scope.Span.GetContext(), basicProperties.Headers, default(ContextPropagation));
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler
             // This is a compromise: we add an additional asynclocal read for the manual tracer when there is no parent trace,
             // but it allows us to remove the asynclocal write for the automatic tracer when running without manual instrumentation.
 
-            return DistributedTrace.Value ?? Tracer.Instance.InternalActiveScope?.Span?.Context;
+            return DistributedTrace.Value ?? Tracer.Instance.InternalActiveScope?.Span?.GetContext();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             var activeScope = Tracer.Instance.InternalActiveScope;
             // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
-            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
+            var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.GetContext();
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, arguments));
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -15,12 +15,12 @@ namespace Datadog.Trace.ClrProfiler
     {
         public int? GetSamplingPriority()
         {
-            return Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext?.SamplingPriority;
+            return Tracer.Instance.InternalActiveScope?.Span.TraceContext?.SamplingPriority;
         }
 
         public void SetSamplingPriority(int? samplingPriority)
         {
-            Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext
+            Tracer.Instance.InternalActiveScope?.Span.TraceContext
                  ?.SetSamplingPriority(samplingPriority, notifyDistributedTracer: false);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -115,11 +115,11 @@ namespace Datadog.Trace.ClrProfiler
 
                 tags.SetAnalyticsSampleRate(integrationId, tracer.Settings, enabledWithGlobalSetting: false);
 
-                if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
+                if (!addToTraceContext && span.TraceContext.SamplingPriority == null)
                 {
                     // If we don't add the span to the trace context, then we need to manually call the sampler
                     var samplingDecision = tracer.TracerManager.Sampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                    span.Context.TraceContext.SetSamplingPriority(samplingDecision);
+                    span.TraceContext.SetSamplingPriority(samplingDecision);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
@@ -97,12 +97,12 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
                 Serverless.Debug("samplingPriority not found");
 
                 var samplingDecision = tracer.TracerManager.Sampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                span.Context.TraceContext?.SetSamplingPriority(samplingDecision);
+                span.TraceContext?.SetSamplingPriority(samplingDecision);
             }
             else
             {
                 Serverless.Debug($"setting the placeholder sampling priority to = {samplingPriority}");
-                span.Context.TraceContext?.SetSamplingPriority(Convert.ToInt32(samplingPriority), notifyDistributedTracer: false);
+                span.TraceContext?.SetSamplingPriority(Convert.ToInt32(samplingPriority), notifyDistributedTracer: false);
             }
 
             return tracer.TracerManager.ScopeManager.Activate(span, false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
                 request.Headers.Set(HttpHeaderNames.TraceId, scope.Span.TraceId.ToString());
                 request.Headers.Set(HttpHeaderNames.SpanId, scope.Span.SpanId.ToString());
 
-                if (scope.Span.Context.TraceContext?.SamplingPriority is { } samplingPriority)
+                if (scope.Span.TraceContext?.SamplingPriority is { } samplingPriority)
                 {
                     request.Headers.Set(HttpHeaderNames.SamplingPriority, samplingPriority.ToString());
                 }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -300,7 +300,7 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             // Create a child span for the MVC action
             var mvcSpanTags = new AspNetCoreMvcTags();
-            var mvcScope = tracer.StartActiveInternal(MvcOperationName, parentSpan.Context, tags: mvcSpanTags);
+            var mvcScope = tracer.StartActiveInternal(MvcOperationName, parentSpan.GetContext(), tags: mvcSpanTags);
             var span = mvcScope.Span;
             span.Type = SpanTypes.Web;
 
@@ -563,7 +563,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (Iast.Iast.Instance.Settings.Enabled)
                 {
-                    span.Context?.TraceContext?.IastRequestContext?.AddRequestData(httpContext.Request, routeValues);
+                    span?.TraceContext?.IastRequestContext?.AddRequestData(httpContext.Request, routeValues);
                 }
             }
         }
@@ -608,7 +608,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (shouldUseIast)
                 {
-                    parentSpan.Context?.TraceContext?.IastRequestContext?.AddRequestData(request, typedArg.RouteData?.Values);
+                    parentSpan.TraceContext?.IastRequestContext?.AddRequestData(request, typedArg.RouteData?.Values);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -50,7 +50,7 @@ internal class IastModule
             return null;
         }
 
-        var traceContext = (tracer.ActiveScope as Scope)?.Span?.Context?.TraceContext;
+        var traceContext = (tracer.ActiveScope as Scope)?.Span.TraceContext;
         var isRequest = traceContext?.RootSpan?.Type == SpanTypes.Web;
 
         if (isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() != true)

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.PlatformHelpers
             if (Iast.Iast.Instance.Settings.Enabled && OverheadController.Instance.AcquireRequest())
             {
                 // If the overheadController disables the vulnerability detection for this request, we do not initialize the iast context of TraceContext
-                scope.Span.Context?.TraceContext?.EnableIastInRequest();
+                scope.Span.TraceContext?.EnableIastInRequest();
             }
 
             tags.SetAnalyticsSampleRate(_integrationId, tracer.Settings, enabledWithGlobalSetting: true);

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Processors
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L133-L135
-            var traceContext = trace.Array![trace.Offset].Context.TraceContext;
+            var traceContext = trace.Array![trace.Offset].TraceContext;
 
             if (!string.IsNullOrEmpty(traceContext.Environment))
             {
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Processors
             if (span.StartTime < Year2000Time)
             {
                 Log.Debug("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now(): {span}", span);
-                var now = span.Context.TraceContext.UtcNow;
+                var now = span.TraceContext.UtcNow;
                 var start = now - span.Duration;
                 if (start.ToUnixTimeNanoseconds() < 0)
                 {

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Sampling
                 return defaultRate;
             }
 
-            var env = span.Context.TraceContext.Environment;
+            var env = span.TraceContext.Environment;
             var service = span.ServiceName;
 
             var key = new SampleRateKey(service, env);

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ServiceFabric
                     if (messageHeaders != null)
                     {
                         SpanContextPropagator.Instance.Inject(
-                            span.Context,
+                            span.GetContext(),
                             messageHeaders,
                             default(ServiceRemotingRequestMessageHeaderSetter));
                     }

--- a/tracer/src/Datadog.Trace/Span.ISpan.cs
+++ b/tracer/src/Datadog.Trace/Span.ISpan.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace
         ulong ISpan.SpanId => SpanId;
 
         /// <inheritdoc />
-        ISpanContext ISpan.Context => Context;
+        ISpanContext ISpan.Context => _context;
 
         /// <inheritdoc />
         ISpan ISpan.SetTag(string key, string value) => SetTag(key, value);

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace
         private static readonly bool IsLogLevelDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
 
         private readonly object _lock = new();
+        private readonly SpanContext _context;
 
         internal Span(SpanContext context, DateTimeOffset? start)
             : this(context, start, null)
@@ -34,9 +35,9 @@ namespace Datadog.Trace
 
         internal Span(SpanContext context, DateTimeOffset? start, ITags tags)
         {
-            Tags = tags ?? new CommonTags();
-            Context = context;
+            _context = context;
             StartTime = start ?? Context.TraceContext.UtcNow;
+            Tags = tags ?? new CommonTags();
 
             if (IsLogLevelDebugEnabled)
             {
@@ -102,7 +103,7 @@ namespace Datadog.Trace
 
         internal ITags Tags { get; set; }
 
-        internal SpanContext Context { get; }
+        internal SpanContext Context => _context;
 
         internal DateTimeOffset StartTime { get; private set; }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Globalization;
-using System.Security.Cryptography;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
@@ -26,7 +25,7 @@ namespace Datadog.Trace
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Span>();
         private static readonly bool IsLogLevelDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         internal Span(SpanContext context, DateTimeOffset? start)
             : this(context, start, null)
@@ -47,7 +46,7 @@ namespace Datadog.Trace
                     "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type: [{tagsType}])",
                     new object[] { SpanId, Context.ParentId, TraceId, Tags, tagsType });
             }
-         }
+        }
 
         /// <summary>
         /// Gets or sets operation name

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -114,8 +114,6 @@ namespace Datadog.Trace
 
         internal ITags Tags { get; set; }
 
-        internal SpanContext Context => _context;
-
         internal DateTimeOffset StartTime { get; private set; }
 
         internal TimeSpan Duration { get; private set; }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Globalization;
+using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
@@ -49,6 +50,8 @@ namespace Datadog.Trace
             }
         }
 
+        internal TraceContext TraceContext => _context.TraceContext;
+
         /// <summary>
         /// Gets or sets operation name
         /// </summary>
@@ -90,6 +93,14 @@ namespace Datadog.Trace
         /// </summary>
         internal ulong SpanId => _context.SpanId;
 
+        internal ulong? ParentId => _context.Parent?.SpanId;
+
+        internal string RawTraceId => _context.RawTraceId;
+
+        internal string RawSpanId => _context.RawSpanId;
+
+        internal ISpanContext Parent => _context.Parent;
+
         /// <summary>
         /// Gets <i>local root span id</i>, i.e. the <c>SpanId</c> of the span that is the root of the local, non-reentrant
         /// sub-operation of the distributed operation that is represented by the trace that contains this span.
@@ -110,6 +121,8 @@ namespace Datadog.Trace
         internal TimeSpan Duration { get; private set; }
 
         internal bool IsFinished { get; private set; }
+
+        internal PathwayContext? PathwayContext => _context.PathwayContext;
 
         internal bool IsRootSpan => _context.TraceContext?.RootSpan == this;
 
@@ -461,5 +474,19 @@ namespace Datadog.Trace
         {
             Duration = duration;
         }
+
+        /// <summary>
+        /// Sets a DataStreams checkpoint
+        /// </summary>
+        /// <param name="manager">The <see cref="DataStreamsManager"/> to use</param>
+        /// <param name="edgeTags">The edge tags for this checkpoint. NOTE: These MUST be sorted alphabetically</param>
+        internal void SetCheckpoint(DataStreamsManager manager, string[] edgeTags) => _context.SetCheckpoint(manager, edgeTags);
+
+        /// <summary>
+        /// Merges two DataStreams <see cref="PathwayContext"/>
+        /// Should be called when a pathway context is extracted from an incoming span
+        /// Used to merge contexts in a "fan in" scenario.
+        /// </summary>
+        internal void MergePathwayContext(PathwayContext? pathwayContext) => _context.MergePathwayContext(pathwayContext);
     }
 }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -149,6 +149,8 @@ namespace Datadog.Trace
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
+        internal SpanContext GetContext() => _context;
+
         /// <summary>
         /// Add a the specified tag to this span.
         /// </summary>

--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace
             TraceContext traceContext = null;
             if (span is Span spanClass)
             {
-                traceContext = spanClass.Context.TraceContext;
+                traceContext = spanClass.TraceContext;
             }
 
             Action<string, string> setTag =

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -181,7 +181,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the active span context dictionary by consulting DistributedTracer.Instance
         /// </summary>
-        internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.Context;
+        internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.GetContext();
 
         /// <summary>
         /// Gets the active scope
@@ -341,7 +341,7 @@ namespace Datadog.Trace
         internal SpanContext CreateSpanContext(ISpanContext parent = null, string serviceName = null, ulong? traceId = null, ulong? spanId = null, string rawTraceId = null, string rawSpanId = null)
         {
             // null parent means use the currently active span
-            parent ??= DistributedTracer.Instance.GetSpanContext() ?? TracerManager.ScopeManager.Active?.Span?.Context;
+            parent ??= DistributedTracer.Instance.GetSpanContext() ?? TracerManager.ScopeManager.Active?.Span?.GetContext();
 
             TraceContext traceContext;
 

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -15,6 +15,6 @@ namespace Datadog.Trace.Util
             ((id * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace) =>
-            trace.Array![trace.Offset].Context.TraceContext?.SamplingPriority > 0;
+            trace.Array![trace.Offset].TraceContext?.SamplingPriority > 0;
     }
 }


### PR DESCRIPTION
## Summary of changes

- remove `Span.Context` property
- replace most uses of `Span.Context` with the corresponding `Span` property
- where a `SpanContext` is required (mostly propagation), replace `Span.Context` with `Span.GetContext()`

After this transition, it will be much easier to remove the `SpanContext` instances from each `Span`, and only create them when required for propagation.

## Reason for change

(copied from previous PR)

The goal is to stop creating a `SpanContext` instance for every `Span` and to have a better separation between the concepts of "local span" and "propagated context." This should make it easier to work with these core tracer types and reduce the amount of heap allocations per span considerably.

We are breaking this refactoring project into several PRs:

1. #3599
2. (this PR) #3600
3. Refactor `Span` creation so it doesn't require a `SpanContext` anymore, but can optionally use one as its parent (this is public API and can't be removed for now). Remove `Span._context` field.
4. Add a new `internal readonly struct PropagatedSpanContext` alternative to `SpanContext`, used to hold values during trace propagation. Update propagators to use this type instead of `SpanContext`.

...

10. (breaking change) mark `ISpanContext` and `SpanContext` as deprecated (v3?) and remove them (v4?)

## Implementation details

## Test coverage

## Other details

Follows from #3599
