### PR TITLE
[Tests] Enable the parametric test suite from the system-tests repo

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3303,6 +3303,17 @@ stages:
         displayName: RCM tests logs
         artifact: _$(System.StageName)_$(Agent.JobName)_logs_rcm_$(System.JobAttempt)
 
+      - script: |
+          cd parametric
+          pip install wheel
+          pip install -r requirements.txt
+          ./run.sh
+        workingDirectory: system-tests
+        displayName: Run parametric tests
+        env:
+          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
+          CLIENTS_ENABLED: dotnet
+
 - stage: installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [package_linux, generate_variables, master_commit_id]


### PR DESCRIPTION
## Summary of changes
Runs the parametric test suite during the system-tests stage

## Reason for change
The new parametric test suite validates additional scenarios like spans sampling and distributed tracing headers.

## Implementation details
Adds a script to run the parametric tests.

## Test coverage
This runs the new tests.

## Other details
N/A
