### PR TITLE
Fix Remote Configuration Service Name not being sent as lower-case + added more DEBUG-level logging 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1969,7 +1969,12 @@ stages:
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
 - stage: integration_tests_arm64_debugger
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsDebuggerChanged'], 'True')
+    )
   dependsOn: [package_arm64, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -35,7 +35,7 @@ partial class Build : NukeBuild
                 GenerateConditionVariableBasedOnGitChange("isTracerChanged", new[] { "tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation", "tracer/src/Datadog.Tracer.Native" }, new string[] {  });
                 GenerateConditionVariableBasedOnGitChange("isDebuggerChanged", new[]
                 {
-                    "tracer/src/Datadog.Trace/Debugger/Instrumentation", 
+                    "tracer/src/Datadog.Trace/Debugger",
                     "tracer/src/Datadog.Tracer.Native", 
                     "tracer/test/Datadog.Trace.Debugger.IntegrationTests",
                     "tracer/test/test-applications/debugger",

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -373,7 +373,7 @@ namespace Datadog.Trace.ClrProfiler
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
                         var tags = GetTags(tracer, rcmSettings);
 
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, TraceUtil.NormalizeTag(tracer.Settings.Environment), tracer.Settings.ServiceVersion, tags);
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, TraceUtil.NormalizeTag(tracer.Settings.Environment), TraceUtil.NormalizeTag(tracer.Settings.ServiceVersion), tags);
                         // see comment above
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmFeaturesProduct);
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmDataProduct);
@@ -397,25 +397,25 @@ namespace Datadog.Trace.ClrProfiler
         {
             var tags = tracer.Settings.GlobalTags?.Select(pair => pair.Key + ":" + pair.Value).ToList() ?? new List<string>();
 
-            var environment = tracer.Settings.Environment;
+            var environment = TraceUtil.NormalizeTag(tracer.Settings.Environment);
             if (!string.IsNullOrEmpty(environment))
             {
                 tags.Add($"env:{environment}");
             }
 
-            var serviceVersion = tracer.Settings.ServiceVersion;
+            var serviceVersion = TraceUtil.NormalizeTag(tracer.Settings.ServiceVersion);
             if (!string.IsNullOrEmpty(serviceVersion))
             {
                 tags.Add($"version:{serviceVersion}");
             }
 
-            var tracerVersion = rcmSettings.TracerVersion;
+            var tracerVersion = TraceUtil.NormalizeTag(rcmSettings.TracerVersion);
             if (!string.IsNullOrEmpty(tracerVersion))
             {
                 tags.Add($"tracer_version:{tracerVersion}");
             }
 
-            var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
+            var hostName = TraceUtil.NormalizeTag(PlatformHelpers.HostMetadata.Instance?.Hostname);
             if (!string.IsNullOrEmpty(hostName))
             {
                 tags.Add($"host_name:{hostName}");

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -19,6 +19,7 @@ using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Processors;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RemoteConfigurationManagement.Transport;
 using Datadog.Trace.ServiceFabric;
@@ -176,7 +177,7 @@ namespace Datadog.Trace.ClrProfiler
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, e.Message);
+                    Log.Error(e, "Failed to initialize Remote Configuration Management.");
                 }
 
                 try
