### PR TITLE
[Debugger] Run integrations tests with different debug type and optimizations

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -954,7 +954,7 @@ stages:
     
     - template: steps/restore-working-directory.yml
 
-    - script: tracer\build.cmd BuildAndRunDebuggerIntegrationTests -Framework $(framework) --code-coverage
+    - script: tracer\build.cmd BuildAndRunDebuggerIntegrationTests -Framework $(framework) --TargetPlatform $(targetPlatform) --DebugType $(debugType) --Optimize $(optimize) --code-coverage
       displayName: Run integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1648,7 +1648,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64"
+        command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
         apikey: $(DD_LOGGER_DD_API_KEY)
 
     - task: DownloadPipelineArtifact@2
@@ -1973,9 +1973,6 @@ stages:
   dependsOn: [package_arm64, generate_variables, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
-    TestAllPackageVersions: true
-    IncludeMinorPackageVersions: $[eq(variables.perform_comprehensive_testing, 'true')]
-    baseImage: debian
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -1985,13 +1982,8 @@ stages:
     - job: Test
       timeoutInMinutes: 60 #default value
       strategy:
-        matrix:
-          net5_0:
-            publishTargetFramework: net5.0
-          net6_0:
-            publishTargetFramework: net6.0
-          net7_0:
-            publishTargetFramework: net7.0
+        matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_arm64_debugger_matrix']]
+
       workspace:
         clean: all
       pool:
@@ -2010,7 +2002,7 @@ stages:
           parameters:
             build: true
             baseImage: $(baseImage)
-            command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64"
+            command: "BuildDebuggerIntegrationTests --framework $(publishTargetFramework) --targetplatform x64 --debugtype portable --optimize $(optimize)"
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
         - task: DownloadPipelineArtifact@2

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -14,6 +14,12 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 partial class Build
 {
+    [Parameter("Specifies the type of debugging information that should be included in the compiled assembly. Used for debugger integrations tests", List = false)]
+    readonly string DebugType;
+
+    [Parameter("Optimize generated code. Used for debugger integrations tests", List = false)]
+    readonly bool? Optimize;
+
     TargetFramework[] TestingFrameworksDebugger =>
         TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NETSTANDARD2_0, TargetFramework.NETCOREAPP3_0, TargetFramework.NET5_0 });
 
@@ -23,9 +29,20 @@ partial class Build
 
     Project DebuggerSamplesTestRuns => Solution.GetProject(Projects.DebuggerSamplesTestRuns);
 
+    Target BuildAndRunDebuggerIntegrationTests => _ => _
+        .Description("Builds and runs the debugger integration tests")
+        .DependsOn(BuildDebuggerIntegrationTests)
+        .DependsOn(RunDebuggerIntegrationTests);
+
+    Target BuildDebuggerIntegrationTests => _ => _
+        .Unlisted()
+        .Description("Builds the debugger integration tests")
+        .DependsOn(CompileDebuggerIntegrationTests);
+
     Target CompileDebuggerIntegrationTests => _ => _
         .Unlisted()
         .After(CompileManagedSrc)
