### PR TITLE
[Profiler] Fix deadlock due to TLS initialization while unwinding

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -35,6 +35,7 @@ namespace Samples.Computer01
 #if NET6_0_OR_GREATER
         private LinuxSignalHandler _linuxSignalHandler;
 #endif
+        private LinuxMallocDeadLock _linuxMallockDeadlock;
 
         public void StartService(Scenario scenario, int nbThreads, int parameter)
         {
@@ -112,6 +113,10 @@ namespace Samples.Computer01
 
                 case Scenario.QuicklyDeadThreads:
                     StartQuicklyDeadThreads(nbThreads, parameter);
+                    break;
+
+                case Scenario.LinuxMallocDeadlock:
+                    StartLinuxMallocDeadlock();
                     break;
 
                 default:
@@ -192,6 +197,10 @@ namespace Samples.Computer01
 
                 case Scenario.QuicklyDeadThreads:
                     StopQuicklyDeadThreads();
+                    break;
+
+                case Scenario.LinuxMallocDeadlock:
+                    StopLinuxMallocDeadlock();
                     break;
             }
         }
@@ -276,6 +285,10 @@ namespace Samples.Computer01
 
                     case Scenario.QuicklyDeadThreads:
                         RunQuicklyDeadThreads(nbThreads, parameter);
+                        break;
+
+                    case Scenario.LinuxMallocDeadlock:
+                        RunLinuxMallocDeadlock();
                         break;
 
                     default:
@@ -401,6 +414,12 @@ namespace Samples.Computer01
             _quicklyDeadThreads.Start();
         }
 
+        private void StartLinuxMallocDeadlock()
+        {
+            _linuxMallockDeadlock = new LinuxMallocDeadLock();
+            _linuxMallockDeadlock.Start();
+        }
+
         private void StopComputer()
         {
             using (_computer)
@@ -485,6 +504,11 @@ namespace Samples.Computer01
         private void StopQuicklyDeadThreads()
         {
             _quicklyDeadThreads.Stop();
+        }
+
+        private void StopLinuxMallocDeadlock()
+        {
+            _linuxMallockDeadlock.Stop();
         }
 
         private void RunComputer()
@@ -591,6 +615,12 @@ namespace Samples.Computer01
 
             var quicklyDeadThreads = new QuicklyDeadThreads(nbThreads, nbThreadsToCreate);
             quicklyDeadThreads.Run();
+        }
+
+        private void RunLinuxMallocDeadlock()
+        {
+            var linuxSignalHandler = new LinuxMallocDeadLock();
+            linuxSignalHandler.Run();
         }
 
         public class MySpecialClassA

--- a/profiler/src/Demos/Samples.Computer01/LinuxMallocDeadlock.cs
+++ b/profiler/src/Demos/Samples.Computer01/LinuxMallocDeadlock.cs
@@ -1,0 +1,99 @@
+// <copyright file="LinuxMallocDeadlock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Computer01
+{
+    internal class LinuxMallocDeadLock
+    {
+        private ManualResetEvent _stopEvent;
+        private Task _runningTask;
+
+        public LinuxMallocDeadLock()
+        {
+        }
+
+        public void Start()
+        {
+            if (_stopEvent != null)
+            {
+                throw new InvalidOperationException("Already running...");
+            }
+
+            _stopEvent = new ManualResetEvent(false);
+
+            var counter = 0;
+            _runningTask = Task.Factory.StartNew(
+                        () =>
+                        {
+                            var loggingClock = Stopwatch.StartNew();
+                            while (!IsEventSet())
+                            {
+                                if (loggingClock.ElapsedMilliseconds >= 1000)
+                                {
+                                    Console.WriteLine($"* Nb execution {counter}");
+                                    Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                                    counter = 0;
+                                    loggingClock.Restart();
+                                }
+
+                                var thread = new Thread(ExecuteAllocationScenario)
+                                {
+                                    IsBackground = false // set to false to prevent the app from shutting down. The test will fail
+                                };
+                                thread.Start();
+                                counter++;
+                            }
+                        },
+                        TaskCreationOptions.LongRunning);
+        }
+
+        public void Run()
+        {
+            Start();
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Stop();
+        }
+
+        public void Stop()
+        {
+            if (_stopEvent == null)
+            {
+                throw new InvalidOperationException("Not running...");
+            }
+
+            _stopEvent.Set();
+
+            _runningTask.Wait();
+
+            _stopEvent.Dispose();
+            _stopEvent = null;
+            _runningTask = null;
+        }
+
+        [DllImport("libc.so.6", EntryPoint = "malloc")]
+        private static extern IntPtr Malloc(int size);
+
+        [DllImport("libc.so.6", EntryPoint = "free")]
+        private static extern void Free(IntPtr ptr);
+
+        private static void ExecuteAllocationScenario()
+        {
+            var ptr = Malloc(1040);
+            Thread.Sleep(TimeSpan.FromMilliseconds(10));
+            Free(ptr);
+        }
+
+        private bool IsEventSet()
+        {
+            return _stopEvent.WaitOne(0);
+        }
+    }
+}

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -27,7 +27,8 @@ namespace Samples.Computer01
         LinuxSignalHandler,
         GarbageCollection,   // parameter = generation 0, 1 or 2
         MemoryLeak,          // parameter = number of objects to allocate
-        QuicklyDeadThreads // parameter = number of short lived threads to create
+        QuicklyDeadThreads, // parameter = number of short lived threads to create
+        LinuxMallocDeadlock
     }
 
     public class Program

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/MallocDeadlock.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/MallocDeadlock.cs
@@ -1,0 +1,30 @@
+// <copyright file="MallocDeadlock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.SmokeTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class MallocDeadlock
+    {
+        private const string ScenarioLinuxMallocDeadlock = "--scenario 15";
+        private readonly ITestOutputHelper _output;
+
+        public MallocDeadlock(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckApplicationDoesNotEndUpInDeadlock(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, ScenarioLinuxMallocDeadlock, _output);
+            runner.RunAndCheck();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Fix a malloc-deadlock case when initializing TLS objects while unwinding.

## Reason for change

When calling `unw_backtrace` or `unw_backtrace2`, libunwind will initialize TLS object for the current thread. A TLS initialization is merely a call to `malloc`. But `malloc` is not signal-safe, which means that we can end up in a deadlock situation if we call `malloc` while being in a signal handler.
Example of callstack you might have:

![image](https://user-images.githubusercontent.com/17292193/212341111-7f8dcec7-c961-452d-a1a6-2dfa35e30e6a.png)

As you can see, the thread was calling malloc and then preempted by the signal. Inside libunwind, `(2)` initializes TLS objects and ends up calling `malloc` in `(3)`.

Related issue could be one of the case in https://github.com/DataDog/dd-trace-dotnet/issues/3625.

## Implementation details

- When assigning an OS thread to a managed thread, we call `unw_backtrace` to initialize the TLS'd data structures. It should be safe in that case to call `unw_backtrace`.

## Test coverage

- Add a new scenario to validate that we do not end up in a deadlock situation.

## Other details
Another alternative could have been adding `malloc`, `calloc`, `realloc` and `free` in the [wrapper](https://github.com/DataDog/dd-trace-dotnet/blob/master/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c) , but we could a significant performance degradation, because at each `malloc` (or other function) call, we would do 2 syscalls (one to prevent signal interruption and another to restore the previous signal mask)

The `pthread_create`-like alternative could have benn a good one: adding a counter to indicate if we are in malloc call.
