### PR TITLE
Write throughput results as a PR comment

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4098,30 +4098,28 @@ stages:
       displayName: Download crank_linux_arm64_1
       inputs:
         artifact: crank_linux_arm64_1 #only download the first lot, ignores retries
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_arm64_1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_arm64_1
 
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_linux_x64_1
       inputs:
         artifact: crank_linux_x64_1 #only download the first lot, ignores retries
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_x64_1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_1
 
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_linux_x64_asm_1
       inputs:
         artifact: crank_linux_x64_asm_1 #only download the first lot, ignores retries
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_x64_asm_1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_asm_1
 
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_windows_x64_1
       inputs:
         artifact: crank_windows_x64_1 #only download the first lot, ignores retries
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_windows_x64_1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_windows_x64_1
 
     - script: tracer\build.cmd CompareThroughputResults
-      continueOnError: true
       displayName: Compare Crank results
-      condition: and(succeeded(), eq(variables.isPullRequest, true))
       env:
         PR_NUMBER: $(System.PullRequest.PullRequestNumber)
         AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4076,6 +4076,57 @@ stages:
     - script: tracer\build.cmd CheckSmokeTestsForErrors
       displayName: CheckSmokeTestsForErrors
 
+- stage: compare_throughput
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  dependsOn: [throughput, throughput_appsec, master_commit_id]
+  variables:
+    masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
+  jobs:
+  - job: compare
+    timeoutInMinutes: 60 #default value
+    pool:
+      vmImage: windows-2022
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - template: steps/install-latest-dotnet-sdk.yml
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download crank_linux_arm64_1
+      inputs:
+        artifact: crank_linux_arm64_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_arm64_1
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download crank_linux_x64_1
+      inputs:
+        artifact: crank_linux_x64_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_x64_1
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download crank_linux_x64_asm_1
+      inputs:
+        artifact: crank_linux_x64_asm_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_linux_x64_asm_1
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download crank_windows_x64_1
+      inputs:
+        artifact: crank_windows_x64_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/pr/crank_windows_x64_1
+
+    - script: tracer\build.cmd CompareThroughputResults
+      continueOnError: true
+      displayName: Compare Crank results
+      condition: and(succeeded(), eq(variables.isPullRequest, true))
+      env:
+        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
+
 - stage: trace_pipeline
   condition: eq(variables['isBenchmarksOnlyBuild'], 'False')
   dependsOn:
@@ -4118,6 +4169,7 @@ stages:
     - msi_installer_smoke_tests
     - tracer_home_smoke_tests
     - coverage
+    - compare_throughput
     - system_tests
   jobs:
   - job: build_and_run

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4127,6 +4127,10 @@ stages:
         AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
         GITHUB_TOKEN: $(GITHUB_TOKEN)
 
+    - publish: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/throughput_report.md
+      displayName: Upload report
+      artifact: crank_throughput_report
+
 - stage: trace_pipeline
   condition: eq(variables['isBenchmarksOnlyBuild'], 'False')
   dependsOn:

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1013,6 +1013,9 @@ partial class Build
 
              var markdown = CompareThroughput.GetMarkdown(sources);
 
+             // save the report so we can upload it as an atefact for prosperity
+             await File.WriteAllTextAsync(throughputDir / "throughput_report.md", markdown);
+
              await HideCommentsInPullRequest(prNumber, "## Throughput/Crank Report");
              await PostCommentToPullRequest(prNumber, markdown);
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1003,7 +1003,7 @@ partial class Build
              var oldBenchmarkBuild = await GetCrankArtifacts(buildHttpClient, "refs/heads/benchmarks/2.9.0", oldBenchmarksDir);
              var (newBenchmarkBuild, benchmarkVersion) = await GetCrankArtifactsForLatestBenchmarkBranch(buildHttpClient, latestBenchmarksDir);
              
