### PR TITLE
Clean up codebase using clang-tidy

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -25,7 +25,7 @@ class IConfiguration;
 class LinuxStackFramesCollector : public StackFramesCollectorBase
 {
 public:
-    explicit LinuxStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration const* const configuration);
+    explicit LinuxStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration const* configuration);
     ~LinuxStackFramesCollector() override;
     LinuxStackFramesCollector(LinuxStackFramesCollector const&) = delete;
     LinuxStackFramesCollector& operator=(LinuxStackFramesCollector const&) = delete;
@@ -56,7 +56,7 @@ private:
 private:
     void NotifyStackWalkCompleted(std::int32_t resultErrorCode);
     void UpdateErrorStats(std::int32_t errorCode);
-    bool ShouldLogStats();
+    static bool ShouldLogStats();
     bool CanCollect(int32_t threadId, pid_t processId) const;
     std::int32_t CollectStackManually(void* ctx);
     std::int32_t CollectStackWithBacktrace2(void* ctx);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -166,14 +166,14 @@ private:
     GCDetails& GetCurrentGC();
     void InitializeGC(GCDetails& gc, GCStartPayload& payload);
     void ClearCollections();
-    void ResetGC(GCDetails& gc);
-    uint64_t GetCurrentTimestamp();
+    static void ResetGC(GCDetails& gc);
+    static uint64_t GetCurrentTimestamp();
 
 
 private:
     // Points to the UTF16, null terminated string from the given event data buffer
     // and update the offset accordingly
