### PR TITLE
Log the version of the native tracer in the managed logs

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -67,6 +67,14 @@ namespace Datadog.Trace.ClrProfiler
         }
 
         /// <summary>
+        /// Gets a value indicating the version of the native Datadog profiler. This method
+        /// is rewritten by the profiler.
+        /// </summary>
+        /// <returns>In a managed-only context, where the profiler is not attached, <c>None</c>,
+        /// otherwise the version of the Datadog native tracer library.</returns>
+        public static string GetNativeTracerVersion() => "None";
+
+        /// <summary>
         /// Initializes global instrumentation values.
         /// </summary>
         public static void Initialize()

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.AgentUrl, value: settings.Exporter.AgentUri.ToString()),
                 new(ConfigTelemetryData.AgentTraceTransport, value: settings.Exporter.TracesTransport.ToString()),
                 new(ConfigTelemetryData.Debug, value: GlobalSettings.Instance.DebugEnabled),
-                new(ConfigTelemetryData.IsManagedOnly, value: !Instrumentation.ProfilerAttached),
+                new(ConfigTelemetryData.NativeTracerVersion, value: Instrumentation.GetNativeTracerVersion()),
 #pragma warning disable CS0618
                 new(ConfigTelemetryData.AnalyticsEnabled, value: settings.AnalyticsEnabled),
 #pragma warning restore CS0618

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.Iast.Settings;
@@ -121,13 +122,14 @@ namespace Datadog.Trace.Telemetry
 
             var settings = _settings.Settings;
 
-            var data = new List<TelemetryValue>(settings.IsRunningInAzureAppService ? 31 : 26)
+            var data = new List<TelemetryValue>(27 + (settings.IsRunningInAzureAppService ? 5 : 0))
             {
                 new(ConfigTelemetryData.Platform, value: FrameworkDescription.Instance.ProcessArchitecture),
                 new(ConfigTelemetryData.Enabled, value: settings.TraceEnabled),
                 new(ConfigTelemetryData.AgentUrl, value: settings.Exporter.AgentUri.ToString()),
                 new(ConfigTelemetryData.AgentTraceTransport, value: settings.Exporter.TracesTransport.ToString()),
                 new(ConfigTelemetryData.Debug, value: GlobalSettings.Instance.DebugEnabled),
+                new(ConfigTelemetryData.IsManagedOnly, value: !Instrumentation.ProfilerAttached),
 #pragma warning disable CS0618
                 new(ConfigTelemetryData.AnalyticsEnabled, value: settings.AnalyticsEnabled),
 #pragma warning restore CS0618

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.Telemetry
         public const string AgentUrl = "agent_url";
         public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
+        public const string IsManagedOnly = "managed_only";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";
         public const string SamplingRules = "sampling_rules";

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Telemetry
         public const string AgentUrl = "agent_url";
         public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
-        public const string IsManagedOnly = "managed_only";
+        public const string NativeTracerVersion = "native_tracer_version";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";
         public const string SamplingRules = "sampling_rules";

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DataStreamsMonitoring;
@@ -308,6 +309,9 @@ namespace Datadog.Trace
 
                     writer.WritePropertyName("version");
                     writer.WriteValue(TracerConstants.AssemblyVersion);
+
+                    writer.WritePropertyName("managed_only");
+                    writer.WriteValue(!Instrumentation.ProfilerAttached);
 
                     writer.WritePropertyName("platform");
                     writer.WriteValue(FrameworkDescription.Instance.ProcessArchitecture);

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -310,8 +310,8 @@ namespace Datadog.Trace
                     writer.WritePropertyName("version");
                     writer.WriteValue(TracerConstants.AssemblyVersion);
 
-                    writer.WritePropertyName("managed_only");
-                    writer.WriteValue(!Instrumentation.ProfilerAttached);
+                    writer.WritePropertyName("native_tracer_version");
+                    writer.WriteValue(Instrumentation.GetNativeTracerVersion());
 
                     writer.WritePropertyName("platform");
                     writer.WriteValue(FrameworkDescription.Instance.ProcessArchitecture);

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1412,4 +1412,39 @@ HRESULT GenericTypeProps::TryParse()
     return S_OK;
 }
 