@@ -357,7 +358,7 @@ namespace Datadog.Trace.ClrProfiler
         private static void InitRemoteConfigurationManagement(Tracer tracer)
         {
             // Service Name must be lowercase, otherwise the agent will not be able to find the service
-            var serviceName = (tracer.Settings.ServiceName ?? tracer.DefaultServiceName).ToLowerInvariant();
+            var serviceName = TraceUtil.NormalizeTag(tracer.Settings.ServiceName ?? tracer.DefaultServiceName);
             var discoveryService = tracer.TracerManager.DiscoveryService;
 
             Task.Run(
@@ -372,7 +373,7 @@ namespace Datadog.Trace.ClrProfiler
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
                         var tags = GetTags(tracer, rcmSettings);
 
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, tracer.Settings.Environment, tracer.Settings.ServiceVersion, tags);
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, TraceUtil.NormalizeTag(tracer.Settings.Environment), tracer.Settings.ServiceVersion, tags);
                         // see comment above
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmFeaturesProduct);
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmDataProduct);

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -356,7 +356,8 @@ namespace Datadog.Trace.ClrProfiler
 
         private static void InitRemoteConfigurationManagement(Tracer tracer)
         {
-            var serviceName = tracer.Settings.ServiceName ?? tracer.DefaultServiceName;
+            // Service Name must be lowercase, otherwise the agent will not be able to find the service
+            var serviceName = (tracer.Settings.ServiceName ?? tracer.DefaultServiceName).ToLowerInvariant();
             var discoveryService = tracer.TracerManager.DiscoveryService;
 
             Task.Run(

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -100,11 +100,11 @@ namespace Datadog.Trace.Debugger
             try
             {
                 Log.Information("Live Debugger initialization started");
-
+                Product.ConfigChanged += (sender, args) => AcceptConfiguration(args);
                 _remoteConfigurationManager.RegisterProduct(Product);
 
                 DebuggerSnapshotSerializer.SetConfig(_settings);
-                Product.ConfigChanged += (sender, args) => AcceptConfiguration(args);
+
                 AppDomain.CurrentDomain.AssemblyLoad += (sender, args) => CheckUnboundProbes();
 
                 await StartAsync().ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Product.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Product.cs
@@ -42,12 +42,12 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 }
             }
 
-            Log.Debug(
+            Log.Debug<int, string, int>(
                 "Received {ConfigsAmount} Remote Configuration records for product {Name}, " +
                       "of which {FilteredAmount} matched the predicate.",
-                changedConfigs.Count.ToString(),
+                changedConfigs.Count,
                 Name,
-                (filteredConfigs?.Count ?? 0).ToString());
+                filteredConfigs?.Count ?? 0);
 
             if (filteredConfigs is not null)
             {

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Product.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Product.cs
@@ -42,6 +42,13 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 }
             }
 
+            Log.Debug(
+                "Received {ConfigsAmount} Remote Configuration records for product {Name}, " +
+                      "of which {FilteredAmount} matched the predicate.",
+                changedConfigs.Count.ToString(),
+                Name,
+                (filteredConfigs?.Count ?? 0).ToString());
+
             if (filteredConfigs is not null)
             {
                 var e = new ProductConfigChangedEventArgs(filteredConfigs);
@@ -53,6 +60,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 {
                     foreach (var item in filteredConfigs)
                     {
+                        Log.Debug(ex, "Failed to apply Remote Configuration record {RecordName} for product {ProductName}", item.Name, Name);
                         e.Error(item.Name, ex.Message);
                     }
                 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -6,10 +6,8 @@
 #nullable enable
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -19,6 +17,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.RemoteConfigurationManagement.Transport;
 using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
@@ -229,6 +228,14 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         private void ProcessResponse(GetRcmResponse response, IDictionary<string, Product> products)
         {
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                string description = response.TargetFiles.Count > 0 ?
+                                        "with the following paths: " + string.Join(",", response.TargetFiles.Select(t => t.Path)) :
+                                        "that is empty.";
+                Log.Debug("Received Remote Configuration response {ResponseDescription}.", description);
+            }
+
             var actualConfigPath =
                 response
                    .ClientConfigs

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
             var apiRequest = _apiRequestFactory.Create(uri);
 
             var requestContent = JsonConvert.SerializeObject(request);
+            Log.Debug("Sending Remote Configuration Request: {Content}", requestContent);
             var bytes = Encoding.UTF8.GetBytes(requestContent);
             var payload = new ArraySegment<byte>(bytes);
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
@@ -76,7 +76,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -131,6 +131,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericClass.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericClass.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "AsyncGenericClass+NestedAsyncGenericClass`1+<Method>d__0`1.MoveNext(generic=Generic, input=.RunAsync): NestedAsyncGenericClass.RunAsync.Method\r\n@return=NestedAsyncGenericClass.RunAsync.Method, output=NestedAsyncGenericClass.RunAsync.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericMethod.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "AsyncGenericMethod+<Method>d__2`1.MoveNext(input=.RunAsync, obj=AsyncWithGenericMethod): AsyncWithGenericMethod.RunAsync.Method\r\n@return=AsyncWithGenericMethod.RunAsync.Method, output=AsyncWithGenericMethod.RunAsync.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
@@ -146,6 +146,6 @@
       "version": "2"
     },
     "message": "AsyncGenericMethodWithLineProbeTest+NestedAsyncGenericStruct`1+<Method>d__2`1.MoveNext(generic=Generic, input=.RunAsync, this=NestedAsyncGenericStruct`1)\r\noutput=NestedAsyncGenericStruct.RunAsync.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncGenericStruct.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "AsyncGenericStruct+NestedAsyncGenericStruct`1+<Method>d__0`1.MoveNext(generic=Generic, input=.RunAsync): NestedAsyncGenericStruct.RunAsync.Method\r\n@return=NestedAsyncGenericStruct.RunAsync.Method, output=NestedAsyncGenericStruct.RunAsync.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -68,7 +68,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -119,6 +119,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
@@ -462,7 +462,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -557,7 +557,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -652,7 +652,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -747,7 +747,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -843,7 +843,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -998,7 +998,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1258,7 +1258,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1512,7 +1512,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1766,7 +1766,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -2020,6 +2020,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInGenericClassTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInGenericClassTest.verified.txt
@@ -43,6 +43,6 @@
       "version": "2"
     },
     "message": "GenericClass`1+<Run>d__0.MoveNext()\r\ndef=null",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -115,6 +115,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -123,7 +123,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -186,6 +186,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticMethod.verified.txt
