### PR TITLE
Stop using the CorProfiler singleton in rejit logic

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -350,6 +350,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     Logger::Info("Profiler attached.");
     this->info_->AddRef();
     is_attached_.store(true);
+    profiler = this;
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -34,7 +34,7 @@ using namespace std::chrono_literals;
 namespace trace
 {
 
-CorProfiler* profiler = nullptr;
+    CorProfiler* profiler = nullptr;
 
 //
 // ICorProfilerCallback methods
@@ -253,10 +253,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     rejit_handler = info10 != nullptr
                         ? std::make_shared<RejitHandler>(info10, work_offloader)
                         : std::make_shared<RejitHandler>(this->info_, work_offloader);
-    tracer_integration_preprocessor = std::make_unique<TracerRejitPreprocessor>(rejit_handler, work_offloader);
+    tracer_integration_preprocessor = std::make_unique<TracerRejitPreprocessor>(this, rejit_handler, work_offloader);
 
     debugger_instrumentation_requester = std::make_unique<debugger::DebuggerProbesInstrumentationRequester>(
-        rejit_handler, work_offloader);
+        this, rejit_handler, work_offloader);
 
     DWORD event_mask = COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
                        COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_MONITOR_APPDOMAIN_LOADS |
@@ -350,7 +350,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     Logger::Info("Profiler attached.");
     this->info_->AddRef();
     is_attached_.store(true);