+void LogManagedProfilerAssemblyDetails()
+{
+    Logger::Info("pcbPublicKey: ", managed_profiler_assembly_property.pcbPublicKey);
+    Logger::Info("ppbPublicKey: ", shared::HexStr(managed_profiler_assembly_property.ppbPublicKey,
+                                                  managed_profiler_assembly_property.pcbPublicKey));
+    Logger::Info("pcbPublicKey: ");
+    const auto ppbPublicKey = (BYTE*) managed_profiler_assembly_property.ppbPublicKey;
+    for (ULONG i = 0; i < managed_profiler_assembly_property.pcbPublicKey; i++)
+    {
+        Logger::Info(" -> ", (int) ppbPublicKey[i]);
+    }
+    Logger::Info("szName: ", managed_profiler_assembly_property.szName);
+
+    Logger::Info("Metadata.cbLocale: ", managed_profiler_assembly_property.pMetaData.cbLocale);
+    Logger::Info("Metadata.szLocale: ", managed_profiler_assembly_property.pMetaData.szLocale);
+
+    if (managed_profiler_assembly_property.pMetaData.rOS != nullptr)
+    {
+        Logger::Info("Metadata.rOS.dwOSMajorVersion: ",
+                     managed_profiler_assembly_property.pMetaData.rOS->dwOSMajorVersion);
+        Logger::Info("Metadata.rOS.dwOSMinorVersion: ",
+                     managed_profiler_assembly_property.pMetaData.rOS->dwOSMinorVersion);
+        Logger::Info("Metadata.rOS.dwOSPlatformId: ",
+                     managed_profiler_assembly_property.pMetaData.rOS->dwOSPlatformId);
+    }
+
+    Logger::Info("Metadata.usBuildNumber: ", managed_profiler_assembly_property.pMetaData.usBuildNumber);
+    Logger::Info("Metadata.usMajorVersion: ", managed_profiler_assembly_property.pMetaData.usMajorVersion);
+    Logger::Info("Metadata.usMinorVersion: ", managed_profiler_assembly_property.pMetaData.usMinorVersion);
+    Logger::Info("Metadata.usRevisionNumber: ", managed_profiler_assembly_property.pMetaData.usRevisionNumber);
+
+    Logger::Info("pulHashAlgId: ", managed_profiler_assembly_property.pulHashAlgId);
+    Logger::Info("sizeof(pulHashAlgId): ", sizeof(managed_profiler_assembly_property.pulHashAlgId));
+    Logger::Info("assemblyFlags: ", managed_profiler_assembly_property.assemblyFlags);
+}
 } // namespace trace

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -633,6 +633,7 @@ HRESULT ResolveType(ICorProfilerInfo4* info, const ComPtr<IMetaDataImport2>& met
                     const mdTypeRef typeRefToken, mdTypeDef& resolvedTypeDefToken,
                     ComPtr<IMetaDataImport2>& resolvedMetadataImport);
 
+void LogManagedProfilerAssemblyDetails();
 } // namespace trace
 
 #endif // DD_CLR_PROFILER_CLR_HELPERS_H_

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -865,6 +865,9 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
             Logger::Debug("Skipping version conflict fix for ", assemblyVersion,
                           " because the version matches the expected one");
         }
