### PR TITLE
Force all tests to run as part of scheduled builds on `master`

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -49,7 +49,13 @@ partial class Build : NukeBuild
                     const string baseBranch = "origin/master";
                     bool isChanged;
                     var forceExplorationTestsWithVariableName = $"force_exploration_tests_with_{variableName}";
-                    if (bool.Parse(Environment.GetEnvironmentVariable(forceExplorationTestsWithVariableName) ?? "false"))
+
+                    if (Environment.GetEnvironmentVariable("Build.Reason") == "Schedule" && bool.Parse(Environment.GetEnvironmentVariable("isMainBranch") ?? "false"))
+                    {
+                        Logger.Info("Running scheduled build on master, forcing tests");
+                        isChanged = true;
+                    }
+                    else if (bool.Parse(Environment.GetEnvironmentVariable(forceExplorationTestsWithVariableName) ?? "false"))
                     {
                         Logger.Info($"{forceExplorationTestsWithVariableName} was set - forcing exploration tests");
                         isChanged = true;

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -52,7 +52,7 @@ partial class Build : NukeBuild
 
                     if (Environment.GetEnvironmentVariable("Build.Reason") == "Schedule" && bool.Parse(Environment.GetEnvironmentVariable("isMainBranch") ?? "false"))
                     {
-                        Logger.Info("Running scheduled build on master, forcing tests");
+                        Logger.Info("Running scheduled build on master, forcing all tests to run regardless of whether there has been a change.");
                         isChanged = true;
                     }
                     else if (bool.Parse(Environment.GetEnvironmentVariable(forceExplorationTestsWithVariableName) ?? "false"))


### PR DESCRIPTION
## Summary of changes
As part of our CI, certain tests only run when the relevant code is changed (e.g. we only run the debugger's tests if the 
debugger has changed, the profiler's tests if the profiler has changed, etc).
This PR changes it so that scheduled builds always run these tests, regardless of whether there has been a change or not.

## Reason for change
The purpose of this change is to identify flaky tests among those that do not run on a regular basis.