-    profiler = this;
     return S_OK;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -462,7 +462,7 @@ HRESULT DebuggerMethodRewriter::ApplyLineProbes(
     ILRewriterWrapper& rewriterWrapper, 
     ULONG lineProbeCallTargetStateIndex, 
     std::vector<EHClause>& newClauses,
-    bool isAsyncMethod) 
+    bool isAsyncMethod) const
 {
     if (isAsyncMethod && caller->type.isGeneric && caller->type.valueType)
     {
@@ -1166,7 +1166,7 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
 }
 
 HRESULT DebuggerMethodRewriter::IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport,
-                                                   const FunctionInfo* caller, bool& isAsyncMethod) 
+                                                   const FunctionInfo* caller, bool& isAsyncMethod) const
 {
     if (caller->name != WStr("MoveNext") || caller->method_signature.NumberOfArguments() > 0 ||
         std::get<unsigned>(caller->method_signature.GetReturnValue().GetElementTypeAndFlags()) != ELEMENT_TYPE_VOID)

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -1,105 +1,117 @@
 #ifndef DD_CLR_PROFILER_DEBUGGER_METHOD_REWRITER_H_
 #define DD_CLR_PROFILER_DEBUGGER_METHOD_REWRITER_H_
 
+#include "../../../shared/src/native-src/util.h"
 #include "cor_profiler.h"
 #include "il_rewriter_wrapper.h"
 #include "method_rewriter.h"
 #include "module_metadata.h"
-#include "../../../shared/src/native-src/util.h"
 
 using namespace trace;
 
 namespace debugger
 {
 
-class DebuggerMethodRewriter : public MethodRewriter, public shared::Singleton<DebuggerMethodRewriter>
+class DebuggerMethodRewriter : public MethodRewriter
 {
-    friend class shared::Singleton<DebuggerMethodRewriter>;
+public:
+    DebuggerMethodRewriter(CorProfiler* corProfiler) : MethodRewriter(corProfiler)
+    {
+    }
 
 private:
-    DebuggerMethodRewriter(){}
-
-    // Holds incremental index that is used on the managed side for grabbing an InstrumentedMethodInfo instance (per instrumented method)
+    // Holds incremental index that is used on the managed side for grabbing an InstrumentedMethodInfo instance (per
+    // instrumented method)
     inline static std::atomic<int> _nextInstrumentedMethodIndex{0};
 
     static int GetNextInstrumentedMethodIndex();
 
-    static HRESULT GetFunctionLocalSignature(const ModuleMetadata& module_metadata, ILRewriter& rewriter, FunctionLocalSignature& localSignature);
-    static HRESULT LoadArgument(CorProfiler* corProfiler, bool isStatic, const ILRewriterWrapper& rewriterWrapper, int argumentIndex,
-                                const TypeSignature& argument);
-    static HRESULT LoadLocal(CorProfiler* corProfiler, const ILRewriterWrapper& rewriterWrapper, int localIndex,
-                             const TypeSignature& argument);
-    static HRESULT WriteCallsToLogArgOrLocal(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
-                                        const std::vector<TypeSignature>& methodArgsOrLocals, int numArgsOrLocals,
+    static HRESULT GetFunctionLocalSignature(const ModuleMetadata& module_metadata, ILRewriter& rewriter,
+                                             FunctionLocalSignature& localSignature);
+    HRESULT LoadArgument(bool isStatic, const ILRewriterWrapper& rewriterWrapper,
+                                int argumentIndex, const TypeSignature& argument) const;
+    HRESULT LoadLocal(const ILRewriterWrapper& rewriterWrapper, int localIndex,
+                             const TypeSignature& argument) const;
+    HRESULT WriteCallsToLogArgOrLocal(ModuleMetadata& moduleMetadata,
+                                             DebuggerTokens* debuggerTokens, bool isStatic,
+                                             const std::vector<TypeSignature>& methodArgsOrLocals, int numArgsOrLocals,
+                                             ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
+                                             ILInstr** beginCallInstruction, bool isArgs, ProbeType probeType) const;
+    HRESULT WriteCallsToLogArg(ModuleMetadata& moduleMetadata,
+                                      DebuggerTokens* debuggerTokens, bool isStatic,
+                                      const std::vector<TypeSignature>& args, int numArgs,
+                                      ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
+                                      ILInstr** beginCallInstruction, ProbeType probeType) const;
+    HRESULT WriteCallsToLogLocal(ModuleMetadata& moduleMetadata,
+                                        DebuggerTokens* debuggerTokens, bool isStatic,
+                                        const std::vector<TypeSignature>& locals, int numLocals,
                                         ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
-                                             ILInstr** beginCallInstruction, bool isArgs, ProbeType probeType);
-    static HRESULT WriteCallsToLogArg(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
-                                const std::vector<TypeSignature>& args, int numArgs, ILRewriterWrapper& rewriterWrapper,
-                                ULONG callTargetStateIndex,
-                                ILInstr** beginCallInstruction,
-                                ProbeType probeType);
-    static HRESULT WriteCallsToLogLocal(ModuleMetadata& moduleMetadata, CorProfiler* corProfiler, DebuggerTokens* debuggerTokens, bool isStatic,
-                                  const std::vector<TypeSignature>& locals, int numLocals,
-                                  ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex,
-                                        ILInstr** beginCallInstruction, ProbeType probeType);
+                                        ILInstr** beginCallInstruction, ProbeType probeType) const;
     static HRESULT LoadInstanceIntoStack(FunctionInfo* caller, bool isStatic, const ILRewriterWrapper& rewriterWrapper,
                                          ILInstr** outLoadArgumentInstr, CallTargetTokens* callTargetTokens);
-    static HRESULT CallLineProbe(int instrumentedMethodIndex, CorProfiler* corProfiler, ModuleID module_id,
+    HRESULT CallLineProbe(int instrumentedMethodIndex, ModuleID module_id,
                                  ModuleMetadata& module_metadata, FunctionInfo* caller, DebuggerTokens* debuggerTokens,
                                  mdToken function_token, bool isStatic, std::vector<TypeSignature>& methodArguments,
                                  int numArgs, ILRewriter& rewriter, std::vector<TypeSignature>& methodLocals,
                                  int numLocals, ILRewriterWrapper& rewriterWrapper, ULONG lineProbeCallTargetStateIndex,
                                  std::vector<EHClause>& lineProbesEHClauses, const std::vector<ILInstr*>& branchTargets,
-                                 const std::shared_ptr<LineProbeDefinition>& lineProbe, bool isAsyncMethod);
-    static HRESULT ApplyLineProbes(int instrumentedMethodIndex, LineProbeDefinitions& lineProbes,
-                           CorProfiler* corProfiler, ModuleID module_id, ModuleMetadata& module_metadata,
-                           FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token, bool isStatic,
-                           std::vector<TypeSignature>& methodArguments, int numArgs, ILRewriter& rewriter,
-                           std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
-                           ULONG lineProbeCallTargetStateIndex, std::vector<EHClause>& lineProbesEHClauses, bool isAsyncMethod) ;
-    HRESULT ApplyMethodProbe(CorProfiler* corProfiler, ModuleID module_id, ModuleMetadata& module_metadata,
-                          FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token,
-                          TypeSignature retFuncArg, bool isVoid, bool isStatic,
-                          const std::vector<TypeSignature>& methodArguments,
-                          int numArgs, const shared::WSTRING& methodProbeId, ILRewriter& rewriter,
-                          const std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
-                          ULONG callTargetStateIndex, ULONG exceptionIndex, ULONG callTargetReturnIndex,
-                          ULONG returnValueIndex, mdToken callTargetReturnToken, ILInstr* firstInstruction,
-                             int instrumentedMethodIndex, ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
-    static HRESULT EndAsyncMethodProbe(CorProfiler* corProfiler, ILRewriterWrapper& rewriterWrapper,
-                                       ModuleMetadata& module_metadata,
-                                       DebuggerTokens* debuggerTokens, FunctionInfo* caller, bool isStatic, TypeSignature* methodReturnType,
-                                       const std::vector<TypeSignature>& methodLocals, int numLocals, ULONG callTargetStateIndex,
-                                       ULONG callTargetReturnIndex, std::vector<EHClause>& newClauses,
-                                       ILInstr** setResultEndMethodTryStartInstr, ILInstr** endMethodOriginalCodeFirstInstr);
+                                 const std::shared_ptr<LineProbeDefinition>& lineProbe, bool isAsyncMethod) const;
+    HRESULT ApplyLineProbes(int instrumentedMethodIndex, LineProbeDefinitions& lineProbes,
+                            ModuleID module_id, ModuleMetadata& module_metadata, FunctionInfo* caller,
+                            DebuggerTokens* debuggerTokens, mdToken function_token, bool isStatic,
+                            std::vector<TypeSignature>& methodArguments, int numArgs, ILRewriter& rewriter,
+                            std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
+                            ULONG lineProbeCallTargetStateIndex, std::vector<EHClause>& lineProbesEHClauses,
+                            bool isAsyncMethod);
+    HRESULT ApplyMethodProbe(ModuleID module_id, ModuleMetadata& module_metadata,
+                             FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token,
+                             TypeSignature retFuncArg, bool isVoid, bool isStatic,
+                             const std::vector<TypeSignature>& methodArguments, int numArgs,
+                             const shared::WSTRING& methodProbeId, ILRewriter& rewriter,
+                             const std::vector<TypeSignature>& methodLocals, int numLocals,
+                             ILRewriterWrapper& rewriterWrapper, ULONG callTargetStateIndex, ULONG exceptionIndex,
+                             ULONG callTargetReturnIndex, ULONG returnValueIndex, mdToken callTargetReturnToken,
+                             ILInstr* firstInstruction, int instrumentedMethodIndex, ILInstr* const& beforeLineProbe,
+                             std::vector<EHClause>& newClauses) const;
+    HRESULT EndAsyncMethodProbe(ILRewriterWrapper& rewriterWrapper,
+                                       ModuleMetadata& module_metadata, DebuggerTokens* debuggerTokens,
+                                       FunctionInfo* caller, bool isStatic, TypeSignature* methodReturnType,
+                                       const std::vector<TypeSignature>& methodLocals, int numLocals,
+                                       ULONG callTargetStateIndex, ULONG callTargetReturnIndex,
+                                       std::vector<EHClause>& newClauses, ILInstr** setResultEndMethodTryStartInstr,
+                                       ILInstr** endMethodOriginalCodeFirstInstr);
     static HRESULT LoadProbeIdIntoStack(ModuleID moduleId, const ModuleMetadata& moduleMetadata, mdToken functionToken,
                                         const shared::WSTRING& methodProbeId, const ILRewriterWrapper& rewriterWrapper);
-    static void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) ;
-    HRESULT ApplyAsyncMethodProbe(CorProfiler* corProfiler, ModuleID moduleId, ModuleMetadata& moduleMetadata,
+    void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) const;
+    HRESULT ApplyAsyncMethodProbe(ModuleID moduleId, ModuleMetadata& moduleMetadata,
                                   FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken functionToken,
-                                  bool isStatic, TypeSignature* methodReturnType,
-                                  const shared::WSTRING& methodProbeId,
-                                  const std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
-                                  ULONG asyncMethodStateIndex, ULONG callTargetReturnIndex,
-                                  ULONG returnValueIndex, mdToken callTargetReturnToken, ILInstr* firstInstruction,
-                                  int instrumentedMethodIndex, ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
+                                  bool isStatic, TypeSignature* methodReturnType, const shared::WSTRING& methodProbeId,
+                                  const std::vector<TypeSignature>& methodLocals, int numLocals,
+                                  ILRewriterWrapper& rewriterWrapper, ULONG asyncMethodStateIndex,
+                                  ULONG callTargetReturnIndex, ULONG returnValueIndex, mdToken callTargetReturnToken,
+                                  ILInstr* firstInstruction, int instrumentedMethodIndex,
+                                  ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
 
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
-                                                        MethodProbeDefinitions& methodProbes,
-                                                        LineProbeDefinitions& lineProbes) const;
-    static HRESULT IsTypeByRefLike(ModuleMetadata& module_metadata, const TypeSignature& typeSig, const mdAssemblyRef& corLibAssemblyRef,
-                                   bool& isTypeIsByRefLike);
-    static HRESULT IsTypeTokenByRefLike(ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken, bool& isTypeIsByRefLike);
+                    MethodProbeDefinitions& methodProbes, LineProbeDefinitions& lineProbes) const;
+    HRESULT IsTypeByRefLike(ModuleMetadata& module_metadata, const TypeSignature& typeSig,
+                                   const mdAssemblyRef& corLibAssemblyRef, bool& isTypeIsByRefLike) const;
+    HRESULT IsTypeTokenByRefLike(ModuleMetadata& module_metadata, mdToken typeDefOrRefOrSpecToken,
+                                        bool& isTypeIsByRefLike) const;
     static std::vector<ILInstr*> GetBranchTargets(ILRewriter* pRewriter);
     static void AdjustBranchTargets(ILInstr* pFromInstr, ILInstr* pToInstr, const std::vector<ILInstr*>& branchTargets);
     static void AdjustExceptionHandlingClauses(ILInstr* pFromInstr, ILInstr* pToInstr, ILRewriter* pRewriter);
 
 public:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) override;
-    static HRESULT IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport, ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine);
-    static HRESULT IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo* caller, bool& isAsyncMethod) ;
-    static HRESULT GetTaskReturnType(const ILInstr* instruction, ModuleMetadata& moduleMetadata, const std::vector<TypeSignature>& methodLocals, TypeSignature* returnType);
-    static void MarkAllProbesAsError(MethodProbeDefinitions& methodProbes, LineProbeDefinitions& lineProbes, const WSTRING& reasoning);
+    static HRESULT IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport,
+                                                     ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine);
+    HRESULT IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo* caller,
+                               bool& isAsyncMethod) ;
+    static HRESULT GetTaskReturnType(const ILInstr* instruction, ModuleMetadata& moduleMetadata,
+                                     const std::vector<TypeSignature>& methodLocals, TypeSignature* returnType);
+    static void MarkAllProbesAsError(MethodProbeDefinitions& methodProbes, LineProbeDefinitions& lineProbes,
+                                     const WSTRING& reasoning);
     static void MarkAllLineProbesAsError(LineProbeDefinitions& lineProbes, const WSTRING& reasoning);
     static void MarkAllMethodProbesAsError(MethodProbeDefinitions& methodProbes, const WSTRING& reasoning);
 };

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -62,7 +62,7 @@ private:
                             std::vector<TypeSignature>& methodArguments, int numArgs, ILRewriter& rewriter,
                             std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
                             ULONG lineProbeCallTargetStateIndex, std::vector<EHClause>& lineProbesEHClauses,