+
+        // Rewrite methods for exposing the native tracer version to managed for telemetry purposes
+        RewriteForTelemetry(module_metadata, module_id);
     }
     else
     {
@@ -2168,6 +2171,81 @@ HRESULT CorProfiler::RewriteForDistributedTracing(const ModuleMetadata& module_m
     {
         Logger::Info(GetILCodes("After -> GetDistributedTracer. ", &getterRewriter,
                                 GetFunctionInfo(module_metadata.metadata_import, getDistributedTraceMethodDef),
+                                module_metadata.metadata_import));
+    }
+
+    return hr;
+}
+
+HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, ModuleID module_id)
+{
+    HRESULT hr = S_OK;
+
+    if (IsDebugEnabled())
+    {
+        LogManagedProfilerAssemblyDetails();
+    }
+
+    //
+    // *** Get Instrumentation TypeDef
+    //
+    mdTypeDef instrumentationTypeDef;
+    hr = module_metadata.metadata_import->FindTypeDefByName(instrumentation_type_name.c_str(),
+                                                            mdTokenNil, &instrumentationTypeDef);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting for Telemetry on getting Instrumentation TypeDef");
+        return hr;
+    }
+
+    //
+    // *** GetNativeTracerVersion MethodDef ***
+    //
+    constexpr COR_SIGNATURE getNativeTracerVersion[] = {IMAGE_CEE_CS_CALLCONV_DEFAULT, 0, ELEMENT_TYPE_STRING};
+    mdMethodDef getNativeTracerVersionMethodDef;
+    hr = module_metadata.metadata_import->FindMethod(instrumentationTypeDef, WStr("GetNativeTracerVersion"),
+                                                     getNativeTracerVersion, 3, &getNativeTracerVersionMethodDef);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting for Telemetry on getting GetNativeTracerVersion MethodDef");
+        return hr;
+    }
+
+    // Define NativeTracerVersion as a string
+    mdString nativeTracerVersionToken;
+    const auto nativeTracerVersion = ToWSTRING(PROFILER_VERSION);
+    hr = module_metadata.metadata_emit->DefineUserString(
+        nativeTracerVersion.c_str(), static_cast<ULONG>(nativeTracerVersion.length()), &nativeTracerVersionToken);
+
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting for Telemetry on DefineUserString for NativeProfilerVersion");
+        return hr;
+    }
+
+    ILRewriter methodRewriter(this->info_, nullptr, module_id, getNativeTracerVersionMethodDef);
+    methodRewriter.InitializeTiny();
+
+    // Modify first instruction from ldstr "None" to ldstr PROFILER_VERSION
+    ILRewriterWrapper wrapper(&methodRewriter);
+    wrapper.SetILPosition(methodRewriter.GetILList()->m_pNext);
+    wrapper.LoadStr(nativeTracerVersionToken);
+    wrapper.Return();
+
+    hr = methodRewriter.Export();
+
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION");
+        return hr;
+    }
+
+    Logger::Info("Rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION");
+
+    if (IsDumpILRewriteEnabled())
+    {
+        Logger::Info(GetILCodes("After -> Instrumentation.GetNativeTracerVersion(). ", &methodRewriter,
+                                GetFunctionInfo(module_metadata.metadata_import, getNativeTracerVersionMethodDef),
                                 module_metadata.metadata_import));
     }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2224,11 +2224,19 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
     }
 
     ILRewriter methodRewriter(this->info_, nullptr, module_id, getNativeTracerVersionMethodDef);
+    hr = methodRewriter.Import();
+
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting for Telemetry: Call to ILRewriter.Import() failed for ", module_id, " ", getNativeTracerVersionMethodDef);
+        return hr;
+    }
+
     ILInstr* pFirstInstr = methodRewriter.GetILList()->m_pNext;
 
     if (pFirstInstr->m_opcode != CEE_LDSTR)
     {
-        Logger::Warn("Error rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION - m_opcode was not CEE_LDSTR, found", pFirstInstr->m_opcode);
+        Logger::Warn("Error rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION - m_opcode was not CEE_LDSTR, found ", pFirstInstr->m_opcode);
         return E_FAIL;
     }
     

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2224,13 +2224,10 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
     }
 
     ILRewriter methodRewriter(this->info_, nullptr, module_id, getNativeTracerVersionMethodDef);
-    methodRewriter.InitializeTiny();
 
     // Modify first instruction from ldstr "None" to ldstr PROFILER_VERSION
-    ILRewriterWrapper wrapper(&methodRewriter);
-    wrapper.SetILPosition(methodRewriter.GetILList()->m_pNext);
-    wrapper.LoadStr(nativeTracerVersionToken);
-    wrapper.Return();
+    ILInstr* pFirstInstr = methodRewriter.GetILList()->m_pNext;
+    pFirstInstr->m_Arg32 = nativeTracerVersionToken;
 
     hr = methodRewriter.Export();
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2232,6 +2232,10 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
         return hr;
     }
 
