### PR TITLE
Bump SDK to 7.0.101 and fix build

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -7,7 +7,7 @@ pr:
 
 # Global variables
 variables:
-  dotnetCoreSdkLatestVersion: 7.0.100
+  dotnetCoreSdkLatestVersion: 7.0.101
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])] # required by update-github-status
   TargetBranch: $[variables['System.PullRequest.TargetBranch']]
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4130,6 +4130,7 @@ stages:
       dd_agent: dd_agent
 
     steps:
+    - template: steps/install-latest-dotnet-sdk.yml
     - bash: dotnet run $(Build.BuildId)
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -95,7 +95,7 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdkLatestVersion: 7.0.100
+  dotnetCoreSdkLatestVersion: 7.0.101
   relativeArtifacts: /tracer/src/bin/artifacts
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts

--- a/.github/actions/run-in-docker/action.yml
+++ b/.github/actions/run-in-docker/action.yml
@@ -13,7 +13,7 @@ runs:
       shell: bash
       run: |
         docker build \
-          --build-arg DOTNETSDK_VERSION=7.0.100 \
+          --build-arg DOTNETSDK_VERSION=7.0.101 \
           --tag dd-trace-dotnet/debian-builder \
           --target builder \
           --file "${GITHUB_WORKSPACE}/tracer/build/_build/docker/debian.dockerfile" \

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Check Snapshots"
         run: ./tracer/build.sh SummaryOfSnapshotChanges

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Add labels"
         run: ./tracer/build.sh AssignLabelsToPullRequest

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Bump Version"
         id: versions

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Bump Version"
         id: versions

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -175,6 +175,11 @@ jobs:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3
 
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            7.0.101
+
       - name: Download profiler artifact
         uses: actions/download-artifact@v3
         with:
@@ -231,6 +236,11 @@ jobs:
     steps:
       - name: Install libasan
         run: sudo apt-get install -y libasan6
+
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            7.0.101
 
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3
@@ -291,6 +301,11 @@ jobs:
     steps:
       - name: Install libubsan
         run: sudo apt-get install -y libubsan1
+
+      - uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: |
+            7.0.101
 
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -93,7 +93,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
 
       - name: Download profiler artifact
         uses: actions/download-artifact@v3
@@ -360,7 +360,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
         
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -416,7 +416,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
     
       - name: Support longpaths
         run: git config --system core.longpaths true
@@ -504,7 +504,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
     
       - name: Install Datadog agent
         continue-on-error: false
@@ -595,7 +595,7 @@ jobs:
         with:
           dotnet-version: |
             6.0.100
-            7.0.100
+            7.0.101
 
       - name: Install Datadog agent
         continue-on-error: false
@@ -707,7 +707,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
     
       - name: Install Datadog agent
         continue-on-error: false
@@ -739,7 +739,7 @@ jobs:
           dotnet-version: |
             3.1.x
             6.0.100
-            7.0.100
+            7.0.101
 
       - name: Build Monitoring home
         run: .\tracer\build.cmd BuildTracerHome BuildNativeLoader --build-configuration ${{matrix.configuration}} --target-platform ${{matrix.platform}}

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 GeneratePackageVersions

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Removing existing generated files"
         run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '7.0.100'
+          dotnet-version: '7.0.101'
 
       - name: "Regenerate docs/span_metadata.md"
         run: .\tracer\build.ps1 GenerateSpanDocumentation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
     volumes:
@@ -363,7 +363,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -450,7 +450,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage --targetplatform x64
     volumes:
@@ -498,7 +498,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --filter Category=Lambda --code-coverage
     volumes:
@@ -550,7 +550,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-centos7}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
     command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -620,7 +620,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:
@@ -708,7 +708,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.100}
+        - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests --framework ${framework:-netcoreapp3.1} --targetplatform x64
     volumes:

--- a/docs/development/CI/RunSmokeTestsLocally.md
+++ b/docs/development/CI/RunSmokeTestsLocally.md
@@ -16,7 +16,7 @@ Then run the following
 docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
 # build the smoke test docker image (using the artifacts)
-docker-compose build --build-arg DOTNETSDK_VERSION=7.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim --build-arg PUBLISH_FRAMEWORK=net6.0 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
+docker-compose build --build-arg DOTNETSDK_VERSION=7.0.101 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim --build-arg PUBLISH_FRAMEWORK=net6.0 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
 
 # start the test-agent (you may get an error on Windows, just ignore it)
 docker-compose run --rm start-test-agent
