### PR TITLE
[CI Visibility] Adds support for NUnit TearDown attributes

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
@@ -21,7 +21,6 @@ internal partial class TestSpanTags : TestSuiteSpanTags
         Suite = suiteTags.Suite;
         Framework = suiteTags.Framework;
         Module = suiteTags.Module;
-        Status = suiteTags.Status;
         Type = suiteTags.Type;
         FrameworkVersion = suiteTags.FrameworkVersion;
         GitBranch = suiteTags.GitBranch;

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSuiteSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSuiteSpanTags.cs
@@ -19,7 +19,6 @@ internal partial class TestSuiteSpanTags : TestModuleSpanTags
         Suite = suiteName;
         Framework = moduleTags.Framework;
         Module = moduleTags.Module;
-        Status = moduleTags.Status;
         Type = moduleTags.Type;
         FrameworkVersion = moduleTags.FrameworkVersion;
         GitBranch = moduleTags.GitBranch;

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -249,7 +249,7 @@ public sealed class Test
         scope.Dispose();
 
         Current = null;
-        CIVisibility.Log.Debug("######### Test Closed: {name} ({suite} | {module})", Name, Suite.Name, Suite.Module.Name);
+        CIVisibility.Log.Debug("######### Test Closed: {name} ({suite} | {module}) | {status}", Name, Suite.Name, Suite.Module.Name, tags.Status);
     }
 
     internal void ResetStartTime()

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -388,7 +388,7 @@ public sealed class TestModule
         span.Finish(duration.Value);
 
         Current = null;
-        CIVisibility.Log.Debug("### Test Module Closed: {name}", Name);
+        CIVisibility.Log.Debug("### Test Module Closed: {name} | {status}", Name, Tags.Status);
 
         if (_fakeSession is { } fakeSession)
         {

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -338,7 +338,7 @@ public sealed class TestSession
         }
 
         Current = null;
-        CIVisibility.Log.Debug("### Test Session Closed: {command}", Command);
+        CIVisibility.Log.Debug("### Test Session Closed: {command} | {status}", Command, Tags.Status);
         return true;
     }
 

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -163,7 +163,7 @@ public sealed class TestSuite
 
         Current = null;
         Module.RemoveSuite(Name);
-        CIVisibility.Log.Debug("###### Test Suite Closed: {name} ({module})", Name, Module.Name);
+        CIVisibility.Log.Debug("###### Test Suite Closed: {name} ({module}) | {status}", Name, Module.Name, Tags.Status);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/ITestExecutionContext.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/ITestExecutionContext.cs
@@ -14,5 +14,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         /// Gets the current test
         /// </summary>
         ITest CurrentTest { get; }
