### PR TITLE
[Tracer] Fix the Datadog ServiceName for spans generated by different ActivitySource's

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -107,13 +107,7 @@ namespace Datadog.Trace.Activity.Handlers
 
             static Scope CreateScopeFromActivity(T activity, SpanContext? parent, ulong? traceId, ulong? spanId, string? rawTraceId, string? rawSpanId)
             {
-                string? serviceName = activity switch
-                {
-                    IActivity5 activity5 => activity5.Source.Name,
-                    _ => null
-                };
-
-                var span = Tracer.Instance.StartSpan(activity.OperationName, parent: parent, serviceName: serviceName, startTime: activity.StartTimeUtc, traceId: traceId, spanId: spanId, rawTraceId: rawTraceId, rawSpanId: rawSpanId);
+                var span = Tracer.Instance.StartSpan(activity.OperationName, parent: parent, startTime: activity.StartTimeUtc, traceId: traceId, spanId: spanId, rawTraceId: rawTraceId, rawSpanId: rawSpanId);
                 Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 
                 return Tracer.Instance.ActivateSpan(span, false);

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -103,7 +103,11 @@ namespace Datadog.Trace.Activity
             if (activity5 is not null)
             {
                 span.SetTag("otel.library.name", activity5.Source.Name);
-                span.SetTag("otel.library.version", activity5.Source.Version);
+
+                if (!string.IsNullOrEmpty(activity5.Source.Version))
+                {
+                    span.SetTag("otel.library.version", activity5.Source.Version);
+                }
             }
 
             // Set OTEL status code and OTEL status description

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -72,8 +72,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 spans.Count.Should().Be(expectedSpanCount);
 
                 var otelSpans = spans.Where(s => s.Service == "MyServiceName");
+                var activitySourceSpans = spans.Where(s => s.Service == customServiceName);
+
                 otelSpans.Count().Should().Be(expectedSpanCount - 1);
+                activitySourceSpans.Count().Should().Be(1);
+
                 ValidateIntegrationSpans(otelSpans, expectedServiceName: "MyServiceName");
+                ValidateIntegrationSpans(activitySourceSpans, expectedServiceName: customServiceName);
 
                 // there's a bug in < 1.2.0 where they get the span parenting wrong
                 // so use a separate snapshot

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -20,11 +20,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     [UsesVerify]
     public class OpenTelemetrySdkTests : TracingIntegrationTest
     {
+        private readonly string customServiceName = "CustomServiceName";
+
         public OpenTelemetrySdkTests(ITestOutputHelper output)
             : base("OpenTelemetrySdk", output)
         {
-            // Intentionally unset service name and version, which may be derived from OTEL SDK
-            SetServiceName(string.Empty);
+            SetServiceName(customServiceName);
             SetServiceVersion(string.Empty);
         }
 
@@ -64,7 +65,43 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                const int expectedSpanCount = 11;
+                const int expectedSpanCount = 12;
+                var spans = agent.WaitForSpans(expectedSpanCount);
+
+                using var s = new AssertionScope();
+                spans.Count.Should().Be(expectedSpanCount);
+
+                var otelSpans = spans.Where(s => s.Service == "MyServiceName");
+                otelSpans.Count().Should().Be(expectedSpanCount - 1);
+                ValidateIntegrationSpans(otelSpans, expectedServiceName: "MyServiceName");
+
+                // there's a bug in < 1.2.0 where they get the span parenting wrong
+                // so use a separate snapshot
+                var filename = nameof(OpenTelemetrySdkTests) + GetSuffix(packageVersion);
+
+                var settings = VerifyHelper.GetSpanVerifierSettings();
+                await VerifyHelper.VerifySpans(spans, settings)
+                                  .UseFileName(filename)
+                                  .DisableRequireUniquePrefix();
+
+                telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+            }
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(PackageVersions.OpenTelemetry), MemberType = typeof(PackageVersions))]
+        public async Task SubmitsTracesWithActivitySource(string packageVersion)
+        {
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
+            SetEnvironmentVariable("ADD_ADDITIONAL_ACTIVITY_SOURCE", "true");
+
+            using (var telemetry = this.ConfigureTelemetry())
+            using (var agent = EnvironmentHelper.GetMockAgent())
+            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            {
+                const int expectedSpanCount = 12;
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
                 using var s = new AssertionScope();
@@ -73,7 +110,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 // there's a bug in < 1.2.0 where they get the span parenting wrong
                 // so use a separate snapshot
-                var filename = nameof(OpenTelemetrySdkTests) + GetSuffix(packageVersion);
+                var filename = nameof(OpenTelemetrySdkTests) + "WithActivitySource" + GetSuffix(packageVersion);
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 await VerifyHelper.VerifySpans(spans, settings)

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -264,7 +264,7 @@
     SpanId: Id_16,
     Name: AdditionalActivitySource.internal,
     Resource: Transform,
-    Service: AdditionalActivitySource,
+    Service: CustomServiceName,
     Type: custom,
     Tags: {
       env: integration_tests,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -270,7 +270,6 @@
       env: integration_tests,
       language: dotnet,
       otel.library.name: AdditionalActivitySource,
-      otel.library.version: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -258,5 +258,31 @@
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
     }
+  },
+  {
+    TraceId: Id_15,
+    SpanId: Id_16,
+    Name: AdditionalActivitySource.internal,
+    Resource: Transform,
+    Service: AdditionalActivitySource,
+    Type: custom,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: AdditionalActivitySource,
+      otel.library.version: ,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_6,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
   }
 ]

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -270,7 +270,6 @@
       env: integration_tests,
       language: dotnet,
       otel.library.name: AdditionalActivitySource,