-             var commitName = isPr ? $"This PR ({PullRequestNumber})" : $"This commit ({testedCommit.Substring(0, 6)})";
+             var commitName = isPr ? $"This PR ({prNumber})" : $"This commit ({testedCommit.Substring(0, 6)})";
              var sources = new List<CrankResultSource>
              {
                  new(commitName, testedCommit, CrankSourceType.CurrentCommit, commitDir),

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -19,6 +19,7 @@ using Nuke.Common.Tools.Git;
 using Octokit;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Model;
+using ThroughputComparison;
 using YamlDotNet.Serialization.NamingConventions;
 using static Nuke.Common.IO.CompressionTasks;
 using static Nuke.Common.IO.FileSystemTasks;
@@ -953,6 +954,121 @@ partial class Build
 
              await HideCommentsInPullRequest(prNumber, "## Benchmarks Report");
              await PostCommentToPullRequest(prNumber, markdown);
+         });
+
+    Target CompareThroughputResults => _ => _
+         .Unlisted()
+         .DependsOn(CreateRequiredDirectories)
+         .Requires(() => AzureDevopsToken)
+         .Requires(() => GitHubRepositoryName)
+         .Requires(() => GitHubToken)
+         .Executes(async () =>
+         {
+             if (!int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber))
+             {
+                 Logger.Warn("No PR_NUMBER variable found. Skipping throughput comparison");
+                 return;
+             }
+
+             var testedCommit = Environment.GetEnvironmentVariable("OriginalCommitId"); 
+             if (string.IsNullOrEmpty(testedCommit))
+             {
+                 Logger.Warn("No OriginalCommitId variable found. Skipping throughput comparison");
+                 return;
+             }
+
+             var throughputDir = BuildDataDirectory / "throughput";
+             var masterDir = throughputDir / "master";
+             var oldBenchmarksDir = throughputDir / "benchmarks_2_9_0";
+             var latestBenchmarksDir = throughputDir / "latest_benchmarks";
+             var prDir = throughputDir / "pr";
+
+             FileSystemTasks.EnsureCleanDirectory(masterDir);
+             FileSystemTasks.EnsureCleanDirectory(oldBenchmarksDir);
+             FileSystemTasks.EnsureCleanDirectory(latestBenchmarksDir);
+
+             // Connect to Azure DevOps Services
+             var connection = new VssConnection(
+                 new Uri(AzureDevopsOrganisation),
+                 new VssBasicCredential(string.Empty, AzureDevopsToken));
+
+             using var buildHttpClient = connection.GetClient<BuildHttpClient>();
+
+             // Grab the comparison artifacts
+             var masterBuild = await GetCrankArtifacts(buildHttpClient, "refs/heads/master", masterDir);
+             var oldBenchmarkBuild = await GetCrankArtifacts(buildHttpClient, "refs/heads/benchmarks/2.9.0", oldBenchmarksDir);
+             var (newBenchmarkBuild, benchmarkVersion) = await GetCrankArtifactsForLatestBenchmarkBranch(buildHttpClient, latestBenchmarksDir);
+             
+             var sources = new List<CrankResultSource>
+             {
+                 new($"This PR ({PullRequestNumber})", testedCommit, CrankSourceType.Pr, prDir),
+                 new("master", masterBuild.SourceVersion, CrankSourceType.Master, masterDir),
+                 new("benchmarks/2.9.0", oldBenchmarkBuild.SourceVersion, CrankSourceType.OldBenchmark, oldBenchmarksDir),
+             };
+
+             if (newBenchmarkBuild is not null && benchmarkVersion is not null)
+             {
+                 sources.Add(new($"benchmarks/{benchmarkVersion}", newBenchmarkBuild.SourceVersion, CrankSourceType.LatestBenchmark, latestBenchmarksDir));
+             }
+
+             var markdown = CompareThroughput.GetMarkdown(sources);
+
+             await HideCommentsInPullRequest(prNumber, "## Throughput/Crank Report");
+             await PostCommentToPullRequest(prNumber, markdown);
+
+             async Task<(Microsoft.TeamFoundation.Build.WebApi.Build, string Version)> GetCrankArtifactsForLatestBenchmarkBranch(BuildHttpClient httpClient, AbsolutePath directory)
+             {
+                 // current (not released version)
+                 var version = new Version(Version);
+                 var versionsToCheck = 3;
+                 while (versionsToCheck > 0)
+                 {
+                     // only looking back across minor releases (ignoring patch etc)
+                     versionsToCheck--;
+                     version = new Version(version.Major, version.Minor - 1, 0);
+
+                     try
+                     {
+                         var thisVersion = $"{version.Major}.{version.Minor}.0";
+                         var build = await GetCrankArtifacts(httpClient, $"refs/heads/benchmarks/{thisVersion}", directory);
+                         return (build, thisVersion);
+                     }
+                     catch (Exception)
+                     {
+                         // if this fails, it's because we have no primary artifacts for that branch
+                         Console.WriteLine($"No artifacts found for version {version}, checking next branch");
+                     }
+                 }
+
+                 Console.WriteLine("No benchmarks found, skipping");
+                 return (null, null);
+             }
+
+             async Task<Microsoft.TeamFoundation.Build.WebApi.Build> GetCrankArtifacts(BuildHttpClient httpClient, string branch, AbsolutePath directory)
+             {
+                 // find the first build with the linux crank results
+                 var (build, _) = await FindAndDownloadAzureArtifact(httpClient, branch, build => "crank_linux_x64_1", directory, buildReason: null);
+
+                 // get all the other artifacts from the same build for consistency
+                 var artifacts = new[] { "crank_linux_arm64_1", "crank_linux_x64_asm_1", "crank_windows_x64_1" };
+                 foreach (var artifactName in artifacts)
+                 {
+                     try
+                     {
+                         var artifact = await httpClient.GetArtifactAsync(
+                                        project: AzureDevopsProjectId,
+                                        buildId: build.Id,
+                                        artifactName: artifactName);
+                         await DownloadAzureArtifact(directory, artifact, AzureDevopsToken);
+                     }
+                     catch (ArtifactNotFoundException)
+                     {
+                         Console.WriteLine($"Could not find {artifactName} artifact for build {build.Id}. Skipping");
+                     }
+                 }
+
+                 return build;
+             }
          });
 
     async Task PostCommentToPullRequest(int prNumber, string markdown)