+        .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CompileDebuggerIntegrationTestsDependencies)
         .DependsOn(CompileDebuggerIntegrationTestsSamples)
         .Requires(() => Framework)

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -1,0 +1,120 @@
+using Nuke.Common;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using static Nuke.Common.EnvironmentInfo;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.Tools.DotNet.DotNetTasks;
+
+// #pragma warning disable SA1306
+// #pragma warning disable SA1134
+// #pragma warning disable SA1111
+// #pragma warning disable SA1400
+// #pragma warning disable SA1401
+
+partial class Build
+{
+    TargetFramework[] TestingFrameworksDebugger =>
+        TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NETSTANDARD2_0, TargetFramework.NETCOREAPP3_0, TargetFramework.NET5_0 });
+
+    Project DebuggerIntegrationTests => Solution.GetProject(Projects.DebuggerIntegrationTests);
+
+    Project DebuggerSamples => Solution.GetProject(Projects.DebuggerSamples);
+
+    Project DebuggerSamplesTestRuns => Solution.GetProject(Projects.DebuggerSamplesTestRuns);
+
+    Target CompileDebuggerIntegrationTests => _ => _
+        .Unlisted()
+        .After(CompileManagedSrc)
+        .DependsOn(CompileDebuggerIntegrationTestsDependencies)
+        .DependsOn(CompileDebuggerIntegrationTestsSamples)
+        .Requires(() => Framework)
+        .Requires(() => MonitoringHomeDirectory != null)
+        .Executes(() =>
+        {
+            DotnetBuild(DebuggerIntegrationTests, framework: Framework);
+        });
+
+    Target CompileDebuggerIntegrationTestsDependencies => _ => _
+        .Unlisted()
+        .Requires(() => Framework)
+        .Requires(() => MonitoringHomeDirectory != null)
+        .Requires(() => Optimize != null)
+        .Requires(() => DebugType != null)
+        .Executes(() =>
+        {
+            // we need to compile DebuggerSamplesTestRuns in AnyCPU and TargetPlatform
+            DotnetBuild(DebuggerSamplesTestRuns, framework: Framework, noDependencies: false);
+            DotnetBuild(DebuggerSamplesTestRuns, platform: TargetPlatform, framework: Framework, noDependencies: false);
+        });
+
+    Target CompileDebuggerIntegrationTestsSamples => _ => _
+        .Unlisted()
+        .DependsOn(CompileDebuggerIntegrationTestsDependencies)
+        .Requires(() => Framework)
+        .Requires(() => MonitoringHomeDirectory != null)
+        .Requires(() => Optimize != null)
+        .Requires(() => DebugType != null)
+        .Executes(() =>
+        {
+            DotnetBuild(DebuggerSamples, platform: TargetPlatform, framework: Framework);
+
+            if (!IsWin)
+            {
+                // The sample helper in the test library assumes that the sample has 
+                // been published when running on Linux
+                DotNetPublish(x => x
+                    .SetFramework(Framework)
+                    .SetConfiguration(BuildConfiguration)
+                    .SetNoWarnDotNetCore3()
+                    .SetProject(DebuggerSamples));
+            }
+        });
+
+    Target RunDebuggerIntegrationTests => _ => _
+        .Unlisted()
+        .After(BuildTracerHome)
+        .After(BuildDebuggerIntegrationTests)
+        .Requires(() => Framework)
+        .Triggers(PrintSnapshotsDiff)
+        .Executes(() =>
+        {
+            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureResultsDirectory(DebuggerIntegrationTests);
+
+            try
+            {
+                DotNetTest(config => config
+                    .SetDotnetPath(TargetPlatform)
+                    .SetConfiguration(BuildConfiguration)
+                    .SetTargetPlatform(TargetPlatform)
+                    .SetFramework(Framework)
+                    .EnableCrashDumps()
+                    .EnableNoRestore()
+                    .EnableNoBuild()
+                    .SetFilter(GetTestFilter())
+                    .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
+                    .SetLogsDirectory(TestLogsDirectory)
+                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .EnableTrxLogOutput(GetResultsDirectory(DebuggerIntegrationTests))
+                    .WithDatadogLogger()
+                    .SetProjectFile(DebuggerIntegrationTests));
+
+                string GetTestFilter()
+                {
+                    var filter = (IsWin, IsArm64) switch
+                    {
+                        (true, _) => "(RunOnWindows=True)",
+                        (_, true) => "(Category!=ArmUnsupported)",
+                        _ => "(Category!=LinuxUnsupported)",
+                    };
+
+                    return Filter is null ? filter : $"{Filter}&{filter}";
+                }
+            }
+            finally
+            {
+                CopyDumpsToBuildData();
+            }
+        });
+}

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -233,7 +233,7 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsDebuggerLinuxMatrix()
             {
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462 });
-                var baseImages = new[] { "debian" };
+                var baseImages = new[] { "centos7", "alpine" };
                 var optimizations = new[] { "true", "false" };
 
                 var matrix = new Dictionary<string, object>();
