### PR TITLE
Add tests that we never write general ambient env vars to the logs

### DIFF
--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -36,6 +36,9 @@ ENV DD_APPSEC_ENABLED=1
 ENV DD_TRACE_DEBUG=1
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -32,6 +32,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -41,6 +41,9 @@ ENV DD_TRACE_DEBUG=1
 ENV ASPNETCORE_URLS=http://localhost:5000
 ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -43,4 +43,10 @@ ENV DD_PROFILING_LOG_DIR=/var/log/datadog/dotnet
 
 ENV ASPNETCORE_URLS=http://localhost:5000
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -43,6 +43,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -46,6 +46,9 @@ ENV CORECLR_ENABLE_PROFILING=1 \
     DD_PROFILING_ENABLED=1 \
     ASPNETCORE_URLS=http://localhost:5000
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -50,6 +50,9 @@ ENV DD_PROFILING_ENABLED=1 \
     DD_PROFILING_LOG_DIR="C:\logs" \
     ASPNETCORE_URLS=http://localhost:5000
 
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -485,17 +485,6 @@ namespace Datadog.Trace
                     writer.WritePropertyName("stats_computation_enabled");
                     writer.WriteValue(instanceSettings.StatsComputationEnabled);
 
-                    // TESTING THAT WE DETECT THIS. DO NOT SHIP!
-                    writer.WritePropertyName("env_vars");
-                    writer.WriteStartArray();
-
-                    foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
-                    {
-                        writer.WriteValue(e.Key);
-                    }
-
-                    writer.WriteEndArray();
-
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -485,6 +485,17 @@ namespace Datadog.Trace
                     writer.WritePropertyName("stats_computation_enabled");
                     writer.WriteValue(instanceSettings.StatsComputationEnabled);
 
+                    // TESTING THAT WE DETECT THIS. DO NOT SHIP!
+                    writer.WritePropertyName("env_vars");
+                    writer.WriteStartArray();
+
+                    foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
+                    {
+                        writer.WriteValue(e.Key);
+                    }
+
+                    writer.WriteEndArray();
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -491,7 +491,7 @@ namespace Datadog.Trace
 
                     foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
                     {
-                        writer.WriteValue(e.Value);
+                        writer.WriteValue(e.Key);
                     }
 
                     writer.WriteEndArray();

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -491,7 +491,7 @@ namespace Datadog.Trace
 
                     foreach (System.Collections.DictionaryEntry e in Environment.GetEnvironmentVariables())
                     {
-                        writer.WriteValue(e.Key);
+                        writer.WriteValue(e.Value);
                     }
 
                     writer.WriteEndArray();

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -193,6 +193,10 @@ namespace Datadog.Trace.TestHelpers
             // see https://github.com/DataDog/dd-trace-dotnet/pull/3579
             environmentVariables["DD_INTERNAL_WORKAROUND_77973_ENABLED"] = "1";
 
+            // Set a canary variable that should always be ignored
+            // and check that it doesn't appear in the logs
+            environmentVariables["SUPER_SECRET_CANARY"] = "MySuperSecretCanary";
+
             // Everything should be using the native loader now
             var nativeLoaderPath = GetNativeLoaderPath();
 


### PR DESCRIPTION
## Summary of changes

Adds a check to our smoke and integration tests that we don't leak ambient environment variables

## Reason for change

We don't want to write arbitrary env vars to the logs, as these could contain sensitive details

## Implementation details

Add a canary variable to the smoke tests and all our integration tests, and then check the logs for the presence of the key or the value.

## Test coverage

Ran tests confirming that if we _do_ write the canary key or value then it fails the jobs, for example [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=126149&view=results).

