### PR TITLE
[tracer] W3C Trace Context part 5: propagate `tracestate` in version-mismatch scenario

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.Propagators
             }
 
             var traceId = ParseUtility.ParseUInt64(carrier, carrierGetter, SpanContext.Keys.TraceId);
+
             if (traceId is null or 0)
             {
                 // a valid traceId is required to use distributed tracing
@@ -36,10 +37,12 @@ namespace Datadog.Trace.Propagators
             var rawTraceId = ParseUtility.ParseString(carrier, carrierGetter, SpanContext.Keys.RawTraceId);
             var rawSpanId = ParseUtility.ParseString(carrier, carrierGetter, SpanContext.Keys.RawSpanId);
             var propagatedTraceTags = ParseUtility.ParseString(carrier, carrierGetter, SpanContext.Keys.PropagatedTags);
+            var w3CTraceState = ParseUtility.ParseString(carrier, carrierGetter, SpanContext.Keys.AdditionalW3CTraceState);
 
             spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId)
                           {
-                              PropagatedTags = propagatedTraceTags
+                              PropagatedTags = propagatedTraceTags,
+                              AdditionalW3CTraceState = w3CTraceState,
                           };
 
             return true;

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -49,9 +49,14 @@ namespace Datadog.Trace.Propagators
                         return _instance;
                     }
 
-                    var distributedContextPropagator = (IContextExtractor)new DistributedContextExtractor();
-                    var datadogPropagator = new DatadogContextPropagator();
-                    _instance ??= new SpanContextPropagator(new[] { datadogPropagator }, new[] { distributedContextPropagator, datadogPropagator });
+                    _instance = new SpanContextPropagator(
+                        new IContextInjector[] { DatadogContextPropagator.Instance },
+                        new IContextExtractor[]
+                        {
+                            DistributedContextExtractor.Instance,
+                            DatadogContextPropagator.Instance
+                        });
+
                     return _instance;
                 }
             }
@@ -60,7 +65,7 @@ namespace Datadog.Trace.Propagators
             {
                 if (value is null)
                 {
-                    ThrowHelper.ThrowArgumentNullException("value");
+                    ThrowHelper.ThrowArgumentNullException(nameof(value));
                 }
 
                 lock (GlobalLock)

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -719,6 +719,12 @@ namespace Datadog.Trace.Propagators
                     break;
             }
 
+            // remove trailing ","
+            if (sb[sb.Length - 1] == TraceStateHeaderValuesSeparator)
+            {
+                sb.Length--;
+            }
+
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace
             Keys.RawTraceId,
             Keys.RawSpanId,
             Keys.PropagatedTags,
+            Keys.AdditionalW3CTraceState,
 
             // For mismatch version support we need to keep supporting old keys.
             HttpHeaderNames.TraceId,
@@ -337,6 +338,11 @@ namespace Datadog.Trace
                     value = TraceContext?.Tags.ToPropagationHeader() ?? PropagatedTags;
                     return true;
 
+                case Keys.AdditionalW3CTraceState:
+                    // return the value from TraceContext if available
+                    value = TraceContext?.AdditionalW3CTraceState ?? AdditionalW3CTraceState;
+                    return true;
+
                 default:
                     value = null;
                     return false;
@@ -392,6 +398,7 @@ namespace Datadog.Trace
             public const string RawTraceId = $"{Prefix}RawTraceId";
             public const string RawSpanId = $"{Prefix}RawSpanId";
             public const string PropagatedTags = $"{Prefix}PropagatedTags";
+            public const string AdditionalW3CTraceState = $"{Prefix}AdditionalW3CTraceState";
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -117,6 +117,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });
@@ -146,6 +148,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -99,6 +99,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "00000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });
@@ -122,6 +124,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "00000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -369,6 +369,10 @@ namespace Datadog.Trace.Tests.Propagators
 
         public ulong SpanId { get; set; }
 