@@ -990,8 +990,8 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsDebuggerArm64Matrices()
             {
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462, TargetFramework.NETCOREAPP3_1,  });
-                var baseImages = new[] { "centos7", "alpine" };
-                var optimizations = new[] { "True", "False" };
+                var baseImages = new[] { "debian" };
+                var optimizations = new[] { "true", "false" };
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -989,7 +989,7 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsDebuggerArm64Matrices()
             {
-                var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462, TargetFramework.NETCOREAPP3_1,  });
+                var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462, TargetFramework.NETCOREAPP2_1, TargetFramework.NETCOREAPP3_1,  });
                 var baseImages = new[] { "debian" };
                 var optimizations = new[] { "true", "false" };
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -87,28 +87,22 @@ partial class Build : NukeBuild
     [Parameter("Should we build and run tests against _all_ target frameworks, or just the reduced set. Defaults to true locally, false in PRs, and true in CI on main branch only", List = false)]
     readonly bool IncludeAllTestFrameworks = true;
 
-    [Parameter("Specifies the type of debugging information that should be included in the compiled assembly. Used for debugger integrations tests", List = false)]
-    readonly string DebugType;
-
-    [Parameter("Optimize generated code. Used for debugger integrations tests", List = false)]
-    readonly bool? Optimize;
-
     Target Info => _ => _
-        .Description("Describes the current configuration")
-        .Before(Clean, Restore, BuildTracerHome)
-        .Executes(() =>
-        {
-            Logger.Info($"Configuration: {BuildConfiguration}");
-            Logger.Info($"Platform: {TargetPlatform}");
-            Logger.Info($"Framework: {Framework}");
-            Logger.Info($"TestAllPackageVersions: {TestAllPackageVersions}");
-            Logger.Info($"MonitoringHomeDirectory: {MonitoringHomeDirectory}");
-            Logger.Info($"ArtifactsDirectory: {ArtifactsDirectory}");
-            Logger.Info($"NugetPackageDirectory: {NugetPackageDirectory}");
-            Logger.Info($"IncludeAllTestFrameworks: {IncludeAllTestFrameworks}");
-            Logger.Info($"IsAlpine: {IsAlpine}");
-            Logger.Info($"Version: {Version}");
-        });
+                       .Description("Describes the current configuration")
+                       .Before(Clean, Restore, BuildTracerHome)
+                       .Executes(() =>
+                        {
+                            Logger.Info($"Configuration: {BuildConfiguration}");
+                            Logger.Info($"Platform: {TargetPlatform}");
+                            Logger.Info($"Framework: {Framework}");
+                            Logger.Info($"TestAllPackageVersions: {TestAllPackageVersions}");
+                            Logger.Info($"MonitoringHomeDirectory: {MonitoringHomeDirectory}");
+                            Logger.Info($"ArtifactsDirectory: {ArtifactsDirectory}");
+                            Logger.Info($"NugetPackageDirectory: {NugetPackageDirectory}");
+                            Logger.Info($"IncludeAllTestFrameworks: {IncludeAllTestFrameworks}");
+                            Logger.Info($"IsAlpine: {IsAlpine}");
+                            Logger.Info($"Version: {Version}");
+                        });
 
     Target Clean => _ => _
         .Description("Cleans all build output")
@@ -211,12 +205,6 @@ partial class Build : NukeBuild
         .DependsOn(CompileIntegrationTests)
         .DependsOn(BuildRunnerTool);
 
-    Target BuildDebuggerIntegrationTests => _ => _
-        .Unlisted()
-        .Description("Builds the debugger integration tests")
-        .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileDebuggerIntegrationTests);
-
     Target BuildAspNetIntegrationTests => _ => _
         .Unlisted()
         .Requires(() => IsWin)
@@ -243,11 +231,6 @@ partial class Build : NukeBuild
         .Description("Builds and runs the Windows (non-IIS) integration tests")
         .DependsOn(BuildWindowsIntegrationTests)
         .DependsOn(RunWindowsIntegrationTests);