-    WCHAR* ReadWideString(LPCBYTE eventData, ULONG cbEventData, ULONG* offset)
+    static WCHAR* ReadWideString(LPCBYTE eventData, ULONG cbEventData, ULONG* offset)
     {
         WCHAR* start = (WCHAR*)(eventData + *offset);
         size_t length = WStrLen(start);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -21,12 +21,12 @@ public:
     virtual uint32_t Count() = 0;
     virtual uint32_t CreateIterator() = 0;
     virtual std::shared_ptr<ManagedThreadInfo> LoopNext(uint32_t iterator) = 0;
-    virtual bool TryGetThreadInfo(const uint32_t profilerThreadInfoId,
+    virtual bool TryGetThreadInfo(uint32_t profilerThreadInfoId,
                           ThreadID* pClrThreadId,
                           DWORD* pOsThreadId,
                           HANDLE* pOsThreadHandle,
                           WCHAR* pThreadNameBuff,
-                          const uint32_t threadNameBuffLen,
+                          uint32_t threadNameBuffLen,
                           uint32_t* pActualThreadNameLen) = 0;
     virtual HRESULT TryGetCurrentThreadInfo(std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -635,7 +635,7 @@ ddog_prof_Exporter_Request* LibddprofExporter::CreateRequest(SerializedProfile c
     return ddog_prof_Exporter_Request_build(exporter, start, end, files, additionalTags.GetFfiTags(), endpointsStats, RequestTimeOutMs);
 }
 
-bool LibddprofExporter::Send(ddog_prof_Exporter_Request* request, ddog_prof_Exporter* exporter) const
+bool LibddprofExporter::Send(ddog_prof_Exporter_Request* request, ddog_prof_Exporter* exporter)
 {
     assert(request != nullptr);
 
@@ -659,7 +659,7 @@ bool LibddprofExporter::Send(ddog_prof_Exporter_Request* request, ddog_prof_Expo
     return !failed;
 }
 
-fs::path LibddprofExporter::CreatePprofOutputPath(IConfiguration* configuration) const
+fs::path LibddprofExporter::CreatePprofOutputPath(IConfiguration* configuration)
 {
     auto const& pprofOutputPath = configuration->GetProfilesOutputDirectory();
     if (pprofOutputPath.empty())

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -128,9 +128,9 @@ private:
     void ExportToDisk(const std::string& applicationName, SerializedProfile const& encodedProfile, int idx);
     void SaveMetricsToDisk(const std::string& content) const;
 
-    bool Send(ddog_prof_Exporter_Request* request, ddog_prof_Exporter* exporter) const;
+    static bool Send(ddog_prof_Exporter_Request* request, ddog_prof_Exporter* exporter) ;
     std::string GeneratePprofFilePath(const std::string& applicationName, int idx) const;
-    fs::path CreatePprofOutputPath(IConfiguration* configuration) const;
+    static fs::path CreatePprofOutputPath(IConfiguration* configuration) ;
     std::string CreateMetricsFileContent() const;
 
     static tags CommonTags;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -46,23 +46,23 @@ public:
 
 public:
     // Inherited via IService
-    virtual bool Start() override;
-    virtual bool Stop() override;
+    bool Start() override;
+    bool Stop() override;
 
     // Inherited via IBatchedSamplesProvider
-    virtual std::list<std::shared_ptr<Sample>> GetSamples() override;
-    virtual const char* GetName() override;
+    std::list<std::shared_ptr<Sample>> GetSamples() override;
+    const char* GetName() override;
 
     // Inherited via ISampledAllocationsListener
-    virtual void OnAllocation(RawAllocationSample& rawSample) override;
+    void OnAllocation(RawAllocationSample& rawSample) override;
 
     // Inherited via IGarbageCollectionsListener
-    virtual void OnGarbageCollectionStart(
+    void OnGarbageCollectionStart(
         int32_t number,
         uint32_t generation,
         GCReason reason,
         GCType type) override;
-    virtual void OnGarbageCollectionEnd(
+    void OnGarbageCollectionEnd(
         int32_t number,
         uint32_t generation,
         GCReason reason,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -58,7 +58,7 @@ public:
 
     inline std::uint64_t GetSnapshotsPerformedSuccessCount() const;
     inline std::uint64_t GetSnapshotsPerformedFailureCount() const;
-    inline std::uint64_t IncSnapshotsPerformedCount(const bool isStackSnapshotSuccessful);
+    inline std::uint64_t IncSnapshotsPerformedCount(bool isStackSnapshotSuccessful);
 
     inline void GetOrResetDeadlocksCount(std::uint64_t deadlocksAggregationPeriodIndex,
                                          std::uint64_t* pPrevCount,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -38,12 +38,12 @@ public:
     uint32_t Count() override;
     uint32_t CreateIterator() override;
     std::shared_ptr<ManagedThreadInfo> LoopNext(uint32_t iterator) override;
-    bool TryGetThreadInfo(const std::uint32_t profilerThreadInfoId,
+    bool TryGetThreadInfo(std::uint32_t profilerThreadInfoId,
                           ThreadID* pClrThreadId,
                           DWORD* pOsThreadId,
                           HANDLE* pOsThreadHandle,
                           WCHAR* pThreadNameBuff,
-                          const std::uint32_t threadNameBuffLen,
+                          std::uint32_t threadNameBuffLen,
                           std::uint32_t* pActualThreadNameLen) override;
     HRESULT TryGetCurrentThreadInfo(std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -36,7 +36,7 @@ public:
     static inline HANDLE GetCurrentProcess();
 
     static bool SetNativeThreadName(std::thread* pNativeThread, const WCHAR* description);
-    static bool GetNativeThreadName(HANDLE windowsThreadHandle, WCHAR* pThreadDescrBuff, const std::uint32_t threadDescrBuffSize);
+    static bool GetNativeThreadName(HANDLE windowsThreadHandle, WCHAR* pThreadDescrBuff, std::uint32_t threadDescrBuffSize);
 
     static bool GetModuleHandleFromInstructionPointer(void* nativeIP, std::uint64_t* pModuleHandle);
     static std::string GetModuleName(void* nativeIP);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -16,7 +16,7 @@ class IConfiguration;
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi {
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration);
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
 uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
 bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
@@ -26,7 +26,7 @@ private:
     static const char* const ExternalFunctionName;
 
     static void* LoadDynamicLibrary(std::string filePath);
-    static void* GetExternalFunction(void* instance, const char* const funcName);
+    static void* GetExternalFunction(void* instance, const char* funcName);
     static bool FreeDynamicLibrary(void* handle);
 
     void* _instance = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -103,9 +103,9 @@ private:
                                      PROFILING_TYPE profilingType);
     void LogEncounteredStackSnapshotResultStatistics(int64_t thisSampleTimestampNanosecs, bool useStdOutInsteadOfLog = false);
     int64_t ComputeWallTime(int64_t currentTimestampNs, int64_t prevTimestampNs);
-    void UpdateSnapshotInfos(StackSnapshotResultBuffer* const pStackSnapshotResult, int64_t representedDurationNanosecs, time_t currentUnixTimestamp);
+    static void UpdateSnapshotInfos(StackSnapshotResultBuffer* pStackSnapshotResult, int64_t representedDurationNanosecs, time_t currentUnixTimestamp);
     void UpdateStatistics(HRESULT hrCollectStack, std::size_t countCollectedStackFrames);
-    time_t GetCurrentTimestamp();
+    static time_t GetCurrentTimestamp();
     void PersistStackSnapshotResults(StackSnapshotResultBuffer const* pSnapshotResult,
                                      std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
                                      PROFILING_TYPE profilingType);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -582,7 +582,7 @@ inline bool StackSamplerLoopManager::GetUpdateIsThreadSafeForStackSampleCollecti
 
 inline bool StackSamplerLoopManager::ShouldCollectThread(
     std::uint64_t threadAggPeriodDeadlockCount,
-    std::uint64_t globalAggPeriodDeadlockCount) const
+    std::uint64_t globalAggPeriodDeadlockCount) 
 {
     return (threadAggPeriodDeadlockCount <= DeadlocksPerThreadThreshold) &&
            (globalAggPeriodDeadlockCount <= TotalDeadlocksThreshold);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -97,7 +97,7 @@ private:
     StackSamplerLoopManager() = delete;
 
     inline bool GetUpdateIsThreadSafeForStackSampleCollection(ManagedThreadInfo* pThreadInfo, bool* pIsStatusChanged);
-    inline bool ShouldCollectThread(std::uint64_t threadAggPeriodDeadlockCount, std::uint64_t globalAggPeriodDeadlockCount) const;
+    static inline bool ShouldCollectThread(std::uint64_t threadAggPeriodDeadlockCount, std::uint64_t globalAggPeriodDeadlockCount) ;
 
     void RunStackSampling();
     void GracefulShutdownStackSampling();

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -177,7 +177,7 @@ public:
         _stopWorker = true;
     }
 
-    void SimulateInPthreadCreate()
+    static void SimulateInPthreadCreate()
     {
         dd_IsPthreadCreateCall = 1;
     }
@@ -224,7 +224,7 @@ public:
         EXPECT_EQ(ips[collectedNbFrames - 2], (uintptr_t)expectedCallstack[expectedNbFrames - 2]);
     }
 
-    ProfilerSignalManager* GetSignalManager()
+    static ProfilerSignalManager* GetSignalManager()
     {
         return ProfilerSignalManager::Get();
     }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -30,8 +30,8 @@ namespace datadog::shared::nativeloader
         ICorProfilerInfo4* m_info;
         std::shared_ptr<ICorProfilerInfo12> m_writeToDiskCorProfilerInfo;
 
-        void InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk);
-        void InspectRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo);
+        static void InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk);
+        static void InspectRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo);
 
     public:
         CorProfiler(IDynamicDispatcher* dispatcher);

--- a/shared/src/native-src/loader.h
+++ b/shared/src/native-src/loader.h
@@ -186,32 +186,32 @@ namespace shared
         HRESULT EmitLoaderCallInMethod(ModuleID moduleId, mdMethodDef methodDef, mdMethodDef loaderMethodDef);
 
         HRESULT EmitLoaderInModule(
-            const ComPtr<IMetaDataImport2> metadataImport,
-            const ComPtr<IMetaDataEmit2> metadataEmit,
+            ComPtr<IMetaDataImport2> metadataImport,
+            ComPtr<IMetaDataEmit2> metadataEmit,
             ModuleID moduleId,
             AppDomainID appDomainId,
             WSTRING assemblyNameString);
 
         HRESULT EmitDDLoadInitializationAssembliesMethod(
-            const ModuleID moduleId,
+            ModuleID moduleId,
             mdTypeDef typeDef,
             WSTRING assemblyName,
             mdMethodDef* pLoaderMethodDef,
             mdMemberRef* pSecuritySafeCriticalCtorMemberRef);
 
         HRESULT GetGetAssemblyAndSymbolsBytesMethodDef(
-            const ComPtr<IMetaDataEmit2> metadataEmit,
+            ComPtr<IMetaDataEmit2> metadataEmit,
             mdTypeDef typeDef,
             mdMethodDef* pGetAssemblyAndSymbolsBytesMethodDef);
 
         HRESULT WriteAssembliesStringArray(
             ILRewriterWrapper& rewriterWrapper,
-            const ComPtr<IMetaDataEmit2> metadataEmit,
+            ComPtr<IMetaDataEmit2> metadataEmit,
             const std::vector<WSTRING>& assemblyStringVector,
             mdTypeRef stringTypeRef);
 
         HRESULT EmitModuleCCtorMethod(
-            const ModuleID moduleId,
+            ModuleID moduleId,
             mdTypeDef typeDef,
             AppDomainID appDomainId,
             mdMethodDef loaderMethodDef);
@@ -247,7 +247,7 @@ namespace shared
         static Loader* GetSingletonInstance();
         static void DeleteSingletonInstance();
 
-        HRESULT InjectLoaderToModuleInitializer(const ModuleID moduleId);
+        HRESULT InjectLoaderToModuleInitializer(ModuleID moduleId);
         HRESULT HandleJitCachedFunctionSearchStarted(FunctionID functionId, BOOL* pbUseCachedFunction);
 
         bool GetAssemblyAndSymbolsBytes(void** ppAssemblyArray, int* pAssemblySize, void** ppSymbolsArray, int* pSymbolsSize, WCHAR* pModuleName);

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -45,13 +45,13 @@ const static WSTRING EndLWStr = WStr("\n");
 
 std::string ToString(const std::string& str);
 std::string ToString(const char* str);
-std::string ToString(const uint64_t i);
+std::string ToString(uint64_t i);
 std::string ToString(const WSTRING& wstr);
 std::string ToString(const WCHAR* wstr, std::size_t nbChars);
 std::string ToString(const GUID& uid);
 
 WSTRING ToWSTRING(const std::string& str);
-WSTRING ToWSTRING(const uint64_t i);
+WSTRING ToWSTRING(uint64_t i);
 
 bool TryParse(WSTRING const& s, int& result);
 

--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -51,7 +51,7 @@ namespace shared
     // GetEnvironmentValues returns environment variable values for the given name
     // split by the delimiter. Space is trimmed and empty values are ignored.
     std::vector<WSTRING> GetEnvironmentValues(const WSTRING& name,
-        const wchar_t delim);
+        wchar_t delim);
 
     // GetEnvironmentValues calls GetEnvironmentValues with a semicolon delimiter.
     std::vector<WSTRING> GetEnvironmentValues(const WSTRING& name);

--- a/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_cor_profiler.h
+++ b/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_cor_profiler.h
@@ -105,11 +105,11 @@ public:
     {
         return E_FAIL;
     }
-    ULONG STDMETHODCALLTYPE AddRef(void) override
+    ULONG STDMETHODCALLTYPE AddRef() override
     {
         return ++m_Ref;
     }
-    ULONG STDMETHODCALLTYPE Release(void) override
+    ULONG STDMETHODCALLTYPE Release() override
     {
         return --m_Ref;
     }

--- a/tracer/src/Datadog.Tracer.Native/calltarget_tokens.h
+++ b/tracer/src/Datadog.Tracer.Native/calltarget_tokens.h
@@ -72,8 +72,8 @@ protected:
     virtual const shared::WSTRING& GetCallTargetReturnGenericType() = 0;
     virtual void AddAdditionalLocals(COR_SIGNATURE (&signatureBuffer)[500], ULONG& signatureOffset, ULONG& signatureSize, bool isAsyncMethod);
 
-    CallTargetTokens(ModuleMetadata* moduleMetadataPtr, const bool enableByRefInstrumentation,
-                     const bool enableCallTargetStateByRef);
+    CallTargetTokens(ModuleMetadata* moduleMetadataPtr, bool enableByRefInstrumentation,
+                     bool enableCallTargetStateByRef);
 
 public:
     virtual int GetAdditionalLocalsCount();

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -622,15 +622,15 @@ HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
 bool FindTypeDefByName(const shared::WSTRING& instrumentationTargetMethodTypeName, const shared::WSTRING& assemblyName,
                        const ComPtr<IMetaDataImport2>& metadata_import, mdTypeDef& typeDef);
 
-HRESULT HasAsyncStateMachineAttribute(const ComPtr<IMetaDataImport2>& metadataImport, const mdMethodDef methodDefToken, bool& hasAsyncAttribute);
-HRESULT IsByRefLike(const ComPtr<IMetaDataImport2>& metadataImport, const mdTypeDef typeDefToken, bool& hasByRefLikeAttribute);
+HRESULT HasAsyncStateMachineAttribute(const ComPtr<IMetaDataImport2>& metadataImport, mdMethodDef methodDefToken, bool& hasAsyncAttribute);
+HRESULT IsByRefLike(const ComPtr<IMetaDataImport2>& metadataImport, mdTypeDef typeDefToken, bool& hasByRefLikeAttribute);
 HRESULT ResolveTypeInternal(ICorProfilerInfo4* info, const std::vector<ModuleID>& loadedModules,
                             const std::vector<WCHAR>& refTypeName,
-                            const mdToken parentToken, const shared::WSTRING& resolutionScopeName,
+                            mdToken parentToken, const shared::WSTRING& resolutionScopeName,
                             mdTypeDef& resolvedTypeDefToken, ComPtr<IMetaDataImport2>& resolvedTypeDefMetadataImport);
 HRESULT ResolveType(ICorProfilerInfo4* info, const ComPtr<IMetaDataImport2>& metadata_import,
                     const ComPtr<IMetaDataAssemblyImport>& assembly_import,
-                    const mdTypeRef typeRefToken, mdTypeDef& resolvedTypeDefToken,
+                    mdTypeRef typeRefToken, mdTypeDef& resolvedTypeDefToken,
                     ComPtr<IMetaDataImport2>& resolvedMetadataImport);
 
 void LogManagedProfilerAssemblyDetails();

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3519,7 +3519,7 @@ extern uint8_t pdb_end[] asm("_binary_Datadog_Trace_ClrProfiler_Managed_Loader_p
 #endif
 
 void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray,
-                                             int* symbolsSize) const
+                                             int* symbolsSize) 
 {
 #ifdef _WIN32
     HINSTANCE hInstance = DllHandle;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -96,7 +96,7 @@ private:
     //
     // Helper methods
     //
-    void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& nativemethods_type_name, const shared::WSTRING& library_path = shared::WSTRING());
+    static void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& nativemethods_type_name, const shared::WSTRING& library_path = shared::WSTRING());
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
@@ -106,14 +106,14 @@ private:
     HRESULT RewriteForTelemetry(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT TryRejitModule(ModuleID module_id);
-    bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);
+    static bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);
     static bool EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata);
     //
     // Startup methods
     //
