### PR TITLE
[CI Visibility] Remove stdout output from debug level in the CoverageCollector

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using Datadog.Trace.Ci.Configuration;
@@ -29,6 +30,7 @@ namespace Datadog.Trace.Coverage.Collector
         private DataCollectionEvents? _events;
         private CIVisibilitySettings? _ciVisibilitySettings;
         private string? _tracerHome;
+        private int _testNumber;
 
         /// <inheritdoc />
         public override void Initialize(XmlElement configurationElement, DataCollectionEvents events, DataCollectionSink dataSink, DataCollectionLogger logger, DataCollectionEnvironmentContext environmentContext)
@@ -48,7 +50,7 @@ namespace Datadog.Trace.Coverage.Collector
                 };
                 events.TestCaseStart += (sender, args) =>
                 {
-                    _logger?.Debug($"Test case start: {args.TestCaseName}");
+                    _logger?.Debug($"Test case start [{Interlocked.Increment(ref _testNumber)}]: {args.TestCaseName}");
                 };
                 events.TestCaseEnd += (sender, args) =>
                 {

--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -72,7 +72,6 @@ namespace Datadog.Trace.Coverage.Collector
         {
             if (_isDebugEnabled)
             {
-                _logger.LogWarning(_collectionContext, text ?? string.Empty);
                 _datadogLogger.Debug(text);
             }
         }


### PR DESCRIPTION
## Summary of changes

This PR remove the debug logs from the collector standard output, these debug logs will be written in the log file.

## Reason for change

Currently we are writing all logs to the collector logger (standard output) (at least 2 log lines for each test), this introduces latency, and also there's a race condition in the last test because the collector logger requires a `DataCollectionContext` that is disposed at the end of the last test by the Test sdk, this PR fixes the race condition.
