### PR TITLE
Add a hook to redirect calls to createdump

### DIFF
--- a/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
+++ b/profiler/src/Demos/Samples.ExceptionGenerator/Program.cs
@@ -19,6 +19,7 @@ namespace Samples.ExceptionGenerator
         GenericExceptions = 4,
         TimeItExceptions = 5,
         MeasureExceptions = 6,
+        Unhandled = 7,
     }
 
     public class Program
@@ -89,6 +90,10 @@ namespace Samples.ExceptionGenerator
                                     new MeasureExceptionsScenario().Run();
                                     Console.WriteLine(" ########### Measuring exceptions...");
                                     break;
+
+                                case Scenario.Unhandled:
+                                    Console.WriteLine(" ########### Crashing...");
+                                    throw new InvalidOperationException("Task failed successfully");
 
                                 default:
                                     Console.WriteLine($" ########### Unknown scenario: {scenario}.");

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -159,7 +159,7 @@ int execve(const char *pathname, char *const argv[], char *const envp[])
 
             // By convention, argv[0] contains the name of the executable
             // Insert createdump as the first actual argument
-            newArgv[0] = argv[0];
+            newArgv[0] = ddTracePath;
             newArgv[1] = "createdump";
 
             // Copy the remaining arguments

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 /* dl_iterate_phdr wrapper
 The .NET profiler on Linux uses a classic signal-based approach to collect thread callstack.

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -149,7 +149,27 @@ int execve(const char *pathname, char *const argv[], char *const envp[])
 
         if (length >= 11 && strcmp(pathname + length - 11, "/createdump") == 0)
         {
-            return __real_execve(ddTracePath, argv, envp);
+            // Execute the alternative crash handler, and prepend "createdump" to the arguments
+
+            // Count the number of arguments (the list ends with a null pointer)
+            int argc = 0;
+            while (argv[argc++] != NULL) ;
+            
+            char** newArgv = malloc((argc + 1) * sizeof(char*));
+
+            // By convention, argv[0] contains the name of the executable
+            // Insert createdump as the first actual argument
+            newArgv[0] = argv[0];
+            newArgv[1] = "createdump";
+
+            // Copy the remaining arguments
+            memcpy(newArgv + 2, argv + 1, sizeof(char*) * (argc - 1));
+
+            int result = __real_execve(ddTracePath, newArgv, envp);
+
+            free(newArgv);
+
+            return result;
         }        
     }
 #pragma clang diagnostic pop

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -192,7 +192,10 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 }
             }
 
-            ConfigureTransportVariables(environmentVariables, agent);
+            if (agent != null)
+            {
+                ConfigureTransportVariables(environmentVariables, agent);
+            }
 
             foreach (var key in CustomEnvironmentVariables.Keys)
             {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/ProcessHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/ProcessHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ProcessHelper.cs" company="Datadog">
+// <copyright file="ProcessHelper.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
@@ -34,7 +34,11 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
 
             _process.BeginOutputReadLine();
             _process.BeginErrorReadLine();
+
+            Process = process;
         }
+
+        public Process Process { get; }
 
         public string StandardOutput => _outputBuffer.ToString();
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -161,9 +161,9 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 throw new XunitException("Agent was not ready to accept connection from profiler");
             }
 
+            var startTime = DateTime.Now;
 
             using var processHelper = LaunchProcess(agent);
-
             var process = processHelper.Process;
 
             var ranToCompletion = process.WaitForExit((int)_maxTestRunDuration.TotalMilliseconds) && processHelper.Drain((int)_maxTestRunDuration.TotalMilliseconds / 2);

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -86,7 +86,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
-            var crashHandler = EnvironmentHelper.IsAlpine ? "/bin/echo" : "/usr/bin/echo";
+            var crashHandler = "/bin/echo";
 
             if (!File.Exists(crashHandler))
             {
@@ -94,7 +94,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
                 throw new FileNotFoundException($"Crash handler {crashHandler} does not exist.");
             }
 
-            runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", EnvironmentHelper.IsAlpine ? "/bin/echo" : "/usr/bin/echo");
+            runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", "/bin/echo");
             runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
             runner.Environment.SetVariable("COMPlus_DbgMiniDumpType", "4");
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -86,7 +86,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
             runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", "/usr/bin/echo");
-            runner.Environment.SetVariable("DOTNET_DbgEnableMiniDump", "1");
+            runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
 
             using var processHelper = runner.LaunchProcess();
 
@@ -102,7 +102,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
             // Don't set DD_TRACE_CRASH_HANDLER. In that case, the call to createdump shouldn't be redirected
-            runner.Environment.SetVariable("DOTNET_DbgEnableMiniDump", "1");
+            runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
 
             using var processHelper = runner.LaunchProcess();
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -109,7 +109,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().Contain(@$"createdump --full {processHelper.Process.Id}")
+            processHelper.StandardOutput.Should().MatchRegex(@"createdump --full \d+")
                 .And.NotContain("Writing full dump");
         }
 
@@ -127,7 +127,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().NotContain(@$"createdump --full {processHelper.Process.Id}")
+            processHelper.StandardOutput.Should().NotMatchRegex(@"createdump --full \d+")
                 .And.Contain("Writing full dump");
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -103,6 +103,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             // Don't set DD_TRACE_CRASH_HANDLER. In that case, the call to createdump shouldn't be redirected
             runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
+            runner.Environment.SetVariable("COMPlus_DbgMiniDumpName ", "/dev/null");
 
             using var processHelper = runner.LaunchProcess();
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -109,7 +109,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().Match(@$"createdump --full {processHelper.Process.Id}")
+            processHelper.StandardOutput.Should().Contain(@$"createdump --full {processHelper.Process.Id}")
                 .And.NotContain("Writing full dump");
         }
 
@@ -127,7 +127,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().NotMatch(@$"createdump --full {processHelper.Process.Id}")
+            processHelper.StandardOutput.Should().NotContain(@$"createdump --full {processHelper.Process.Id}")
                 .And.Contain("Writing full dump");
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -85,7 +85,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         {
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
-            runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", "/usr/bin/echo");
+            runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", EnvironmentHelper.IsAlpine ? "/bin/echo" : "/usr/bin/echo");
             runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
 
             using var processHelper = runner.LaunchProcess();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -83,7 +83,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         [TestAppFact("Samples.ExceptionGenerator")]
         public void RedirectCrashHandler(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 6");
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
             runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", "/usr/bin/echo");
             runner.Environment.SetVariable("DOTNET_DbgEnableMiniDump", "1");
@@ -99,7 +99,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         [TestAppFact("Samples.ExceptionGenerator")]
         public void DontRedirectCrashHandlerIfPathNotSet(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 6");
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
             // Don't set DD_TRACE_CRASH_HANDLER. In that case, the call to createdump shouldn't be redirected
             runner.Environment.SetVariable("DOTNET_DbgEnableMiniDump", "1");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -93,7 +93,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().MatchRegex(@"createdump \d+ --signal 6 --crashthread \d+")
-                .And.NotContain("[createdump] Dump successfully written");
+                .And.NotContain("Writing minidump with heap");
         }
 
         [TestAppFact("Samples.ExceptionGenerator")]
@@ -109,7 +109,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().NotMatchRegex(@"createdump \d+ --signal 6 --crashthread \d+")
-                .And.Contain("[createdump] Dump successfully written");
+                .And.Contain("Writing minidump with heap");
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -108,6 +108,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             using var processHelper = runner.LaunchProcess();
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
+            processHelper.Drain();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().MatchRegex(@"createdump --full \d+")
                 .And.NotContain("Writing full dump");
@@ -126,6 +127,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             using var processHelper = runner.LaunchProcess();
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
+            processHelper.Drain();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().NotMatchRegex(@"createdump --full \d+")
                 .And.Contain("Writing full dump");

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -92,7 +92,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().MatchRegex(@"createdump \d+ --signal 6 --crashthread \d+")
+            processHelper.StandardOutput.Should().MatchRegex(@"createdump \d+")
                 .And.NotContain("Writing minidump with heap");
         }
 
@@ -108,7 +108,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().NotMatchRegex(@"createdump \d+ --signal 6 --crashthread \d+")
+            processHelper.StandardOutput.Should().NotMatchRegex(@"createdump \d+")
                 .And.Contain("Writing minidump with heap");
         }
     }


### PR DESCRIPTION
## Summary of changes

Add a hook to redirect calls to createdump. This will be used by dd-trace to generate a crash report.

## Implementation details

Uses LD_PRELOAD to detour the `execve` function. If the executable name ends with `/createdump`, it instead calls the executable defined in the `DD_TRACE_CRASH_HANDLER` environment variable.
