### PR TITLE
Fix the tag sanitization algorithm used for RCM requests

### DIFF
--- a/tracer/src/Datadog.Trace/Util/TagsHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/TagsHelper.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="TagsHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace Datadog.Trace.Util;
+
+/// <summary>
+/// Taken from:
+/// https://github.com/DataDog/dd-trace-java/blob/069ada67c23fd6735fb6722a8d57b9d3e40edc87/internal-api/src/main/java/datadog/trace/util/TagsHelper.java
+/// which was originally taken from:
+/// https://github.com/DataDog/logs-backend/blob/d0b3289ce2c63c1e8f961f03fc4e03318fb36b0f/processing/src/main/java/com/dd/logs/processing/common/Tags.java#L44
+/// </summary>
+internal sealed class TagsHelper
+{
+    private const int MaxLength = 200;
+
+    /// <summary>
+    /// Sanitizes a tag, more or less following (but not exactly) the recommended Datadog guidelines.
+    ///
+    /// See the exact guidelines:
+    /// https://docs.datadoghq.com/getting_started/tagging/#tags-best-practices
+    ///
+    /// 1. Tags must start with a letter, and after that may contain: - Alphanumerics - Underscores
+    /// - Minuses - Colons - Periods - Slashes Other special characters get converted to underscores.
+    /// Note: A tag cannot end with a colon (e.g., tag:)
+    ///
+    /// 2. Tags can be up to 200 characters long and support unicode.
+    ///
+    /// 3. Tags are converted to lowercase.
+    ///
+    /// 4. A tag can have a value or a key:value syntax: For optimal functionality, we recommend
+    /// constructing tags that use the key:value syntax. The key is always what precedes the first
+    /// colon of the global tag definition, e.g.: - role:database:mysql is parsed as key:role ,
+    /// value:database:mysql - role_database:mysql is parsed as key:role_database , value:mysql
+    /// Examples of commonly used metric tag keys are env, instance, name, and role.
+    ///
+    /// 5. device, host, and source are reserved tag keys and cannot be specified in the standard
+    /// way.
+    ///
+    /// 6. Tags shouldn't originate from unbounded sources, such as EPOCH timestamps or user IDs.
+    /// These tags may impact platform performance and billing.
+    ///
+    /// Changes: we trim leading and trailing spaces.
+    /// </summary>
+    /// <param name="tag">The tag to sanitize.</param>
+    /// <returns>A sanitized tag, or null if the provided tag was null.</returns>
+    public static string? Sanitize(string? tag)
+    {
+        if (tag == null)
+        {
+            return null;
+        }
+
+        string lower = tag.ToLower(CultureInfo.InvariantCulture).Trim();
+        int length = Math.Min(lower.Length, MaxLength);
+        var sanitized = StringBuilderCache.Acquire(length);
+
+        for (int i = 0; i < length; ++i)
+        {
+            char c = lower[i];
+            sanitized.Append(IsValid(c) ? c : '_');
+        }
+
+        return StringBuilderCache.GetStringAndRelease(sanitized);
+
+        bool IsValid(char c) => char.IsLetterOrDigit(c) || c is '-' or '_' or '.' or '/' or ':';
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/TagsHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/TagsHelperTests.cs
@@ -1,0 +1,83 @@
+﻿// <copyright file="TagsHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Text;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+#nullable enable
+
+namespace Datadog.Trace.Tests.Util;
+
+/// <summary>
+/// Taken from https://github.com/DataDog/dd-trace-java/blob/069ada67c23fd6735fb6722a8d57b9d3e40edc87/internal-api/src/test/java/datadog/trace/util/TagsHelperTest.java
+/// </summary>
+public class TagsHelperTests
+{
+    [Fact]
+    public void ValidTagDoesNotChange()
+    {
+        var keyValue = "key:value";
+        var validChars = "abc..xyz1234567890-_./:";
+        TagsHelper.Sanitize(keyValue).Should().Be(keyValue);
+        TagsHelper.Sanitize(validChars).Should().Be(validChars);
+    }
+
+    [Fact]
+    public void NullIsSupported()
+    {
+        TagsHelper.Sanitize(tag: null).Should().Be(expected: null);
+    }
+
+    [Fact]
+    public void UpperCase()
+    {
+        TagsHelper.Sanitize("key:VALUE").Should().Be("key:value");
+    }
+
+    [Fact]
+    public void TrimSpaces()
+    {
+        TagsHelper.Sanitize("    service-name  ").Should().Be("service-name");
+        TagsHelper.Sanitize("    service name  ").Should().Be("service_name");
+    }
+
+    [Fact]
+    public void InvalidCharsConvertedToUnderscore()
+    {
+        TagsHelper.Sanitize("my@email.com").Should().Be("my_email.com");
+        TagsHelper.Sanitize("smile and \u1234").Should().Be("smile_and__");
+    }
+
+    [Fact]
+    public void TagTrimmedToMaxLength()
+    {
+        StringBuilder tag = new StringBuilder(capacity: 401);
+        for (var i = 0; i < 400; i++)
+        {
+            tag.Append("a");
+        }
+
+        var sanitized = TagsHelper.Sanitize(tag.ToString());
+        sanitized!.Length.Should().Be(expected: 200);
+        Encoding.UTF8.GetByteCount(sanitized).Should().Be(expected: 200);
+    }
+
+    [Fact]
+    public void TagTrimmedToMaxLengthWorkWithUnicode()
+    {
+        var tag = new StringBuilder(capacity: 401);
+        for (var i = 0; i < 400; i++)
+        {
+            tag.Append("\u1234");
+        }
+
+        var sanitized = TagsHelper.Sanitize(tag.ToString());
+        sanitized.Should().NotBeNullOrEmpty();
+        sanitized!.Length.Should().Be(expected: 200);
+        Encoding.UTF8.GetByteCount(sanitized).Should().Be(expected: 200);
+    }
+}


### PR DESCRIPTION
## Summary of changes
Use the same tag sanitization algorithm for the tags we pass along to Remote Configuration Management requests as the [one used in the Java tracer](https://github.com/DataDog/dd-trace-java/blob/069ada67c23fd6735fb6722a8d57b9d3e40edc87/internal-api/src/main/java/datadog/trace/util/TagsHelper.java).

## Reason for change
In https://github.com/DataDog/dd-trace-dotnet/pull/3614, we added processing to the tags to sanitize them and convert them to lowercase using `TraceUtil.NormalizeTag`. Unfortunately, this was a bad choice - while this fixed the original bug that occurred when the service name had uppercase characters, in introduced a new bug as it caused the `service version` to be errantly trimmed (e.g. from `1.0.0` to an empty string). This broke the RCM functionality, and broke the relevant system-tests.

## Test coverage
This is covered by the system-tests that are currently failing on `master`. I had accidentally merged #3614 as I did not notice these failures originally.