### PR TITLE
RCM requests should normalize 'service' and 'env`, but not other tags

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -384,7 +384,7 @@ namespace Datadog.Trace.ClrProfiler
                         var rcmApi = RemoteConfigurationApiFactory.Create(tracer.Settings.Exporter, rcmSettings, discoveryService);
                         var tags = GetTags(tracer, rcmSettings);
 
-                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, TraceUtil.NormalizeTag(tracer.Settings.Environment), TraceUtil.NormalizeTag(tracer.Settings.ServiceVersion), tags);
+                        var configurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, TraceUtil.NormalizeTag(tracer.Settings.Environment), tracer.Settings.ServiceVersion, tags);
                         // see comment above
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmFeaturesProduct);
                         configurationManager.RegisterProduct(AsmRemoteConfigurationProducts.AsmDataProduct);
@@ -414,19 +414,19 @@ namespace Datadog.Trace.ClrProfiler
                 tags.Add($"env:{environment}");
             }
 
-            var serviceVersion = TraceUtil.NormalizeTag(tracer.Settings.ServiceVersion);
+            var serviceVersion = tracer.Settings.ServiceVersion;
             if (!string.IsNullOrEmpty(serviceVersion))
             {
                 tags.Add($"version:{serviceVersion}");
             }
 
-            var tracerVersion = TraceUtil.NormalizeTag(rcmSettings.TracerVersion);
+            var tracerVersion = rcmSettings.TracerVersion;
             if (!string.IsNullOrEmpty(tracerVersion))
             {
                 tags.Add($"tracer_version:{tracerVersion}");
             }
 
-            var hostName = TraceUtil.NormalizeTag(PlatformHelpers.HostMetadata.Instance?.Hostname);
+            var hostName = PlatformHelpers.HostMetadata.Instance?.Hostname;
             if (!string.IsNullOrEmpty(hostName))
             {
                 tags.Add($"host_name:{hostName}");


### PR DESCRIPTION
## Summary of changes
Change the logic of building RCM requests so that only `service` and `environment` tag values are normalized, whereas the others are left untouched, as per the behavior [that is implemented ](https://github.com/DataDog/datadog-agent/pull/13843)in `datadog-agent v7.42` and onwards.

## Reason for change
In https://github.com/DataDog/dd-trace-dotnet/pull/3614, we added processing to the tags to sanitize them and convert them to lowercase using `TraceUtil.NormalizeTag`. 

To be safe, we decided to apply this to all tags that are passed along to RCM requests. Unfortunately, this was a bad choice - while it fixed the original bug that occurred when the service name had uppercase characters, it introduced a new bug as it caused the `app_version` to be errantly trimmed (e.g. from `"1.0.0"` to an empty string). This broke the RCM functionality, and broke the relevant system-tests.

## Test coverage
This is covered by the system-tests that are currently failing on `master`. I had accidentally merged #3614 as I did not notice these failures originally.