### PR TITLE
[ASM] Fix rcm integration tests flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRemoteRules.cs
@@ -29,17 +29,15 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var url = "/Health/?[$slice]=value";
             await TryStartApp();
             var agent = Fixture.Agent;
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{Fixture.Process.ProcessName}*", LogDirectory);
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
             var spans1 = await SendRequestsAsync(agent, url);
-
-            await agent.SetupRcmAndWait(Output, new[] { (GetRules("2.22.222"), "1") }, "ASM_DD");
-            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
+            var acknowledgedId = nameof(TestNewRemoteRules);
+            await agent.SetupRcmAndWait(Output, new[] { (GetRules("2.22.222"), testid: acknowledgedId) }, "ASM_DD", appliedServiceNames: new[] { acknowledgedId });
             var spans2 = await SendRequestsAsync(agent, url);
 
-            await agent.SetupRcmAndWait(Output, new[] { (GetRules("3.33.333"), "2") }, "ASM_DD");
-            await logEntryWatcher.WaitForLogEntry(WafUpdateRule(), LogEntryWatcherTimeout);
+            var acknowledgedId2 = nameof(TestNewRemoteRules) + 2;
+            await agent.SetupRcmAndWait(Output, new[] { (GetRules("3.33.333"), "2") }, "ASM_DD", appliedServiceNames: new[] { acknowledgedId2 });
             var spans3 = await SendRequestsAsync(agent, url);
 
             var spans = new List<MockSpan>();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRulesToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmRulesToggle.cs
@@ -38,13 +38,15 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var ruleId = "crs-942-290";
 
             var spans1 = await SendRequestsAsync(agent, url);
+            var acknowledgedId = nameof(TestRulesToggling);
 
-            var request1 = await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload() { RuleStatus = new[] { new RuleStatus { Id = ruleId, Enabled = false } } }, "1") }, ASMProduct);
+            var request1 = await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload() { RuleStatus = new[] { new RuleStatus { Id = ruleId, Enabled = false } } }, acknowledgedId) }, ASMProduct, appliedServiceNames: new[] { acknowledgedId });
             CheckAckState(request1, ASMProduct, ApplyStates.ACKNOWLEDGED, null, "First RCM call");
 
             var spans2 = await SendRequestsAsync(agent, url);
+            var acknowledgedId2 = nameof(TestRulesToggling) + 2;
 
-            var request2 = await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload() { RuleStatus = new[] { new RuleStatus { Id = ruleId, Enabled = true } } }, "2") }, ASMProduct);
+            var request2 = await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload() { RuleStatus = new[] { new RuleStatus { Id = ruleId, Enabled = true } } }, acknowledgedId2) }, ASMProduct, appliedServiceNames: new[] { acknowledgedId2 });
             CheckAckState(request2, ASMProduct, ApplyStates.ACKNOWLEDGED, null, "Second RCM call");
 
             var spans3 = await SendRequestsAsync(agent, url);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -7,6 +7,7 @@
 #pragma warning disable SA1402 // File may only contain a single class
 #pragma warning disable SA1649 // File name must match first type name
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -61,46 +62,38 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public async Task TestSecurityToggling()
         {
             uint expectedState = EnableSecurity == false ? ApplyStates.UNACKNOWLEDGED : ApplyStates.ACKNOWLEDGED;
-            uint expectedCapabilities = EnableSecurity == false ?
-                    (RcmCapabilitiesIndices.AsmIpBlockingUInt32 | RcmCapabilitiesIndices.AsmDdRulesUInt32)
-                    : (RcmCapabilitiesIndices.AsmActivationUInt32 | RcmCapabilitiesIndices.AsmIpBlockingUInt32 | RcmCapabilitiesIndices.AsmDdRulesUInt32);
+            uint expectedCapabilities = EnableSecurity == false
+                                            ? (RcmCapabilitiesIndices.AsmIpBlockingUInt32 | RcmCapabilitiesIndices.AsmDdRulesUInt32)
+                                            : (RcmCapabilitiesIndices.AsmActivationUInt32 | RcmCapabilitiesIndices.AsmIpBlockingUInt32 | RcmCapabilitiesIndices.AsmDdRulesUInt32);
 
             var url = "/Health/?[$slice]=value";
             await TryStartApp();
             var agent = Fixture.Agent;
             var settings = VerifyHelper.GetSpanVerifierSettings();
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{Fixture.Process.ProcessName}*", LogDirectory);
 
             var spans1 = await SendRequestsAsync(agent, url);
+            var acknowledgedId = nameof(TestSecurityToggling) + Guid.NewGuid();
 
-            var request1 = await agent.SetupRcmAndWait(Output, new[] { ((object)new AsmFeatures() { Asm = new AsmFeature() { Enabled = false } }, "1") }, "ASM_FEATURES", "first");
+            var request1 = await agent.SetupRcmAndWait(Output, new[] { ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = false } }, acknowledgedId) }, "ASM_FEATURES", "first", new[] { acknowledgedId });
 
             RcmBase.CheckAckState(request1, "ASM_FEATURES", expectedState, null, "First RCM call");
             CheckCapabilities(request1, expectedCapabilities, "First RCM call");
             request1.Client.State.BackendClientState.Should().Be("first");