+        public string RawTraceId { get; set; }
+
+        public string RawSpanId { get; set; }
+
         public string Origin { get; set; }
 
         public int? SamplingPriority { get; set; }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -375,6 +375,8 @@ namespace Datadog.Trace.Tests.Propagators
 
         public string PropagatedTags { get; set; }
 
+        public string AdditionalW3CTraceState { get; set; }
+
         public ISpanContext Parent { get; set; }
 
         public ulong? ParentId { get; set; }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Tagging;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -18,10 +19,10 @@ public class DistributedPropagatorTests
     private const ulong SpanId = 2;
     private const int SamplingPriority = SamplingPriorityValues.UserReject;
     private const string Origin = "origin";
-    private const string RawTraceId = "1";
-    private const string RawSpanId = "2";
-    private const string PropagatedTags = "key1=value1;key2=value2";          // note: semicolon separator
-    private const string AdditionalW3CTraceState = "key3=value3,key4=value4"; // note: comma separator
+    private const string RawTraceId = "1a";
+    private const string RawSpanId = "2b";
+    private const string PropagatedTags = "_dd.p.key1=value1,_dd.p.key2=value2";
+    private const string AdditionalW3CTraceState = "key3=value3,key4=value4";
 
     private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
 
@@ -58,7 +59,10 @@ public class DistributedPropagatorTests
     [Fact]
     public void Extract_ReadOnlyDictionary()
     {
+        // set up all key/value pairs
         var headers = SetupMockReadOnlyDictionary();
+
+        // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
         VerifyGetCalls(headers);
@@ -69,6 +73,8 @@ public class DistributedPropagatorTests
                    {
                        TraceId = TraceId,
                        SpanId = SpanId,
+                       RawTraceId = RawTraceId,
+                       RawSpanId = RawSpanId,
                        Origin = Origin,
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTags,
@@ -106,15 +112,32 @@ public class DistributedPropagatorTests
     [Fact]
     public void SpanContextRoundTrip()
     {
-        var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin, RawTraceId, RawSpanId)
-                      {
-                          PropagatedTags = PropagatedTags,
-                          AdditionalW3CTraceState = AdditionalW3CTraceState
-                      };
+        var propagatedTags = new TraceTagCollection(100);
+        propagatedTags.SetTag("_dd.p.key1", "value1");
+        propagatedTags.SetTag("_dd.p.key2", "value2");
 
+        var traceContext = new TraceContext(tracer: null, propagatedTags);
+        traceContext.SetSamplingPriority(SamplingPriority);
+        traceContext.Origin = Origin;
+        traceContext.AdditionalW3CTraceState = AdditionalW3CTraceState;
+
+        // create and populate SpanContext
+        IReadOnlyDictionary<string, string> context = new SpanContext(
+            parent: SpanContext.None,
+            traceContext,
+            serviceName: null,
+            TraceId,
+            SpanId,
+            RawTraceId,
+            RawSpanId);
+
+        // extract SpanContext
         var result = Propagator.Extract(context);
 
+        // they are not the same SpanContext instance...
         result.Should().NotBeSameAs(context);
+
+        // ...but they contain the same values
         result.Should().BeEquivalentTo(context);
     }
 
@@ -122,12 +145,14 @@ public class DistributedPropagatorTests
     [MemberData(nameof(GetInvalidIds))]
     public void Extract_InvalidTraceId(string traceId)
     {
+        // set up all key/value pairs
         var headers = SetupMockReadOnlyDictionary();
 
         // replace TraceId setup
         var value = traceId;
         headers.Setup(h => h.TryGetValue("__DistributedKey-TraceId", out value)).Returns(true);
 
+        // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
         // invalid traceId should return a null context even if other values are set
@@ -138,12 +163,14 @@ public class DistributedPropagatorTests
     [MemberData(nameof(GetInvalidIds))]
     public void Extract_InvalidSpanId(string spanId)
     {
+        // set up all key/value pairs
         var headers = SetupMockReadOnlyDictionary();
 
         // replace ParentId setup
         var value = spanId;
         headers.Setup(h => h.TryGetValue("__DistributedKey-ParentId", out value)).Returns(true);
 
+        // extract SpanContext
         var result = Propagator.Extract(headers.Object);
 
         result.Should()
@@ -153,6 +180,8 @@ public class DistributedPropagatorTests
                        // SpanId has default value
                        TraceId = TraceId,
                        Origin = Origin,
+                       RawTraceId = RawTraceId,
+                       RawSpanId = RawSpanId,
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTags,
                        AdditionalW3CTraceState = AdditionalW3CTraceState
@@ -171,12 +200,14 @@ public class DistributedPropagatorTests
         // even if we don't recognize its value (to allow forward compatibility with newly added values).
         // ignore the extracted sampling priority if it is not a valid integer.
 
+        // set up all key/value pairs
         var headers = SetupMockReadOnlyDictionary();
 
         // replace SamplingPriority setup
         var value = samplingPriority;
         headers.Setup(h => h.TryGetValue("__DistributedKey-SamplingPriority", out value)).Returns(true);
 
+        // extract SpanContext
         object result = Propagator.Extract(headers.Object);
 
         result.Should()
@@ -185,6 +216,8 @@ public class DistributedPropagatorTests
                    {
                        TraceId = TraceId,
                        SpanId = SpanId,
+                       RawTraceId = RawTraceId,
+                       RawSpanId = RawSpanId,
                        Origin = Origin,
                        SamplingPriority = expectedSamplingPriority,
                        PropagatedTags = PropagatedTags,

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
@@ -21,7 +21,7 @@ public class DistributedPropagatorTests
     private const string RawTraceId = "1";
     private const string RawSpanId = "2";
     private const string PropagatedTags = "key1=value1;key2=value2";          // note: semicolon separator
-    private const string AdditionalW3CTraceState = "key3=value3,key3=value3"; // note: comma separator
+    private const string AdditionalW3CTraceState = "key3=value3,key4=value4"; // note: comma separator
 
     private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
 
@@ -106,7 +106,7 @@ public class DistributedPropagatorTests
     [Fact]
     public void SpanContextRoundTrip()
     {
-        var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin)
+        var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin, RawTraceId, RawSpanId)
                       {
                           PropagatedTags = PropagatedTags,
                           AdditionalW3CTraceState = AdditionalW3CTraceState

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -113,6 +113,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });
@@ -134,6 +136,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "00000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });
@@ -160,6 +164,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                        });
@@ -190,6 +196,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -251,6 +251,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",
@@ -284,6 +286,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",
@@ -350,9 +354,12 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = "_dd.p.dm=-4,_dd.p.usr.id=12345",
+                           AdditionalW3CTraceState = "abc=123,foo=bar",
                            Parent = null,
                            ParentId = null,
                        });