-                            bool isAsyncMethod);
+                            bool isAsyncMethod) const;
     HRESULT ApplyMethodProbe(ModuleID module_id, ModuleMetadata& module_metadata,
                              FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token,
                              TypeSignature retFuncArg, bool isVoid, bool isStatic,
@@ -79,10 +79,10 @@ private:
                                        const std::vector<TypeSignature>& methodLocals, int numLocals,
                                        ULONG callTargetStateIndex, ULONG callTargetReturnIndex,
                                        std::vector<EHClause>& newClauses, ILInstr** setResultEndMethodTryStartInstr,
-                                       ILInstr** endMethodOriginalCodeFirstInstr);
+                                       ILInstr** endMethodOriginalCodeFirstInstr) const;
     static HRESULT LoadProbeIdIntoStack(ModuleID moduleId, const ModuleMetadata& moduleMetadata, mdToken functionToken,
                                         const shared::WSTRING& methodProbeId, const ILRewriterWrapper& rewriterWrapper);
-    void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) const;
+    static void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) ;
     HRESULT ApplyAsyncMethodProbe(ModuleID moduleId, ModuleMetadata& moduleMetadata,
                                   FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken functionToken,
                                   bool isStatic, TypeSignature* methodReturnType, const shared::WSTRING& methodProbeId,
@@ -107,7 +107,7 @@ public:
     static HRESULT IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport,
                                                      ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine);
     HRESULT IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo* caller,
