### PR TITLE
[Debugger] Limit snapshot size

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -327,7 +327,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (!ProbeInfo.IsFullSnapshot)
                     {
                         var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
-                        LiveDebugger.Instance.AddSnapshot(snapshot);
+                        LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         break;
                     }
 
@@ -351,7 +351,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     if (!ProbeInfo.IsFullSnapshot)
                     {
                         var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
-                        LiveDebugger.Instance.AddSnapshot(snapshot);
+                        LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         break;
                     }
 
@@ -383,7 +383,7 @@ namespace Datadog.Trace.Debugger.Expressions
                         }
 
                         var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
-                        LiveDebugger.Instance.AddSnapshot(snapshot);
+                        LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         snapshotCreator.Stop();
                         break;
                     }
@@ -427,7 +427,7 @@ namespace Datadog.Trace.Debugger.Expressions
                     }
 
                     var snapshot = snapshotCreator.FinalizeLineSnapshot(ProbeInfo.ProbeId, ref info);
-                    LiveDebugger.Instance.AddSnapshot(snapshot);
+                    LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                     snapshotCreator.Stop();
                     break;
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -357,9 +357,9 @@ namespace Datadog.Trace.Debugger
             }
         }
 
-        internal void AddSnapshot(string snapshot)
+        internal void AddSnapshot(string probeId, string snapshot)
         {
-            _debuggerSink.AddSnapshot(snapshot);
+            _debuggerSink.AddSnapshot(probeId, snapshot);
         }
 
         internal void AddReceivedProbeStatus(string probeId)

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
+using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
@@ -30,7 +31,8 @@ internal class LiveDebuggerFactory
             return LiveDebugger.Create(settings, string.Empty, null, null, null, null, null, null);
         }
 
-        var snapshotStatusSink = SnapshotSink.Create(settings);
+        var snapshotSlicer = SnapshotSlicer.Create(settings);
+        var snapshotStatusSink = SnapshotSink.Create(settings, snapshotSlicer);
         var probeStatusSink = ProbeStatusSink.Create(serviceName, settings);
 
         var apiFactory = AgentTransportStrategy.Get(

--- a/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
@@ -132,9 +132,9 @@ namespace Datadog.Trace.Debugger.Sink
             return newInterval;
         }
 
-        public void AddSnapshot(string snapshot)
+        public void AddSnapshot(string probeId, string snapshot)
         {
-            _snapshotSink.Add(snapshot);
+            _snapshotSink.Add(probeId, snapshot);
         }
 
         public void AddProbeStatus(string probeId, Status status, Exception exception = null, string errorMessage = null)

