### PR TITLE
[ASM] Added parent span Id to vulnerability json.

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -43,6 +43,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     return null;
                 }
 
+                if (Iast.Iast.Instance.Settings.Enabled)
+                {
+                    IastModule.OnSqlQuery(command.CommandText, integrationId);
+                }
+
                 var tags = new SqlTags
                            {
                                DbType = dbType,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
                 if (Iast.Iast.Instance.Settings.Enabled)
                 {
-                    IastModule.OnSqlQuery(command.CommandText, integrationId, Iast.Iast.Instance);
+                    IastModule.OnSqlQuery(command.CommandText, integrationId);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -43,11 +43,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     return null;
                 }
 
-                if (Iast.Iast.Instance.Settings.Enabled)
-                {
-                    IastModule.OnSqlQuery(command.CommandText, integrationId);
-                }
-
                 var tags = new SqlTags
                            {
                                DbType = dbType,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CryptographyAlgorithm/SymmetricAlgorithmIntegrationCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CryptographyAlgorithm/SymmetricAlgorithmIntegrationCommon.cs
@@ -28,7 +28,7 @@ internal class SymmetricAlgorithmIntegrationCommon
 
         try
         {
-            return ((instance is null) ? null : IastModule.OnCipherAlgorithm(instance.GetType(), IntegrationId, iast));
+            return ((instance is null) ? null : IastModule.OnCipherAlgorithm(instance.GetType(), IntegrationId));
         }
         catch (Exception ex)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/HashAlgorithm/HashAlgorithmIntegrationCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/HashAlgorithm/HashAlgorithmIntegrationCommon.cs
@@ -29,7 +29,7 @@ internal class HashAlgorithmIntegrationCommon
 
             try
             {
-                return IastModule.OnHashingAlgorithm(GetAlgorithmName(algorithm.GetType()), IntegrationId, iast);
+                return IastModule.OnHashingAlgorithm(GetAlgorithmName(algorithm.GetType()), IntegrationId);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -22,11 +22,6 @@ internal static class IastModule
 
     public static Scope? OnSqlQuery(string query, IntegrationId integrationId)
     {
-        return GetScope(query, integrationId, VulnerabilityType.SqlInjection, OperationNameSqlInjection, true);
-    }
-
-    public static Scope? OnCipherAlgorithm(Type type, IntegrationId integrationId)
-    {
         return GetScope(query, integrationId, VulnerabilityTypeName.SqlInjection, OperationNameSqlInjection, true);
     }
 

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -39,7 +39,6 @@ internal static class IastModule
 
     public static Scope? OnHashingAlgorithm(string? algorithm, IntegrationId integrationId)
     {
-        var iast = Iast.Instance;
         if (algorithm == null || !InvalidHashAlgorithm(algorithm))
         {
             return null;

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -9,56 +9,61 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Iast.Settings;
 
 namespace Datadog.Trace.Iast;
 
-internal class IastModule
+internal static class IastModule
 {
     private const string OperationNameWeakHash = "weak_hashing";
     private const string OperationNameWeakCipher = "weak_cipher";
     private const string OperationNameSqlInjection = "sql_injection";
+    private static IastSettings iastSettings = Iast.Instance.Settings;
 
-    public IastModule()
+    public static Scope? OnSqlQuery(string query, IntegrationId integrationId)
     {
+        return GetScope(query, integrationId, VulnerabilityType.SqlInjection, OperationNameSqlInjection, true);
     }
 
-    public static Scope? OnSqlQuery(string query, IntegrationId integrationId, Iast iast)
+    public static Scope? OnCipherAlgorithm(Type type, IntegrationId integrationId)
     {
-        return GetScope(query, integrationId, VulnerabilityTypeName.SqlInjection, OperationNameSqlInjection, iast, true);
+        return GetScope(query, integrationId, VulnerabilityTypeName.SqlInjection, OperationNameSqlInjection, true);
     }
 
-    public static Scope? OnCipherAlgorithm(Type type, IntegrationId integrationId, Iast iast)
+    public static Scope? OnCipherAlgorithm(Type type, IntegrationId integrationId)
     {
         var algorithm = type.BaseType?.Name;
 
-        if (algorithm is null || !InvalidCipherAlgorithm(type, algorithm, iast))
+        if (algorithm is null || !InvalidCipherAlgorithm(type, algorithm))
         {
             return null;
         }
 
-        return GetScope(algorithm, integrationId, VulnerabilityTypeName.WeakCipher, OperationNameWeakCipher, iast);
+        return GetScope(algorithm, integrationId, VulnerabilityTypeName.WeakCipher, OperationNameWeakCipher);
     }
 
-    public static Scope? OnHashingAlgorithm(string? algorithm, IntegrationId integrationId, Iast iast)
+    public static Scope? OnHashingAlgorithm(string? algorithm, IntegrationId integrationId)
     {
-        if (algorithm == null || !InvalidHashAlgorithm(algorithm, iast))
+        var iast = Iast.Instance;
+        if (algorithm == null || !InvalidHashAlgorithm(algorithm))
         {
             return null;
         }
 
-        return GetScope(algorithm, integrationId, VulnerabilityTypeName.WeakHash, OperationNameWeakHash, iast);
+        return GetScope(algorithm, integrationId, VulnerabilityTypeName.WeakHash, OperationNameWeakHash);
     }
 
-    private static Scope? GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, Iast iast, bool taintedFromEvidenceRequired = false)
+    private static Scope? GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, bool taintedFromEvidenceRequired = false)
     {
         var tracer = Tracer.Instance;
-        if (!iast.Settings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
+        if (!iastSettings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
         {
             // integration disabled, don't create a scope, skip this span
             return null;
         }
 
-        var traceContext = (tracer.ActiveScope as Scope)?.Span?.Context?.TraceContext;
+        var currentSpan = (tracer.ActiveScope as Scope)?.Span;
+        var traceContext = currentSpan?.Context?.TraceContext;
         var isRequest = traceContext?.RootSpan?.Type == SpanTypes.Web;
 
         // We do not have, for now, tainted objects in console apps, so further checking is not neccessary.
@@ -93,9 +98,9 @@ internal class IastModule
 
         // Sometimes we do not have the file/line but we have the method/class.
         var filename = frameInfo.StackFrame?.GetFileName();
-        var vulnerability = new Vulnerability(vulnerabilityType, new Location(filename ?? GetMethodName(frameInfo.StackFrame), filename != null ? frameInfo.StackFrame?.GetFileLineNumber() : null), new Evidence(evidenceValue, tainted?.Ranges));
+        var vulnerability = new Vulnerability(vulnerabilityType, new Location(filename ?? GetMethodName(frameInfo.StackFrame), filename != null ? frameInfo.StackFrame?.GetFileLineNumber() : null, currentSpan?.SpanId), new Evidence(evidenceValue, tainted?.Ranges));
 
-        if (!iast.Settings.DeduplicationEnabled || HashBasedDeduplication.Instance.Add(vulnerability))
+        if (!iastSettings.DeduplicationEnabled || HashBasedDeduplication.Instance.Add(vulnerability))
         {
             if (isRequest)
             {
@@ -144,9 +149,9 @@ internal class IastModule
         return $"{namespaceName}.{typeName}::{methodName}";
     }
 
-    private static bool InvalidHashAlgorithm(string algorithm, Iast iast)
+    private static bool InvalidHashAlgorithm(string algorithm)
     {
-        foreach (var weakHashAlgorithm in iast.Settings.WeakHashAlgorithmsArray)
+        foreach (var weakHashAlgorithm in iastSettings.WeakHashAlgorithmsArray)
         {
             if (string.Equals(algorithm, weakHashAlgorithm, StringComparison.OrdinalIgnoreCase))
             {
@@ -157,14 +162,14 @@ internal class IastModule
         return false;
     }
 
-    private static bool InvalidCipherAlgorithm(Type type, string algorithm, Iast iast)
+    private static bool InvalidCipherAlgorithm(Type type, string algorithm)
     {
         if (ProviderValid(type.Name))
         {
             return false;
         }
 
-        foreach (var weakCipherAlgorithm in iast.Settings.WeakCipherAlgorithmsArray)
+        foreach (var weakCipherAlgorithm in iastSettings.WeakCipherAlgorithmsArray)
         {
             if (string.Equals(algorithm, weakCipherAlgorithm, StringComparison.OrdinalIgnoreCase))
             {

--- a/tracer/src/Datadog.Trace/IAST/Location.cs
+++ b/tracer/src/Datadog.Trace/IAST/Location.cs
@@ -24,8 +24,6 @@ internal readonly struct Location
 
     public override int GetHashCode()
     {
-        // we do not include the span id in the hash because that can cause repeated vulnerabilities if DbScopeFactory.CreateDbCommandScope
-        // is called multiple times within the same sql query with different active spans
-        return IastUtils.GetHashCode(Path, Line);
+        return IastUtils.GetHashCode(Path, Line, SpanId);
     }
 }

--- a/tracer/src/Datadog.Trace/IAST/Location.cs
+++ b/tracer/src/Datadog.Trace/IAST/Location.cs
@@ -13,7 +13,7 @@ internal readonly struct Location
     {
         this.Path = path;
         this.Line = line;
-        this.SpanId = spanId;
+        this.SpanId = spanId == 0 ? null : spanId;
     }
 
     public ulong? SpanId { get; }

--- a/tracer/src/Datadog.Trace/IAST/Location.cs
+++ b/tracer/src/Datadog.Trace/IAST/Location.cs
@@ -9,11 +9,14 @@ namespace Datadog.Trace.Iast;
 
 internal readonly struct Location
 {
-    public Location(string? path, int? line)
+    public Location(string? path, int? line, ulong? spanId)
     {
         this.Path = path;
         this.Line = line;
+        this.SpanId = spanId;
     }
+
+    public ulong? SpanId { get; }
 
     public string? Path { get; }
 
@@ -21,6 +24,6 @@ internal readonly struct Location
 
     public override int GetHashCode()
     {
-        return IastUtils.GetHashCode(Path, Line);
+        return IastUtils.GetHashCode(Path, Line, SpanId);
     }
 }

--- a/tracer/src/Datadog.Trace/IAST/Location.cs
+++ b/tracer/src/Datadog.Trace/IAST/Location.cs
@@ -24,6 +24,8 @@ internal readonly struct Location
 
     public override int GetHashCode()
     {
-        return IastUtils.GetHashCode(Path, Line, SpanId);
+        // we do not include the span id in the hash because that can cause repeated vulnerabilities if DbScopeFactory.CreateDbCommandScope
+        // is called multiple times within the same sql query with different active spans
+        return IastUtils.GetHashCode(Path, Line);
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             var spans = await SendRequestsAsync(agent, new string[] { url });
             var parentSpan = spans.First(x => x.ParentId == null);
             var childSpan = spans.First(x => x.ParentId == parentSpan.SpanId);
-            var vulnerabilityJson = parentSpan.GetTag("_dd.iast.json");
+            var vulnerabilityJson = parentSpan.GetTag(Tags.IastJson);
             vulnerabilityJson.Should().Contain("\"spanId\": " + childSpan.SpanId);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -198,6 +198,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
         public virtual async Task TryStartApp()
         {
             EnableIast(IastEnabled);
+            SetEnvironmentVariable(ConfigurationKeys.DebugEnabled, "1");
             DisableObfuscationQueryString();
             SetEnvironmentVariable(ConfigurationKeys.Iast.IsIastDeduplicationEnabled, IsIastDeduplicationEnabled?.ToString() ?? string.Empty);
             SetEnvironmentVariable(ConfigurationKeys.Iast.VulnerabilitiesPerRequest, VulnerabilitiesPerRequest?.ToString() ?? string.Empty);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
@@ -137,7 +137,6 @@ public class HashBasedDeduplicationTests
     {
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
-        var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue2")), new Range(1, 1, new Source(0, "sourceName", "sourceValue2")) };
         Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 1), new Evidence("MD5", ranges1))));
         Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
@@ -133,12 +133,12 @@ public class HashBasedDeduplicationTests
     }
 
     [Fact]
-    public void GivenTwoDifferentVulnerabilitiesBySpanId_WhenAddedToDeduplication_OneIsStored()
+    public void GivenTwoDifferentVulnerabilitiesBySpanId_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 1), new Evidence("MD5", ranges1))));
-        Assert.False(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
@@ -34,8 +34,8 @@ public class HashBasedDeduplicationTests
     public void GivenTwoDifferentVulnerabilitiesByType_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityType.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityType.WeakCipher, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakCipher, new Location("path.cs", 23, 0), new Evidence("MD5"))));
     }
 
     [Fact]
@@ -133,12 +133,12 @@ public class HashBasedDeduplicationTests
     }
 
     [Fact]
-    public void GivenTwoDifferentVulnerabilitiesBySpanId_WhenAddedToDeduplication_BothAreStored()
+    public void GivenTwoDifferentVulnerabilitiesBySpanId_WhenAddedToDeduplication_OneIsStored()
     {
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 1), new Evidence("MD5", ranges1))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
+        Assert.False(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
@@ -15,7 +15,7 @@ public class HashBasedDeduplicationTests
     {
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
-        var vulnerability = new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1));
+        var vulnerability = new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1));
         Assert.True(instance.Add(vulnerability));
         Assert.False(instance.Add(vulnerability));
     }
