### PR TITLE
Small changes to improve stability

### DIFF
--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -46,11 +46,11 @@ namespace Datadog.Trace.Util
             }
             catch (NotSupportedException nsException)
             {
-                Log.Warning(nsException, "Connection cannot be retrieved from the command.");
+                Log.Debug(nsException, "Connection cannot be retrieved from the command.");
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error trying to retrieve the connection from the command.");
+                Log.Debug(ex, "Error trying to retrieve the connection from the command.");
             }
 
             var connectionString = dbConnection?.ConnectionString;

--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -39,8 +39,21 @@ namespace Datadog.Trace.Util
 
         public static TagsCacheItem GetTagsFromDbCommand(IDbCommand command)
         {
-            var connectionString = command.Connection?.ConnectionString;
+            IDbConnection dbConnection = null;
+            try
+            {
+                dbConnection = command.Connection;
+            }
+            catch (NotSupportedException nsException)
+            {
+                Log.Warning(nsException, "Connection cannot be retrieved from the command.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error trying to retrieve the connection from the command.");
+            }
 
+            var connectionString = dbConnection?.ConnectionString;
             if (connectionString is null)
             {
                 return default;


### PR DESCRIPTION
## Summary of changes

This PR includes small changes to improve stability (handling some exceptions).

## Reason for change

Solve the following scenarios:

- Catching the exception thrown when extracting the connection from a DbCommand created by DbDataSource ([source](https://source.dot.net/#System.Data.Common/System/Data/Common/DbDataSource.cs,342)) and avoid the following log entry:
```
2023-01-23 10:32:23.827 +00:00 [ERR] Connection and transaction access is not supported on commands created from DbDataSource. System.NotSupportedException: Connection and transaction access is not supported on commands created from DbDataSource.
   at Npgsql.NpgsqlDataSourceCommand.get_DbConnection() in D:\a\npgsql\npgsql\src\Npgsql\NpgsqlDataSourceCommand.cs:line 63
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.DbScopeFactory.Cache`1.GetTagsFromConnectionString(IDbCommand command) in /_/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs:line 241
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.DbScopeFactory.Cache`1.CreateDbCommandScope(Tracer tracer, IDbCommand command) in /_/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs:line 182
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarIntegration.OnMethodBegin[TTarget](TTarget instance) in /_/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs:line 29
   at Npgsql.NpgsqlCommand.ExecuteScalar() in D:\a\npgsql\npgsql\src\Npgsql\NpgsqlCommand.cs:line 1206

```
- Adding more logs on the custom assembly resolver for the Code Coverage feature to check the reason and conditions of this type of exception:
```
2023-01-20 17:06:51.712 +00:00 [ERR] Specified argument was out of the range of valid values. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
   at Mono.Cecil.PE.Image.ResolveVirtualAddress(UInt32 rva)
   at Mono.Cecil.PE.ImageReader.MoveTo(DataDirectory directory)
   at Mono.Cecil.PE.ImageReader.ReadMetadata()
   at Mono.Cecil.PE.ImageReader.ReadImage()
   at Mono.Cecil.PE.ImageReader.ReadImage(Disposable`1 stream, String file_name)
   at Mono.Cecil.ModuleDefinition.ReadModule(Disposable`1 stream, String fileName, ReaderParameters parameters)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName)
   at Mono.Cecil.AssemblyDefinition.ReadAssembly(String fileName)
   at Datadog.Trace.Coverage.Collector.AssemblyProcessor.CustomResolver.Resolve(AssemblyNameReference name)
   at Mono.Cecil.MetadataResolver.Resolve(TypeReference type)
   at Mono.Cecil.ModuleDefinition.Resolve(TypeReference type)
   at Mono.Cecil.TypeReference.Resolve()
   at Mono.Cecil.Mixin.CheckedResolve(TypeReference self)
   at Mono.Cecil.MetadataBuilder.GetConstantType(TypeReference constant_type, Object constant)
   at Mono.Cecil.MetadataBuilder.AddConstant(IConstantProvider owner, TypeReference type)
   at Mono.Cecil.MetadataBuilder.AddParameter(UInt16 sequence, ParameterDefinition parameter, ParamTable table)
   at Mono.Cecil.MetadataBuilder.AddParameters(MethodDefinition method)
   at Mono.Cecil.MetadataBuilder.AddMethod(MethodDefinition method)
   at Mono.Cecil.MetadataBuilder.AddMethods(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddType(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddTypes()
   at Mono.Cecil.MetadataBuilder.BuildTypes()
   at Mono.Cecil.MetadataBuilder.BuildModule()
   at Mono.Cecil.MetadataBuilder.BuildMetadata()
   at Mono.Cecil.ModuleWriter.<>c.<BuildMetadata>b__2_0(MetadataBuilder builder, MetadataReader _)
   at Mono.Cecil.ModuleDefinition.Read[TItem,TRet](TItem item, Func`3 read)
   at Mono.Cecil.ModuleWriter.BuildMetadata(ModuleDefinition module, MetadataBuilder metadata)
   at Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleDefinition.Write(Stream stream, WriterParameters parameters)
   at Mono.Cecil.ModuleDefinition.Write(WriterParameters parameters)
   at Datadog.Trace.Coverage.Collector.AssemblyProcessor.Process()
```