-            if (EnableSecurity == true)
-            {
-                await logEntryWatcher.WaitForLogEntry(AppSecDisabledMessage(), LogEntryWatcherTimeout);
-            }
 
             RcmBase.CheckAckState(request1, "ASM_FEATURES", expectedState, null, "First RCM call");
             CheckCapabilities(request1, expectedCapabilities, "First RCM call");
 
             var spans2 = await SendRequestsAsync(agent, url);
+            var acknowledgedId2 = nameof(TestSecurityToggling) + Guid.NewGuid();
 
-            var request2 = await agent.SetupRcmAndWait(Output, new[] { ((object)new AsmFeatures() { Asm = new AsmFeature() { Enabled = true } }, "2") }, "ASM_FEATURES", "second");
+            var request2 = await agent.SetupRcmAndWait(Output, new[] { ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, acknowledgedId2) }, "ASM_FEATURES", "second", new[] { acknowledgedId2 });
 
             RcmBase.CheckAckState(request2, "ASM_FEATURES", expectedState, null, "Second RCM call");
             CheckCapabilities(request2, expectedCapabilities, "Second RCM call");
-            if (EnableSecurity != false)
-            {
-                await logEntryWatcher.WaitForLogEntry(AppSecEnabledMessage(), LogEntryWatcherTimeout);
-            }
 
-            var spans3 = await SendRequestsAsync(agent, url);
-
-            var request3 = await agent.WaitRcmRequestAndReturnLast();
+            var request3 = await agent.WaitRcmRequestAndReturnLast(appliedServiceNames: new[] { acknowledgedId2 });
             request3.Client.State.BackendClientState.Should().Be("second");
+            var spans3 = await SendRequestsAsync(agent, url);
 
             var spans = new List<MockSpan>();
             spans.AddRange(spans1);
@@ -129,8 +122,9 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var settings = VerifyHelper.GetSpanVerifierSettings();
 
             var spans1 = await SendRequestsAsync(agent, url);
+            var acknowledgedId = nameof(TestRemoteConfigError);
 
-            var request = await agent.SetupRcmAndWait(Output, new[] { ((object)"haha, you weren't expect this!", "1") }, "ASM_FEATURES");
+            var request = await agent.SetupRcmAndWait(Output, new[] { ((object)"haha, you weren't expect this!", acknowledgedId) }, "ASM_FEATURES", appliedServiceNames: new[] { acknowledgedId });
 
             RcmBase.CheckAckState(request, "ASM_FEATURES", ApplyStates.ERROR, "Error converting value \"haha, you weren't expect this!\" to type 'Datadog.Trace.AppSec.AsmFeatures'. Path '', line 1, position 32.", "First RCM call");
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -70,8 +71,8 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
         _iisFixture = iisFixture;
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5AsmData)
-                 + (classicMode ? ".Classic" : ".Integrated")
-                 + ".enableSecurity=" + enableSecurity;
+                                + (classicMode ? ".Classic" : ".Integrated")
+                                + ".enableSecurity=" + enableSecurity;
         SetHttpPort(iisFixture.HttpPort);
     }
 
@@ -82,34 +83,21 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
     [Trait("LoadFromGAC", "True")]
     public async Task TestBlockedRequestIp(string test, string url)
     {
-        HttpStatusCode expectedStatusCode = SecurityEnabled ? HttpStatusCode.OK : HttpStatusCode.Forbidden;
-        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{_iisFixture.IisExpress.Process.ProcessName}*", LogDirectory);
         var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
         // we want to see the ip here
         var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
         var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: new object[] { test, sanitisedUrl });
         var spanBeforeAsmData = await SendRequestsAsync(_iisFixture.Agent, url);