-    HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata);
-    HRESULT GenerateVoidILStartupMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
-    HRESULT AddIISPreStartInitFlags(const ModuleID module_id, const mdToken function_token);
+    HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&, ModuleID module_id, mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata);
+    HRESULT GenerateVoidILStartupMethod(ModuleID module_id, mdMethodDef* ret_method_token);
+    HRESULT AddIISPreStartInitFlags(ModuleID module_id, mdToken function_token);
 
     //
     // Initialization methods
@@ -126,7 +126,7 @@ public:
     bool IsAttached() const;
 
     void GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray,
-                                    int* symbolsSize) const;
+                                    int* symbolsSize) ;
 
     //
     // ICorProfilerCallback methods

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -465,7 +465,7 @@ HRESULT DebuggerMethodRewriter::ApplyLineProbes(
     ILRewriterWrapper& rewriterWrapper, 
     ULONG lineProbeCallTargetStateIndex, 
     std::vector<EHClause>& newClauses,
-    bool isAsyncMethod) const
+    bool isAsyncMethod) 
 {
     if (isAsyncMethod && caller->type.isGeneric && caller->type.valueType)
     {
@@ -909,7 +909,7 @@ HRESULT DebuggerMethodRewriter::LoadProbeIdIntoStack(const ModuleID moduleId, co
     return hr;
 }
 
-void DebuggerMethodRewriter::LogDebugCallerInfo(const FunctionInfo* caller, const int instrumentedMethodIndex) const
+void DebuggerMethodRewriter::LogDebugCallerInfo(const FunctionInfo* caller, const int instrumentedMethodIndex) 
 {
     if (!IsDebugEnabled()) return;
 
@@ -1171,7 +1171,7 @@ HRESULT DebuggerMethodRewriter::IsTypeImplementIAsyncStateMachine(const ComPtr<I
 }
 
 HRESULT DebuggerMethodRewriter::IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport,
-                                                   const FunctionInfo* caller, bool& isAsyncMethod) const
+                                                   const FunctionInfo* caller, bool& isAsyncMethod) 
 {
     if (caller->name != WStr("MoveNext") || caller->method_signature.NumberOfArguments() > 0 ||
         std::get<unsigned>(caller->method_signature.GetReturnValue().GetElementTypeAndFlags()) != ELEMENT_TYPE_VOID)

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.h
@@ -51,12 +51,12 @@ private:
                                  int numLocals, ILRewriterWrapper& rewriterWrapper, ULONG lineProbeCallTargetStateIndex,
                                  std::vector<EHClause>& lineProbesEHClauses, const std::vector<ILInstr*>& branchTargets,
                                  const std::shared_ptr<LineProbeDefinition>& lineProbe, bool isAsyncMethod);
-    HRESULT ApplyLineProbes(int instrumentedMethodIndex, LineProbeDefinitions& lineProbes,
+    static HRESULT ApplyLineProbes(int instrumentedMethodIndex, LineProbeDefinitions& lineProbes,
                            CorProfiler* corProfiler, ModuleID module_id, ModuleMetadata& module_metadata,
                            FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token, bool isStatic,
                            std::vector<TypeSignature>& methodArguments, int numArgs, ILRewriter& rewriter,
                            std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
-                           ULONG lineProbeCallTargetStateIndex, std::vector<EHClause>& lineProbesEHClauses, bool isAsyncMethod) const;
+                           ULONG lineProbeCallTargetStateIndex, std::vector<EHClause>& lineProbesEHClauses, bool isAsyncMethod) ;
     HRESULT ApplyMethodProbe(CorProfiler* corProfiler, ModuleID module_id, ModuleMetadata& module_metadata,
                           FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken function_token,
                           TypeSignature retFuncArg, bool isVoid, bool isStatic,
@@ -74,7 +74,7 @@ private:
                                        ILInstr** setResultEndMethodTryStartInstr, ILInstr** endMethodOriginalCodeFirstInstr);
     static HRESULT LoadProbeIdIntoStack(ModuleID moduleId, const ModuleMetadata& moduleMetadata, mdToken functionToken,
                                         const shared::WSTRING& methodProbeId, const ILRewriterWrapper& rewriterWrapper);
-    void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) const;
+    static void LogDebugCallerInfo(const FunctionInfo* caller, int instrumentedMethodIndex) ;
     HRESULT ApplyAsyncMethodProbe(CorProfiler* corProfiler, ModuleID moduleId, ModuleMetadata& moduleMetadata,
                                   FunctionInfo* caller, DebuggerTokens* debuggerTokens, mdToken functionToken,
                                   bool isStatic, TypeSignature* methodReturnType,
@@ -82,7 +82,7 @@ private:
                                   const std::vector<TypeSignature>& methodLocals, int numLocals, ILRewriterWrapper& rewriterWrapper,
                                   ULONG asyncMethodStateIndex, ULONG callTargetReturnIndex,
                                   ULONG returnValueIndex, mdToken callTargetReturnToken, ILInstr* firstInstruction,
-                                  const int instrumentedMethodIndex, ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
+                                  int instrumentedMethodIndex, ILInstr* const& beforeLineProbe, std::vector<EHClause>& newClauses) const;
 
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler,
                                                         MethodProbeDefinitions& methodProbes,
