### PR TITLE
Add instance info to the IL dump

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -2436,6 +2436,10 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
             {
                 const auto memberInfo = GetFunctionInfo(metadata_import, (mdMemberRef) cInstr->m_Arg32);
                 augmented = true;
+                if (memberInfo.signature.IsInstanceMethod())
+                {
+                    orig_sstream << "instance ";
+                }
                 orig_sstream << shared::ToString(memberInfo.type.name);
                 orig_sstream << ".";
                 orig_sstream << shared::ToString(memberInfo.name);


### PR DESCRIPTION
## Summary of changes

This PR adds the `instance` info for method calls in the DumpIL log mode.
