### PR TITLE
[Profiler] Fix using nanoseconds instead of milliseconds

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -276,7 +276,7 @@ void StackSamplerLoop::CpuProfilingIteration()
 #endif
                         // ensure that we don't overlap
                         // -> only the largest possibly CPU consumption is accounted = diff between the 2 timestamps
-                        cpuForSample = thisSampleTimestampNanosecs - lastCpuTimestamp - 1000; // removing 1 microsecond to be sure
+                        cpuForSample = (thisSampleTimestampNanosecs - lastCpuTimestamp - 1000) / 1000000; // removing 1 microsecond to be sure
                     }
                     _targetThread->SetCpuConsumptionMilliseconds(currentConsumption, thisSampleTimestampNanosecs);
                     CollectOneThreadStackSample(_targetThread, thisSampleTimestampNanosecs, cpuForSample, PROFILING_TYPE::CpuTime);


### PR DESCRIPTION
## Summary of changes
Convert nano-seconds into milli-seconds for CPU sampling

## Reason for change
Fix missing conversion

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