@@ -96,8 +96,8 @@ private:
 
 public:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) override;
-    static HRESULT IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport, const ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine);
-    HRESULT IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo* caller, bool& isAsyncMethod) const;
+    static HRESULT IsTypeImplementIAsyncStateMachine(const ComPtr<IMetaDataImport2>& metadataImport, ULONG32 typeToken, bool& isTypeImplementIAsyncStateMachine);
+    static HRESULT IsAsyncMethodProbe(const ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo* caller, bool& isAsyncMethod) ;
     static HRESULT GetTaskReturnType(const ILInstr* instruction, ModuleMetadata& moduleMetadata, const std::vector<TypeSignature>& methodLocals, TypeSignature* returnType);
     static void MarkAllProbesAsError(MethodProbeDefinitions& methodProbes, LineProbeDefinitions& lineProbes, const WSTRING& reasoning);
     static void MarkAllLineProbesAsError(LineProbeDefinitions& lineProbes, const WSTRING& reasoning);

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.h
@@ -40,9 +40,9 @@ public:
     void PerformInstrumentAllIfNeeded(const ModuleID& module_id, const mdToken& function_token);
     const std::vector<std::shared_ptr<ProbeDefinition>>& GetProbes() const;
     DebuggerRejitPreprocessor* GetPreprocessor();