-
-    Target BuildAndRunDebuggerIntegrationTests => _ => _
-        .Description("Builds and runs the debugger integration tests")
-        .DependsOn(BuildDebuggerIntegrationTests)
-        .DependsOn(RunDebuggerIntegrationTests);
 
     Target BuildAndRunWindowsRegressionTests => _ => _
         .Requires(() => IsWin)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -87,6 +87,12 @@ partial class Build : NukeBuild
     [Parameter("Should we build and run tests against _all_ target frameworks, or just the reduced set. Defaults to true locally, false in PRs, and true in CI on main branch only", List = false)]
     readonly bool IncludeAllTestFrameworks = true;
 
+    [Parameter("Specifies the type of debugging information that should be included in the compiled assembly. Used for debugger integrations tests", List = false)]
+    readonly string DebugType;
+
+    [Parameter("Optimize generated code. Used for debugger integrations tests", List = false)]
+    readonly bool? Optimize;
+
     Target Info => _ => _
         .Description("Describes the current configuration")
         .Before(Clean, Restore, BuildTracerHome)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/ProbeTestDescription.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/ProbeTestDescription.cs
@@ -1,0 +1,28 @@
+// <copyright file="ProbeTestDescription.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Debugger.IntegrationTests.Helpers;
+
+public class ProbeTestDescription : IXunitSerializable
+{
+    public bool IsOptimized { get; set; }
+
+    public Type TestType { get; set; }
+
+    public void Deserialize(IXunitSerializationInfo info)
+    {
+        IsOptimized = info.GetValue<bool>(nameof(IsOptimized));
+        TestType = info.GetValue<Type>(nameof(TestType));
+    }
+
+    public void Serialize(IXunitSerializationInfo info)
+    {
+        info.AddValue(nameof(IsOptimized), IsOptimized);
+        info.AddValue(nameof(TestType), TestType);
+    }
+}

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Debugger.IntegrationTests.Assertions;
 using Datadog.Trace.Debugger.IntegrationTests.Helpers;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.TestHelpers;
+using Samples.Probes.TestRuns.SmokeTests;
 using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
@@ -54,10 +55,10 @@ public class LiveDebuggerTests : TestHelper
 
     private async Task RunTest()
     {
-        var testType = DebuggerTestHelper.FirstSupportedProbeTestType(EnvironmentHelper.GetTargetFramework());
+        var testType = DebuggerTestHelper.SpecificTestDescription<AsyncVoid>();
 
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var sample = StartSample(agent, $"--test-name {testType.FullName}", string.Empty, aspNetCorePort: 5000);
+        using var sample = StartSample(agent, $"--test-name {testType.TestType}", string.Empty, aspNetCorePort: 5000);
         using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.ProcessName}*");
         await logEntryWatcher.WaitForLogEntry(LiveDebuggerDisabledLogEntry);
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -32,6 +32,25 @@ public class ProbesTests : TestHelper
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
     private const string ProbesInstrumentedLogEntry = "Live Debugger.InstrumentProbes: Request to instrument probes definitions completed.";
 
+    private static readonly Type[] _unoptimizedNotSupportedTypes = new[]
+    {
+        typeof(AsyncCallChain),
+        typeof(AsyncGenericClass),
+        typeof(AsyncGenericMethodWithLineProbeTest),
+        typeof(AsyncGenericStruct),
+        typeof(AsyncInstanceMethod),
+        typeof(AsyncLineProbeWithFieldsArgsAndLocalsTest),
+        typeof(AsyncMethodInsideTaskRun),
+        typeof(AsyncRecursiveCall),
+        typeof(AsyncStaticMethod),
+        typeof(AsyncThrowException),
+        typeof(AsyncVoid),
+        typeof(AsyncWithGenericArgumentAndLocal),
+        typeof(HasLocalsAndReturnValue),
+        typeof(MultipleLineProbes),
+        typeof(NotSupportedFailureTest)
+    };
+
     private readonly string[] _typesToScrub = { nameof(IntPtr), nameof(Guid) };
     private readonly string[] _knownPropertiesToReplace = { "duration", "timestamp", "dd.span_id", "dd.trace_id", "id", "lineNumber", "thread_name", "thread_id", "<>t__builder", "s_taskIdCounter", "<>u__1", "stack" };
 