-                               bool& isAsyncMethod) ;
+                               bool& isAsyncMethod) const;
     static HRESULT GetTaskReturnType(const ILInstr* instruction, ModuleMetadata& moduleMetadata,
                                      const std::vector<TypeSignature>& methodLocals, TypeSignature* returnType);
     static void MarkAllProbesAsError(MethodProbeDefinitions& methodProbes, LineProbeDefinitions& lineProbes,

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.h
@@ -12,6 +12,7 @@ namespace debugger
 class DebuggerProbesInstrumentationRequester
 {
 private:
+    CorProfiler* m_corProfiler;
     std::recursive_mutex m_probes_mutex;
     std::vector<ProbeDefinition_S> m_probes;
     std::unique_ptr<DebuggerRejitPreprocessor> m_debugger_rejit_preprocessor = nullptr;
@@ -30,7 +31,7 @@ private:
     void DetermineReInstrumentProbes(std::set<MethodIdentifier>& revertRequests, std::set<MethodIdentifier>& reInstrumentRequests) const;
 
 public:
-    DebuggerProbesInstrumentationRequester(std::shared_ptr<trace::RejitHandler> rejit_handler,
+    DebuggerProbesInstrumentationRequester(CorProfiler* corProfiler, std::shared_ptr<trace::RejitHandler> rejit_handler,
                                            std::shared_ptr<trace::RejitWorkOffloader> work_offloader);
 
     void InstrumentProbes(debugger::DebuggerMethodProbeDefinition* methodProbes, int methodProbesLength,

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_handler_module_method.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_handler_module_method.cpp
@@ -7,14 +7,10 @@ namespace debugger
 DebuggerRejitHandlerModuleMethod::DebuggerRejitHandlerModuleMethod(
                                                     mdMethodDef methodDef, 
                                                     RejitHandlerModule* module,
-                                                    const FunctionInfo& functionInfo) :
-    RejitHandlerModuleMethod(methodDef, module, functionInfo)
+                                                    const FunctionInfo& functionInfo,
+                                                    std::unique_ptr<MethodRewriter> methodRewriter) :
+    RejitHandlerModuleMethod(methodDef, module, functionInfo, std::move(methodRewriter))
 {
-}
-
-MethodRewriter* DebuggerRejitHandlerModuleMethod::GetMethodRewriter()
-{
-    return DebuggerMethodRewriter::Instance();
 }
 
 void DebuggerRejitHandlerModuleMethod::AddProbe(ProbeDefinition_S probe)

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_handler_module_method.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_handler_module_method.h
@@ -20,9 +20,9 @@ private:
 public:
     DebuggerRejitHandlerModuleMethod(mdMethodDef methodDef, 
                                      RejitHandlerModule* module,
-                                     const FunctionInfo& functionInfo);
+                                     const FunctionInfo& functionInfo,
+                                     std::unique_ptr<MethodRewriter> methodRewriter);
 
-    MethodRewriter* GetMethodRewriter() override;
     void AddProbe(ProbeDefinition_S probe);
     bool RemoveProbe(const shared::WSTRING& probeId);
     std::vector<ProbeDefinition_S>& GetProbes();

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -238,14 +238,14 @@ const std::unique_ptr<RejitHandlerModuleMethod>
 DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module,
                                         const FunctionInfo& functionInfo, const MethodProbeDefinition& methodProbe)
 {
-    return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo);
+    return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo, std::make_unique<DebuggerMethodRewriter>(m_corProfiler));
 }
 
 const std::unique_ptr<RejitHandlerModuleMethod>
 DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module,
                                         const FunctionInfo& functionInfo) 
 {
-    return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo);
+    return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo, std::make_unique<DebuggerMethodRewriter>(m_corProfiler));
 }
 
 void DebuggerRejitPreprocessor::UpdateMethod(RejitHandlerModuleMethod* methodHandler,

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -243,7 +243,7 @@ DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandle
 
 const std::unique_ptr<RejitHandlerModuleMethod>
 DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module,
-                                        const FunctionInfo& functionInfo) 
+                                        const FunctionInfo& functionInfo) const
 {
     return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo, std::make_unique<DebuggerMethodRewriter>(m_corProfiler));
 }

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
@@ -37,8 +37,8 @@ protected:
     const std::unique_ptr<RejitHandlerModuleMethod>
     CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
                  const MethodProbeDefinition& methodProbe) final;