@@ -68,6 +68,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
@@ -51,6 +51,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
@@ -46,7 +46,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -101,6 +101,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
@@ -213,6 +213,6 @@
       "version": "2"
     },
     "message": "AsyncWithGenericArgumentAndLocal+NestedAsyncGenericClass`1+<Method>d__6.MoveNext(generic=NestedAsyncGenericClass`1, input=.RunAsync): AsyncWithGenericArgumentAndLocal.RunAsync.Hello.MethodSamples.Probes.Shared.Generic - Array\r\n@return=AsyncWithGenericArgumentAndLocal.RunAsync.Hello.MethodSamples.Probes.Shared.Generic - Array, list=count: 1, output=AsyncWithGenericArgumentAndLocal.RunAsync.Hello.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
@@ -42,7 +42,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -87,7 +87,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -132,6 +132,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CtorTransparentCodeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CtorTransparentCodeTest.verified.txt
@@ -70,6 +70,6 @@
       "version": "2"
     },
     "message": "CtorTransparentCodeTest.Run()\r\ninstance=SecurityTransparentTest",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CtorTransparentCodeTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.CtorTransparentCodeTest_#1..verified.txt
@@ -79,6 +79,6 @@
       "version": "2"
     },
     "message": "CtorTransparentCodeTest.Run(this=CtorTransparentCodeTest)\r\ninstance=SecurityTransparentTest",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.EmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.EmptyCtorTest.verified.txt
@@ -56,6 +56,6 @@
       "version": "2"
     },
     "message": ".ctor()",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -98,7 +98,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -199,7 +199,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -300,7 +300,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -402,7 +402,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -563,7 +563,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -829,7 +829,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1095,7 +1095,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1361,7 +1361,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1627,7 +1627,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -1893,7 +1893,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -2159,6 +2159,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -180,7 +180,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -289,6 +289,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
@@ -90,6 +90,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
@@ -72,6 +72,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
@@ -92,6 +92,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
@@ -464,6 +464,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
@@ -472,6 +472,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -76,7 +76,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -127,7 +127,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -178,7 +178,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -239,6 +239,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
@@ -64,6 +64,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
@@ -102,6 +102,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -109,6 +109,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
@@ -58,6 +58,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
@@ -68,7 +68,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -131,7 +131,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -194,7 +194,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -257,6 +257,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -123,7 +123,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -186,7 +186,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -249,7 +249,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -312,6 +312,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -123,7 +123,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -186,7 +186,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -249,6 +249,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
@@ -60,6 +60,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -123,7 +123,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -186,6 +186,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -82,7 +82,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -143,6 +143,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
@@ -52,7 +52,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -107,7 +107,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -162,7 +162,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -217,6 +217,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
@@ -246,6 +246,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
@@ -54,7 +54,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -103,7 +103,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -152,7 +152,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -201,7 +201,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -250,7 +250,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -299,6 +299,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NonEmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NonEmptyCtorTest.verified.txt
@@ -120,6 +120,6 @@
       "version": "2"
     },
     "message": ".ctor()",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -60,7 +60,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -123,7 +123,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -174,7 +174,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -225,7 +225,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -276,7 +276,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -327,7 +327,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -378,7 +378,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -427,7 +427,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -476,6 +476,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
@@ -112,6 +112,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
@@ -72,7 +72,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -139,7 +139,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -484,7 +484,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -547,7 +547,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -694,7 +694,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -757,7 +757,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -820,7 +820,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -893,7 +893,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -956,6 +956,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
@@ -84,6 +84,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
@@ -52,7 +52,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -97,6 +97,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
@@ -72,7 +72,7 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "dd.span_id": "ScrubbedValue",
@@ -127,6 +127,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticVoidMethod.verified.txt
@@ -46,6 +46,6 @@
       "version": "2"
     },
     "message": "ScrubbedValue",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.EmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.EmptyCtorTest.verified.txt
