### PR TITLE
Add comparison of execution benchmarks posting to PR

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3159,7 +3159,7 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Windows]
+      jobs: [Windows, compare]
 
   - job: Windows
     strategy:
@@ -3237,6 +3237,42 @@ stages:
       inputs:
         targetType: 'inline'
         script: 'Start-Sleep -s 20'
+
+  - job: compare
+    timeoutInMinutes: 60 #default value
+    dependsOn: [Windows]
+    pool:
+      vmImage: windows-2022
+
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        masterCommitId: $(masterCommitId)
+
+    - template: steps/install-latest-dotnet-sdk.yml
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download HttpMessageHandler
+      inputs:
+        artifact: execution_time_benchmarks_windows_x64_HttpMessageHandler_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_HttpMessageHandler_1
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download FakeDbCommand
+      inputs:
+        artifact: execution_time_benchmarks_windows_x64_FakeDbCommand_1 #only download the first lot, ignores retries
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_HttpMessageHandler_1
+
+    - script: tracer\build.cmd CompareExecutionTimeBenchmarkResults
+      displayName: Compare execution-time results
+      env:
+        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
+
+    - publish: $(System.DefaultWorkingDirectory)/tracer/build_data/execution_benchmarks/execution_time_report.md
+      displayName: Upload report
+      artifact: execution_time_report
 
 - stage: system_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3261,7 +3261,7 @@ stages:
       displayName: Download FakeDbCommand
       inputs:
         artifact: execution_time_benchmarks_windows_x64_FakeDbCommand_1 #only download the first lot, ignores retries
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_HttpMessageHandler_1
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/execution_benchmarks/current/execution_time_benchmarks_windows_x64_FakeDbCommand_1
 
     - script: tracer\build.cmd CompareExecutionTimeBenchmarkResults
       displayName: Compare execution-time results

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -966,20 +966,7 @@ partial class Build
          {
              var isPr = int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber);
 
-             var testedCommit = Environment.GetEnvironmentVariable("OriginalCommitId"); 
-             if (string.IsNullOrEmpty(testedCommit))
-             {
-                 testedCommit = GitTasks.Git($"rev-parse HEAD").FirstOrDefault().Text;
-                 if(string.IsNullOrEmpty(testedCommit))
-                 {
-                    Logger.Warn("No OriginalCommitId variable found and unable to infer commit. Skipping throughput comparison");
-                    return;
-                 }
-                 else
-                 {
-                    Logger.Info($"No OriginalCommitId variable found. Using inferred commit {testedCommit}");
-                 }
-             }
+             var testedCommit = GetCommitDetails();
 
              var throughputDir = BuildDataDirectory / "throughput";
              var masterDir = throughputDir / "master";
@@ -1094,21 +1081,7 @@ partial class Build
          .Executes(async () =>
          {
              var isPr = int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber);
-
-             var testedCommit = Environment.GetEnvironmentVariable("OriginalCommitId"); 
-             if (string.IsNullOrEmpty(testedCommit))
-             {
-                 testedCommit = GitTasks.Git($"rev-parse HEAD").FirstOrDefault().Text;
-                 if(string.IsNullOrEmpty(testedCommit))
-                 {
-                    Logger.Warn("No OriginalCommitId variable found and unable to infer commit. Skipping throughput comparison");
-                    return;
-                 }
-                 else
-                 {
-                    Logger.Info($"No OriginalCommitId variable found. Using inferred commit {testedCommit}");
-                 }
-             }
+             var testedCommit = GetCommitDetails();
 
              var executionDir = BuildDataDirectory / "execution_benchmarks";
              var masterDir = executionDir / "master";
@@ -1434,6 +1407,26 @@ partial class Build
                                     new MilestoneRequest { State = ItemStateFilter.Open });
 
         return allOpenMilestones.FirstOrDefault(x => x.Title == milestoneName);