--- a/tracer/src/Datadog.Trace/Debugger/Sink/IDebuggerSink.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/IDebuggerSink.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Debugger.Sink
     {
         Task StartFlushingAsync();
 
-        void AddSnapshot(string snapshot);
+        void AddSnapshot(string probeId, string snapshot);
 
         void AddProbeStatus(string probeId, Status status, Exception exception = null, string errorMessage = null);
     }

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
@@ -1,0 +1,113 @@
+// <copyright file="SnapshotSlicer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Text;
+using Datadog.Trace.Debugger.Sink;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Debugger.Snapshots
+{
+    internal class SnapshotSlicer
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerSink));
+
+        private readonly int _maxDepth;
+        private readonly int _maxSnapshotSize;
+
+        private SnapshotSlicer(int maxDepth, int maxSnapshotSize)
+        {
+            _maxSnapshotSize = maxSnapshotSize;
+            _maxDepth = maxDepth;
+        }
+
+        public static SnapshotSlicer Create(DebuggerSettings settings, int maxSnapshotSize = 1 * 1024 * 1024)
+        {
+            return new SnapshotSlicer(settings.MaximumDepthOfMembersToCopy, maxSnapshotSize);
+        }
+
+        public string SliceIfNeeded(string probeId, string snapshot)
+        {
+            var payloadSize = Encoding.UTF8.GetByteCount(snapshot);
+            if (payloadSize < _maxSnapshotSize)
+            {
+                return snapshot;
+            }
+
+            try
+            {
+                return SliceSnapshot(snapshot, probeId, payloadSize);
+            }
+            catch (Exception e)
+            {
+                Log.Warning($"Failed to fit snapshot with probe id {probeId} due to exception", e);
+                return snapshot;
+            }
+        }
+
+        private string SliceSnapshot(string snapshot, string probeId, int payloadSize)
+        {
+            var maxDepth = _maxDepth;
+            var maxFieldDepth = 0;
+
+            while (maxDepth > 0 && payloadSize >= _maxSnapshotSize)
+            {
+                Log.Information($"Trying to slice snapshot with probe id {probeId} by removing {maxDepth} `field` depth property");
+
+                var fieldDepth = 0;
+                var skipFields = false;
+                var stringBuilder = StringBuilderCache.Acquire(payloadSize);
+
+                using var jsonReader = new JsonTextReader(new StringReader(snapshot));
+                using var jsonWriter = new JsonTextWriter(new StringWriter(stringBuilder));
+
+                while (jsonReader.Read())
+                {
+                    if (jsonReader.TokenType == JsonToken.PropertyName)
+                    {
+                        if (jsonReader.Value?.ToString() == "fields")
+                        {
+                            fieldDepth++;
+
+                            if (fieldDepth == maxDepth)
+                            {
+                                skipFields = true;
+                            }
+
+                            maxFieldDepth = Math.Max(maxFieldDepth, fieldDepth);
+                        }
+                    }
+
+                    if (skipFields)
+                    {
+                        jsonReader.Skip();
+                        skipFields = false;
+                        fieldDepth--;
+                    }
+                    else
+                    {
+                        jsonWriter.WriteToken(jsonReader, false);
+                    }
+                }
+
+                snapshot = StringBuilderCache.GetStringAndRelease(stringBuilder);
+                payloadSize = Encoding.UTF8.GetByteCount(snapshot);
+                maxDepth = Math.Min(maxFieldDepth, maxDepth - 1);
+            }
+
+            Log.Information(
+                payloadSize >= _maxSnapshotSize
+                    ? $"Failed to fit snapshot with probe id {probeId} size to the {_maxSnapshotSize}"
+                    : $"Succeed to fit snapshot with probe id {probeId} size to the {_maxSnapshotSize}");
+
+            return snapshot;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -5,13 +5,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace.Debugger.Expressions;
-using Datadog.Trace.Debugger.Snapshots;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using VerifyTests;
 using VerifyXunit;
@@ -94,76 +90,15 @@ namespace Datadog.Trace.Tests.Debugger
         }
 
         /// <summary>
-        /// Generate a debugger snapshot by simulating the same flow of method calls as our instrumentation produces for a method probe.
-        /// </summary>
-        private static string GenerateSnapshot(object instance, object[] args, object[] locals)
-        {
-            var snapshotCreator = new DebuggerSnapshotCreator(isFullSnapshot: true, ProbeLocation.Method, hasCondition: false);
-            {
-                // method entry
-                snapshotCreator.StartEntry();
-                if (instance != null)
-                {
-                    snapshotCreator.CaptureInstance(instance, instance.GetType());
-                }
-
-                for (var i = 0; i < args.Length; i++)
-                {
-                    snapshotCreator.CaptureArgument(args[i], "arg" + i, args[i].GetType());
-                }
-
-                snapshotCreator.EndEntry(hasArgumentsOrLocals: args.Length > 0);
-            }
-
-            {
-                // method exit
-                snapshotCreator.StartReturn();
-                for (var i = 0; i < locals.Length; i++)
-                {
-                    snapshotCreator.CaptureLocal(locals[i], "local" + i, locals[i]?.GetType() ?? typeof(object));
-                }
-
-                for (var i = 0; i < args.Length; i++)
-                {
-                    snapshotCreator.CaptureArgument(args[i], "arg" + i, args[i].GetType());
-                }
-
-                if (instance != null)
-                {
-                    snapshotCreator.CaptureInstance(instance, instance.GetType());
-                }
-
-                snapshotCreator.EndReturn(hasArgumentsOrLocals: args.Length + locals.Length > 0);
-            }
-
-            snapshotCreator.FinalizeSnapshot("Foo", "Bar", DateTimeOffset.MinValue, "foo");
-
-            var snapshot = snapshotCreator.GetSnapshotJson();
-            return JsonPrettify(snapshot);
-        }
-
-        private static string JsonPrettify(string json)
-        {
-            using (var stringReader = new StringReader(json))
-            using (var stringWriter = new StringWriter())
-            {
-                var jsonReader = new JsonTextReader(stringReader);
-                var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.Indented };
-                jsonWriter.WriteToken(jsonReader);
-                return stringWriter.ToString();
-            }
-        }
-
-        /// <summary>
         /// Validate that we produce valid json for a specific value, and that the output conforms to the given set of limits on capture.
         /// </summary>