@@ -43,7 +43,7 @@ To test and update the .NET Core 2.1 snapshots, use the following steps instead
 docker pull ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
 
 # build the .NET Core 2.1 smoke test docker image (using the artifacts)
-docker-compose build --build-arg DOTNETSDK_VERSION=7.0.100 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:2.1-bionic --build-arg PUBLISH_FRAMEWORK=netcoreapp2.1 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
+docker-compose build --build-arg DOTNETSDK_VERSION=7.0.101 --build-arg RUNTIME_IMAGE=mcr.microsoft.com/dotnet/aspnet:2.1-bionic --build-arg PUBLISH_FRAMEWORK=netcoreapp2.1 --build-arg INSTALL_CMD="dpkg -i ./datadog-dotnet-apm*_amd64.deb" smoke-tests
 
 # start the test-agent (you may get an error on Windows, just ignore it)
 docker-compose run --rm start-test-agent

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.101",
     "rollForward": "disable"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "7.0.101",
-    "rollForward": "disable"
+    "rollForward": "patch"
   }
 }

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -820,6 +820,7 @@ partial class Build
         .Executes(() =>
         {
             DotnetBuild(TracerDirectory.GlobFiles("src/**/Datadog.InstrumentedAssembly*.csproj"), noDependencies: false);
+            DotnetBuild(TracerDirectory.GlobFiles("src/**/Datadog.InstrumentedAssembly*.csproj"), noDependencies: false, platform: TargetPlatform);
         });
 
     Target CompileManagedTestHelpers => _ => _
@@ -1056,7 +1057,7 @@ partial class Build
         .Requires(() => MonitoringHomeDirectory != null)
         .Executes(() =>
         {
-            DotnetBuild(Solution.GetProject(Projects.DebuggerIntegrationTests), framework: Framework);
+            DotnetBuild(Solution.GetProject(Projects.DebuggerIntegrationTests), framework: Framework, platform: TargetPlatform);
         });
 
     Target CompileDebuggerIntegrationTestsDependencies => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -830,8 +830,16 @@ partial class Build
         .Executes(() =>
         {
             //we need to build in this exact order
-            DotnetBuild(TracerDirectory.GlobFiles("test/**/*TestHelpers.csproj"));
-            DotnetBuild(TracerDirectory.GlobFiles("test/**/*TestHelpers.AutoInstrumentation.csproj"));
+            var helperLibs = TracerDirectory.GlobFiles("test/**/*TestHelpers.csproj");
+            var autoHelperLibs = TracerDirectory.GlobFiles("test/**/*TestHelpers.AutoInstrumentation.csproj");
+            DotnetBuild(helperLibs);
+            DotnetBuild(autoHelperLibs);
+            
+            // we need to build the platform-specific versions because the integration tests
+            // currently target x64/x86
+            DotnetBuild(helperLibs, platform: TargetPlatform);
+            DotnetBuild(autoHelperLibs, platform: TargetPlatform);
+            
         });
 
     Target CompileManagedUnitTests => _ => _
@@ -1043,7 +1051,7 @@ partial class Build
                     .Where(project => Solution.GetProject(project).GetTargetFrameworks().Contains(Framework))
                 ;
 
-            DotnetBuild(projects, framework: Framework);
+            DotnetBuild(projects, framework: Framework, platform: TargetPlatform);
         });
 
     Target CompileDebuggerIntegrationTests => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1035,7 +1035,7 @@ partial class Build
             if (!Framework.ToString().StartsWith("net46"))
             {
                 // we need to build RazorPages before integration tests for .net46x
-                DotnetBuild(Solution.GetProject(Projects.RazorPages), framework: Framework);
+                DotnetBuild(Solution.GetProject(Projects.RazorPages), framework: Framework, platform: TargetPlatform);
             }
 
             var projects = TracerDirectory

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -667,8 +667,8 @@ partial class Build
                 $"src/**/bin/{BuildConfiguration}",
                 $"src/Datadog.Trace.Tools.Runner/obj/{BuildConfiguration}",
                 $"src/Datadog.Trace.Tools.Runner/bin/{BuildConfiguration}",