-    static const std::unique_ptr<RejitHandlerModuleMethod>
-    CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo) ;
+    const std::unique_ptr<RejitHandlerModuleMethod>
+    CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo) const;
     void UpdateMethod(RejitHandlerModuleMethod* methodHandler, const MethodProbeDefinition& methodProbe) override;
     static void UpdateMethod(RejitHandlerModuleMethod* methodHandler, const ProbeDefinition_S& probe);
     [[nodiscard]] std::tuple<HRESULT, mdMethodDef, FunctionInfo> PickMethodToRejit(

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -96,8 +96,6 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     auto _ = trace::Stats::Instance()->CallTargetRewriterCallbackMeasure();
 
-    auto corProfiler = trace::profiler;
-
     ModuleID module_id = moduleHandler->GetModuleId();
     ModuleMetadata& module_metadata = *moduleHandler->GetModuleMetadata();
     FunctionInfo* caller = methodHandler->GetFunctionInfo();
@@ -121,7 +119,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** Get reference to the integration type
     mdTypeRef integration_type_ref = mdTypeRefNil;
-    if (!corProfiler->GetIntegrationTypeRef(module_metadata, module_id, *integration_definition, integration_type_ref))
+    if (!m_corProfiler->GetIntegrationTypeRef(module_metadata, module_id, *integration_definition, integration_type_ref))
     {
         Logger::Warn("*** CallTarget_RewriterCallback() skipping method: Integration Type Ref cannot be found for ",
                      " token=", function_token, " caller_name=", caller->type.name, ".", caller->name, "()");
@@ -137,7 +135,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     }
 
     // First we check if the managed profiler has not been loaded yet
-    if (!corProfiler->ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata.app_domain_id))
+    if (!m_corProfiler->ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata.app_domain_id))
     {
         Logger::Warn(
             "*** CallTarget_RewriterCallback() skipping method: Method replacement found but the managed profiler has "
@@ -148,7 +146,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     }
 
     // *** Create rewriter
-    ILRewriter rewriter(corProfiler->info_, methodHandler->GetFunctionControl(), module_id, function_token);
+    ILRewriter rewriter(m_corProfiler->info_, methodHandler->GetFunctionControl(), module_id, function_token);
     bool modified = false;
     auto hr = rewriter.Import();
     if (FAILED(hr))
@@ -162,7 +160,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     std::string original_code;
     if (IsDumpILRewriteEnabled())
     {
-        original_code = corProfiler->GetILCodes("*** CallTarget_RewriterCallback(): Original Code: ", &rewriter,
+        original_code = m_corProfiler->GetILCodes("*** CallTarget_RewriterCallback(): Original Code: ", &rewriter,
                                                 *caller, module_metadata.metadata_import);
     }
 
@@ -258,7 +256,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
             for (int i = 0; i < numArgs; i++)
             {
                 const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
-                if (corProfiler->enable_by_ref_instrumentation)
+                if (m_corProfiler->enable_by_ref_instrumentation)
                 {
                     if (argTypeFlags & TypeFlagByRef)
                     {
@@ -392,7 +390,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     // *** Filter exception
     ILInstr* filter = nullptr;
     ILInstr* beginMethodCatchFirstInstr = nullptr;
-    if (corProfiler->call_target_bubble_up_exception_available)
+    if (m_corProfiler->call_target_bubble_up_exception_available)
     {
         filter = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
                                           tracerTokens->GetBubbleUpExceptionTypeRef(),
@@ -407,7 +405,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** BeginMethod exception handling clause
     EHClause beginMethodExClause{};
-    if (corProfiler->call_target_bubble_up_exception_available)
+    if (m_corProfiler->call_target_bubble_up_exception_available)
     {
         beginMethodExClause.m_Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
         beginMethodExClause.m_pTryBegin = firstInstruction;
@@ -519,7 +517,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     }
 
     reWriterWrapper.LoadLocal(exceptionIndex);
-    if (corProfiler->enable_calltarget_state_by_ref)
+    if (m_corProfiler->enable_calltarget_state_by_ref)
     {
         reWriterWrapper.LoadLocalAddress(callTargetStateIndex);
     }
@@ -554,7 +552,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     ILInstr* filterEnd = nullptr;
     ILInstr* endMethodCatchFirstInstr = nullptr;
-    if (corProfiler->call_target_bubble_up_exception_available)
+    if (m_corProfiler->call_target_bubble_up_exception_available)
     {
         Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException (end method).");
         filterEnd = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
@@ -572,7 +570,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** EndMethod exception handling clause
     EHClause endMethodExClause{};
-    if (corProfiler->call_target_bubble_up_exception_available)
+    if (m_corProfiler->call_target_bubble_up_exception_available)
     {
         endMethodExClause.m_Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
         endMethodExClause.m_pTryBegin = endMethodTryStartInstr;
@@ -683,7 +681,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (IsDumpILRewriteEnabled())
     {
         Logger::Info(original_code);
-        Logger::Info(corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller,
+        Logger::Info(m_corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller,
                                              module_metadata.metadata_import));
     }
 

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.h
@@ -26,6 +26,8 @@ public:
     }
 
     virtual HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) = 0;
+
+    virtual ~MethodRewriter() = default;
 };
 
 

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.h
@@ -12,23 +12,34 @@ namespace trace
     // forward declarations
     class RejitHandlerModule;
     class RejitHandlerModuleMethod;
+    class CorProfiler;
 
 class MethodRewriter
 {
+protected:
+    CorProfiler* m_corProfiler;
+
 public:
+    MethodRewriter(CorProfiler* corProfiler)
+        : m_corProfiler(corProfiler)
+    {        
+    }
+
     virtual HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) = 0;
 };
 
 
-class TracerMethodRewriter : public MethodRewriter, public shared::Singleton<TracerMethodRewriter>
+class TracerMethodRewriter : public MethodRewriter
 {
-    friend class shared::Singleton<TracerMethodRewriter>;
-
 private:
-    TracerMethodRewriter(){}
-    static ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, ULONG exceptionValueIndex) ;
+    ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, ULONG exceptionValueIndex);
 
 public:
+
+    TracerMethodRewriter(CorProfiler* corProfiler) : MethodRewriter(corProfiler)
+    {
+    }
+
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) override;
 };
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -1,5 +1,6 @@
 #include "rejit_handler.h"
 
+#include "cor_profiler.h"
 #include "dd_profiler_constants.h"
 #include "logger.h"
 #include "stats.h"
@@ -12,11 +13,12 @@ namespace trace
 //
 
 RejitHandlerModuleMethod::RejitHandlerModuleMethod(mdMethodDef methodDef, RejitHandlerModule* module,
-                                                   const FunctionInfo& functionInfo) :
+                                                   const FunctionInfo& functionInfo, std::unique_ptr<MethodRewriter> methodRewriter) :
     m_methodDef(methodDef),
     m_module(module),
     m_pFunctionControl(nullptr),
