### PR TITLE
Drop SDK in global.json down to 7.0.100

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.101",
+    "version": "7.0.100",
     "rollForward": "patch"
   }
 }


### PR DESCRIPTION
## Summary of changes

Drops the minimum required SDK version to `7.0.100` in the SDK

## Reason for change

We no longer _need_ it to be `7.0.101` after the changes we made to x64/x86 handling. Allowing people to use an earlier SDK version will reduce friction. The build in CI is unchanged and still uses `7.0.101`

## Implementation details

`7.0.101 -> 7.0.100`

## Test coverage

CI reveals all

## Other details

This was triggered by me trying to run x86 tests locally, and realizing I only had version of 7.0.100 of the 32-bit version installed (although I have 7.0.102 of the 64-bit version). 