### PR TITLE
[CI Visibility] Modify the .deps.json file only when the Datadog.Trace.dll is copied

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -71,10 +71,13 @@ namespace Datadog.Trace.Coverage.Collector
 
         public string FilePath => _assemblyFilePath;
 
+        public bool HasTracerAssemblyCopied { get; private set; }
+
         public void Process()
         {
             try
             {
+                HasTracerAssemblyCopied = false;
                 _logger.Debug($"Processing: {_assemblyFilePath}");
 
                 // Check if the assembly is in the ignored assemblies list.
@@ -602,6 +605,7 @@ namespace Datadog.Trace.Coverage.Collector
                         }
                     }
 
+                    HasTracerAssemblyCopied = true;
                     return outputAssemblyDllLocation;
                 }
             }

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -166,11 +166,13 @@ namespace Datadog.Trace.Coverage.Collector
                             {
                                 var asmProcessor = new AssemblyProcessor(file, _tracerHome, _logger, _ciVisibilitySettings);
                                 asmProcessor.Process();
-
-                                lock (processedDirectories)
+                                Interlocked.Increment(ref numAssemblies);
+                                if (asmProcessor.HasTracerAssemblyCopied)
                                 {
-                                    numAssemblies++;
-                                    processedDirectories.Add(Path.GetDirectoryName(file) ?? string.Empty);
+                                    lock (processedDirectories)
+                                    {
+                                        processedDirectories.Add(Path.GetDirectoryName(file) ?? string.Empty);
+                                    }
                                 }
                             }
                             catch (PdbNotFoundException)


### PR DESCRIPTION
## Summary of changes

This PR ensures that the modification of the `.deps.json` file when applying code coverage happens only if the `Datadog.Trace.dll` assembly is copied to the application folder.

## Reason for change

If the AssemblyProcessor don't copy the assembly and we modify the `.deps.json` file the application crashes because the dependency is not found. This can happen when the `Process` methods return because is missing the `.SNK` file.

## Implementation details
We set a flag when a copy of the `Datadog.Trace.dll` assembly is done. Later we check the flag before trying to modify the .json files.