@@ -43,7 +62,7 @@ public class ProbesTests : TestHelper
 
     public static IEnumerable<object[]> ProbeTests()
     {
-        return DebuggerTestHelper.AllProbeTestTypes();
+        return DebuggerTestHelper.AllTestDescriptions();
     }
 
     [SkippableFact]
@@ -53,7 +72,7 @@ public class ProbesTests : TestHelper
     {
         Skip.If(true, "Not supported yet. Internal Jira Ticket: #DEBUG-1092.");
 
-        var testType = typeof(AsyncMethodInGenericClassTest);
+        var testDescription = DebuggerTestHelper.SpecificTestDescription<AsyncMethodInGenericClassTest>();
         const int expectedNumberOfSnapshots = 1;
 
         var guidGenerator = new DeterministicGuidGenerator();
@@ -63,7 +82,7 @@ public class ProbesTests : TestHelper
             CreateProbe("GenericClass`1", "Run", guidGenerator)
         };
 
-        await RunSingleTestWithApprovals(testType, isMultiPhase: false, expectedNumberOfSnapshots, probes);
+        await RunSingleTestWithApprovals(testDescription, expectedNumberOfSnapshots, probes);
     }
 
     [SkippableFact(Skip = "Too flakey")]
@@ -71,7 +90,7 @@ public class ProbesTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task TransparentCodeCtorInstrumentationTest()
     {
-        var testType = typeof(CtorTransparentCodeTest);
+        var testDescription = DebuggerTestHelper.SpecificTestDescription<CtorTransparentCodeTest>();
         const int expectedNumberOfSnapshots = 1;
 
         var guidGenerator = new DeterministicGuidGenerator();
@@ -82,25 +101,25 @@ public class ProbesTests : TestHelper
             CreateProbe("CtorTransparentCodeTest", "Run", guidGenerator)
         };
 
-        await RunSingleTestWithApprovals(testType, isMultiPhase: false, expectedNumberOfSnapshots, probes);
+        await RunSingleTestWithApprovals(testDescription, expectedNumberOfSnapshots, probes);
     }
 
-    [SkippableTheory]
+    [SkippableFact]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
-    [InlineData(typeof(OverloadAndSimpleNameTest))]
-    public async Task InstallAndUninstallMethodProbeWithOverloadsTest(Type testType)
+    public async Task InstallAndUninstallMethodProbeWithOverloadsTest()
     {
+        var testDescription = DebuggerTestHelper.SpecificTestDescription<OverloadAndSimpleNameTest>();
         const int expectedNumberOfSnapshots = 9;
 
-        var probes = GetProbeConfiguration(testType, true, new DeterministicGuidGenerator());
+        var probes = GetProbeConfiguration(testDescription.TestType, true, new DeterministicGuidGenerator());
 
         if (probes.Length != 1)
         {
             throw new InvalidOperationException($"{nameof(InstallAndUninstallMethodProbeWithOverloadsTest)} expected one probe request to exist, but found {probes.Length} probes.");
         }
 
-        await RunSingleTestWithApprovals(testType, isMultiPhase: true, expectedNumberOfSnapshots, probes.Select(p => p.Probe).ToArray());
+        await RunSingleTestWithApprovals(testDescription, expectedNumberOfSnapshots, probes.Select(p => p.Probe).ToArray());
     }
 
     [Fact]
@@ -108,14 +127,14 @@ public class ProbesTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task LineProbeEmit100SnapshotsTest()
     {
-        var testType = typeof(Emit100LineProbeSnapshotsTest);
+        var testDescription = DebuggerTestHelper.SpecificTestDescription<Emit100LineProbeSnapshotsTest>();
         const int expectedNumberOfSnapshots = 100;
 
-        var probes = GetProbeConfiguration(testType, true, new DeterministicGuidGenerator());
+        var probes = GetProbeConfiguration(testDescription.TestType, true, new DeterministicGuidGenerator());
 
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
+        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
@@ -151,10 +170,10 @@ public class ProbesTests : TestHelper
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
     [MemberData(nameof(ProbeTests))]
-    public async Task MethodProbeTest(Type testType)
+    public async Task MethodProbeTest(ProbeTestDescription testDescription)
     {
-        SkipOverTestIfNeeded(testType);
-        await RunMethodProbeTests(testType);
+        SkipOverTestIfNeeded(testDescription);
+        await RunMethodProbeTests(testDescription);
     }
 
     [SkippableFact]
@@ -169,10 +188,10 @@ public class ProbesTests : TestHelper
             throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
         }
 
