### PR TITLE
Simplify `ThreadSafeRandom` API

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/AdaptiveSampler.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
 
         internal double NextDouble()
         {
-            return ThreadSafeRandom.NextDouble();
+            return ThreadSafeRandom.Shared.NextDouble();
         }
 
         private double ComputeIntervalAlpha(int lookback)

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -381,7 +381,7 @@ namespace Datadog.Trace
             // The code randomly chooses between the two PathwayContexts.
             // If there is a race, then that's okay
             // Randomly select between keeping the current context (0) or replacing (1)
-            if (ThreadSafeRandom.Next(2) == 1)
+            if (ThreadSafeRandom.Shared.Next(2) == 1)
             {
                 PathwayContext = pathwayContext;
             }

--- a/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/tracer/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -14,8 +14,8 @@ namespace Datadog.Trace.Util
             ulong value;
             do
             {
-                long high = ThreadSafeRandom.Next(int.MinValue, int.MaxValue);
-                long low = ThreadSafeRandom.Next(int.MinValue, int.MaxValue);
+                long high = ThreadSafeRandom.Shared.Next(int.MinValue, int.MaxValue);
+                long low = ThreadSafeRandom.Shared.Next(int.MinValue, int.MaxValue);
 
                 // Concatenate both values, and truncate the 32 top bits from low
                 value = (ulong)(high << 32 | (low & 0xFFFFFFFF)) & 0x7FFFFFFFFFFFFFFF;

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -13,12 +13,6 @@ internal static class ThreadSafeRandom
 {
 #if NET6_0_OR_GREATER
     public static Random Shared => Random.Shared;
-
-    public static int Next(int maxValue) => Random.Shared.Next(maxValue);
-
-    public static int Next(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
-
-    public static double NextDouble() => Random.Shared.NextDouble();
 #else
     private static readonly Random Global = new();
 
@@ -32,6 +26,7 @@ internal static class ThreadSafeRandom
             if (_local is null)
             {
                 int seed;
+
                 lock (Global)
                 {
                     seed = Global.Next();
@@ -44,19 +39,5 @@ internal static class ThreadSafeRandom
         }
     }
 
-    public static int Next(int maxValue)
-    {
-        return Shared.Next(maxValue);
-    }
-
-    public static int Next(int minValue, int maxValue)
-    {
-        return Shared.Next(minValue, maxValue);
-    }
-
-    public static double NextDouble()
-    {
-        return Shared.NextDouble();
-    }
 #endif
 }

--- a/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
+++ b/tracer/src/Datadog.Trace/Util/ThreadSafeRandom.cs
@@ -6,13 +6,14 @@
 #nullable enable
 
 using System;
-using System.Threading;
 
 namespace Datadog.Trace.Util;
 
 internal static class ThreadSafeRandom
 {
 #if NET6_0_OR_GREATER
+    public static Random Shared => Random.Shared;
+
     public static int Next(int maxValue) => Random.Shared.Next(maxValue);
 
     public static int Next(int minValue, int maxValue) => Random.Shared.Next(minValue, maxValue);
@@ -24,7 +25,7 @@ internal static class ThreadSafeRandom
     [ThreadStatic]
     private static Random? _local;
 
-    private static Random Local
+    public static Random Shared
     {
         get
         {
@@ -45,17 +46,17 @@ internal static class ThreadSafeRandom
 
     public static int Next(int maxValue)
     {
-        return Local.Next(maxValue);
+        return Shared.Next(maxValue);
     }
 
     public static int Next(int minValue, int maxValue)
     {
-        return Local.Next(minValue, maxValue);
+        return Shared.Next(minValue, maxValue);
     }
 
     public static double NextDouble()
     {
-        return Local.NextDouble();
+        return Shared.NextDouble();
     }
 #endif
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -107,8 +107,8 @@ public class DataStreamsMonitoringTransportTests
     private StatsPoint CreateStatsPoint()
         => new StatsPoint(
             edgeTags: new[] { "direction:out", "type:kafka" },
-            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
-            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
+            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
             timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
             pathwayLatencyNs: 5_000_000_000,
             edgeLatencyNs: 2_000_000_000);

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -356,8 +356,8 @@ public class DataStreamsWriterTests
     private static StatsPoint CreateStatsPoint()
         => new StatsPoint(
             edgeTags: new[] { "direction:out", "type:kafka" },
-            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
-            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Next(int.MaxValue))),
+            hash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
+            parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
             timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
             pathwayLatencyNs: 5_000_000_000,
             edgeLatencyNs: 2_000_000_000);


### PR DESCRIPTION
## Summary of changes

This PR changes the `ThreadSafeRandom.Local` API to more closely match the built-in `System.Random.Shared`.

```csharp
// before
var i = ThreadSafeRandom.Next();
var d = ThreadSafeRandom.NextDouble();

// after, ThreadSafeRandom.Shared returns the threadstatic Random instance
var i = ThreadSafeRandom.Shared.Next();
var d = ThreadSafeRandom.Shared.NextDouble();

// on .NET 6 or above, the "after" lines above are equivalent to using Random.Shared directly
var i = Random.Shared.Next();
var d = Random.Shared.NextDouble();
```

## Reason for change

This API better matches the `Random.Shared.{Method}` API in .NET 6 and above, keeps our `ThreadSafeRandom` type smaller, and requires less maintenance going forwards (for example, we no longer need to add new methods that delegate to the internal `Random` instance).

On .NET 6 and above, `ThreadSafeRandom.Shared` simply returns `Random.Shared`.

## Implementation details

This PR renames `ThreadSafeRandom.Local` to `Shared` and makes it public. It also replaces previous uses of `ThreadSafeRandom.{Method}` with `ThreadSafeRandom.Shared.{Method}`. Lastly, on .NET 6 or above, `ThreadSafeRandom.Shared` simply returns `Random.Shared`.

## Test coverage

Not required.

## Other details

See https://github.com/dotnet/runtime/pull/50297 regarding `System.Random.Shared`.
