### PR TITLE
[CIVisibility] - Replace the datacollector logger error calls with warnings

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -46,19 +46,29 @@ namespace Datadog.Trace.Coverage.Collector
 
         public void Error(string? text)
         {
-            _logger.LogError(_collectionContext, text ?? string.Empty);
+            _logger.LogWarning(_collectionContext, text ?? string.Empty);
             _datadogLogger.Error(text);
         }
 
         public void Error(Exception exception)
         {
-            _logger.LogError(_collectionContext, exception);
+            _logger.LogWarning(_collectionContext, exception.ToString());
             _datadogLogger.Error(exception, exception.Message);
         }
 
         public void Error(Exception exception, string? text)
         {
-            _logger.LogError(_collectionContext, text ?? string.Empty, exception);
+            var textToLogger = text;
+            if (string.IsNullOrEmpty(textToLogger))
+            {
+                textToLogger = exception?.ToString();
+            }
+            else
+            {
+                textToLogger += Environment.NewLine + exception;
+            }
+
+            _logger.LogWarning(_collectionContext, textToLogger);
             _datadogLogger.Error(exception, text);
         }
 


### PR DESCRIPTION
This PR Replace the datacollector logger error calls with warnings to avoid failing the test process in case of a datacollector error.

## Reason for change

Currently if the datacollector fails to apply code coverage, then the exit code of the test process is != 0 even with all tests passing. We don't want to change the results of the test, code coverage should be a best effort feature.