-    void RequestRejitForLoadedModule(const ModuleID moduleId);
-    void ModuleLoadFinished_AddMetadataToModule(const ModuleID moduleId) const;
-    HRESULT STDMETHODCALLTYPE ModuleLoadFinished(const ModuleID moduleId);
+    void RequestRejitForLoadedModule(ModuleID moduleId);
+    void ModuleLoadFinished_AddMetadataToModule(ModuleID moduleId) const;
+    HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID moduleId);
 
     static HRESULT NotifyReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId, HRESULT hrStatus);
 };

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -243,7 +243,7 @@ DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandle
 
 const std::unique_ptr<RejitHandlerModuleMethod>
 DebuggerRejitPreprocessor::CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module,
-                                        const FunctionInfo& functionInfo) const
+                                        const FunctionInfo& functionInfo) 
 {
     return std::make_unique<DebuggerRejitHandlerModuleMethod>(methodDef, module, functionInfo);
 }
@@ -294,7 +294,7 @@ void DebuggerRejitPreprocessor::EnqueueNewMethod(const MethodProbeDefinition& de
 }
 
 HRESULT DebuggerRejitPreprocessor::GetMoveNextMethodFromKickOffMethod(const ComPtr<IMetaDataImport2>& metadataImport, mdTypeDef typeDef, mdMethodDef methodDef, 
-                                                                      const FunctionInfo& function, mdMethodDef& moveNextMethod, mdTypeDef& nestedAsyncClassOrStruct) const
+                                                                      const FunctionInfo& function, mdMethodDef& moveNextMethod, mdTypeDef& nestedAsyncClassOrStruct) 
 {
     // TODO: We might consider rewriting this code using CustomAttributeParser [AsyncStateMachine(typeof(<X>d__1))]
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
@@ -35,10 +35,10 @@ protected:
     const bool GetIsInterface(const MethodProbeDefinition& definition) final;
     const bool GetIsExactSignatureMatch(const MethodProbeDefinition& definition) final;
     const std::unique_ptr<RejitHandlerModuleMethod>
-    CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
+    CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
                  const MethodProbeDefinition& methodProbe) final;
-    const std::unique_ptr<RejitHandlerModuleMethod>
-    CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo) const;
+    static const std::unique_ptr<RejitHandlerModuleMethod>
+    CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo) ;
     void UpdateMethod(RejitHandlerModuleMethod* methodHandler, const MethodProbeDefinition& methodProbe) override;
     static void UpdateMethod(RejitHandlerModuleMethod* methodHandler, const ProbeDefinition_S& probe);
     [[nodiscard]] std::tuple<HRESULT, mdMethodDef, FunctionInfo> PickMethodToRejit(
@@ -52,8 +52,8 @@ protected:
                           ComPtr<IMetaDataEmit2>& metadataEmit, const ModuleInfo& moduleInfo, mdTypeDef typeDef,
                           std::vector<MethodIdentifier>& rejitRequests, unsigned methodDef,
                           const FunctionInfo& functionInfo, RejitHandlerModule* moduleHandler) override;
-    HRESULT GetMoveNextMethodFromKickOffMethod(const ComPtr<IMetaDataImport2>& metadataImport, mdTypeDef typeDef, mdMethodDef methodDef, const FunctionInfo& function,
-                                               mdMethodDef& moveNextMethod, mdTypeDef& nestedAsyncClassOrStruct) const;
+    static HRESULT GetMoveNextMethodFromKickOffMethod(const ComPtr<IMetaDataImport2>& metadataImport, mdTypeDef typeDef, mdMethodDef methodDef, const FunctionInfo& function,
+                                               mdMethodDef& moveNextMethod, mdTypeDef& nestedAsyncClassOrStruct) ;
     static std::tuple<HRESULT, mdMethodDef, FunctionInfo> TransformKickOffToMoveNext(const ComPtr<IMetaDataImport2>& metadataImport,
                                                                                      const ComPtr<IMetaDataEmit2>& metadataEmit,
                                                                                      mdMethodDef moveNextMethod, mdTypeDef nestedAsyncClassOrStruct);

--- a/tracer/src/Datadog.Tracer.Native/iast/aspect.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/aspect.h
@@ -51,7 +51,7 @@ namespace iast
     AspectType ParseAspectType(const std::string& txt);
     std::string ToString(VulnerabilityType type);
     VulnerabilityType ParseVulnerabilityType(const std::string& txt);
-    std::string ToString(const std::vector<VulnerabilityType> types);
+    std::string ToString(std::vector<VulnerabilityType> types);
     std::vector<VulnerabilityType> ParseVulnerabilityTypes(const std::string& txt);
 
     class Aspect;

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
@@ -78,7 +78,7 @@ namespace iast
         MethodInfo* JITProcessMethod(ModuleID moduleId, mdToken methodId, bool isRejit = false);
 
         std::vector<DataflowAspectReference*> GetAspects(ModuleInfo* module);
-        InstrumentResult InstrumentInstruction(ILRewriter* rewriter, ILInstr* instruction, std::vector<DataflowAspectReference*>& aspects);
+        static InstrumentResult InstrumentInstruction(ILRewriter* rewriter, ILInstr* instruction, std::vector<DataflowAspectReference*>& aspects);
 
     public:
         bool IsInitialized();

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -35,18 +35,18 @@ namespace iast
         MemberRefInfo(ModuleInfo* pModuleInfo, mdMemberRef memberRef);
         virtual ~MemberRefInfo();
     protected:
-        ModuleInfo* _module = NULL;
+        ModuleInfo* _module = nullptr;
         WSTRING _name = EmptyWStr;
         WSTRING _fullName = EmptyWStr;
         WSTRING _fullNameWithReturnType = EmptyWStr;
         WSTRING _memberName = EmptyWStr;
 
         mdTypeDef _typeDef = 0;