@@ -26,40 +26,40 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
-        Assert.False(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
+        Assert.False(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
     }
 
     [Fact]
     public void GivenTwoDifferentVulnerabilitiesByType_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5"))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakCipher, new Location("path.cs", 23), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityType.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityType.WeakCipher, new Location("path.cs", 23, 0), new Evidence("MD5"))));
     }
 
     [Fact]
     public void GivenTwoDifferentVulnerabilitiesByFile_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5"))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path2.cs", 23), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path2.cs", 23, 0), new Evidence("MD5"))));
     }
 
     [Fact]
     public void GivenTwoDifferentVulnerabilitiesByLine_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5"))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 24), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 24, 0), new Evidence("MD5"))));
     }
 
     [Fact]
     public void GivenTwoDifferentVulnerabilitiesByEvidence_WhenAddedToDeduplication_BothAreStored()
     {
         var instance = new HashBasedDeduplication();
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5"))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("DES"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("DES"))));
     }
 
     [Fact]
@@ -68,8 +68,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(2, 1, new Source(0, "sourceName", "sourceValue")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 2, new Source(0, "sourceName", "sourceValue")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -88,8 +88,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(1, "sourceName", "sourceValue")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -98,8 +98,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName2", "sourceValue")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -108,8 +108,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue2")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -118,8 +118,8 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue1")), new Range(1, 1, new Source(0, "sourceName", "sourceValue1")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue1")), new Range(1, 1, new Source(0, "sourceName", "sourceValue2")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
@@ -128,21 +128,31 @@ public class HashBasedDeduplicationTests
         var instance = new HashBasedDeduplication();
         var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
         var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue2")), new Range(1, 1, new Source(0, "sourceName", "sourceValue2")) };
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges2))));
-        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges2))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5", ranges1))));
+    }
+
+    [Fact]
+    public void GivenTwoDifferentVulnerabilitiesBySpanId_WhenAddedToDeduplication_BothAreStored()
+    {
+        var instance = new HashBasedDeduplication();
+        var ranges1 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue")) };
+        var ranges2 = new Range[] { new Range(1, 1, new Source(0, "sourceName", "sourceValue2")), new Range(1, 1, new Source(0, "sourceName", "sourceValue2")) };
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 1), new Evidence("MD5", ranges1))));
+        Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 33), new Evidence("MD5", ranges1))));
     }
 
     [Fact]
     public void GivenManyVulnerabilities_WhenAddedToDeduplication_CacheIsCleared()
     {
         var instance = new HashBasedDeduplication();
-        var vulnerability1 = new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23), new Evidence("MD5"));
+        var vulnerability1 = new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("path.cs", 23, 0), new Evidence("MD5"));
         Assert.True(instance.Add(vulnerability1));
         Assert.False(instance.Add(vulnerability1));
 
         for (int i = 1; i <= HashBasedDeduplication.MaximumSize; i++)
         {
-            Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("pathNew.cs", i), new Evidence("MD5"))));
+            Assert.True(instance.Add(new Vulnerability(VulnerabilityTypeName.WeakHash, new Location("pathNew.cs", i, 0), new Evidence("MD5"))));
         }
 
         Assert.True(instance.Add(vulnerability1));


### PR DESCRIPTION
## Summary of changes

To comply the vulnerability json format, the parent span must be added in vulnerabilities within requests. 

Also, a small refactor has been made in order to avoid passing the iast settings everytime we hit an instrumentation point.

## Reason for change

Comply with the required format: https://github.com/DataDog/experimental/blob/main/teams/asm/vulnerability_schema/vulnerability_example.json

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