--- a/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
+++ b/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
@@ -82,12 +82,9 @@ public class CompareThroughput
             Throughput results for AspNetCoreSimpleController comparing the following branches/commits:
             {string.Join('\n', GetSourceMarkdown(sources))}
 
-            Cases where throughput results for the PR are worse than latest master ({(int)((1 - ThresholdForCritical) * 100)}% drop or greater),
-            results are shown in **red**.
-            Note that these results are based on a _single_ point-in-time result for each branch.
-            For full results, see [one](https://ddstaging.datadoghq.com/dashboard/fnz-afi-c2i/apm-net-crank) 
-            of the [many](https://ddstaging.datadoghq.com/dashboard/c5g-i7d-kcy/ciapp-apm-net-throughput-tests),
-            [many](https://ddstaging.datadoghq.com/dashboard/uxh-m8j-qhi/ciapp-apm-net-throughput-tests-kevin) dashboards!
+            Cases where throughput results for the PR are worse than latest master ({(int)((1 - ThresholdForCritical) * 100)}% drop or greater), results are shown in **red**.
+
+            Note that these results are based on a _single_ point-in-time result for each branch. For full results, see [one](https://ddstaging.datadoghq.com/dashboard/fnz-afi-c2i/apm-net-crank) of the [many](https://ddstaging.datadoghq.com/dashboard/c5g-i7d-kcy/ciapp-apm-net-throughput-tests), [many](https://ddstaging.datadoghq.com/dashboard/uxh-m8j-qhi/ciapp-apm-net-throughput-tests-kevin) dashboards!
 
             {string.Join('\n', charts)}
             """;

--- a/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
+++ b/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using Nuke.Common.IO;
+
+namespace ThroughputComparison;
+
+public class CompareThroughput
+{
+    const decimal ThresholdForCritical = 0.95m;
+
+    public static string GetMarkdown(List<CrankResultSource> sources)
+    {
+        var crankResults = sources.SelectMany(ReadJsonResults).ToList();
+
+        // Group crankResults by test suite (result type), then 
+        var charts = crankResults
+                    .GroupBy(x => x.TestSuite)
+                    .Select(group =>
+                     {
+
+                         var scenarios = group
+                                        .Select(x => x)
+                                        .OrderBy(x => x.Scenario)
+                                        .GroupBy(x => x.Scenario)
+                                        .Select(scenarioResults => GetMermaidSection(scenarioResults.Key, scenarioResults));
+                         return $"""
+                        ```mermaid
+                        gantt
+                            title Throughput {GetName(group.Key)} (Total requests) 
+                            dateFormat  X
+                            axisFormat %s
+                        {string.Join(Environment.NewLine, scenarios)}
+                        ```
+                        """;
+                     });
+
+        return GetCommentMarkdown(sources, charts);
+    }
+
+    static string GetMermaidSection(CrankScenario scenario, IEnumerable<CrankResult> results)
+    {
+        const string offset = "    ";
+        var sb = new StringBuilder();
+        sb.Append(offset).Append("section ").AppendLine(GetName(scenario));
+        var orderedResults = results.OrderBy(x => x.Source.SourceType).ToList();
+
+        var threshold = orderedResults
+                       .Where(x => x.Source.SourceType == CrankSourceType.Master)
+                       .Select(x => (long?)(x.Requests * ThresholdForCritical))
+                       .FirstOrDefault();
+
+        foreach (var result in orderedResults)
+        {
+            var formattedRequests = (result.Requests / 1_000_000m).ToString("N3");
+            var format = threshold.HasValue
+                      && result.Source.SourceType == CrankSourceType.Pr
+                      && scenario != CrankScenario.Baseline
+                      && result.Requests <= threshold.Value
+                             ? "crit ,"
+                             : string.Empty;
+            sb.Append(offset).Append(result.Source.BranchName)
+              .Append(" (").Append(formattedRequests).Append("M)   : ")
+              .Append(format).Append("0, ").Append(result.Requests)
+              .AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    private static string GetCommentMarkdown(List<CrankResultSource> sources, IEnumerable<string> charts)
+    {
+        return $"""
+            ## Throughput/Crank Report:zap:
+
+            Throughput results for AspNetCoreSimpleController comparing the following branches/commits:
+            {string.Join('\n', GetSourceMarkdown(sources))}
+
+            Cases where throughput results for the PR are worse than latest master ({(int)((1 - ThresholdForCritical) * 100)}% drop or greater),
+            results are shown in **red**.
+            Note that these results are based on a _single_ point-in-time result for each branch.
+            For full results, see [one](https://ddstaging.datadoghq.com/dashboard/fnz-afi-c2i/apm-net-crank) 
+            of the [many](https://ddstaging.datadoghq.com/dashboard/c5g-i7d-kcy/ciapp-apm-net-throughput-tests),
+            [many](https://ddstaging.datadoghq.com/dashboard/uxh-m8j-qhi/ciapp-apm-net-throughput-tests-kevin) dashboards!
+
+            {string.Join('\n', charts)}
+            """;
+
+        IEnumerable<string> GetSourceMarkdown(List<CrankResultSource> crankResultSources)
+            => crankResultSources.Select(x => $"- {x.Markdown}");
+    }
+
+    private static string GetName(CrankTestSuite source) => source switch
+    {
+        CrankTestSuite.LinuxX64 => "Linux x64",
+        CrankTestSuite.LinuxArm64 => "Linux arm64",
+        CrankTestSuite.WindowsX64 => "Windows x64",
+        CrankTestSuite.ASMLinuxX64 => "Linux x64 (ASM)",
+        _ => throw new NotImplementedException(),
+    };
+
+    private static string GetName(CrankScenario source) => source switch
+    {
+        CrankScenario.Baseline => "Baseline",
+        CrankScenario.Instrumented => "Instrumented",
+        CrankScenario.TraceStats => "Trace stats",
+        CrankScenario.NoAttack => "No attack",
+        CrankScenario.AttackNoBlocking => "Attack",
+        CrankScenario.AttackBlocking => "Blocking",
+        _ => throw new NotImplementedException(),
+    };
+
+    static readonly (string Path, CrankTestSuite Type, (string Filename, CrankScenario Scenario)[] Scenarios)[] ExpectedScenarios =
+    {
+        ("crank_linux_x64_1", CrankTestSuite.LinuxX64, new[] { ("baseline_linux.json", CrankScenario.Baseline), ("calltarget_ngen_linux.json", CrankScenario.Instrumented), ("trace_stats_linux.json", CrankScenario.TraceStats), }
+        ),
+        ("crank_linux_arm64_1", CrankTestSuite.LinuxArm64, new[] { ("baseline_linux_arm64.json", CrankScenario.Baseline), ("calltarget_ngen_linux_arm64.json", CrankScenario.Instrumented), ("trace_stats_linux_arm64.json", CrankScenario.TraceStats), }
+        ),
+        ("crank_windows_x64_1", CrankTestSuite.WindowsX64, new[] { ("baseline_windows.json", CrankScenario.Baseline), ("calltarget_ngen_windows.json", CrankScenario.Instrumented), ("trace_stats_windows.json", CrankScenario.TraceStats), }
+        ),
+        ("crank_linux_x64_asm_1", CrankTestSuite.ASMLinuxX64, new[] { ("appsec_baseline.json", CrankScenario.Baseline), ("appsec_noattack.json", CrankScenario.NoAttack), ("appsec_attack_noblocking.json", CrankScenario.AttackNoBlocking), ("appsec_attack_blocking.json", CrankScenario.AttackBlocking), }
+        ),
+    };
+
+    public static List<CrankResult> ReadJsonResults(CrankResultSource source)
+    {
+        var results = new List<CrankResult>();
+        foreach (var (path, type, scenarios) in ExpectedScenarios)
+        foreach (var (filename, scenario) in scenarios)
+        {
+            var fileName = source.Path / path / filename;
+            try
+            {
+                using var file = File.OpenRead(fileName);
+                var node = JsonNode.Parse(file)!;
+                var requests = (double)node["jobResults"]!["jobs"]!["load"]!["results"]!["bombardier/requests"];
+                results.Add(new(source, type, scenario, (long)requests));
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error reading {fileName}: {ex.Message}. Skipping");
+            }
+        }
+
+        return results;
+    }
+
+    public record CrankResult(CrankResultSource Source, CrankTestSuite TestSuite, CrankScenario Scenario, long Requests);
+
+    public enum CrankTestSuite
+    {
+        LinuxX64,
+        LinuxArm64,
+        WindowsX64,
+        ASMLinuxX64,
+    }
+
+    public enum CrankScenario
+    {
+        Baseline,
+        Instrumented,
+        TraceStats,
+        NoAttack,
+        AttackNoBlocking,
+        AttackBlocking,
+    }
+}
+
+public record CrankResultSource(string BranchName, string CommitSha, CrankSourceType SourceType, AbsolutePath Path)
+{
+    public string Markdown => $"[{BranchName}](https://github.com/DataDog/dd-trace-dotnet/tree/{CommitSha})";
+}
+
+public enum CrankSourceType
+{
+    Pr,
+    Master,
+    LatestBenchmark,
+    OldBenchmark,
+}


### PR DESCRIPTION
## Summary of changes

Posts a summary of the throughput tests for a PR as a comment on GitHub

## Reason for change

We want to make it easier to see regressions in performance, similar to the way we do for code coverage and benchmarks

## Implementation details

We started saving the throughput/crank results as build artifacts in #3581. After this PR, we compare the throughput results for the commit being run against the latest master results, and the latest named benchmark results. We do a simple comparison of number of requests, upload the report as an artifact, and (for PRs) write a comment on GitHub.

Currently this only compares the "total requests" field. We could compare more fields, or do some averaging, but I think this is good enough, and we can always view the dashboards on DD if we need to 

## Test coverage

Ran an individual (non PR) test, and will see the results on this one too

## Other details

The report (and PR comment) will look something like this:

---

## Throughput/Crank Report:zap:

Throughput results for AspNetCoreSimpleController comparing the following branches/commits:
- [This commit (60191c)](https://github.com/DataDog/dd-trace-dotnet/tree/60191c4cc6ec5d9955d427d820c5b2f224bc9c2c)
- [master](https://github.com/DataDog/dd-trace-dotnet/tree/a8abc21d58ea9d91bc0b5b2ba5f9d265f97e41d9)
- [benchmarks/2.9.0](https://github.com/DataDog/dd-trace-dotnet/tree/0d56b1d9f25673f5257b1b7df97a3754d2df63f4)
- [benchmarks/2.21.0](https://github.com/DataDog/dd-trace-dotnet/tree/994d914bd3a83ab18a13a54b2a0907dc1d7e6b86)

Cases where throughput results for the PR are worse than latest master (5% drop or greater), results are shown in **red**.

Note that these results are based on a _single_ point-in-time result for each branch. For full results, see [one](https://ddstaging.datadoghq.com/dashboard/fnz-afi-c2i/apm-net-crank) of the [many](https://ddstaging.datadoghq.com/dashboard/c5g-i7d-kcy/ciapp-apm-net-throughput-tests), [many](https://ddstaging.datadoghq.com/dashboard/uxh-m8j-qhi/ciapp-apm-net-throughput-tests-kevin) dashboards!

```mermaid
gantt
    title Throughput Linux x64 (Total requests) 
    dateFormat  X
    axisFormat %s
    section Baseline
    This commit (60191c) (6.243M)   : 0, 6243213
    master (6.145M)   : 0, 6144635
    benchmarks/2.21.0 (6.245M)   : 0, 6244879
    benchmarks/2.9.0 (6.201M)   : 0, 6200566

    section Instrumented
    This commit (60191c) (4.198M)   : 0, 4198472
    master (4.038M)   : 0, 4038357
    benchmarks/2.21.0 (4.279M)   : 0, 4279078
    benchmarks/2.9.0 (4.423M)   : 0, 4422687

    section Trace stats
    master (4.150M)   : 0, 4150070
    benchmarks/2.21.0 (4.133M)   : 0, 4132576

```
```mermaid
gantt
    title Throughput Linux arm64 (Total requests) 
    dateFormat  X
    axisFormat %s
    section Baseline
    This commit (60191c) (5.156M)   : 0, 5155688
    master (5.598M)   : 0, 5597511
    benchmarks/2.21.0 (5.481M)   : 0, 5481181
    benchmarks/2.9.0 (5.424M)   : 0, 5423903

    section Instrumented
    This commit (60191c) (3.654M)   : 0, 3654052
    master (3.699M)   : 0, 3699122
    benchmarks/2.21.0 (3.925M)   : 0, 3924769

    section Trace stats
    master (3.606M)   : 0, 3605547
    benchmarks/2.21.0 (3.591M)   : 0, 3591431

```
```mermaid
gantt
    title Throughput Windows x64 (Total requests) 
    dateFormat  X
    axisFormat %s
    section Baseline
    This commit (60191c) (5.041M)   : 0, 5041393
    master (5.982M)   : 0, 5981706
    benchmarks/2.21.0 (6.118M)   : 0, 6117965
    benchmarks/2.9.0 (6.197M)   : 0, 6197101

    section Instrumented
    This commit (60191c) (3.915M)   : 0, 3915024
    master (4.062M)   : 0, 4061626
    benchmarks/2.21.0 (4.078M)   : 0, 4077786
    benchmarks/2.9.0 (4.196M)   : 0, 4196298

    section Trace stats
    master (4.125M)   : 0, 4124689
    benchmarks/2.21.0 (4.094M)   : 0, 4094000

```
```mermaid
gantt
    title Throughput Linux x64 (ASM) (Total requests) 
    dateFormat  X
    axisFormat %s
    section Baseline
    This commit (60191c) (3.516M)   : 0, 3516254
    master (3.463M)   : 0, 3462667
    benchmarks/2.21.0 (3.512M)   : 0, 3512411
    benchmarks/2.9.0 (3.643M)   : 0, 3643314

    section No attack
    This commit (60191c) (1.265M)   : 0, 1265018
    master (1.261M)   : 0, 1261202
    benchmarks/2.21.0 (1.266M)   : 0, 1266269
    benchmarks/2.9.0 (1.273M)   : 0, 1272523

    section Attack
    This commit (60191c) (1.088M)   : 0, 1087768
    master (1.080M)   : 0, 1079760
    benchmarks/2.21.0 (1.094M)   : 0, 1094454
    benchmarks/2.9.0 (1.093M)   : 0, 1092875

    section Blocking
    This commit (60191c) (2.125M)   : 0, 2124784
    master (2.106M)   : 0, 2106359
    benchmarks/2.21.0 (2.081M)   : 0, 2081171

```
