### PR TITLE
Fix path to FakeDbCommand in execution time benchmarks

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -19,7 +19,7 @@
       }
     }
   ],
-  "processName": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net462\\Samples.FakeDbCommand.dll.exe",
+  "processName": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net462\\Samples.FakeDbCommand.exe",
   "processArguments": "no-wait",
   "processTimeout": 15,
   "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net462",


### PR DESCRIPTION
## Summary of changes

Fixes the path to the execution benchmarks

## Reason for change

I fat fingered it in #3654 

## Implementation details

`.dll.exe -> .exe`

## Test coverage

Yeah... I'll check it properly this time 🤦‍♂️ 