+        var acknowledgedId = nameof(TestBlockedRequestIp) + Guid.NewGuid();
+        var acknowledgedId2 = nameof(TestBlockedRequestIp) + Guid.NewGuid();
 
         var product = new AsmDataProduct();
         _iisFixture.Agent.SetupRcm(
             Output,
-            new[]
-            {
-                    (
-                        (object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp } } } } }, "asm_data"),
-                    (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } }, "asm_data_servicea"),
-            },
+            new[] { ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp } } } } }, acknowledgedId), (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } }, acknowledgedId2), },
             product.Name);
 
-        var request1 = await _iisFixture.Agent.WaitRcmRequestAndReturnLast();
-        if (SecurityEnabled)
-        {
-            await logEntryWatcher.WaitForLogEntry(RulesUpdatedMessage(_iisFixture.IisExpress.Process.Id), LogEntryWatcherTimeout);
-        }
-        else
-        {
-            await Task.Delay(1500);
-        }
+        await _iisFixture.Agent.WaitRcmRequestAndReturnLast(appliedServiceNames: new[] { acknowledgedId, acknowledgedId2 });
 
         var spanAfterAsmData = await SendRequestsAsync(_iisFixture.Agent, url);
         var spans = new List<MockSpan>();
@@ -128,29 +116,18 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
         SetClientIp("90.91.8.235");
         try
         {
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{_iisFixture.IisExpress.Process.ProcessName}*", LogDirectory);
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(parameters: new object[] { test, sanitisedUrl });
             var spanBeforeAsmData = await SendRequestsAsync(_iisFixture.Agent, url);
+            var acknowledgedId = nameof(TestBlockedRequestUser) + Guid.NewGuid();
 
             var product = new AsmDataProduct();
             _iisFixture.Agent.SetupRcm(
                 Output,
-                new[]
-                {
-                    ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = "user3" } } } } }, "asm_data")
-                },
+                new[] { ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = "user3" } } } } }, acknowledgedId) },
                 product.Name);
 
-            var request1 = await _iisFixture.Agent.WaitRcmRequestAndReturnLast();
-            if (SecurityEnabled)
-            {
-                await logEntryWatcher.WaitForLogEntry(RulesUpdatedMessage(_iisFixture.IisExpress.Process.Id), LogEntryWatcherTimeout);
-            }
-            else
-            {
-                await Task.Delay(1500);
-            }
+            await _iisFixture.Agent.WaitRcmRequestAndReturnLast(appliedServiceNames: new[] { acknowledgedId });
 
             var spanAfterAsmData = await SendRequestsAsync(_iisFixture.Agent, url);
             var spans = new List<MockSpan>();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -22,7 +22,7 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
     protected const string LogFileNamePrefix = "dotnet-tracer-managed-";
 
-    public RcmBase(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool? enableSecurity, string testName)
+    protected RcmBase(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool? enableSecurity, string testName)
         : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
     {
         Fixture = fixture;
@@ -37,8 +37,6 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     protected AspNetCoreTestFixture Fixture { get; }
 
     protected bool? EnableSecurity { get; }
-
-    protected TimeSpan LogEntryWatcherTimeout => TimeSpan.FromSeconds(20);
 
     protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(), $"{GetType().Name}Logs");
 
@@ -72,12 +70,4 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 #endif
         capabilities.Should().Be(expectedState, message);
     }
-
-    protected string AppSecDisabledMessage() => $"AppSec is now Disabled, _settings.Enabled is false, coming from remote config: true  {{ MachineName: \".\", Process: \"[{Fixture.Process.Id}";
-
-    protected string AppSecEnabledMessage() => $"AppSec is now Enabled, _settings.Enabled is true, coming from remote config: true  {{ MachineName: \".\", Process: \"[{Fixture.Process.Id}";
-
-    protected string RulesUpdatedMessage() => $"rules have been updated and waf status is \"DDWAF_OK\"  {{ MachineName: \".\", Process: \"[{Fixture.Process.Id}";
-
-    protected string WafUpdateRule() => $"DDAS-0015-00: AppSec loaded 1 rules from file RemoteConfig.  {{ MachineName: \".\", Process: \"[{Fixture.Process.Id}";
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -19,7 +19,7 @@ public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
 