+    Logger::Info(GetILCodes("Before -> Instrumentation.GetNativeTracerVersion(). ", &methodRewriter,
+                            GetFunctionInfo(module_metadata.metadata_import, getNativeTracerVersionMethodDef),
+                            module_metadata.metadata_import));
+
     ILInstr* pFirstInstr = methodRewriter.GetILList()->m_pNext;
 
     if (pFirstInstr->m_opcode != CEE_LDSTR)

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2062,38 +2062,7 @@ HRESULT CorProfiler::RewriteForDistributedTracing(const ModuleMetadata& module_m
 
     if (IsDebugEnabled())
     {
-        Logger::Info("pcbPublicKey: ", managed_profiler_assembly_property.pcbPublicKey);
-        Logger::Info("ppbPublicKey: ", shared::HexStr(managed_profiler_assembly_property.ppbPublicKey,
-                                                      managed_profiler_assembly_property.pcbPublicKey));
-        Logger::Info("pcbPublicKey: ");
-        const auto ppbPublicKey = (BYTE*) managed_profiler_assembly_property.ppbPublicKey;
-        for (ULONG i = 0; i < managed_profiler_assembly_property.pcbPublicKey; i++)
-        {
-            Logger::Info(" -> ", (int) ppbPublicKey[i]);
-        }
-        Logger::Info("szName: ", managed_profiler_assembly_property.szName);
-
-        Logger::Info("Metadata.cbLocale: ", managed_profiler_assembly_property.pMetaData.cbLocale);
-        Logger::Info("Metadata.szLocale: ", managed_profiler_assembly_property.pMetaData.szLocale);
-
-        if (managed_profiler_assembly_property.pMetaData.rOS != nullptr)
-        {
-            Logger::Info("Metadata.rOS.dwOSMajorVersion: ",
-                         managed_profiler_assembly_property.pMetaData.rOS->dwOSMajorVersion);
-            Logger::Info("Metadata.rOS.dwOSMinorVersion: ",
-                         managed_profiler_assembly_property.pMetaData.rOS->dwOSMinorVersion);
-            Logger::Info("Metadata.rOS.dwOSPlatformId: ",
-                         managed_profiler_assembly_property.pMetaData.rOS->dwOSPlatformId);
-        }
-
-        Logger::Info("Metadata.usBuildNumber: ", managed_profiler_assembly_property.pMetaData.usBuildNumber);
-        Logger::Info("Metadata.usMajorVersion: ", managed_profiler_assembly_property.pMetaData.usMajorVersion);
-        Logger::Info("Metadata.usMinorVersion: ", managed_profiler_assembly_property.pMetaData.usMinorVersion);
-        Logger::Info("Metadata.usRevisionNumber: ", managed_profiler_assembly_property.pMetaData.usRevisionNumber);
-
-        Logger::Info("pulHashAlgId: ", managed_profiler_assembly_property.pulHashAlgId);
-        Logger::Info("sizeof(pulHashAlgId): ", sizeof(managed_profiler_assembly_property.pulHashAlgId));
-        Logger::Info("assemblyFlags: ", managed_profiler_assembly_property.assemblyFlags);
+        LogManagedProfilerAssemblyDetails();
     }
 
     //

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2224,11 +2224,16 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
     }
 
     ILRewriter methodRewriter(this->info_, nullptr, module_id, getNativeTracerVersionMethodDef);
-
-    // Modify first instruction from ldstr "None" to ldstr PROFILER_VERSION
     ILInstr* pFirstInstr = methodRewriter.GetILList()->m_pNext;
-    pFirstInstr->m_Arg32 = nativeTracerVersionToken;
 