+
+        /// <summary>
+        /// Gets the current result
+        /// </summary>
+        ITestResult CurrentResult { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemPerformOneTimeTearDownIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemPerformOneTimeTearDownIntegration.cs
@@ -1,4 +1,4 @@
-// <copyright file="NUnitCompositeWorkItemPerformOneTimeSetUpIntegration.cs" company="Datadog">
+// <copyright file="NUnitCompositeWorkItemPerformOneTimeTearDownIntegration.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,12 +11,12 @@ using Datadog.Trace.DuckTyping;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit;
 
 /// <summary>
-/// NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformOneTimeSetUp() calltarget instrumentation
+/// NUnit.Framework.Internal.Execution.CompositeWorkItem.PerformOneTimeTearDown() calltarget instrumentation
 /// </summary>
 [InstrumentMethod(
     AssemblyName = "nunit.framework",
     TypeName = "NUnit.Framework.Internal.Execution.CompositeWorkItem",
-    MethodName = "PerformOneTimeSetUp",
+    MethodName = "PerformOneTimeTearDown",
     ReturnTypeName = ClrNames.Void,
     ParameterTypeNames = new string[0],
     MinimumVersion = "3.0.0",
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit;
     IntegrationName = NUnitIntegration.IntegrationName)]
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
-public class NUnitCompositeWorkItemPerformOneTimeSetUpIntegration
+public class NUnitCompositeWorkItemPerformOneTimeTearDownIntegration
 {
     /// <summary>
     /// OnMethodEnd callback

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
@@ -50,7 +50,7 @@ public class NUnitCompositeWorkItemSkipChildrenIntegration
 
             if (typeName == "CompositeWorkItem" && testSuite.TryDuckCast<ICompositeWorkItem>(out var compositeWorkItem))
             {
-                // In case we have a CompositeWorkItem we check if there is a OneTimeSetUp failure
+                // In case we have a CompositeWorkItem we check if there is a setup or teardown failure
                 if (compositeWorkItem.Result.ResultState.Status == TestStatus.Failed || message.Contains("Exception:"))
                 {
                     if (compositeWorkItem.Result.ResultState.Site == FailureSite.SetUp)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
@@ -51,11 +51,21 @@ public class NUnitCompositeWorkItemSkipChildrenIntegration
             if (typeName == "CompositeWorkItem" && testSuite.TryDuckCast<ICompositeWorkItem>(out var compositeWorkItem))
             {
                 // In case we have a CompositeWorkItem we check if there is a OneTimeSetUp failure
-                if ((compositeWorkItem.Result.ResultState.Status == TestStatus.Failed &&
-                    compositeWorkItem.Result.ResultState.Site == FailureSite.SetUp) ||
-                    message.Contains("NpgsqlException"))
+                if (compositeWorkItem.Result.ResultState.Status == TestStatus.Failed || message.Contains("Exception:"))
                 {
-                    NUnitIntegration.WriteSetUpError(compositeWorkItem);
+                    if (compositeWorkItem.Result.ResultState.Site == FailureSite.SetUp)
+                    {
+                        NUnitIntegration.WriteSetUpOrTearDownError(compositeWorkItem, "SetUpException");
+                    }
+                    else if (compositeWorkItem.Result.ResultState.Site == FailureSite.TearDown)
+                    {
+                        NUnitIntegration.WriteSetUpOrTearDownError(compositeWorkItem, "TearDownException");
+                    }
+                    else if (message.Contains("Exception:"))
+                    {
+                        NUnitIntegration.WriteSetUpOrTearDownError(compositeWorkItem, "Exception");
+                    }
+
                     return CallTargetState.GetDefault();
                 }
             }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -265,6 +265,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 // NUnit
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeSetUp",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"),
+               new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeTearDown",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "SkipChildren",  new[] { "System.Void", "_", "NUnit.Framework.Interfaces.ResultState", "System.String" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
@@ -726,6 +727,7 @@ namespace Datadog.Trace.ClrProfiler
                     => Datadog.Trace.Configuration.IntegrationId.NLog,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitTestCommandExecuteIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -266,6 +266,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 // NUnit
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeSetUp",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"),
+               new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeTearDown",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "SkipChildren",  new[] { "System.Void", "_", "NUnit.Framework.Interfaces.ResultState", "System.String" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
@@ -745,6 +746,7 @@ namespace Datadog.Trace.ClrProfiler
                     => Datadog.Trace.Configuration.IntegrationId.NLog,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitTestCommandExecuteIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -266,6 +266,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 // NUnit
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeSetUp",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"),
+               new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeTearDown",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "SkipChildren",  new[] { "System.Void", "_", "NUnit.Framework.Interfaces.ResultState", "System.String" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
@@ -745,6 +746,7 @@ namespace Datadog.Trace.ClrProfiler
                     => Datadog.Trace.Configuration.IntegrationId.NLog,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitTestCommandExecuteIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.InstrumentationDefinitions.InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -266,6 +266,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 // NUnit
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeSetUp",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"),
+               new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "PerformOneTimeTearDown",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.CompositeWorkItem", "SkipChildren",  new[] { "System.Void", "_", "NUnit.Framework.Interfaces.ResultState", "System.String" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"),
                new ("nunit.framework", "NUnit.Framework.Internal.Execution.WorkItem", "WorkItemComplete",  new[] { "System.Void" }, 3, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"),
 
@@ -745,6 +746,7 @@ namespace Datadog.Trace.ClrProfiler
                     => Datadog.Trace.Configuration.IntegrationId.NLog,
                 "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitTestCommandExecuteIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeSetUpIntegration"
+                    or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemPerformOneTimeTearDownIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitCompositeWorkItemSkipChildrenIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemPerformWorkIntegration"
                     or "Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit.NUnitWorkItemWorkItemCompleteIntegration"

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitTests : TestHelper
     {
-        private const int ExpectedSpanCount = 28;
+        private const int ExpectedSpanCount = 30;
 
         private const string TestBundleName = "Samples.NUnitTests";
         private static string[] _testSuiteNames =
@@ -31,6 +31,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             "Samples.NUnitTests.TestFixtureSetupError(\"Test01\")",
             "Samples.NUnitTests.TestFixtureSetupError(\"Test02\")",
             "Samples.NUnitTests.TestSetupError",
+            "Samples.NUnitTests.TestTearDownError",
+            "Samples.NUnitTests.TestTearDown2Error",
         };
 
         public NUnitTests(ITestOutputHelper output)

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -190,4 +190,22 @@ namespace Samples.NUnitTests
             throw new Exception("SetUp exception.");
         }
     }
+    
+    public class TestTearDownError : TestBase<object>
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            throw new Exception("TearDown exception.");
+        }
+    }
+
+    public class TestTearDown2Error : TestBase<object>
+    {
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            throw new Exception("TearDown exception.");
+        }
+    }
 }


### PR DESCRIPTION
## Summary of changes

This PR adds support to report failures in NUnit `TearDownAttribute` and `OneTimeTearDownAttribute` attributes.
The PR also includes an small fix to the Test suite visibility (remove 1 line).

## Reason for change

We didn't have any visibility over failures in both attributes.

## Test coverage

The NUnit samples app and tests were updated with the teardown cases.