+    }
+
+    static string GetCommitDetails()
+    {
+        var testedCommit = Environment.GetEnvironmentVariable("OriginalCommitId"); 
+        if (string.IsNullOrEmpty(testedCommit))
+        {
+            testedCommit = GitTasks.Git($"rev-parse HEAD").FirstOrDefault().Text;
+            if(string.IsNullOrEmpty(testedCommit))
+            {
+                Logger.Warn("No OriginalCommitId variable found and unable to infer commit. Skipping throughput comparison");
+                return null;
+            }
+            else
+            {
+                Logger.Info($"No OriginalCommitId variable found. Using inferred commit {testedCommit}");
+            }
+        }
+
+        return testedCommit;
     }
 
     class LabbelerConfiguration

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1149,7 +1149,7 @@ partial class Build
 
              async Task<Microsoft.TeamFoundation.Build.WebApi.Build> GetExecutionBenchmarkArtifacts(BuildHttpClient httpClient, string branch, AbsolutePath directory)
              {
-                 // find the first build with the linux crank results
+                 // find the first build with the execution benchmarks results
                  var (build, _) = await FindAndDownloadAzureArtifact(httpClient, branch, build => "execution_time_benchmarks_windows_x64_HttpMessageHandler_1", directory, buildReason: null);
 
                  // get all the other artifacts from the same build for consistency

--- a/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
+++ b/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
@@ -124,7 +124,7 @@ public class CompareExecutionTime
 
             Note that these results are based on a _single_ point-in-time result for each branch. For full results, see the [dashboard](https://ddstaging.datadoghq.com/dashboard/4qn-6fi-54p/apm-net-execution-time-benchmarks).
 
-            Graphs show the p99 interval based on the mean and StdDev of the test run, as well as the mean valur.
+            Graphs show the p99 interval based on the mean and StdDev of the test run, as well as the mean value of the run (shown as a diamond below the graph).
             {string.Join('\n', charts)}
             """;
 

--- a/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
+++ b/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Nodes;
+using Nuke.Common;
+using Nuke.Common.IO;
+using Perfolizer.Mathematics.SignificanceTesting;
+using Perfolizer.Mathematics.Thresholds;
+
+public class CompareExecutionTime
+{
+    private static readonly Threshold SignificantResultThreshold = Threshold.Create(ThresholdUnit.Ratio, 0.05);
+    private static readonly Threshold NoiseThreshold = Threshold.Create(ThresholdUnit.Milliseconds, 5);
+
+    public static string GetMarkdown(List<ExecutionTimeResultSource> sources)
+    {
+        Logger.Info("Reading execution benchmarkResults results");
+        var results = sources.SelectMany(ReadJsonResults).ToList();
+
+        // Group execution time benchmarks by Sample Name, Framework
+        Logger.Info($"Found {results.Count} results: building markdown");
+        var charts = results
+                    .GroupBy(x => (x.TestSample, x.Framework))
+                    .Select(group =>
+                     {
+                         var scenarios = group
+                                        .Select(x => x)
+                                        .OrderBy(x => x.Scenario)
+                                        .GroupBy(x => x.Scenario)
+                                        .Select((scenarioResults, i) => GetMermaidSection(scenarioResults.Key, scenarioResults));
+                         return $"""
+                        ```mermaid
+                        gantt
+                            title Execution time (ms) {group.Key.TestSample} ({GetName(group.Key.Framework)}) 
+                            dateFormat  X
+                            axisFormat %s
+                            todayMarker off
+                        {string.Join(Environment.NewLine, scenarios)}
+                        ```
+                        """;
+                     });
+
+        return GetCommentMarkdown(sources, charts);
+    }
+ 
+    static string GetMermaidSection(string scenario, IEnumerable<ExecutionTimeResult> results)
+    {
+        
+        const decimal msToNs = 1_000_000m;
+        const decimal zScore = 2.3263m;
+        const string offset = "    ";
+        var orderedResults = results
+                            .OrderBy(x => x.Source.SourceType)
+                            .ThenBy(x => x.Scenario) // baseline first
+                            .ToList();
+
+        var pairedResults = orderedResults
+                           .GroupBy(x => x.Scenario)
+                           .Select(@pairedScenarios =>
+                            {
+                                // assumes we only have master + PR for now
+                                var masterValues = pairedScenarios.FirstOrDefault(x => x.Source.SourceType == ExecutionTimeSourceType.Master)?.Result.Durations;
+                                var commitValues = pairedScenarios.FirstOrDefault(x => x.Source.SourceType == ExecutionTimeSourceType.CurrentCommit)?.Result.Durations;
+
+                                if (masterValues is null || commitValues is null)
+                                {
+                                    return (@pairedScenarios.Key, conclusion: EquivalenceTestConclusion.Same);
+                                }
+
+                                var userThresholdResult = StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, SignificantResultThreshold);
+                                var conclusion = userThresholdResult.Conclusion switch
+                                {
+                                    EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
+                                    _ when StatisticalTestHelper.CalculateTost(WelchTest.Instance, masterValues, commitValues, NoiseThreshold).Conclusion == EquivalenceTestConclusion.Same => EquivalenceTestConclusion.Same,
+                                    _ => userThresholdResult.Conclusion,
+                                };
+
+                                return (@pairedScenarios.Key, conclusion);
+                            })
+                           .ToDictionary(x => x.Key, x => x.conclusion);
+
+        var sb = new StringBuilder();
+        sb.Append(offset).Append("section ").AppendLine(scenario);
+
+        foreach (var result in orderedResults)
+        {
+            // convert everything to ms from ns
+            var min = result.Result.Min / msToNs;
+            var max = result.Result.Max / msToNs;
+            var mean = result.Result.Mean / msToNs;
+            var q05 = (result.Result.Mean - zScore * result.Result.Stdev) / msToNs;
+            var q95 = (result.Result.Mean + zScore * result.Result.Stdev) / msToNs;
+
+            var formattedMean = mean.ToString("N0");
+            var format = result.Source.SourceType == ExecutionTimeSourceType.CurrentCommit
+                      && scenario != "Baseline"
+                      && pairedResults[scenario] == EquivalenceTestConclusion.Slower
+                             ? "crit"
+                             : "done";
+
+            sb.AppendLine($"""
+            {offset}{result.Source.BranchName} - mean ({formattedMean}ms)  : {format}, {q05:F0}, {q95:F0}
+            {offset} .   : {format}, milestone, {mean:F0},
+            """);
+        }
+
+        return sb.ToString();
+    }
+
+    static string GetCommentMarkdown(List<ExecutionTimeResultSource> sources, IEnumerable<string> charts)
+    {
+        return $"""
+            ## Execution-Time Benchmarks Report :stopwatch:
+
+            Execution-time results for samples comparing the following branches/commits:
+            {string.Join('\n', GetSourceMarkdown(sources))}
+
+            Execution-time benchmarks measure the whole time it takes to execute a program. And are intended to measure the one-off costs. Cases where the execution time results for the PR are worse than latest master results are shown in **red**. The following thresholds were used for comparing the execution times:
+            * Welch test with statistical test for significance of **5%**
+            * Only results indicating a difference greater than **{SignificantResultThreshold}** and **{NoiseThreshold}** are considered.
+
+
+            Note that these results are based on a _single_ point-in-time result for each branch. For full results, see the [dashboard](https://ddstaging.datadoghq.com/dashboard/4qn-6fi-54p/apm-net-execution-time-benchmarks).
+
+            Graphs show the p99 interval based on the mean and StdDev of the test run, as well as the mean valur.
+            {string.Join('\n', charts)}
+            """;
+
+        IEnumerable<string> GetSourceMarkdown(List<ExecutionTimeResultSource> ExecutionTimeResultSources)
+            => ExecutionTimeResultSources.Select(x => $"- {x.Markdown}");
+    }
+
+    private static string GetName(ExecutionTimeFramework source) => source switch
+    {
+        ExecutionTimeFramework.NetFramework462 => ".NET Framework 4.6.2",
+        ExecutionTimeFramework.Netcoreapp31 => ".NET Core 3.1",
+        ExecutionTimeFramework.Net6 => ".NET 6",
+        _ => throw new NotImplementedException(),
+    };
+
+    static readonly (string Path, ExecutionTimeSample Sample, (string Filename, ExecutionTimeFramework Framework)[] TestRuns)[] ExpectedTestRuns =
+    {
+        ("execution_time_benchmarks_windows_x64_FakeDbCommand_1", ExecutionTimeSample.FakeDbCommand, new[] { 
+            ("results_Samples.FakeDbCommand.windows.net462.json", ExecutionTimeFramework.NetFramework462),
+            ("results_Samples.FakeDbCommand.windows.netcoreapp31.json", ExecutionTimeFramework.Netcoreapp31),
+            ("results_Samples.FakeDbCommand.windows.net60.json", ExecutionTimeFramework.Net6),
+        }),
+        ("execution_time_benchmarks_windows_x64_HttpMessageHandler_1", ExecutionTimeSample.HttpMessageHandler, new[] { 
+            ("results_Samples.HttpMessageHandler.windows.net462.json", ExecutionTimeFramework.NetFramework462),
+            ("results_Samples.HttpMessageHandler.windows.netcoreapp31.json", ExecutionTimeFramework.Netcoreapp31),
+            ("results_Samples.HttpMessageHandler.windows.net60.json", ExecutionTimeFramework.Net6),
+        }),
+    };
+
+    public static List<ExecutionTimeResult> ReadJsonResults(ExecutionTimeResultSource source)
+    {
+        var results = new List<ExecutionTimeResult>();
+        foreach (var (path, sample, testRuns) in ExpectedTestRuns)
+        foreach (var (filename, framework) in testRuns)
+        {
+            var fileName = source.Path / path / filename;
+            try
+            {
+                using var file = File.OpenRead(fileName);
+                var node = JsonNode.Parse(file)!;
+                foreach(var job in node.AsArray())
+                {
+                    var scenario = job["name"].ToString();
+                    var durations = job["durations"].AsArray().Select(x => (double)x).ToList();
+                    // remove the last duration, because it's actually the mean!
+                    durations.RemoveAt(durations.Count - 1);
+                    var result = new Result((long)job["min"], (long)job["max"], (decimal)job["mean"], (decimal)job["stdev"], durations.ToArray());
+                    results.Add(new (source, sample, framework, scenario, result));
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Info($"Error reading {fileName}: {ex.Message}. Skipping");
+            }
+        }
+
+        return results;
+    }
+
+    public record ExecutionTimeResult(ExecutionTimeResultSource Source, ExecutionTimeSample TestSample, ExecutionTimeFramework Framework, string Scenario, Result Result);
+    public record Result(long Min, long Max, decimal Mean, decimal Stdev, double[] Durations)
+    {
+
+    }
+
+    public enum ExecutionTimeSample
+    {
+        FakeDbCommand,
+        HttpMessageHandler,
+    }
+
+    public enum ExecutionTimeFramework
+    {
+        NetFramework462,
+        Netcoreapp31,
+        Net6,
+    }
+}
+
+public record ExecutionTimeResultSource(string BranchName, string CommitSha, ExecutionTimeSourceType SourceType, AbsolutePath Path)
+{
+    public string Markdown => $"[{BranchName}](https://github.com/DataDog/dd-trace-dotnet/tree/{CommitSha})";
+}
+
+public enum ExecutionTimeSourceType
+{
+    CurrentCommit,
+    Master,
+}

--- a/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
+++ b/tracer/build/_build/ExecutionTimeComparison/CompareExecutionTime.cs
@@ -97,12 +97,12 @@ public class CompareExecutionTime
             var format = result.Source.SourceType == ExecutionTimeSourceType.CurrentCommit
                       && scenario != "Baseline"
                       && pairedResults[scenario] == EquivalenceTestConclusion.Slower
-                             ? "crit"
-                             : "done";
+                             ? "crit, "
+                             : string.Empty;
 
             sb.AppendLine($"""
-            {offset}{result.Source.BranchName} - mean ({formattedMean}ms)  : {format}, {q05:F0}, {q95:F0}
-            {offset} .   : {format}, milestone, {mean:F0},
+            {offset}{result.Source.BranchName} - mean ({formattedMean}ms)  : {format}{q05:F0}, {q95:F0}
+            {offset} .   : {format}milestone, {mean:F0},
             """);
         }
 
@@ -169,8 +169,6 @@ public class CompareExecutionTime
                 {
                     var scenario = job["name"].ToString();
                     var durations = job["durations"].AsArray().Select(x => (double)x).ToList();
-                    // remove the last duration, because it's actually the mean!
-                    durations.RemoveAt(durations.Count - 1);
                     var result = new Result((long)job["min"], (long)job["max"], (decimal)job["mean"], (decimal)job["stdev"], durations.ToArray());
                     results.Add(new (source, sample, framework, scenario, result));
                 }


### PR DESCRIPTION
## Summary of changes

Adds comparison of the execution-time benchmarks and posting to PRs

## Reason for change

We want to make sure we keep track of changes to startup times

## Implementation details

Essentially the same as the throughput test comparison. In this case we have all the test results though, and they're normally distributed, so we can use a proper statistical test to compare the results properly. Arbitrarily chosen the thresholds though, so we can tweak them if needs be.

## Test coverage

Only comparing with `master` for now, because it's a bit complicated to do for the benchmark branches, but I think that'll do for now

## Other details
The report is shown below in this PR!