-        private async Task ValidateSingleValue(object local)
+        internal async Task ValidateSingleValue(object local)
         {
-            var snapshot = GenerateSnapshot(null, new object[] { }, new object[] { local });
+            var snapshot = SnapshotHelper.GenerateSnapshot(local);
 
             var verifierSettings = new VerifySettings();
             verifierSettings.ScrubLinesContaining(new[] { "id", "timestamp", "duration" });
-            var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals");
+            var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return");
             await Verifier.Verify(localVariableAsJson, verifierSettings);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests.Debugger
 
             var verifierSettings = new VerifySettings();
             verifierSettings.ScrubLinesContaining(new[] { "id", "timestamp", "duration" });
-            var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return");
+            var localVariableAsJson = JObject.Parse(snapshot).SelectToken("debugger.snapshot.captures.return.locals");
             await Verifier.Verify(localVariableAsJson, verifierSettings);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -142,7 +142,7 @@ public class LiveDebuggerTests
             return Task.CompletedTask;
         }
 
-        public void AddSnapshot(string snapshot)
+        public void AddSnapshot(string probeId, string snapshot)
         {
             throw new NotImplementedException();
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotHelper.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotHelper.cs
@@ -1,0 +1,79 @@
+// <copyright file="SnapshotHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Debugger.Expressions;
+using Datadog.Trace.Debugger.Snapshots;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+internal static class SnapshotHelper
+{
+    internal static string GenerateSnapshot(object instance, bool prettify = true)
+    {
+        return GenerateSnapshot(null, new object[] { }, new object[] { instance }, prettify);
+    }
+
+    /// <summary>
+    /// Generate a debugger snapshot by simulating the same flow of method calls as our instrumentation produces for a method probe.
+    /// </summary>
+    private static string GenerateSnapshot(object instance, object[] args, object[] locals, bool prettify)
+    {
+        var snapshotCreator = new DebuggerSnapshotCreator(isFullSnapshot: true, ProbeLocation.Method, hasCondition: false);
+        {
+            // method entry
+            snapshotCreator.StartEntry();
+            if (instance != null)
+            {
+                snapshotCreator.CaptureInstance(instance, instance.GetType());
+            }
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                snapshotCreator.CaptureArgument(args[i], "arg" + i, args[i].GetType());
+            }
+
+            snapshotCreator.EndEntry(hasArgumentsOrLocals: args.Length > 0);
+        }
+
+        {
+            // method exit
+            snapshotCreator.StartReturn();
+            for (var i = 0; i < locals.Length; i++)
+            {
+                snapshotCreator.CaptureLocal(locals[i], "local" + i, locals[i]?.GetType() ?? typeof(object));
+            }
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                snapshotCreator.CaptureArgument(args[i], "arg" + i, args[i].GetType());
+            }
+
+            if (instance != null)
+            {
+                snapshotCreator.CaptureInstance(instance, instance.GetType());
+            }
+
+            snapshotCreator.EndReturn(hasArgumentsOrLocals: args.Length + locals.Length > 0);
+        }
+
+        snapshotCreator.FinalizeSnapshot("Foo", "Bar", DateTimeOffset.MinValue, "foo");
+
+        var snapshot = snapshotCreator.GetSnapshotJson();
+        return prettify ? JsonPrettify(snapshot) : snapshot;
+    }
+
+    private static string JsonPrettify(string json)
+    {
+        using var stringReader = new StringReader(json);
+        using var stringWriter = new StringWriter();
+        var jsonReader = new JsonTextReader(stringReader);
+        var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.Indented };
+        jsonWriter.WriteToken(jsonReader);
+        return stringWriter.ToString();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_OneLevel_LevelSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_OneLevel_LevelSliced.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  entry: {},
+  return: {
+    locals: {
+      local0: {
+        type: ComplexClass,
+        value: ComplexClass
+      }
+    }
+  }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced.verified.txt
@@ -1,0 +1,11 @@
+﻿{
+  entry: {},
+  return: {
+    locals: {
+      local0: {
+        type: VeryComplexClass,
+        value: VeryComplexClass
+      }
+    }
+  }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced.verified.txt
@@ -1,0 +1,21 @@
+﻿{
+  entry: {},
+  return: {
+    locals: {
+      local0: {
+        fields: {
+          Class: {
+            isNull: true,
+            type: VeryComplexClass
+          },
+          ComplexClass: {
+            type: ComplexClass,
+            value: ComplexClass
+          }
+        },
+        type: VeryComplexClass,
+        value: VeryComplexClass
+      }
+    }
+  }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
@@ -1,0 +1,88 @@
+// <copyright file="SnapshotSlicerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Debugger;
+using Datadog.Trace.Debugger.Snapshots;
+using Newtonsoft.Json.Linq;
+using VerifyXunit;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger
+{
+    [UsesVerify]
+    public class SnapshotSlicerTests
+    {
+        [Fact]
+        public void SnapshotSmallerThanMaxSize_NothingSliced()
+        {
+            var snapshot = SnapshotHelper.GenerateSnapshot(new SimpleClass(), false);
+            var slicer = GetSlicer(3, snapshot.Length + 1);
+            var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
+            Assert.Equal(snapshot, modifiedSnapshot);
+        }
+
+        [Fact]
+        public async Task SnapshotBiggerThanMaxSize_OneLevel_LevelSliced()
+        {
+            var snapshot = SnapshotHelper.GenerateSnapshot(new ComplexClass(), false);
+            var slicer = GetSlicer(3, snapshot.Length - 1);
+            var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
+
+            var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
+            await Verifier.Verify(captures);
+        }
+
+        [Fact]
+        public async Task SnapshotBiggerThanMaxSize_TwoLevel_OneSliced()
+        {
+            var snapshot = SnapshotHelper.GenerateSnapshot(new VeryComplexClass() { ComplexClass = new ComplexClass() { SimpleClass = new SimpleClass() } }, false);
+            var slicer = GetSlicer(3, snapshot.Length - 1);
+            var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
+
+            var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
+            await Verifier.Verify(captures);
+        }
+
+        [Fact]
+        public async Task SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced()
+        {
+            var snapshot = SnapshotHelper.GenerateSnapshot(new VeryComplexClass() { Class = new VeryComplexClass() { ComplexClass = new ComplexClass() { SimpleClass = new SimpleClass() } } }, false);
+            var slicer = GetSlicer(3, snapshot.Length - 326);
+            var modifiedSnapshot = slicer.SliceIfNeeded("id", snapshot);
+
+            var captures = JObject.Parse(modifiedSnapshot).SelectToken("debugger.snapshot.captures");
+            await Verifier.Verify(captures);
+        }
+
+        private SnapshotSlicer GetSlicer(int maxDepth, int maxSize)
+        {
+            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.Debugger.MaxDepthToSerialize, maxDepth.ToString() },
+            }));
+
+            return SnapshotSlicer.Create(settings, maxSize);
+        }
+
+        private class SimpleClass
+        {
+        }
+
+        private class ComplexClass
+        {
+            public SimpleClass SimpleClass { get; set; }
+        }
+
+        private class VeryComplexClass
+        {
+            public VeryComplexClass Class { get; set; }
+
+            public ComplexClass ComplexClass { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Add `SnapshotSlicer` for reducing size of large snapshots.

## Reason for change
The current method for sending snapshots involves using the Event Platform "logs intake", which has a message size limit of 1 MB. However, in some cases, the size of the snapshots may exceed this limit. This PR try to solve this problem, by iteratively  removing `fields` at the deepest nesting level of the snapshot.