### PR TITLE
[Profiler] Provides an alternative stackwalk

### DIFF
--- a/profiler/build/PiComputation.linux.net60.json
+++ b/profiler/build/PiComputation.linux.net60.json
@@ -40,7 +40,7 @@
       }
     },
     {
-      "name": "Profiler_cpu_walltime_manual_stackwalk",
+      "name": "Profiler_cpu_walltime_old_stackwalk",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",

--- a/profiler/build/PiComputation.linux.net60.json
+++ b/profiler/build/PiComputation.linux.net60.json
@@ -35,6 +35,17 @@
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_USE_BACKTRACE2": "1",
+        "DD_TRACE_ENABLED" : "0"
+      }
+    },
+    {
+      "name": "Profiler_cpu_walltime_manual_stackwalk",
+      "environmentVariables": {
+        "DD_CLR_ENABLE_NGEN": "true",
+        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_USE_BACKTRACE2": "0",
         "DD_TRACE_ENABLED" : "0"
       }
     }

--- a/profiler/build/PiComputation.linux.netcoreapp31.json
+++ b/profiler/build/PiComputation.linux.netcoreapp31.json
@@ -40,7 +40,7 @@
       }
     },
     {
-      "name": "Profiler_cpu_walltime_manual_stackwalk",
+      "name": "Profiler_cpu_walltime_old_stackwalk",
       "environmentVariables": {
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",

--- a/profiler/build/PiComputation.linux.netcoreapp31.json
+++ b/profiler/build/PiComputation.linux.netcoreapp31.json
@@ -35,9 +35,21 @@
         "DD_CLR_ENABLE_NGEN": "true",
         "DD_PROFILING_ENABLED": "1",
         "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_USE_BACKTRACE2": "1",
+        "DD_TRACE_ENABLED" : "0"
+      }
+    },
+    {
+      "name": "Profiler_cpu_walltime_manual_stackwalk",
+      "environmentVariables": {
+        "DD_CLR_ENABLE_NGEN": "true",
+        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_USE_BACKTRACE2": "0",
         "DD_TRACE_ENABLED" : "0"
       }
     }
+
   ],
   "processName": "dotnet",
   "processArguments": "Samples.Computer01.dll --scenario 5 --iterations 1",

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -12,6 +12,7 @@
 #include <unordered_map>
 #include <errno.h>
 
+#include "IConfiguration.h"
 #include "Log.h"
 #include "ManagedThreadInfo.h"
 #include "OpSysTools.h"
@@ -24,12 +25,13 @@ using namespace std::chrono_literals;
 std::mutex LinuxStackFramesCollector::s_stackWalkInProgressMutex;
 LinuxStackFramesCollector* LinuxStackFramesCollector::s_pInstanceCurrentlyStackWalking = nullptr;
 
-LinuxStackFramesCollector::LinuxStackFramesCollector(ProfilerSignalManager* signalManager) :
+LinuxStackFramesCollector::LinuxStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration const* const configuration) :
     _lastStackWalkErrorCode{0},
     _stackWalkFinished{false},
     _errorStatistics{},
     _processId{OpSysTools::GetProcId()},
-    _signalManager{signalManager}
+    _signalManager{signalManager},
+    _useBacktrace2{configuration->UseBacktrace2()}
 {
     _signalManager->RegisterHandler(LinuxStackFramesCollector::CollectStackSampleSignalHandler);
 }
@@ -175,24 +177,88 @@ std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
         // Collect data for TraceContext tracking:
         bool traceContextDataCollected = TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
 
-        auto* context = reinterpret_cast<unw_context_t*>(ctx);
-
-        // Now walk the stack:
-        auto [data, size] = Data();
-        auto count = unw_backtrace2((void**)data, size, context);
-
-        if (count == 0)
-        {
-            return E_FAIL;
-        }
-
-        SetFrameCount(count);
-        return S_OK;
+        return _useBacktrace2 ? CollectStackWithBacktrace2(ctx) : CollectStackManually(ctx);
     }
     catch (...)
     {
         return E_ABORT;
     }
