### PR TITLE
Update global.json to pin to the only supported version of the SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "allowPrerelease": true
+    "version": "7.0.100",
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
## Summary of changes

Updates the `global.json` file to pin to a specific version of the .NET SDK

## Reason for change

_sigh_ Gather round children, for I have a story to tell&hellip;

Many moons ago (~50 days) Microsoft released a shiny new version of .NET, .NET 7. However, as part of that release, they subtly changed the way things built when using x64/x86, which broke our (frustratingly convoluted) build. This led [to hacky workarounds](https://github.com/DataDog/dd-trace-dotnet/blame/62195aaf8b3a07b5d5f27135c9949a0677074056/tracer/build/_build/Build.Steps.cs#L1053-L1056):

```csharp
// Including this apparently breaks the integration tests when running against with the .NET 7 SDK
// as dotnet test doesn't look in the right folder. No, I don't understand it either
// .SetTargetPlatform(TargetPlatform)
.SetTargetPlatformAnyCPU()
```

Well, in 7.0.101, they reverted the broken behaviour. Which means the hack I made now _breaks_ the build, so I need to revert it. Our current Nuke build _works_ on `7.0.100`, and _fails_ on `7.0.101`.

_However_, I can't just fix and bump the SDK version in CI because of the way the VMs are shared between runs. As our builds are incompatible, this would lead to random failures, depending whether you got a clean VM (no SDK installed) or a used VM (could be either version installed).

So&hellip;

Pinning to a _specific_ version of the `global.json` means we can update the SDK in CI safely without breaking everyone's build. The downside is that you must have _this exact version_ installed to build locally.

## Implementation details

Pinned to a specific version in the `global.json`.

## Test coverage

If it builds in CI :shipit: 

## Other details
I'll do a subsequent PR to update to 7.0.101 and fix the build