-        TypeInfo* _typeInfo = NULL;
+        TypeInfo* _typeInfo = nullptr;
         mdMemberRef _id = 0;
         DWORD _methodAttributes = 0;
-        SignatureInfo* _pSignature = NULL;
-        PCCOR_SIGNATURE _pSig = NULL;
+        SignatureInfo* _pSignature = nullptr;
+        PCCOR_SIGNATURE _pSig = nullptr;
         ULONG _nSig = 0;
 
     public:
@@ -104,20 +104,20 @@ namespace iast
         bool _disableInlining = false;
         bool _isWritten = false;
 
-        LPCBYTE _pOriginalMehodIL = NULL;
+        LPCBYTE _pOriginalMehodIL = nullptr;
         DWORD _nOriginalMehodIL = 0;
-        LPBYTE _pMethodIL = NULL;
+        LPBYTE _pMethodIL = nullptr;
         DWORD _nMethodIL = 0;
 
     protected:
-        ILRewriter* _rewriter = NULL;
+        ILRewriter* _rewriter = nullptr;
         std::string _applyMessage = "";
     private:
         // LPBYTE AllocBuffer(DWORD size);
         void FreeBuffer();
     public:
         MethodInfo(ModuleInfo* pModuleInfo, mdMethodDef methodDef);
-        virtual ~MethodInfo();
+        ~MethodInfo() override;
 
         WSTRING GetMethodName();
         WSTRING GetKey(FunctionID functionID = 0);
@@ -136,12 +136,12 @@ namespace iast
         HRESULT CommitILRewriter(const std::string& applyMessage = "");
         HRESULT GetMethodIL(LPCBYTE* ppMehodIL, ULONG* pnSize, bool original = false);
         
-        HRESULT SetMethodIL(ULONG nSize, LPCBYTE pMehodIL, ICorProfilerFunctionControl* pFunctionControl = NULL);
-        HRESULT ApplyFinalInstrumentation(ICorProfilerFunctionControl* pFunctionControl = NULL);
+        HRESULT SetMethodIL(ULONG nSize, LPCBYTE pMehodIL, ICorProfilerFunctionControl* pFunctionControl = nullptr);
+        HRESULT ApplyFinalInstrumentation(ICorProfilerFunctionControl* pFunctionControl = nullptr);
 
         void ReJITCompilationStarted();
         void ReJITCompilationFinished();
 
-        void DumpIL(const std::string message = "", ULONG pnMethodIL = 0, LPCBYTE pMethodIL = NULL);
+        void DumpIL(std::string message = "", ULONG pnMethodIL = 0, LPCBYTE pMethodIL = nullptr);
     };
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -393,7 +393,7 @@ WSTRING ModuleInfo::GetTypeName(mdTypeDef typeDef)
     auto typeFromToken = TypeFromToken(typeDef);
     if (typeFromToken == mdtTypeDef)
     {
-        _metadataImport->GetTypeDefProps(typeDef, typeName, 1024, nullptr, &typeDefFlags, 0);
+        _metadataImport->GetTypeDefProps(typeDef, typeName, 1024, nullptr, &typeDefFlags, nullptr);
         res = typeName;
     }
     else if (typeFromToken == mdtTypeRef)
@@ -418,7 +418,7 @@ WSTRING ModuleInfo::GetTypeName(mdTypeDef typeDef)
         hr = _metadataImport->GetNestedClassProps(typeDef, &enclosingClassTypeDef);
         if (SUCCEEDED(hr))
         {
-            hr = _metadataImport->GetTypeDefProps(enclosingClassTypeDef, typeName, 1024, nullptr, &typeDefFlags, 0);
+            hr = _metadataImport->GetTypeDefProps(enclosingClassTypeDef, typeName, 1024, nullptr, &typeDefFlags, nullptr);
         }
         if (FAILED(hr))
         {

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -57,11 +57,11 @@ namespace iast
         //std::map<mdMethodDef, std::function<HRESULT(MethodInfo*, Dataflow*)>> _jitHooks;
 
     protected:
-        Dataflow* _dataflow = NULL;
-        IMetaDataImport2* _metadataImport = NULL;
-        IMetaDataEmit2* _metadataEmit = NULL;
-        IMetaDataAssemblyImport* _assemblyImport = NULL;
-        IMetaDataAssemblyEmit* _assemblyEmit = NULL;
+        Dataflow* _dataflow = nullptr;
+        IMetaDataImport2* _metadataImport = nullptr;
+        IMetaDataEmit2* _metadataEmit = nullptr;
+        IMetaDataAssemblyImport* _assemblyImport = nullptr;
+        IMetaDataAssemblyEmit* _assemblyEmit = nullptr;
         bool _isExcluded = false;
 
 
@@ -75,7 +75,7 @@ namespace iast
         HRESULT GetTypeRef(mdToken tkResolutionScope, const WSTRING& name, mdTypeRef* typeRef, bool create = true);
         HRESULT GetMemberRefInfo(mdTypeRef typeRef, const WSTRING& memberName, PCCOR_SIGNATURE pSignature, ULONG nSignature, mdMemberRef* memberRef, bool create = true);
 
-        HRESULT FindTypeRefByName(const WSTRING& name, mdTypeRef* typeRef, mdToken* tkResolutionScope = NULL);
+        HRESULT FindTypeRefByName(const WSTRING& name, mdTypeRef* typeRef, mdToken* tkResolutionScope = nullptr);
         
         mdString DefineUserString(const WSTRING& string);
 
@@ -131,10 +131,10 @@ namespace iast
         MethodInfo* GetMethod(const WSTRING& typeName, const WSTRING& methodName, const WSTRING& methodParams);
         MethodInfo* GetMethod(mdTypeDef typeDef, const WSTRING& methodName, const WSTRING& methodParams);
 
-        HRESULT GetILRewriter(MethodInfo* methodInfo, ILRewriter** rewriter);
+        static HRESULT GetILRewriter(MethodInfo* methodInfo, ILRewriter** rewriter);
         HRESULT GetILRewriter(const WSTRING& typeName, const WSTRING& methodName, int requiredParamCount, ILRewriter** rewriter);
-        HRESULT GetILRewriter(const WSTRING& typeName, const WSTRING& methodName, PCCOR_SIGNATURE pSignature, ULONG nSignature, ILRewriter** rewriter, MethodInfo** pMethodInfo = NULL);
-        HRESULT CommitILRewriter(ILRewriter** rewriter, const std::string& applyMessage = "");
+        HRESULT GetILRewriter(const WSTRING& typeName, const WSTRING& methodName, PCCOR_SIGNATURE pSignature, ULONG nSignature, ILRewriter** rewriter, MethodInfo** pMethodInfo = nullptr);
+        static HRESULT CommitILRewriter(ILRewriter** rewriter, const std::string& applyMessage = "");
 
         bool AreSameTypes(mdTypeRef typeRef1, mdTypeRef typeRef2);
 

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_info.h
@@ -27,10 +27,10 @@ namespace iast
         WSTRING GetReturnTypeString();
         WSTRING GetParamsRepresentation();
     protected:
-        ModuleInfo* _module = NULL;
+        ModuleInfo* _module = nullptr;
 
         std::vector<BYTE> _dynamicSig;
-        PCCOR_SIGNATURE _pSig = NULL;
+        PCCOR_SIGNATURE _pSig = nullptr;
         DWORD _nSig = 0;
         SignatureTypes _signatureType;
 
@@ -47,7 +47,7 @@ namespace iast
 
     public:
         CorCallingConvention _callingConvention = IMAGE_CEE_CS_CALLCONV_DEFAULT;
-        SignatureType* _returnType = NULL;
+        SignatureType* _returnType = nullptr;
         ULONG _genericParamCount = 0;
         std::vector<SignatureType*> _params;
 
@@ -55,16 +55,16 @@ namespace iast
         WSTRING _paramsString;
 
         SignatureTypes GetType();
-        PCCOR_SIGNATURE GetSignature(DWORD* sigSize = NULL);
+        PCCOR_SIGNATURE GetSignature(DWORD* sigSize = nullptr);
         bool HasThis();
         int GetEffectiveParamCount();
         WSTRING CharacterizeMember(WSTRING memberName, bool addReturyType);
 
     public:
         // Inherited via ISignatureBuilder
-        virtual HRESULT AddElementType(CorElementType corType) override;
-        virtual HRESULT AddToken(mdToken token) override;
-        virtual HRESULT AddData(const BYTE* data, ULONG size) override;
-        virtual HRESULT Add(DWORD data) override;
+        HRESULT AddElementType(CorElementType corType) override;
+        HRESULT AddToken(mdToken token) override;
+        HRESULT AddData(const BYTE* data, ULONG size) override;
+        HRESULT Add(DWORD data) override;
     };
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_types.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_types.h
@@ -56,7 +56,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureSimpleType(CorElementType corType);
-        virtual ~SignatureSimpleType();
+        ~SignatureSimpleType() override;
     };
 
     class SignatureTokenType : public SignatureType //, public ITokenType