+}
+
+std::int32_t LinuxStackFramesCollector::CollectStackManually(void* ctx)
+{
+    std::int32_t resultErrorCode;
+
+    // if we are in the signal handler, ctx won't be null, so we will use the context
+    // This will allow us to skip the syscall frame and start from the frame before the syscall.
+    auto flag = UNW_INIT_SIGNAL_FRAME;
+    unw_context_t context;
+    if (ctx != nullptr)
+    {
+        context = *reinterpret_cast<unw_context_t*>(ctx);
+    }
+    else
+    {
+        // not in signal handler. Get the context and initialize the cursor form here
+        resultErrorCode = unw_getcontext(&context);
+        if (resultErrorCode != 0)
+        {
+            return E_ABORT; // unw_getcontext does not return a specific error code. Only -1
+        }
+
+        flag = static_cast<unw_init_local2_flags_t>(0);
+    }
+
+    unw_cursor_t cursor;
+    resultErrorCode = unw_init_local2(&cursor, &context, flag);
+
+    if (resultErrorCode < 0)
+    {
+        return resultErrorCode;
+    }
+
+    do
+    {
+        // After every lib call that touches non-local state, check if the StackSamplerLoopManager requested this walk to abort:
+        if (IsCurrentCollectionAbortRequested())
+        {
+            AddFakeFrame();
+            return E_ABORT;
+        }
+
+        unw_word_t ip;
+        resultErrorCode = unw_get_reg(&cursor, UNW_REG_IP, &ip);
+        if (resultErrorCode != 0)
+        {
+            return resultErrorCode;
+        }
+
+        if (!AddFrame(ip))
+        {
+            return S_FALSE;
+        }
+
+        resultErrorCode = unw_step(&cursor);
+    } while (resultErrorCode > 0);
+
+    return resultErrorCode;
+}
+
+std::int32_t LinuxStackFramesCollector::CollectStackWithBacktrace2(void* ctx)
+{
+    auto* context = reinterpret_cast<unw_context_t*>(ctx);
+
+    // Now walk the stack:
+    auto [data, size] = Data();
+    auto count = unw_backtrace2((void**)data, size, context);
+
+    if (count == 0)
+    {
+        return E_FAIL;
+    }
+
+    SetFrameCount(count);
+    return S_OK;
 }
 
 bool LinuxStackFramesCollector::CanCollect(int32_t threadId, pid_t processId) const

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -20,11 +20,12 @@
 class IManagedThreadList;
 class ProfilerSignalManager;
 class ProfilerSignalManager;
+class IConfiguration;
 
 class LinuxStackFramesCollector : public StackFramesCollectorBase
 {
 public:
-    explicit LinuxStackFramesCollector(ProfilerSignalManager* signalManager);
+    explicit LinuxStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration const* const configuration);
     ~LinuxStackFramesCollector() override;
     LinuxStackFramesCollector(LinuxStackFramesCollector const&) = delete;
     LinuxStackFramesCollector& operator=(LinuxStackFramesCollector const&) = delete;
@@ -57,6 +58,8 @@ private:
     void UpdateErrorStats(std::int32_t errorCode);
     bool ShouldLogStats();
     bool CanCollect(int32_t threadId, pid_t processId) const;
+    std::int32_t CollectStackManually(void* ctx);
+    std::int32_t CollectStackWithBacktrace2(void* ctx);
 
     std::int32_t _lastStackWalkErrorCode;
     std::condition_variable _stackWalkInProgressWaiter;
@@ -80,4 +83,5 @@ private:
     std::int32_t CollectCallStackCurrentThread(void* ucontext);
 
     ErrorStatistics _errorStatistics;
+    bool _useBacktrace2;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -10,6 +10,7 @@
 #include "OsSpecificApi.h"
 #include "OpSysTools.h"
 
