### PR TITLE
Adds the `ci crank-import` command

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/CrankCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/CrankCommand.cs
@@ -1,0 +1,16 @@
+// <copyright file="CrankCommand.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Spectre.Console.Cli;
+
+namespace Datadog.Trace.Tools.Runner.Crank;
+
+internal class CrankCommand : Command<CrankSettings>
+{
+    public override int Execute(CommandContext context, CrankSettings settings)
+    {
+        return Importer.Process(settings.InputFile);
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/CrankSettings.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/CrankSettings.cs
@@ -1,0 +1,14 @@
+// <copyright file="CrankSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Spectre.Console.Cli;
+
+namespace Datadog.Trace.Tools.Runner.Crank;
+
+internal class CrankSettings : CommandSettings
+{
+    [CommandArgument(0, "<input-file>")]
+    public string InputFile { get; set; }
+}

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Datadog.Trace.Tools.Runner.Crank;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Spectre.Console.Rendering;
@@ -125,6 +126,10 @@ namespace Datadog.Trace.Tools.Runner
                     c.AddCommand<RunCiCommand>("run")
                         .WithDescription("Run a command and instrument the tests")
                         .WithExample("ci run -- dotnet test".Split(' '));
+                    c.AddCommand<CrankCommand>("crank-import")
+                        .IsHidden()
+                        .WithDescription("Import a Microsoft Crank json file")
+                        .WithExample("ci crank-import ./crank-results.json".Split(' '));
                 });
 
             config.AddBranch(

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CrankImporterCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CrankImporterCommandTests.cs
@@ -1,0 +1,32 @@
+// <copyright file="CrankImporterCommandTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tools.Runner.IntegrationTests;
+
+[Collection(nameof(ConsoleTestsCollection))]
+public class CrankImporterCommandTests
+{
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public void CommandTest()
+    {
+        var commandLine = "ci crank-import crank-results.json";
+
+        using var console = ConsoleHelper.Redirect();
+        var result = Program.Main(commandLine.Split(' '));
+
+        // This should fail because crank-results.json doesn't exist, it doesn't matter because we are testing
+        // the execution of the command not the results
+        result.Should().Be(1);
+
+        // We check now if the right command ran.
+        Assert.Contains("Importing Crank json result file...", console.Output);
+        Assert.Contains("FileNotFoundException", console.Output);
+        Assert.Contains("crank-results.json", console.Output);
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR adds a new `ci crank-import` hidden command to the `dd-trace` tool.

## Reason for change

Since the last refactor of the tool the `dd-trace crank-import` command is broken. This means that our crank controllers cannot be updated to the latest version of  `dd-trace`.

## Test coverage

Added a simple test to check if the command is being called.