-                $"test/Datadog.Trace.TestHelpers/**/obj/{BuildConfiguration}",
-                $"test/Datadog.Trace.TestHelpers/**/bin/{BuildConfiguration}",
+                $"test/Datadog.Trace.TestHelpers*/**/obj/{BuildConfiguration}",
+                $"test/Datadog.Trace.TestHelpers*/**/bin/{BuildConfiguration}",
                 $"test/test-applications/integrations/dependency-libs/**/bin/{BuildConfiguration}"
             );
 
@@ -830,16 +830,8 @@ partial class Build
         .Executes(() =>
         {
             //we need to build in this exact order
-            var helperLibs = TracerDirectory.GlobFiles("test/**/*TestHelpers.csproj");
-            var autoHelperLibs = TracerDirectory.GlobFiles("test/**/*TestHelpers.AutoInstrumentation.csproj");
-            DotnetBuild(helperLibs);
-            DotnetBuild(autoHelperLibs);
-            
-            // we need to build the platform-specific versions because the integration tests
-            // currently target x64/x86
-            DotnetBuild(helperLibs, platform: TargetPlatform);
-            DotnetBuild(autoHelperLibs, platform: TargetPlatform);
-            
+            DotnetBuild(TracerDirectory.GlobFiles("test/**/*TestHelpers.csproj"));
+            DotnetBuild(TracerDirectory.GlobFiles("test/**/*TestHelpers.AutoInstrumentation.csproj"));
         });
 
     Target CompileManagedUnitTests => _ => _
@@ -847,6 +839,7 @@ partial class Build
         .After(Restore)
         .After(CompileManagedSrc)
         .After(BuildRunnerTool)
+        .After(CreatePlatformlessSymlinks)
         .DependsOn(CopyNativeFilesForAppSecUnitTests)
         .DependsOn(CompileManagedTestHelpers)
         .Executes(() =>

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -184,6 +184,7 @@ partial class Build : NukeBuild
         .After(Clean, BuildTracerHome, BuildProfilerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(BuildRunnerTool)
+        .DependsOn(CreatePlatformlessSymlinks)
         .DependsOn(CompileManagedUnitTests)
         .DependsOn(RunManagedUnitTests);
 

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -3,8 +3,8 @@ FROM ${BASE_IMAGE}
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # VS Build tool link found from https://learn.microsoft.com/en-gb/visualstudio/releases/2022/release-history#release-dates-and-build-numbers
-ENV DOTNET_VERSION="7.0.100" \
-    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5b9d1f0d-9c56-4bef-b950-c1b439489b27/b4aa387715207faa618a99e9b2dd4e35/dotnet-sdk-7.0.100-win-x64.exe" \
+ENV DOTNET_VERSION="7.0.101" \
+    DOTNET_DOWNLOAD_URL="https://download.visualstudio.microsoft.com/download/pr/5b9d1f0d-9c56-4bef-b950-c1b439489b27/b4aa387715207faa618a99e9b2dd4e35/dotnet-sdk-7.0.101-win-x64.exe" \
     DOTNET_SHA512="32dceb94ca6b2445ec39802d7bb962e2d389801609ffb6706925539380fcb9c9ed75b932daae734ea8d5189d34c956494f50648d3dc3e292392607360bb47f35" \
     VSBUILDTOOLS_VERSION="17.4.33110.190" \
     VSBUILDTOOLS_SHA256="FABDA7E422ADA90C229262A4447C08933EC5BF66A9F38129CD19490EEA2DD180" \

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -12,7 +12,7 @@ $BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME="dd-trace-dotnet/alpine-base"
 
 &docker build `
-   --build-arg DOTNETSDK_VERSION=7.0.100 `
+   --build-arg DOTNETSDK_VERSION=7.0.101 `
    --tag $IMAGE_NAME `
    --file "$BUILD_DIR/docker/alpine.dockerfile" `
    "$BUILD_DIR"

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=7.0.100 \
+   --build-arg DOTNETSDK_VERSION=7.0.101 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/centos7.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
## Summary of changes

Bump SDK to 7.0.101 and fix build

## Reason for change

7.0.100 contained a change in build behaviour, which broke our build, as described in #3601. This PR updates the SDK, and reverts the behaviour to fix the build

## Implementation details

- Find and replace `7.0.100` -> `7.0.101`
- Explicitly build integration tests and helper for x86/x64 again

## Test coverage

If it builds, I think we're ok

## Other details
Once this is merged, I'll fix the docker image cache on the linux vmss