-        // evem if not using the log entry watcher , it s nice to have different logs directories to read artifacts
+        // even if not using the log entry watcher , it's nice to have different logs directories to read artifacts
         Directory.CreateDirectory(LogDirectory);
         SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -3,16 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.IO;
-using System.Linq;
-using System.Numerics;
-using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
-using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.TestHelpers;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,21 +14,15 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm;
 
 public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
-    protected const string LogFileNamePrefix = "dotnet-tracer-managed-";
-
     public RcmBaseFramework(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null)
         : base(sampleName, outputHelper,  shutdownPath, samplesDir, testName)
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
 
-        // the directory would be created anyway, but in certain case a delay can lead to an exception from the LogEntryWatcher
+        // evem if not using the log entry watcher , it s nice to have different logs directories to read artifacts
         Directory.CreateDirectory(LogDirectory);
         SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
     }
 
-    protected TimeSpan LogEntryWatcherTimeout => TimeSpan.FromSeconds(20);
-
     protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(), $"{GetType().Name}Logs");
-
-    protected string RulesUpdatedMessage(int procId) => $"rules have been updated and waf status is \"DDWAF_OK\"  {{ MachineName: \".\", Process: \"[{procId}";
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -7,9 +7,11 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using Xunit;
 
 namespace Datadog.Trace.TestHelpers
 {
+    [CollectionDefinition("IisTests", DisableParallelization = false)]
     public sealed class IisFixture : GacFixture, IDisposable
     {
         public (Process Process, string ConfigFile) IisExpress { get; private set; }

--- a/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.TestHelpers
                 {
                     // prefer a request that has been processed, meaning the config states have been filled in
                     request = JsonConvert.DeserializeObject<GetRcmRequest>(lastRemoteConfigPayload);
-                    if (request?.Client?.State?.ConfigStates?.Count is > 0 && (appliedServiceNames == null || !appliedServiceNames.Except(request.Client.State.ConfigStates.Select(c => c.Id)).Any()))
+                    if (request?.Client?.State?.ConfigStates?.Count is > 0 && (appliedServiceNames == null || appliedServiceNames.All(s => request.Client.State.ConfigStates.Any(c => c.Id == s))))
                     {
                         return request;
                     }

--- a/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
@@ -67,12 +67,9 @@ namespace Datadog.Trace.TestHelpers
                 {
                     // prefer a request that has been processed, meaning the config states have been filled in
                     request = JsonConvert.DeserializeObject<GetRcmRequest>(lastRemoteConfigPayload);
-                    if (request?.Client?.State?.ConfigStates?.Count is > 0)
+                    if (request?.Client?.State?.ConfigStates?.Count is > 0 && (appliedServiceNames == null || !appliedServiceNames.Except(request.Client.State.ConfigStates.Select(c => c.Id)).Any()))
                     {
-                        if (appliedServiceNames == null || !appliedServiceNames.Except(request.Client.State.ConfigStates.Select(c => c.Id)).Any())
-                        {
-                            return request;
-                        }
+                        return request;
                     }
                 }
             }

--- a/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/RemoteConfigTestHelper.cs
@@ -17,35 +17,35 @@ namespace Datadog.Trace.TestHelpers
 {
     public static class RemoteConfigTestHelper
     {
+        public const int WaitForAcknowledgmentTimeout = 50000;
+
         public static void SetupRcm(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
         {
             var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName, opaqueBackEndSate);
             agent.RcmResponse = response;
-            output.WriteLine("Using RCM response: " + response);
+            output.WriteLine($"{DateTime.UtcNow}: Using RCM response: {response}");
         }
 
-        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
+        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(object Config, string Id)> configurations, string productName, string opaqueBackEndSate = null, IEnumerable<string> appliedServiceNames = null)
         {
             var response = BuildRcmResponse(configurations.Select(c => (JsonConvert.SerializeObject(c.Config), c.Id)), productName, opaqueBackEndSate);
             agent.RcmResponse = response;
-            output.WriteLine("Using RCM response: " + response);
-            var res = await agent.WaitRcmRequestAndReturnLast();
-            await Task.Delay(1000);
+            output.WriteLine($"{DateTime.UtcNow}: Using RCM response: {response}");
+            var res = await agent.WaitRcmRequestAndReturnLast(appliedServiceNames: appliedServiceNames);
             return res;
         }
 
-        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(string Config, string Id)> configurations, string productName, string opaqueBackEndSate = null)
+        internal static async Task<GetRcmRequest> SetupRcmAndWait(this MockTracerAgent agent, ITestOutputHelper output, IEnumerable<(string Config, string Id)> configurations, string productName, string opaqueBackEndSate = null, IEnumerable<string> appliedServiceNames = null)
         {
             var response = BuildRcmResponse(configurations, productName, opaqueBackEndSate);
             agent.RcmResponse = response;
-            output.WriteLine("Using RCM response: " + response);
-            var res = await agent.WaitRcmRequestAndReturnLast();
-            await Task.Delay(1000);
+            output.WriteLine($"{DateTime.UtcNow}: Using RCM response: {response}");
+            var res = await agent.WaitRcmRequestAndReturnLast(appliedServiceNames: appliedServiceNames);
             return res;
         }
 
         // doing multiple things here, waiting for the request and return the latest one
-        internal static async Task<GetRcmRequest> WaitRcmRequestAndReturnLast(this MockTracerAgent agent, int timeoutInMilliseconds = 50000)
+        internal static async Task<GetRcmRequest> WaitRcmRequestAndReturnLast(this MockTracerAgent agent, int timeoutInMilliseconds = WaitForAcknowledgmentTimeout, IEnumerable<string> appliedServiceNames = null)
         {
             var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
 
@@ -67,9 +67,12 @@ namespace Datadog.Trace.TestHelpers
                 {
                     // prefer a request that has been processed, meaning the config states have been filled in
                     request = JsonConvert.DeserializeObject<GetRcmRequest>(lastRemoteConfigPayload);
-                    if (request?.Client?.State?.ConfigStates?.Count is not null and > 0)
+                    if (request?.Client?.State?.ConfigStates?.Count is > 0)
                     {
-                        return request;
+                        if (appliedServiceNames == null || !appliedServiceNames.Except(request.Client.State.ConfigStates.Select(c => c.Id)).Any())
+                        {
+                            return request;
+                        }
                     }
                 }
             }
@@ -90,36 +93,14 @@ namespace Datadog.Trace.TestHelpers
 
                 clientConfigs.Add(path);
 
-                targetFiles.Add(new RcmFile()
-                {
-                    Path = path,
-                    Raw = Encoding.UTF8.GetBytes(configuration.Config)
-                });
+                targetFiles.Add(new RcmFile() { Path = path, Raw = Encoding.UTF8.GetBytes(configuration.Config) });
 
-                targets.Add(path, new Target()
-                {
-                    Hashes = new Dictionary<string, string> { { "guid", Guid.NewGuid().ToString() } }
-                });
+                targets.Add(path, new Target() { Hashes = new Dictionary<string, string> { { "guid", Guid.NewGuid().ToString() } } });
             }
 
-            var root = new TufRoot()
-            {
-                Signed = new Signed()
-                {
-                    Targets = targets,
-                    Custom = new TargetsCustom()
-                    {
-                        OpaqueBackendState = opaqueBackEndSate
-                    }
-                }
-            };
+            var root = new TufRoot() { Signed = new Signed() { Targets = targets, Custom = new TargetsCustom() { OpaqueBackendState = opaqueBackEndSate } } };
 
-            var response = new GetRcmResponse()
-            {
-                ClientConfigs = clientConfigs,
-                TargetFiles = targetFiles,
-                Targets = root
-            };
+            var response = new GetRcmResponse() { ClientConfigs = clientConfigs, TargetFiles = targetFiles, Targets = root };
 
             return JsonConvert.SerializeObject(response);
         }


### PR DESCRIPTION
## Summary of changes

Remove the log entry watcher for security integration tests.
Waiting for a remote config request with the right acknowledgment id should  be enough. Before we didnt pass ids, and as tests were running parallel, we were probably not waiting for the right acknowledged rcm request.

Add missing [CollectionDefinition] missing for all [Collection] IisTests. As this was missing, the tests never ran parallel, which doesnt seem to be an issue for iis express tests. 

## Reason for change

Rcm flakiness. 

## Implementation details

We were waiting for a log entry in the logs, but we dont need this. This was flaky because sometimes the log entry would happen too early, before we start listening.
We just need to create unique ids to wait for the rcm requests confirmation for tests running parallel. (Otherwise we miht receive an acknowledgment for other tests)

## Test coverage

same

## Other details
<!-- Fixes #{issue} -->