-        var testType = DebuggerTestHelper.FirstSupportedProbeTestType(EnvironmentHelper.GetTargetFramework());
+        var testDescription = DebuggerTestHelper.SpecificTestDescription<AsyncGenericMethod>();
         EnvironmentHelper.EnableWindowsNamedPipes();
 
-        await RunMethodProbeTests(testType);
+        await RunMethodProbeTests(testDescription);
     }
 
 #if NETCOREAPP3_1_OR_GREATER
@@ -181,7 +200,7 @@ public class ProbesTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task MethodProbeTest_UDS()
     {
-        var testType = DebuggerTestHelper.FirstSupportedProbeTestType(EnvironmentHelper.GetTargetFramework());
+        var testType = DebuggerTestHelper.SpecificTestDescription<AsyncGenericMethod>();
         EnvironmentHelper.EnableUnixDomainSockets();
 
         await RunMethodProbeTests(testType);
@@ -204,13 +223,13 @@ public class ProbesTests : TestHelper
         };
     }
 
-    private async Task RunMethodProbeTests(Type testType)
+    private async Task RunMethodProbeTests(ProbeTestDescription testDescription)
     {
-        var probes = GetProbeConfiguration(testType, false, new DeterministicGuidGenerator());
+        var probes = GetProbeConfiguration(testDescription.TestType, false, new DeterministicGuidGenerator());
 
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
+        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
@@ -268,7 +287,7 @@ public class ProbesTests : TestHelper
                 {
                     snapshots = await agent.WaitForSnapshots(expectedNumberOfSnapshots);
                     Assert.Equal(expectedNumberOfSnapshots, snapshots?.Length);
-                    await ApproveSnapshots(snapshots, testType, isMultiPhase, phaseNumber);
+                    await ApproveSnapshots(snapshots, testDescription, isMultiPhase, phaseNumber);
                     agent.ClearSnapshots();
                 }
 
@@ -280,7 +299,7 @@ public class ProbesTests : TestHelper
                 var statuses = await agent.WaitForProbesStatuses(probeData.Length);
 
                 Assert.Equal(probeData.Length, statuses?.Length);
-                await ApproveStatuses(statuses, testType, isMultiPhase, phaseNumber);
+                await ApproveStatuses(statuses, testDescription, isMultiPhase, phaseNumber);
                 agent.ClearProbeStatuses();
             }
         }
@@ -290,23 +309,25 @@ public class ProbesTests : TestHelper
         }
     }
 
-    /// <summary>
-    /// Internal Jira Ticket: DEBUG-1092.
-    /// </summary>
-    private void SkipOverTestIfNeeded(Type testType)
+    private void SkipOverTestIfNeeded(ProbeTestDescription testDescription)
     {
-        if (testType == typeof(AsyncInstanceMethod) && !EnvironmentTools.IsWindows())
+        if (testDescription.TestType == typeof(AsyncInstanceMethod) && !EnvironmentTools.IsWindows())
         {
             throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
         }
+
+        if (!testDescription.IsOptimized && _unoptimizedNotSupportedTypes.Contains(testDescription.TestType))
+        {
+            throw new SkipException("Current test is not supported with unoptimized code.");
+        }
     }
 
-    private async Task RunSingleTestWithApprovals(Type testType, bool isMultiPhase, int expectedNumberOfSnapshots, params SnapshotProbe[] probes)
+    private async Task RunSingleTestWithApprovals(ProbeTestDescription testDescription, int expectedNumberOfSnapshots, params SnapshotProbe[] probes)
     {
         using var agent = EnvironmentHelper.GetMockAgent();
 
         SetDebuggerEnvironment(agent);
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testType.FullName);
+        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{sample.Process.ProcessName}*");
@@ -318,12 +339,12 @@ public class ProbesTests : TestHelper
 
             var snapshots = await agent.WaitForSnapshots(expectedNumberOfSnapshots);
             Assert.Equal(expectedNumberOfSnapshots, snapshots?.Length);