-    m_functionInfo(std::make_unique<FunctionInfo>(functionInfo))
+    m_functionInfo(std::make_unique<FunctionInfo>(functionInfo)),
+    m_methodRewriter(std::move(methodRewriter))
 {
 }
 
@@ -129,14 +131,19 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
     return false;
 }
 
+MethodRewriter* RejitHandlerModuleMethod::GetMethodRewriter()
+{
+    return m_methodRewriter.get();
+}
+
 //
 // TracerRejitHandlerModuleMethod
 //
 
 TracerRejitHandlerModuleMethod::TracerRejitHandlerModuleMethod(
     mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
-    const IntegrationDefinition& integrationDefinition) :
-    RejitHandlerModuleMethod(methodDef, module, functionInfo),
+    const IntegrationDefinition& integrationDefinition, std::unique_ptr<MethodRewriter> methodRewriter) :
+    RejitHandlerModuleMethod(methodDef, module, functionInfo, std::move(methodRewriter)),
     m_integrationDefinition(std::make_unique<IntegrationDefinition>(integrationDefinition))
 {
 }
@@ -144,11 +151,6 @@ TracerRejitHandlerModuleMethod::TracerRejitHandlerModuleMethod(
 IntegrationDefinition* TracerRejitHandlerModuleMethod::GetIntegrationDefinition()
 {
     return m_integrationDefinition.get();
-}
-
-MethodRewriter* TracerRejitHandlerModuleMethod::GetMethodRewriter()
-{
-    return TracerMethodRewriter::Instance();
 }
 
 //

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -31,6 +31,9 @@ class RejitHandler;
 /// </summary>
 class RejitHandlerModuleMethod
 {
+private:
+    std::unique_ptr<MethodRewriter> m_methodRewriter;
+
 protected:
     mdMethodDef m_methodDef;
     ICorProfilerFunctionControl* m_pFunctionControl;
@@ -39,7 +42,7 @@ protected:
     RejitHandlerModule* m_module;
 
 public:
-    RejitHandlerModuleMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo);
+    RejitHandlerModuleMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo, std::unique_ptr<MethodRewriter> methodRewriter); 
     mdMethodDef GetMethodDef();
     RejitHandlerModule* GetModule();
 