@@ -64,7 +64,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureTokenType(ModuleInfo* module, mdToken token, CorElementType type);
-        virtual ~SignatureTokenType();
+        ~SignatureTokenType() override;
     private:
         mdToken _token;
         ModuleInfo* _pOwningModule;
@@ -86,7 +86,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureCompositeType(CorElementType type, SignatureType* relatedType);
-        virtual ~SignatureCompositeType();
+        ~SignatureCompositeType() override;
     private:
         SignatureType* _relatedType;
     public:
@@ -103,7 +103,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureFunctionType(CorCallingConvention callingConvention, SignatureType* pReturnType, const std::vector<SignatureType*>& parameters, DWORD dwGenericParameterCount);
-        virtual ~SignatureFunctionType();
+        ~SignatureFunctionType() override;
     private:
         CorCallingConvention _callingConvention;
         SignatureType* _pReturnType;
@@ -119,14 +119,14 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureArrayType(SignatureType* relatedType, ULONG rank, const std::vector<ULONG>& counts, const std::vector<ULONG>& bounds);
-        virtual ~SignatureArrayType();
+        ~SignatureArrayType() override;
     private:
         ULONG _rank;
         std::vector<ULONG> _counts;
         std::vector<ULONG> _bounds;
     public:
         // IType
-        HRESULT AddToSignature(ISignatureBuilder* pSignatureBuilder);
+        HRESULT AddToSignature(ISignatureBuilder* pSignatureBuilder) override;
 
     };
 
@@ -135,7 +135,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureGenericParameterType(CorElementType type, ULONG position);
-        virtual ~SignatureGenericParameterType();
+        ~SignatureGenericParameterType() override;
     private:
         ULONG _position;
     public:
@@ -152,7 +152,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureGenericInstance(SignatureType* typeDefinition, const std::vector<SignatureType*>& genericParameters);
-        virtual ~SignatureGenericInstance();
+        ~SignatureGenericInstance() override;
     private:
         std::vector<SignatureType*> _genericParameters;
     public:
@@ -166,7 +166,7 @@ namespace iast
         friend class SignatureInfo;
     protected:
         SignatureModifierType(CorElementType type, mdToken token);
-        virtual ~SignatureModifierType();
+        ~SignatureModifierType() override;
     private:
         mdToken _token;
     public:

--- a/tracer/src/Datadog.Tracer.Native/iast/string_optimization_aspect_filter.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/string_optimization_aspect_filter.h
@@ -24,12 +24,12 @@ namespace iast
 		HRESULT ResolveTargetMemberRefs();
 
 		bool IsTargetMemberRef(mdMemberRef memberRef);
-		bool IsStLoc(int opcode);
-		bool IsCall(int opcode);
+		static bool IsStLoc(int opcode);
+		static bool IsCall(int opcode);
 
 	public:
 		StringOptimizationAspectFilter(ModuleAspects* module);
-		virtual ~StringOptimizationAspectFilter();
+		~StringOptimizationAspectFilter() override;
 
 		bool AllowInstruction(ILInstr* instruction, ILRewriter* processor) override;
 	

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.h
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.h
@@ -24,7 +24,7 @@ public:
     void LoadInt32(INT32 value) const;
     ILInstr* LoadArgument(UINT16 index) const;
     ILInstr* LoadArgumentRef(UINT16 index) const;
-    void LoadFieldAddress(const mdFieldDef field_def) const;
+    void LoadFieldAddress(mdFieldDef field_def) const;
     void Cast(mdTypeRef type_ref) const;
     void Box(mdTypeRef type_ref) const;
     void UnboxAny(mdTypeRef type_ref) const;

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -704,7 +704,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 }
 
 ILInstr* trace::TracerMethodRewriter::CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception,