-            await ApproveSnapshots(snapshots, testType, isMultiPhase: true, phaseNumber: 1);
+            await ApproveSnapshots(snapshots, testDescription, isMultiPhase: true, phaseNumber: 1);
             agent.ClearSnapshots();
 
             var statuses = await agent.WaitForProbesStatuses(probes.Length);
             Assert.Equal(probes.Length, statuses?.Length);
-            await ApproveStatuses(statuses, testType, isMultiPhase: true, phaseNumber: 1);
+            await ApproveStatuses(statuses, testDescription, isMultiPhase: true, phaseNumber: 1);
             agent.ClearProbeStatuses();
 
             SetProbeConfiguration(agent, Array.Empty<SnapshotProbe>());
@@ -336,17 +357,17 @@ public class ProbesTests : TestHelper
         }
     }
 
-    private async Task ApproveSnapshots(string[] snapshots, Type testType, bool isMultiPhase, int phaseNumber)
+    private async Task ApproveSnapshots(string[] snapshots, ProbeTestDescription testDescription, bool isMultiPhase, int phaseNumber)
     {
-        await ApproveOnDisk(snapshots, testType, isMultiPhase, phaseNumber, "snapshots");
+        await ApproveOnDisk(snapshots, testDescription, isMultiPhase, phaseNumber, "snapshots");
     }
 
-    private async Task ApproveStatuses(string[] statuses, Type testType, bool isMultiPhase, int phaseNumber)
+    private async Task ApproveStatuses(string[] statuses, ProbeTestDescription testDescription, bool isMultiPhase, int phaseNumber)
     {
-        await ApproveOnDisk(statuses, testType, isMultiPhase, phaseNumber, "statuses");
+        await ApproveOnDisk(statuses, testDescription, isMultiPhase, phaseNumber, "statuses");
     }
 
-    private async Task ApproveOnDisk(string[] dataToApprove, Type testType, bool isMultiPhase, int phaseNumber, string path)
+    private async Task ApproveOnDisk(string[] dataToApprove, ProbeTestDescription testDescription, bool isMultiPhase, int phaseNumber, string path)
     {
         if (dataToApprove.Length > 1)
         {
@@ -356,7 +377,7 @@ public class ProbesTests : TestHelper
 
         var settings = new VerifySettings();
 
-        var testName = isMultiPhase ? $"{testType.Name}_#{phaseNumber}." : testType.Name;
+        var testName = isMultiPhase ? $"{testDescription.TestType.Name}_#{phaseNumber}." : testDescription.TestType.Name;
         settings.UseFileName($"{nameof(ProbeTests)}.{testName}");
         settings.DisableRequireUniquePrefix();
         settings.ScrubEmptyLines();

--- a/tracer/test/test-applications/debugger/Directory.Build.props
+++ b/tracer/test/test-applications/debugger/Directory.Build.props
@@ -13,8 +13,10 @@
   <PropertyGroup>
     <Platforms>x64;x86</Platforms>
     <LangVersion>latest</LangVersion>
-    <DebugType>full</DebugType>
+    
+    <DebugType>portable</DebugType>
     <Optimize>True</Optimize>
+    
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NotSupportedFailureTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/NotSupportedFailureTest.cs
@@ -16,7 +16,7 @@ namespace Samples.Probes.TestRuns.SmokeTests
     [LineProbeTestData(50)]
     [LineProbeTestData(57, expectedNumberOfSnapshots: 0)]
     [LineProbeTestData(63)]
-    internal class NotSupportedFailureTest : IRun
+    public class NotSupportedFailureTest : IRun
     {
         public void Run()
         {


### PR DESCRIPTION
## Summary of changes
Run tests with `DebugType` portable/full and optimized/unoptimized code.

## Reason for change
Run integrations tests with different debug type and optimizations