@@ -50,7 +53,7 @@ public:
     void SetFunctionInfo(const FunctionInfo& functionInfo);
 
     bool RequestRejitForInlinersInModule(ModuleID moduleId);
-    virtual MethodRewriter* GetMethodRewriter() = 0;
+    MethodRewriter* GetMethodRewriter();
 
     virtual ~RejitHandlerModuleMethod() = default;
 };
@@ -68,10 +71,10 @@ public:
                     mdMethodDef methodDef,
                     RejitHandlerModule* module,
                     const FunctionInfo& functionInfo,
-                    const IntegrationDefinition& integrationDefinition);
+                    const IntegrationDefinition& integrationDefinition,
+                    std::unique_ptr<MethodRewriter> methodRewriter);
     
     IntegrationDefinition* GetIntegrationDefinition();
-    MethodRewriter* GetMethodRewriter() override;
 };
 
 using RejitHandlerModuleMethodCreatorFunc = std::function<std::unique_ptr<RejitHandlerModuleMethod>(const mdMethodDef, RejitHandlerModule*)>;

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -9,9 +9,10 @@ namespace trace
 
 // RejitPreprocessor
 template <class RejitRequestDefinition>
-RejitPreprocessor<RejitRequestDefinition>::RejitPreprocessor(std::shared_ptr<RejitHandler> rejit_handler,
+RejitPreprocessor<RejitRequestDefinition>::RejitPreprocessor(CorProfiler* corProfiler,
+                                                             std::shared_ptr<RejitHandler> rejit_handler,
                                                              std::shared_ptr<RejitWorkOffloader> work_offloader) :
-    m_rejit_handler(std::move(rejit_handler)), m_work_offloader(std::move(work_offloader))
+    m_corProfiler(corProfiler), m_rejit_handler(std::move(rejit_handler)), m_work_offloader(std::move(work_offloader))
 {
 }
 
@@ -820,9 +821,10 @@ const std::unique_ptr<RejitHandlerModuleMethod> TracerRejitPreprocessor::CreateM
                                                 const IntegrationDefinition& integrationDefinition)
 {
     return std::make_unique<TracerRejitHandlerModuleMethod>(methodDef,
-                                                                       module,
-                                                                       functionInfo,
-                                                                       integrationDefinition);
+                                                            module,
+                                                            functionInfo,
+                                                            integrationDefinition,
+                                                            std::make_unique<TracerMethodRewriter>(m_corProfiler));
 }
 
 bool TracerRejitPreprocessor::ShouldSkipModule(const ModuleInfo& moduleInfo, const IntegrationDefinition& integrationDefinition)

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -9,6 +9,7 @@
 
 namespace trace
 {
+class CorProfiler;
 class RejitHandler;
 class RejitWorkOffloader;
 class RejitHandlerModuleMethod;
@@ -22,6 +23,7 @@ template <class RejitRequestDefinition>
 class RejitPreprocessor
 {
 protected:
+    CorProfiler* m_corProfiler;
     std::shared_ptr<RejitHandler> m_rejit_handler = nullptr;
     std::shared_ptr<RejitWorkOffloader> m_work_offloader = nullptr;
 
@@ -54,7 +56,7 @@ protected:
                           const FunctionInfo& functionInfo, RejitHandlerModule* moduleHandler);
 
 public:
-    RejitPreprocessor(std::shared_ptr<RejitHandler> rejit_handler, std::shared_ptr<RejitWorkOffloader> work_offloader);
+    RejitPreprocessor(CorProfiler* corProfiler, std::shared_ptr<RejitHandler> rejit_handler, std::shared_ptr<RejitWorkOffloader> work_offloader);
 
     ULONG RequestRejitForLoadedModules(const std::vector<ModuleID>& modules,
                                        const std::vector<RejitRequestDefinition>& requests,


### PR DESCRIPTION
## Summary of changes

When running an application with mixed runtimes (.NET Framework + .NET Core), we can end up in a situation where ICorProfilerCallback is invoked for a runtime (say, .NET Framework) but the CorProfiler singleton is set to another runtime (.NET Core). This can crash the application.

The rejit logic doesn't actually need the singleton (it's only used for convenience), so this PR refactors the code to stop using it.

Note: it doesn't mean that the tracer will work properly with mixed runtimes. For instance, the singleton is still used in the p/invokes. But at the very least it won't crash.

## Reason for change

The crash was reported by a customer: APMS-8552

## Implementation details

The MethodRewriters are not singletons anymore and they're created with a reference to CorProfiler.