@@ -56,6 +56,6 @@
       "version": "2"
     },
     "message": ".ctor()",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.NonEmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.NonEmptyCtorTest.verified.txt
@@ -396,6 +396,6 @@
       "version": "2"
     },
     "message": ".ctor()",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncCallChain.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncCallChain.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericClass.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericClass.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethod.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericMethodWithLineProbeTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -25,6 +25,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncGenericStruct.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,7 +21,7 @@
       }
     },
     "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -33,7 +33,7 @@
       }
     },
     "message": "Installed probe 31d232fd-e292-63a1-cfc5-f0e71d98afd1.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -57,7 +57,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -69,7 +69,7 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -81,7 +81,7 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -93,7 +93,7 @@
       }
     },
     "message": "Installed probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -105,7 +105,7 @@
       }
     },
     "message": "Installed probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -117,6 +117,6 @@
       }
     },
     "message": "Installed probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncMethodInGenericClassTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncMethodInGenericClassTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncRecursiveCall.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncRecursiveCall.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncStaticMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncStaticMethod.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncThrowException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncThrowException.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncVoid.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncVoid.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncWithGenericArgumentAndLocal.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ByRefLikeTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -29,7 +29,7 @@
       }
     },
     "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -57,7 +57,7 @@
       }
     },
     "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -69,7 +69,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -81,6 +81,6 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CtorTransparentCodeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CtorTransparentCodeTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -25,6 +25,6 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CtorTransparentCodeTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.CtorTransparentCodeTest_#1..verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -25,6 +25,6 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.EmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.EmptyCtorTest.verified.txt
@@ -13,6 +13,6 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 03da93fa-95b1-4bbc-89e2-6c29cb8f1744.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -29,7 +29,7 @@
       }
     },
     "message": "Error installing probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Error installing probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -61,7 +61,7 @@
       }
     },
     "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -77,7 +77,7 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -89,7 +89,7 @@
       }
     },
     "message": "Installed probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -101,7 +101,7 @@
       }
     },
     "message": "Installed probe 23827d5e-fc78-6898-4039-dec54409f8c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -113,7 +113,7 @@
       }
     },
     "message": "Installed probe 31d232fd-e292-63a1-cfc5-f0e71d98afd1.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -125,7 +125,7 @@
       }
     },
     "message": "Installed probe 35543785-ac9a-85ea-44af-13938dff3136.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -137,7 +137,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -149,7 +149,7 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -161,7 +161,7 @@
       }
     },
     "message": "Installed probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -173,7 +173,7 @@
       }
     },
     "message": "Installed probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -185,7 +185,7 @@
       }
     },
     "message": "Installed probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -197,7 +197,7 @@
       }
     },
     "message": "Installed probe d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -209,6 +209,6 @@
       }
     },
     "message": "Installed probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericInnerValueTypeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericInnerValueTypeTest.verified.txt
@@ -13,6 +13,6 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GenericRefReturnTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -25,6 +25,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasArgumentsAndLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasArgumentsAndLocals.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasFieldLazyValueInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasFieldLazyValueInitialized.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalListOfObjects.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalListOfObjects.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,7 +21,7 @@
       }
     },
     "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -33,7 +33,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,6 +45,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasReturnValue.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasVarAndMvar.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.HasVarAndMvar.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.InstanceMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.InstanceMethodWithArguments.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.InstanceVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.InstanceVoidMethod.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,7 +21,7 @@
       }
     },
     "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -33,7 +33,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,6 +45,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 31d232fd-e292-63a1-cfc5-f0e71d98afd1.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,7 +21,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -33,7 +33,7 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Installed probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -57,6 +57,6 @@
       }
     },
     "message": "Installed probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#6..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LineProbesWithRevertTest_#6..verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 35543785-ac9a-85ea-44af-13938dff3136.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultidimensionalArrayTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultidimensionalArrayTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultipleLineProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.MultipleLineProbes.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,7 +21,7 @@
       }
     },
     "message": "Installed probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -33,7 +33,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -57,7 +57,7 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -69,6 +69,6 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonEmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonEmptyCtorTest.verified.txt