-      otel.library.version: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -103,26 +103,6 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: MyServiceName.internal,
-    Resource: StartActiveSpan.Child,
-    Service: MyServiceName,
-    Type: custom,
-    ParentId: Id_2,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
-      service.instance.id: Guid_3,
-      service.name: MyServiceName,
-      service.version: 1.0.x,
-      span.kind: internal
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_7,
-    Name: MyServiceName.internal,
     Resource: InnerSpanOk,
     Service: MyServiceName,
     Type: custom,
@@ -141,7 +121,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_8,
+    SpanId: Id_7,
     Name: MyServiceName.internal,
     Resource: InnerSpanError,
     Service: MyServiceName,
@@ -164,7 +144,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_9,
+    SpanId: Id_8,
     Name: MyServiceName.internal,
     Resource: InnerSpanUpdated,
     Service: MyServiceName,
@@ -184,7 +164,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_10,
+    SpanId: Id_9,
     Name: OtherLibrary.internal,
     Resource: Response,
     Service: MyServiceName,
@@ -195,6 +175,26 @@
       language: dotnet,
       otel.library.name: OtherLibrary,
       otel.library.version: 4.0.0,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
+      span.kind: internal
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: MyServiceName.internal,
+    Resource: StartActiveSpan.Child,
+    Service: MyServiceName,
+    Type: custom,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
@@ -264,7 +264,7 @@
     SpanId: Id_16,
     Name: AdditionalActivitySource.internal,
     Resource: Transform,
-    Service: AdditionalActivitySource,
+    Service: MyServiceName,
     Type: custom,
     Tags: {
       env: integration_tests,
@@ -274,6 +274,9 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -264,7 +264,7 @@
     SpanId: Id_16,
     Name: AdditionalActivitySource.internal,
     Resource: Transform,
-    Service: AdditionalActivitySource,
+    Service: MyServiceName,
     Type: custom,
     Tags: {
       env: integration_tests,
@@ -274,6 +274,9 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
       _dd.p.dm: -0
     },

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -270,7 +270,6 @@
       env: integration_tests,
       language: dotnet,
       otel.library.name: AdditionalActivitySource,
-      otel.library.version: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -264,7 +264,7 @@
     SpanId: Id_16,
     Name: AdditionalActivitySource.internal,
     Resource: Transform,
-    Service: AdditionalActivitySource,
+    Service: CustomServiceName,
     Type: custom,
     Tags: {
       env: integration_tests,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -270,7 +270,6 @@
       env: integration_tests,
       language: dotnet,
       otel.library.name: AdditionalActivitySource,
-      otel.library.version: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,

--- a/tracer/test/snapshots/TelemetryTests.verified.txt
+++ b/tracer/test/snapshots/TelemetryTests.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -47,18 +47,18 @@
     SpanId: Id_5,
     Name: opentelemetry.internal,
     Resource: HttpListener.ReceivedRequest,
-    Service: ,
+    Service: Samples.Telemetry,
     Type: custom,
     Tags: {
       content: PONG,
       env: integration_tests,
       language: dotnet,
       otel.library.name: ,
-      otel.library.version: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_2,
       runtime-id: Guid_1,
       span.kind: internal,
+      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/CustomTracerProviderBuilderExtensions.cs
@@ -20,4 +20,15 @@ public static class CustomTracerProviderBuilderExtensions
 
         return builder;
     }
+
+    public static TracerProviderBuilder AddActivitySourceIfEnvironmentVariablePresent(this TracerProviderBuilder builder)
+    {
+        if (Environment.GetEnvironmentVariable("ADD_ADDITIONAL_ACTIVITY_SOURCE") is string value
+&& value == "true")
+        {
+            return builder.AddSource(Program._additionalActivitySourceName);
+        }
+        
+        return builder;
+    }
 }

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Properties/launchSettings.json
@@ -3,17 +3,16 @@
     "WithDatadog": {
       "commandName": "Project",
       "environmentVariables": {
-        "DD_ENV": "",
-        "DD_SERVICE": "",
+        "DD_SERVICE": "CustomServiceName",
         "DD_VERSION": "",
 
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         "DD_TRACE_OTEL_ENABLED": "true"


### PR DESCRIPTION
## Summary of changes
When generating Datadog spans in the `DefaultActivityHandler`, inherit the ServiceName of the active Datadog Tracer.

## Reason for change
There are two scenarios we encounter when listening to Activity objects generated from ActivitySource's:
1. The OTEL SDK has been instructed to listen to the ActivitySource
2. The OTEL SDK has NOT been instructed to listen to the ActivitySource

In the first case, the corresponding Datadog span that we generate will receive the same OTEL service.name resource like all other OTEL spans (see https://github.com/DataDog/dd-trace-dotnet/pull/3572).

In the second case, based on changes in https://github.com/DataDog/dd-trace-dotnet/pull/3556, we are setting the ServiceName of the Datadog span to the name of the ActivitySource. This causes spans from different ActivitySources to have different ServiceName's, which is not a desirable experience. Instead, all spans from the same application should share the same ServiceName.

## Implementation details
The only change in the product is that when the `DefaultActivityHandler` creates a span it does not customize the ServiceName, so the new span will inherit the ServiceName of the Datadog Tracer.

## Test coverage
Adds another span to the Samples.OpenTelemetrySdk to cover this scenario

## Other details
Follows up on the discussion in https://github.com/DataDog/dd-trace-dotnet/issues/3027