+#include "IConfiguration.h"
 #include "Log.h"
 #include "LinuxStackFramesCollector.h"
 #include "ProfilerSignalManager.h"
@@ -17,9 +18,9 @@
 #include "shared/src/native-src/loader.h"
 
 namespace OsSpecificApi {
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo)
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration)
 {
-    return std::make_unique<LinuxStackFramesCollector>(ProfilerSignalManager::Get());
+    return std::make_unique<LinuxStackFramesCollector>(ProfilerSignalManager::Get(), pConfiguration);
 }
 
 // https://linux.die.net/man/5/proc

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -7,6 +7,7 @@
 
 #include "OsSpecificApi.h"
 
+#include "IConfiguration.h"
 #include "StackFramesCollectorBase.h"
 #include "SystemTime.h"
 #include "Windows32BitStackFramesCollector.h"
@@ -16,7 +17,7 @@
 
 namespace OsSpecificApi {
 
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo)
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration)
 {
 #ifdef BIT64
     static_assert(8 * sizeof(void*) == 64);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -4,6 +4,7 @@
 #include "AllocationsProvider.h"
 #include "COMHelpers.h"
 #include "HResultConverter.h"
+#include "IConfiguration.h"
 #include "IManagedThreadList.h"
 #include "IFrameStore.h"
 #include "IThreadsCpuManager.h"
@@ -43,7 +44,8 @@ AllocationsProvider::AllocationsProvider(
     _pFrameStore(pFrameStore),
     _sampleLimit(pConfiguration->AllocationSampleLimit()),
     _sampler(pConfiguration->AllocationSampleLimit(), pConfiguration->GetUploadInterval()),
-    _pListener(pListener)
+    _pListener(pListener),
+    _pConfiguration(pConfiguration)
 {
     _allocationsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_allocations");
     _allocationsSizeMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_allocations_size");
@@ -74,7 +76,7 @@ void AllocationsProvider::OnAllocation(uint32_t allocationKind,
     std::shared_ptr<ManagedThreadInfo> threadInfo;
     CALL(_pManagedThreadList->TryGetCurrentThreadInfo(threadInfo))
 
-    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo);
+    const auto pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, _pConfiguration);
     pStackFramesCollector->PrepareForNextCollection();
 
     uint32_t hrCollectStack = E_FAIL;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
@@ -12,6 +12,7 @@
 #include "RawAllocationSample.h"
 #include "SumMetric.h"
 
+class IConfiguration;
 class IManagedThreadList;
 class IFrameStore;
 class IThreadsCpuManager;
@@ -55,6 +56,7 @@ private:
     ISampledAllocationsListener* _pListener = nullptr;
     GenericSampler _sampler;
     int32_t _sampleLimit;
+    IConfiguration const* const _pConfiguration;
     std::shared_ptr<CounterMetric> _allocationsCountMetric;
     std::shared_ptr<MeanMaxMetric> _allocationsSizeMetric;
     std::shared_ptr<CounterMetric> _sampledAllocationsCountMetric;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -64,6 +64,7 @@ Configuration::Configuration()
     _minimumCores = GetEnvironmentValue<double>(EnvironmentVariables::CoreMinimumOverride, 1.0);
     _namedPipeName = GetEnvironmentValue(EnvironmentVariables::NamedPipeName, DefaultEmptyString);
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
+    _useBacktrace2 = GetEnvironmentValue(EnvironmentVariables::UseBacktrace2, true);
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -242,6 +243,11 @@ std::string const& Configuration::GetApiKey() const
 std::string const& Configuration::GetServiceName() const
 {
     return _serviceName;
+}
+
+bool Configuration::UseBacktrace2() const
+{
+    return _useBacktrace2;
 }
 
 fs::path Configuration::GetApmBaseDirectory()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -55,6 +55,7 @@ public:
     int32_t CodeHotspotsThreadsThreshold() const override;
     bool IsGarbageCollectionProfilingEnabled() const override;
     bool IsHeapProfilingEnabled() const override;
+    bool UseBacktrace2() const override;
 
 private:
     static tags ExtractUserTags();
@@ -121,6 +122,7 @@ private:
     int32_t _walltimeThreadsThreshold;
     int32_t _cpuThreadsThreshold;
     int32_t _codeHotspotsThreadsThreshold;
+    bool _useBacktrace2;
 
     double _minimumCores;
     std::string _namedPipeName;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -11,6 +11,7 @@
 #include "CounterMetric.h"
 #include "MeanMaxMetric.h"
 
+class IConfiguration;
 class IManagedThreadList;
 class IFrameStore;
 class IThreadsCpuManager;
@@ -43,6 +44,7 @@ private:
     GenericSampler _sampler;
     int32_t _contentionDurationThreshold;
     int32_t _sampleLimit;
+    IConfiguration const* const _pConfiguration;
     std::shared_ptr<CounterMetric> _lockContentionsCountMetric;
     std::shared_ptr<MeanMaxMetric> _lockContentionsDurationMetric;
     std::shared_ptr<CounterMetric> _sampledLockContentionsCountMetric;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -242,6 +242,7 @@ private:
     static void InspectProcessorInfo();
     static void InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerInfo, USHORT& major, USHORT& minor, COR_PRF_RUNTIME_TYPE& runtimeType);
     static const char* SysInfoProcessorArchitectureToStr(WORD wProcArch);
+    static void PrintEnvironmentVariables();
 
     void DisposeInternal();
     bool InitializeServices();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -51,7 +51,4 @@ public:
     inline static const shared::WSTRING Agentless                   = WStr("DD_PROFILING_AGENTLESS");
     inline static const shared::WSTRING CoreMinimumOverride         = WStr("DD_PROFILING_MIN_CORES_THRESHOLD");
     inline static const shared::WSTRING UseBacktrace2               = WStr("DD_INTERNAL_USE_BACKTRACE2");
-
-    // feature flags
-    inline static const shared::WSTRING FF_LibddprofEnabled = WStr("DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -50,6 +50,7 @@ public:
     inline static const shared::WSTRING DevelopmentConfiguration    = WStr("DD_INTERNAL_USE_DEVELOPMENT_CONFIGURATION");
     inline static const shared::WSTRING Agentless                   = WStr("DD_PROFILING_AGENTLESS");
     inline static const shared::WSTRING CoreMinimumOverride         = WStr("DD_PROFILING_MIN_CORES_THRESHOLD");
+    inline static const shared::WSTRING UseBacktrace2               = WStr("DD_INTERNAL_USE_BACKTRACE2");
 
     // feature flags
     inline static const shared::WSTRING FF_LibddprofEnabled = WStr("DD_INTERNAL_PROFILING_LIBDDPROF_ENABLED");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -15,6 +15,8 @@
 #include "MetricsRegistry.h"
 #include "CounterMetric.h"
 
+class IConfiguration;
+
 class ExceptionsProvider
     : public CollectorBase<RawExceptionSample>
 {
@@ -53,6 +55,7 @@ private:
     std::unordered_map<ClassID, std::string> _exceptionTypes;
     std::mutex _exceptionTypesLock;
     GroupSampler<std::string> _sampler;
+    IConfiguration const* const _pConfiguration;
     std::shared_ptr<CounterMetric> _exceptionsCountMetric;
     std::shared_ptr<CounterMetric> _sampledExceptionsCountMetric;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -52,4 +52,5 @@ public:
     virtual int32_t CodeHotspotsThreadsThreshold() const = 0;
     virtual bool IsGarbageCollectionProfilingEnabled() const = 0;
     virtual bool IsHeapProfilingEnabled() const = 0;
+    virtual bool UseBacktrace2() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -11,11 +11,12 @@
 namespace shared {
 struct LoaderResourceMonikerIDs;
 }
+class IConfiguration;
 
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi {
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo);
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration);
 uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
 bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -63,7 +63,7 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _deadlockCounterMetric{metricsRegistry.GetOrRegister<CounterMetric>("dotnet_internal_deadlocks")}
 {
     _pCorProfilerInfo->AddRef();
-    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo);
+    _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, pConfiguration);
 
     _currentStatistics = std::make_unique<Statistics>();
     _statisticCollectionStartNs = OpSysTools::GetHighPrecisionNanoseconds();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -22,5 +22,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string NamedPipeName = "DD_TRACE_PIPE_NAME";
         public const string TimestampsAsLabelEnabled = "DD_INTERNAL_PROFILING_TIMESTAMPS_AS_LABEL_ENABLED";
         public const string GarbageCollectionProfilerEnabled = "DD_PROFILING_GC_ENABLED";
+        public const string UseBacktrace2 = "DD_INTERNAL_USE_BACKTRACE2";
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Profiler.SmokeTests
@@ -20,6 +22,15 @@ namespace Datadog.Profiler.SmokeTests
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.BuggyBits")]
+        public void CheckSmokeForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 using System.Collections.Generic;
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Profiler.SmokeTests
@@ -50,6 +52,42 @@ namespace Datadog.Profiler.SmokeTests
         public void CheckFibonacci(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", _output);
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckAppDomainForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckGenericsForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckPiForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Computer01")]
+        public void CheckFibonacciForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/ExceptionGeneratorTest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Profiler.SmokeTests
@@ -20,6 +22,15 @@ namespace Datadog.Profiler.SmokeTests
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.ExceptionGenerator")]
+        public void CheckSmokeForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
@@ -45,7 +45,7 @@ namespace Datadog.Profiler.SmokeTests
             _testApplicationRunner = new TestApplicationRunner(appName, framework, appAssembly, output, commandLine);
         }
 
-        private EnvironmentHelper EnvironmentHelper
+        internal EnvironmentHelper EnvironmentHelper
         {
             get => _testApplicationRunner.Environment;
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/WebsiteAspNetCore01Test.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Profiler.SmokeTests
@@ -20,6 +22,15 @@ namespace Datadog.Profiler.SmokeTests
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);
+            runner.RunAndCheck();
+        }
+
+        [Trait("Category", "LinuxOnly")]
+        [TestAppFact("Samples.Website-AspNetCore01")]
+        public void CheckSmokeForOldWayToStackWalk(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, _output);
+            runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -624,3 +624,23 @@ TEST(ConfigurationTest, CheckHeapProfilingIsDisabledIfEnvVarSetToFalse)
     auto configuration = Configuration{};
     ASSERT_THAT(configuration.IsHeapProfilingEnabled(), false);
 }
