### PR TITLE
[Tracer] Update span metadata rules documentation with integration names

### DIFF
--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -1,5 +1,8 @@
 # Span Metadata
 This file is intended for development purposes only. The markdown is generated from assertions authored [here](/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs) and the assertions are actively tested in the tracing integration tests.
+
+The Integration Name (used for configuring individual integrations) of each span corresponds to the markdown header, with the following exceptions:
+- The `AspNetCoreMvc` span has the Integration Name `AspNetCore`
 ## AdoNet
 ### Span properties
 Name | Required |
@@ -113,6 +116,7 @@ network.client.ip | No
 span.kind | `server`
 
 ## AspNetCoreMvc
+> ⚠️ Note: This span is controlled by integration name `AspNetCore`
 ### Span properties
 Name | Required |
 ---------|----------------|
@@ -280,7 +284,7 @@ kafka.tombstone | No
 message.queue_time_ms | No
 span.kind | Yes
 
-## MongoDB
+## MongoDb
 ### Span properties
 Name | Required |
 ---------|----------------|
@@ -399,27 +403,6 @@ component | `RabbitMQ`
 message.size | No
 span.kind | Yes
 
-## ServiceFabric
-### Span properties
-Name | Required |
----------|----------------|
-Name | `service_remoting.client`; `service_remoting.server`
-### Tags
-Name | Required |
----------|----------------|
-service-fabric.application-id | Yes
-service-fabric.application-name | Yes
-service-fabric.node-id | Yes
-service-fabric.node-name | Yes
-service-fabric.partition-id | Yes
-service-fabric.service-name | Yes
-service-fabric.service-remoting.interface-id | No
-service-fabric.service-remoting.invocation-id | No
-service-fabric.service-remoting.method-id | No
-service-fabric.service-remoting.method-name | Yes
-service-fabric.service-remoting.uri | Yes
-span.kind | `client`; `server`
-
 ## ServiceRemoting
 ### Span properties
 Name | Required |
@@ -428,6 +411,12 @@ Name | `service_remoting.client`; `service_remoting.server`
 ### Tags
 Name | Required |
 ---------|----------------|
+service-fabric.application-id | No
+service-fabric.application-name | No
+service-fabric.node-id | No
+service-fabric.node-name | No
+service-fabric.partition-id | No
+service-fabric.service-name | No
 service-fabric.service-remoting.interface-id | No
 service-fabric.service-remoting.invocation-id | No
 service-fabric.service-remoting.method-id | No

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMongoDB();
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMongoDb();
 
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.MongoDB), MemberType = typeof(PackageVersions))]

--- a/tracer/test/Datadog.Trace.TestHelpers/Result.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Result.cs
@@ -42,6 +42,8 @@ namespace Datadog.Trace.TestHelpers
             return this;
         }
 
+        public Result WithIntegrationName(string name) => this;
+
         public Result Properties(Action<SpanPropertyAssertion> propertyAssertions)
         {
             var p = new SpanPropertyAssertion(this);

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -112,6 +112,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("span.kind", "server"));
 
         public static Result IsAspNetCoreMvc(this MockSpan span) => Result.FromSpan(span)
+            .WithIntegrationName("AspNetCore")
             .Properties(s => s
                 .Matches(Name, "aspnet_core_mvc.request")
                 .Matches(Type, "web"))
@@ -239,7 +240,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "kafka")
                 .IsPresent("span.kind"));
 
-        public static Result IsMongoDB(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsMongoDb(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s
                 .Matches(Name, "mongodb.query")
                 .Matches(Type, "mongodb"))
@@ -333,27 +334,16 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "RabbitMQ")
                 .IsPresent("span.kind"));
 
-        public static Result IsServiceFabric(this MockSpan span) => Result.FromSpan(span)
-            .Properties(s => s
-                .MatchesOneOf(Name, "service_remoting.client", "service_remoting.server"))
-            .Tags(s => s
-                .IsPresent("service-fabric.application-id")
-                .IsPresent("service-fabric.application-name")
-                .IsPresent("service-fabric.partition-id")
-                .IsPresent("service-fabric.node-id")
-                .IsPresent("service-fabric.node-name")
-                .IsPresent("service-fabric.service-name")
-                .IsPresent("service-fabric.service-remoting.uri")
-                .IsPresent("service-fabric.service-remoting.method-name")
-                .IsOptional("service-fabric.service-remoting.method-id")
-                .IsOptional("service-fabric.service-remoting.interface-id")
-                .IsOptional("service-fabric.service-remoting.invocation-id")
-                .MatchesOneOf("span.kind", "client", "server"));
-
         public static Result IsServiceRemoting(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s
                 .MatchesOneOf(Name, "service_remoting.client", "service_remoting.server"))
             .Tags(s => s
+                .IsOptional("service-fabric.application-id")
+                .IsOptional("service-fabric.application-name")
+                .IsOptional("service-fabric.partition-id")
+                .IsOptional("service-fabric.node-id")
+                .IsOptional("service-fabric.node-name")
+                .IsOptional("service-fabric.service-name")
                 .IsPresent("service-fabric.service-remoting.uri")
                 .IsPresent("service-fabric.service-remoting.method-name")
                 .IsOptional("service-fabric.service-remoting.method-id")


### PR DESCRIPTION
## Summary of changes
Aligns the span metadata header names with the integration name that generates the corresponding spans. For the outlier AspNetCoreMvc span, document the actual integration name.

## Reason for change
Before the change, it was not clear what integration name controlled which spans, so this seeks to clarify that.

## Implementation details
Slightly updates the metadata rules and updates the markdown generator.

## Test coverage
None needed.

## Other details
N/A