+    if (pFirstInstr->m_opcode != CEE_LDSTR)
+    {
+        Logger::Warn("Error rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION - m_opcode was not CEE_LDSTR, found", pFirstInstr->m_opcode);
+        return E_FAIL;
+    }
+    
+    // Modify first instruction from ldstr "None" to ldstr PROFILER_VERSION
+    pFirstInstr->m_Arg32 = nativeTracerVersionToken;
     hr = methodRewriter.Export();
 
     if (FAILED(hr))

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -92,6 +92,7 @@ private:
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
                            const ComPtr<IMetaDataImport2>& metadata_import);
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);
+    HRESULT RewriteForTelemetry(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT TryRejitModule(ModuleID module_id);
     bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -97,6 +97,8 @@ const shared::WSTRING calltargetbubbleexception_tracer_type_name = WStr("Datadog
 const shared::WSTRING distributed_tracer_interface_name = WStr("Datadog.Trace.ClrProfiler.IDistributedTracer");
 const shared::WSTRING distributed_tracer_target_method_name = WStr("__GetInstanceForProfiler__");
 
+const shared::WSTRING instrumentation_type_name = WStr("Datadog.Trace.ClrProfiler.Instrumentation");
+
 #ifdef _WIN32
 const shared::WSTRING native_dll_filename = WStr("DATADOG.TRACER.NATIVE.DLL");
 #elif MACOS

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var data = telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            telemetry.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
+            telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
             AssertTelemetry(data);
             agent.Telemetry.Should().BeEmpty();
         }
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-            agent.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
+            agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
             AssertTelemetry(data);
         }
 
@@ -155,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
-                agent.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
+                agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
 
                 AssertTelemetry(data);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var data = telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+            telemetry.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
             AssertTelemetry(data);
             agent.Telemetry.Should().BeEmpty();
         }
@@ -81,6 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+            agent.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
             AssertTelemetry(data);
         }
 
@@ -153,6 +155,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+                agent.AssertConfiguration(ConfigTelemetryData.IsManagedOnly, false);
 
                 AssertTelemetry(data);
             }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -229,7 +229,7 @@ namespace Datadog.Trace.Tests.Telemetry
 
             var data = collector.GetConfigurationData().ToDictionary(x => x.Name, x => x.Value);
 
-            data[ConfigTelemetryData.IsManagedOnly].Should().Be(true);
+            data[ConfigTelemetryData.NativeTracerVersion].Should().Be("None");
         }
 
 #if NETFRAMEWORK

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -220,6 +220,18 @@ namespace Datadog.Trace.Tests.Telemetry
             data[ConfigTelemetryData.CodeHotspotsEnabled].Should().Be(codeHotspotsEnabled);
         }
 
+        [Fact]
+        public void ConfigurationDataShouldMarkAsManagedOnlyWhenProfilerNotAttached()
+        {
+            var collector = new ConfigurationTelemetryCollector();
+
+            collector.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), ServiceName);
+
+            var data = collector.GetConfigurationData().ToDictionary(x => x.Name, x => x.Value);
+
+            data[ConfigTelemetryData.IsManagedOnly].Should().Be(true);
+        }
+
 #if NETFRAMEWORK
         [Theory]
         [InlineData(false)]


### PR DESCRIPTION
## Summary of changes

- Add a `native_tracer_version` entry to the startup log indicating the version of the native tracer
- Include the same flag in config telemetry

## Reason for change

Being in a "managed only" (i.e. `Datadog.Trace` NuGet only) situation limits the features available. There are various "indicators" of this (e.g. no native logs etc), but having an explicit flag in the logs/telemetry will likely be useful for support/planning. This will allow us to detect version mismatch scenarios in an obvious way

## Implementation details

Added a function `Instrumentation.GetNativeTracerVersion()` that returns "None" by default. The automatic tracer then rewrites this to return the version of the native profiler attached.

I previously took a different approach, but have now shifted to the above.
~Call `Instrumentation.IsProfilerAttached` which does a PInvoke to determine if the native profiler is there. Doing a PInvoke obviously is pretty heavy, but we only do it off the hot path, so I don't think it's a big deal?~

## Test coverage

- Added unit test for testing `native_tracer_version=None` when no profiler
- Updated integration test to assert `native_tracer_version=2.20.0` (for example) when there is a profiler

## Other details
~Ideally, it would nice to be able to PInvoke to the native lib to get the _version_ of the native lib, or have the native lib re-write a property that returns the native lib version. That way we could explicitly include that in the logs, identifying version-mismatch. If we went with the latter approach, we could avoid the PInvoke (in this PR) entirely? Do people think that's worth it?~ Took this approach