+
+TEST(ConfigurationTest, CheckBacktrace2IsUsedByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.UseBacktrace2(), true);
+}
+
+TEST(ConfigurationTest, CheckBacktrace2IsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::UseBacktrace2, WStr("0"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.UseBacktrace2(), false);
+}
+
+TEST(ConfigurationTest, CheckBacktrace2IsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::UseBacktrace2, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.UseBacktrace2(), true);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -57,6 +57,7 @@ public:
     MOCK_METHOD(int32_t, CodeHotspotsThreadsThreshold, (), (const override));
     MOCK_METHOD(bool, IsGarbageCollectionProfilingEnabled, (), (const override));
     MOCK_METHOD(bool, IsHeapProfilingEnabled, (), (const override));
+    MOCK_METHOD(bool, UseBacktrace2, (), (const override));
 };
 
 class MockExporter : public IExporter


### PR DESCRIPTION
## Summary of changes

Provide an alternative stackwalk mechanism.

## Reason for change

We would like to compare the old/manual way  and the new way to stackwalk a thread on linux. The goal is to continuously see improvements or degradation, and also propose an alternative to investigate customer issue.

## Implementation details

- Add a new internal env var to select the stackwalk algorithm
- Switch between the two algorithm depending on the env var.
- Add benchmark tests.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