@@ -13,6 +13,6 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonSupportedInstrumentationTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NonSupportedInstrumentationTest.verified.txt
@@ -13,6 +13,6 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -13,7 +13,7 @@
       }
     },
     "message": "Error installing probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -29,7 +29,7 @@
       }
     },
     "message": "Error installing probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -45,7 +45,7 @@
       }
     },
     "message": "Error installing probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -61,7 +61,7 @@
       }
     },
     "message": "Error installing probe 35543785-ac9a-85ea-44af-13938dff3136.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -77,7 +77,7 @@
       }
     },
     "message": "Error installing probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -93,7 +93,7 @@
       }
     },
     "message": "Error installing probe d1bf6b7f-7fae-6c5f-3c28-d47a96e0ad70.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -105,7 +105,7 @@
       }
     },
     "message": "Installed probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -117,7 +117,7 @@
       }
     },
     "message": "Installed probe 23827d5e-fc78-6898-4039-dec54409f8c4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -129,7 +129,7 @@
       }
     },
     "message": "Installed probe 31d232fd-e292-63a1-cfc5-f0e71d98afd1.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -141,7 +141,7 @@
       }
     },
     "message": "Installed probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -153,7 +153,7 @@
       }
     },
     "message": "Installed probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -165,7 +165,7 @@
       }
     },
     "message": "Installed probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -177,7 +177,7 @@
       }
     },
     "message": "Installed probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -189,7 +189,7 @@
       }
     },
     "message": "Installed probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -201,6 +201,6 @@
       }
     },
     "message": "Installed probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleNestedTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleNestedTypeNameTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleTypeNameTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticMethodWithArguments.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticType.verified.txt
@@ -9,7 +9,7 @@
       }
     },
     "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "Probes"
+    "service": "probes"
   },
   {
     "ddsource": "dd_debugger",
@@ -21,6 +21,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.StaticVoidMethod.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.EmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.EmptyCtorTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.NonEmptyCtorTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbesTests.MethodProbeTest_testType=Samples.Probes.SmokeTests.NonEmptyCtorTest.verified.txt
@@ -9,6 +9,6 @@
       }
     },
     "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
-    "service": "Probes"
+    "service": "probes"
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -39,6 +39,7 @@ public class ProbesTests : TestHelper
         : base("Probes", Path.Combine("test", "test-applications", "debugger"), output)
     {
         SetServiceVersion("1.0.0");
+        EnableDebugMode();
     }
 
     public static IEnumerable<object[]> ProbeTests()
@@ -512,7 +513,7 @@ public class ProbesTests : TestHelper
         var probeConfiguration = new ProbeConfiguration { Id = Guid.Empty.ToString(), SnapshotProbes = snapshotProbes };
         var configurations = new List<(object Config, string Id)>
         {
-            new(probeConfiguration, EnvironmentHelper.SampleName.ToUUID())
+            new(probeConfiguration, EnvironmentHelper.SampleName.ToLowerInvariant().ToUUID())
         };
 
         agent.SetupRcm(Output, configurations, LiveDebuggerProduct.ProductName);


### PR DESCRIPTION
## Summary of changes

1. Fix issue where a customer could not get the Dynamic Instrumentation beta to work, since the tracer did not receive any configurations. The root cause of this issue was that when we makes requests to `datadog-agent`'s Remote Configuration endpoint (`/0.7/config`) we do not normalize the service name to be lowercase, [unlike we do in the Java tracer](https://github.com/DataDog/dd-trace-java/blob/dd965263e69bc9822caa9be9292a1dfed6c56c1a/remote-config/src/main/java/datadog/remoteconfig/PollerRequestFactory.java#L43). As it turns out, our backend expects to receive this value normalized, and therefore any customer that had uppercase characters in the service name would not receive configurations.
**_Note_:** Starting with the yet-to-be-released `datadog-agent v7.42`, we will also be normalizing the service name and environment we report to Remote Configuration Management [in the agent](https://github.com/DataDog/datadog-agent/pull/13843), in the same way we're already doing this for APM spans. Therefore, this fix is only required when working against earlier versions of `datadog-agent`.

3. Added some more DEBUG-level logging for the flow of sending and receiving Remote Configuration requests, including writing out the contents of the `GetRcmRequest` to the log, and the paths of the configuration records that were returned.
Also, until now if an exception occurred while deserializing or processing configuration occurred, we would report it to our backend, but we neglected to actually write it to our log. This was addressed as well.

## Reason for change
Without this fix, Remote Configuration did not behave correctly when the Service Name contained capital letters. 

Moreover, we are starting to onboard more customers to beta products that utilize Remote Configuration Management, and it can be incredibly difficult to diagnose issues where configuration is missing or not getting applied for a specific customer, so the additional logging should come in handy.