### PR TITLE
[Tracer] Wait for ReJIT request call to complete before returning from ModuleLoadFinished profiler callback

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -596,8 +596,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         // We call the function to analyze the module and request the ReJIT of integrations defined in this module.
         if (tracer_integration_preprocessor != nullptr && !integration_definitions_.empty())
         {
-            const auto numReJITs = tracer_integration_preprocessor->RequestRejitForLoadedModules(
-                rejitModuleIds, integration_definitions_);
+            std::promise<ULONG> promise;
+            std::future<ULONG> future = promise.get_future();
+            tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(rejitModuleIds, integration_definitions_,
+                                                                                &promise);
+
+            // wait and get the value from the future<int>
+            const auto& numReJITs = future.get();
+
             Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
         }
     }
@@ -1102,8 +1108,13 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
         // We call the function to analyze the module and request the ReJIT of integrations defined in this module.
         if (tracer_integration_preprocessor != nullptr && !integration_definitions_.empty())
         {
-            const auto numReJITs = tracer_integration_preprocessor->RequestRejitForLoadedModules(
-                std::vector<ModuleID>{module_id}, integration_definitions_);
+            std::promise<ULONG> promise;
+            std::future<ULONG> future = promise.get_future();
+            tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(std::vector<ModuleID>{module_id}, integration_definitions_,
+                                                                                &promise);
+
+            // wait and get the value from the future<int>
+            const auto& numReJITs = future.get();
             Logger::Debug("[Tracer] Total number of ReJIT Requested: ", numReJITs);
         }
     }
@@ -1345,7 +1356,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
                                       caller.name == WStr("InvokePreStartInitMethods");
     }
     else if (module_metadata->assemblyName == WStr("System") ||
-             module_metadata->assemblyName == WStr("System.Net.Http"))
+             module_metadata->assemblyName == WStr("System.Net.Http") ||
+             module_metadata->assemblyName == WStr("System.Linq")) // Avoid instrumenting System.Linq which is used as part of the async state machine
     {
         valid_startup_hook_callsite = false;
     }

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -601,7 +601,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
             tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(rejitModuleIds, integration_definitions_,
                                                                                 &promise);
 
-            // wait and get the value from the future<int>
+            // wait and get the value from the future<ULONG>
             const auto& numReJITs = future.get();
 
             Logger::Debug("Total number of ReJIT Requested: ", numReJITs);
@@ -1113,7 +1113,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
             tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(std::vector<ModuleID>{module_id}, integration_definitions_,
                                                                                 &promise);
 
-            // wait and get the value from the future<int>
+            // wait and get the value from the future<ULONG>
             const auto& numReJITs = future.get();
             Logger::Debug("[Tracer] Total number of ReJIT Requested: ", numReJITs);
         }


### PR DESCRIPTION
## Summary of changes
This PR ensures that we wait for the ReJIT request to finish before returning from the ModuleLoadFinished callback. This type of wait already occurs when we initialize our instrumentations for the first time, but it was missing in this instance.

## Reason for change
We've seen some testing flake where we suspect the targeted library methods are being run before our instrumentation rewrites them. This was highlighted by the related OTEL PR which instruments a method that only runs once at startup and ended up in lots of flaky tests.

## Implementation details
On ModuleLoadFinished when we request a ReJIT for targeted methods, we now use a promise to wait on the separate ReJIT thread to finish the rewriting before returning from the CorProfiler callback.

## Test coverage
Existing tests should cover this.

## Other details
Related to https://github.com/DataDog/dd-trace-dotnet/pull/3572
