### PR TITLE
Add missing dependencies to `build_runner_tool_and_standalone` stage 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2324,7 +2324,7 @@ stages:
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [build_windows_tracer, build_linux_tracer, build_arm64_tracer, build_macos, master_commit_id]
+  dependsOn: [build_windows_tracer, build_windows_profiler, build_linux_tracer, build_linux_profiler, build_arm64_tracer, build_arm64_profiler, build_macos, master_commit_id]
   variables:
     masterCommitId: $[ stageDependencies.master_commit_id.fetch.outputs['set_sha.master']]
   jobs:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.101",
     "rollForward": "patch"
   }
 }


### PR DESCRIPTION
## Summary of changes

- Add missing stage dependencies
- Bump the global.json to 7.0.101.

## Reason for change

[A build recently failed](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=124932&view=logs&s=a4ad5d10-76e5-5fda-5efd-66e7d30f782c) because the `build_runner_tool_and_standalone` ran before the arm64 version of the profiler had finished building.

Leaving the global.json at `7.0.100` with a `patch` rollforward means that the CI tries to use `7.0.100` if it's available (which it sometimes is) _in preference_ to `7.0.101`. That's an issue. Bumping to `7.0.101` should pin the value in CI, while still allowing floating versions locally.

## Implementation details

Add the missing dependencies and change the global.json

## Test coverage

YOLO

