### PR TITLE
[Debugger] Add default sampling rate for log probes

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
@@ -290,15 +290,22 @@ namespace Datadog.Trace.Debugger.Instrumentation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LogException(Exception exception, ref AsyncMethodDebuggerState asyncState)
         {
-            if (!asyncState.IsActive)
+            try
             {
-                // Already encountered `LogException`
-                return;
-            }
+                if (!asyncState.IsActive)
+                {
+                    // Already encountered `LogException`
+                    return;
+                }
 
-            Log.Warning(exception, "Error caused by our instrumentation");
-            asyncState.IsActive = false;
-            RestoreContext();
+                Log.Warning(exception, "Error caused by our instrumentation");
+                asyncState.IsActive = false;
+                RestoreContext();
+            }
+            catch
+            {
+                // ignored
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
@@ -267,14 +267,21 @@ namespace Datadog.Trace.Debugger.Instrumentation
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LogException(Exception exception, ref MethodDebuggerState state)
         {
-            if (!state.IsActive)
+            try
             {
-                // Already encountered `LogException`
-                return;
-            }
+                if (!state.IsActive)
+                {
+                    // Already encountered `LogException`
+                    return;
+                }
 
-            Log.Warning(exception, "Error caused by our instrumentation");
-            state.IsActive = false;
+                Log.Warning(exception, "Error caused by our instrumentation");
+                state.IsActive = false;
+            }
+            catch
+            {
+                // ignored
+            }
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -208,9 +208,16 @@ namespace Datadog.Trace.Debugger
                 foreach (var probe in addedProbes)
                 {
                     ProbeExpressionsProcessor.Instance.AddProbeProcessor(probe);
-                    if (probe is LogProbe { Sampling: { } } logProbe)
+                    if (probe is LogProbe logProbe)
                     {
-                        ProbeRateLimiter.Instance.SetRate(probe.Id, (int)logProbe.Sampling.Value.SnapshotsPerSecond);
+                        if (logProbe.Sampling is { } sampling)
+                        {
+                            ProbeRateLimiter.Instance.SetRate(probe.Id, (int)sampling.SnapshotsPerSecond);
+                        }
+                        else
+                        {
+                            ProbeRateLimiter.Instance.SetRate(probe.Id, logProbe.CaptureSnapshot ? 1 : 5000);
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary of changes

Add a hardcoded default sampling rate for Log Probes (1 per second if we're capturing a snapshot, otherwise 5000 per second).

## Reason for change
The sampling rate might not be included in the probe definition, so the debugger must set sensible defaults in those cases.