### PR TITLE
[tracer] add missing private ctors to singleton propagators

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -29,6 +29,10 @@ namespace Datadog.Trace.Propagators
 
         public static readonly B3MultipleHeaderContextPropagator Instance = new();
 
+        private B3MultipleHeaderContextPropagator()
+        {
+        }
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -19,6 +19,10 @@ namespace Datadog.Trace.Propagators
 
         public static readonly B3SingleHeaderContextPropagator Instance = new();
 
+        private B3SingleHeaderContextPropagator()
+        {
+        }
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -13,6 +13,10 @@ namespace Datadog.Trace.Propagators
     {
         public static readonly DatadogContextPropagator Instance = new();
 
+        private DatadogContextPropagator()
+        {
+        }
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -13,6 +13,10 @@ namespace Datadog.Trace.Propagators
     {
         public static readonly DistributedContextExtractor Instance = new();
 
+        private DistributedContextExtractor()
+        {
+        }
+
         public bool TryExtract<TCarrier, TCarrierGetter>(TCarrier carrier, TCarrierGetter carrierGetter, out SpanContext? spanContext)
             where TCarrierGetter : struct, ICarrierGetter<TCarrier>
         {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -89,6 +89,10 @@ namespace Datadog.Trace.Propagators
 
         public static readonly W3CTraceContextPropagator Instance = new();
 
+        private W3CTraceContextPropagator()
+        {
+        }
+
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {


### PR DESCRIPTION
## Summary of changes

Add private constructors to the span context propagators to force singleton usage. Each propagators type has a static `Instance` property added in #3446.

## Reason for change

While working on #3630, we found code creating new propagator instances instead of using the static singletons. That PR fixed the code to used the statics, and now this PR makes it so the constructors can't be used anymore to prevent this from happening again.

## Implementation details

Add empty private constructors.

## Test coverage

It compiles, yeah?