@@ -383,6 +390,8 @@ namespace Datadog.Trace.Tests.Propagators
                        {
                            TraceId = 123456789,
                            SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                            Origin = null,
                            PropagatedTags = null,

--- a/tracer/test/Datadog.Trace.Tests/SpanContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Linq;
 using Datadog.Trace.Tagging;
 using FluentAssertions;
 using Xunit;
@@ -44,76 +45,84 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void EnumerateKeys()
         {
+            var expectedKeys = new HashSet<string>
+                               {
+                                   "__DistributedKey-TraceId",
+                                   "__DistributedKey-ParentId",
+                                   "__DistributedKey-SamplingPriority",
+                                   "__DistributedKey-Origin",
+                                   "__DistributedKey-RawTraceId",
+                                   "__DistributedKey-RawSpanId",
+                                   "__DistributedKey-PropagatedTags",
+                                   "__DistributedKey-AdditionalW3CTraceState",
+                                   "x-datadog-trace-id",
+                                   "x-datadog-parent-id",
+                                   "x-datadog-sampling-priority",
+                                   "x-datadog-origin",
+                               };
+
             var context = CreateSpanContext();
+            var actualKeys = context.Keys.ToArray();
 
-            // fail test if new keys are added
-            context.Keys.Should().HaveCount(12);
+            // check for missing and unexpected keys
+            actualKeys.Should().BeSubsetOf(expectedKeys);
+            expectedKeys.Should().BeSubsetOf(actualKeys);
 
-            // fail tests if any key is missing
-            context.Keys.Should()
-                   .Contain(
-                        new[]
-                        {
-                            "__DistributedKey-TraceId",
-                            "__DistributedKey-ParentId",
-                            "__DistributedKey-SamplingPriority",
-                            "__DistributedKey-Origin",
-                            "__DistributedKey-RawTraceId",
-                            "__DistributedKey-RawSpanId",
-                            "__DistributedKey-PropagatedTags",
-                            "__DistributedKey-AdditionalW3CTraceState",
-                            "x-datadog-trace-id",
-                            "x-datadog-parent-id",
-                            "x-datadog-sampling-priority",
-                            "x-datadog-origin",
-                        });
+            // check for duplicate keys
+            actualKeys.Should().BeEquivalentTo(actualKeys.Distinct());
         }
 
         [Fact]
         public void EnumerateValues()
         {
+            var expectedValues = new HashSet<string>
+                                 {
+                                     "1",
+                                     "2",
+                                     "-1",
+                                     "origin",
+                                     "1a",
+                                     "2b",
+                                     "_dd.p.key1=value1,_dd.p.key2=value2",
+                                     "key3=value3,key4=value4",
+                                 };
+
             var context = CreateSpanContext();
+            var actualValues = context.Values.ToArray();
 
-            context.Values.Should().HaveCount(12);
-
-            context.Values.Should()
-                   .Contain(
-                        new[]
-                        {
-                            "1",      // twice
-                            "2",      // twice
-                            "-1",     // twice
-                            "origin", // twice
-                            "1a",
-                            "2b",
-                            "_dd.p.key1=value1,_dd.p.key2=value2",
-                            "key3=value3,key4=value4",
-                        });
+            // check for missing and unexpected values
+            actualValues.Should().BeSubsetOf(expectedValues);
+            expectedValues.Should().BeSubsetOf(actualValues);
         }
 
         [Fact]
         public void EnumeratePairs()
         {
+            var expectedPairs = new HashSet<KeyValuePair<string, string>>
+                                {
+                                    new("__DistributedKey-TraceId", "1"),
+                                    new("__DistributedKey-ParentId", "2"),
+                                    new("__DistributedKey-SamplingPriority", "-1"),
+                                    new("__DistributedKey-Origin", "origin"),
+                                    new("__DistributedKey-RawTraceId", "1a"),
+                                    new("__DistributedKey-RawSpanId", "2b"),
+                                    new("__DistributedKey-PropagatedTags", "_dd.p.key1=value1,_dd.p.key2=value2"),
+                                    new("__DistributedKey-AdditionalW3CTraceState", "key3=value3,key4=value4"),
+                                    new("x-datadog-trace-id", "1"),
+                                    new("x-datadog-parent-id", "2"),
+                                    new("x-datadog-sampling-priority", "-1"),
+                                    new("x-datadog-origin", "origin")
+                                };
+
             var context = CreateSpanContext();
+            var actualPairs = context.ToArray();
 
-            // fail test if new keys are added
-            context.Should().HaveCount(12);
+            // check for missing and unexpected keys
+            actualPairs.Should().BeSubsetOf(expectedPairs);
+            expectedPairs.Should().BeSubsetOf(actualPairs);
 
-            // fail tests if any key is missing
-            context.Should()
-                   .Contain(
-                        new("__DistributedKey-TraceId", "1"),
-                        new("__DistributedKey-ParentId", "2"),
-                        new("__DistributedKey-SamplingPriority", "-1"),
-                        new("__DistributedKey-Origin", "origin"),
-                        new("__DistributedKey-RawTraceId", "1a"),
-                        new("__DistributedKey-RawSpanId", "2b"),
-                        new("__DistributedKey-PropagatedTags", "_dd.p.key1=value1,_dd.p.key2=value2"),
-                        new("__DistributedKey-AdditionalW3CTraceState", "key3=value3,key4=value4"),
-                        new("x-datadog-trace-id", "1"),
-                        new("x-datadog-parent-id", "2"),
-                        new("x-datadog-sampling-priority", "-1"),
-                        new("x-datadog-origin", "origin"));
+            // check for duplicate keys
+            actualPairs.Should().BeEquivalentTo(actualPairs.Distinct());
         }
 
         private static IReadOnlyDictionary<string, string> CreateSpanContext()

--- a/tracer/test/Datadog.Trace.Tests/SpanContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -37,6 +38,53 @@ namespace Datadog.Trace.Tests
 
             spanContext.SpanId.Should().Be(childSpanId);
             spanContext.TraceId.Should().Be(parentTraceId, "trace id shouldn't be overriden if a parent trace exists. Doing so would break the HttpWebRequest.GetRequestStream/GetResponse integration.");
+        }
+
+        [Fact]
+        public void EnumerateKeys()
+        {
+            const ulong traceId = 1;
+            const ulong spanId = 2;
+            const int samplingPriority = SamplingPriorityValues.UserReject;
+            const string origin = "origin";
+            const string rawTraceId = "1a";
+            const string rawSpanId = "2b";
+            const string propagatedTags = "key1=value1;key2=value2";          // note: semicolon separator
+            const string additionalW3CTraceState = "key3=value3,key4=value4"; // note: comma separator
+
+            IReadOnlyDictionary<string, string> context = new SpanContext(
+                                                              traceId,
+                                                              spanId,
+                                                              samplingPriority,
+                                                              serviceName: null,
+                                                              origin,
+                                                              rawTraceId,
+                                                              rawSpanId)
+                                                          {
+                                                              PropagatedTags = propagatedTags,
+                                                              AdditionalW3CTraceState = additionalW3CTraceState
+                                                          };
+
+            context.Keys.Should().HaveCount(8);
+
+            context.Keys.Should()
+                   .Contain(
+                        new[]
+                        {
+                            "__DistributedKey-TraceId",
+                            "__DistributedKey-ParentId",
+                            "__DistributedKey-SamplingPriority",
+                            "__DistributedKey-Origin",
+                            "__DistributedKey-RawTraceId",
+                            "__DistributedKey-RawSpanId",
+                            "__DistributedKey-PropagatedTags",
+                            "__DistributedKey-AdditionalW3CTraceState",
+
+                            "x-datadog-trace-id",
+                            "x-datadog-parent-id",
+                            "x-datadog-sampling-priority",
+                            "x-datadog-origin",
+                        });
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Propagate additional W3C trace state values in version mismatch scenarios that were missed in #3578.

## Reason for change

When two traces exist due to version mismatch, we want add `SpanContext.AdditionalW3CTraceState` to the list of fields we propagate across tracers.

## Implementation details

- update `DistributedContextExtractor.TryExtract()` to extract `"__DistributedKey-AdditionalW3CTraceState"` from carrier and populate `SpanContext.AdditionalW3CTraceState`
- update `IReadOnlyDictionary<string, string>.TryGetValue()` implementation in `SpanContext` to return `SpanContext.AdditionalW3CTraceState` when `"__DistributedKey-AdditionalW3CTraceState"` is requested

Bonus fix in `W3CTraceContextPropagator`:
- remove trailing comma when combining multiple `tracestate` headers

Bonus code clean-up in `SpanContextPropagator`:
- use singleton properties `DatadogContextPropagator.Instance` and `DatadogContextPropagator.Instance` instead of creating new instances

## Test coverage

- `DistributedPropagatorTests` was updated to reflect the changes in this PR
- added tests to `SpanContextTests` to cover `IReadOnlyDictionary` properties like `Keys` and `Values`
- add missing `AdditionalW3CTraceState` property to `SpanContextMock` and validate it relevant in W3C tests

Bonus:
- add missing `RawTraceId` and `RawSpanId` properties to `SpanContextMock` and validate those in W3c and B3 tests

## Other details

Fixes AIT-5624

Follows:
1. #3446
2. #3491
3. #3578
4. #3583