-                                                               mdTypeRef type_ref, ULONG exceptionValueIndex) const
+                                                               mdTypeRef type_ref, ULONG exceptionValueIndex) 
 {
     ILInstr* filter = rewriter->CreateInstr(CEE_ISINST);
     filter->m_Arg32 = exception;

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.h
@@ -26,7 +26,7 @@ class TracerMethodRewriter : public MethodRewriter, public shared::Singleton<Tra
 
 private:
     TracerMethodRewriter(){}
-    ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, ULONG exceptionValueIndex) const;
+    static ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, ULONG exceptionValueIndex) ;
 
 public:
     HRESULT Rewrite(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler) override;

--- a/tracer/src/Datadog.Tracer.Native/probes_tracker.h
+++ b/tracer/src/Datadog.Tracer.Native/probes_tracker.h
@@ -24,9 +24,9 @@ namespace debugger
         ProbesMetadataTracker() = default;
 
         bool TryGetMetadata(const shared::WSTRING& probeId, std::shared_ptr<ProbeMetadata>& probeMetadata);
-        std::set<WSTRING> GetProbeIds(const ModuleID moduleId, const mdMethodDef methodId);
+        std::set<WSTRING> GetProbeIds(ModuleID moduleId, mdMethodDef methodId);
         void CreateNewProbeIfNotExists(const shared::WSTRING& probeId);
-        void AddMethodToProbe(const shared::WSTRING& probeId, const ModuleID moduleId, const mdMethodDef methodId);
+        void AddMethodToProbe(const shared::WSTRING& probeId, ModuleID moduleId, mdMethodDef methodId);
         bool SetProbeStatus(const shared::WSTRING& probeId, ProbeStatus newStatus);
         bool SetErrorProbeStatus(const shared::WSTRING& probeId, const shared::WSTRING& errorMessage);
         int RemoveProbes(const std::vector<shared::WSTRING>& probes);

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -101,7 +101,7 @@ public:
     ModuleMetadata* GetModuleMetadata();
     void SetModuleMetadata(ModuleMetadata* metadata);
 
-    bool CreateMethodIfNotExists(const mdMethodDef methodDef, RejitHandlerModuleMethodCreatorFunc creator,
+    bool CreateMethodIfNotExists(mdMethodDef methodDef, RejitHandlerModuleMethodCreatorFunc creator,
                                  RejitHandlerModuleMethodUpdaterFunc updater);
     bool ContainsMethod(mdMethodDef methodDef);
     bool TryGetMethod(mdMethodDef methodDef, /* OUT */ RejitHandlerModuleMethod** methodHandler);
@@ -159,7 +159,7 @@ public:
 
     HRESULT NotifyReJITParameters(ModuleID moduleId, mdMethodDef methodId,
                                   ICorProfilerFunctionControl* pFunctionControl);
-    HRESULT NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId);
+    static HRESULT NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId);
 
     ICorProfilerInfo7* GetCorProfilerInfo();
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -28,7 +28,7 @@ protected:
     void ProcessTypeDefForRejit(const RejitRequestDefinition& definition, ComPtr<IMetaDataImport2>& metadataImport,
                             ComPtr<IMetaDataEmit2>& metadataEmit, ComPtr<IMetaDataAssemblyImport>& assemblyImport,
                             ComPtr<IMetaDataAssemblyEmit>& assemblyEmit, const ModuleInfo& moduleInfo,
-                            const mdTypeDef typeDef, std::vector<MethodIdentifier>& rejitRequests);
+                            mdTypeDef typeDef, std::vector<MethodIdentifier>& rejitRequests);
 
     virtual void ProcessTypesForRejit(std::vector<MethodIdentifier>& rejitRequests, const ModuleInfo& moduleInfo,
                           ComPtr<IMetaDataImport2> metadataImport, ComPtr<IMetaDataEmit2> metadataEmit,
@@ -40,7 +40,7 @@ protected:
     virtual const bool GetIsDerived(const RejitRequestDefinition& definition) = 0;
     virtual const bool GetIsInterface(const RejitRequestDefinition& definition) = 0;
     virtual const bool GetIsExactSignatureMatch(const RejitRequestDefinition& definition) = 0;
-    virtual const std::unique_ptr<RejitHandlerModuleMethod> CreateMethod(const mdMethodDef methodDef,
+    virtual const std::unique_ptr<RejitHandlerModuleMethod> CreateMethod(mdMethodDef methodDef,
                                                                          RejitHandlerModule* module,
                                                                          const FunctionInfo& functionInfo,
                                                                          const RejitRequestDefinition& definition) = 0;
@@ -101,7 +101,7 @@ protected:
     const bool GetIsInterface(const IntegrationDefinition& definition) final;
     const bool GetIsExactSignatureMatch(const IntegrationDefinition& definition) final;
     const std::unique_ptr<RejitHandlerModuleMethod>
-    CreateMethod(const mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
+    CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
                  const IntegrationDefinition& integrationDefinition) final;
     bool ShouldSkipModule(const ModuleInfo& moduleInfo, const IntegrationDefinition& integrationDefinition) final;
 };

--- a/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
+++ b/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
@@ -29,14 +29,14 @@ protected:
     void AddAdditionalLocals(COR_SIGNATURE (&signatureBuffer)[500], ULONG& signatureOffset, ULONG& signatureSize, bool isAsyncMethod) override;
 
 public:
-    TracerTokens(ModuleMetadata* module_metadata_ptr, const bool enableByRefInstrumentation,
-                 const bool enableCallTargetStateByRef);
+    TracerTokens(ModuleMetadata* module_metadata_ptr, bool enableByRefInstrumentation,
+                 bool enableCallTargetStateByRef);
 
     int GetAdditionalLocalsCount() override;
 
     HRESULT WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef, const TypeInfo* currentType,
                              const std::vector<TypeSignature>& methodArguments,
-                             const bool ignoreByRefInstrumentation, ILInstr** instruction);
+                             bool ignoreByRefInstrumentation, ILInstr** instruction);
 
     HRESULT WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
                                         const TypeInfo* currentType, ILInstr** instruction);


### PR DESCRIPTION
## Summary of changes

Clean up codebase using `clang-tidy`.
command line: `-header-filter='.*' -checks='-*,modernize-use-nullptr,modernize-use-override,modernize-redundant-void-arg,readability-convert-member-functions-to-static,readability-avoid-const-params-in-decls' -fix`
