### PR TITLE
[CI Visibility] - Add retries support for IOException in the coverage collector

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -162,33 +162,54 @@ namespace Datadog.Trace.Coverage.Collector
                     {
                         if (File.Exists(Path.Combine(path, fileWithoutExtension + ".pdb")) || File.Exists(Path.Combine(path, fileWithoutExtension + ".PDB")))
                         {
-                            try
+                            List<Exception>? lstExceptions = null;
+                            var remain = 3;
+                            Retry:
+                            if (--remain > 0)
                             {
-                                var asmProcessor = new AssemblyProcessor(file, _tracerHome, _logger, _ciVisibilitySettings);
-                                asmProcessor.Process();
-                                Interlocked.Increment(ref numAssemblies);
-                                if (asmProcessor.HasTracerAssemblyCopied)
+                                try
                                 {
-                                    lock (processedDirectories)
+                                    var asmProcessor = new AssemblyProcessor(file, _tracerHome, _logger, _ciVisibilitySettings);
+                                    asmProcessor.Process();
+                                    Interlocked.Increment(ref numAssemblies);
+                                    if (asmProcessor.HasTracerAssemblyCopied)
                                     {
-                                        processedDirectories.Add(Path.GetDirectoryName(file) ?? string.Empty);
+                                        lock (processedDirectories)
+                                        {
+                                            processedDirectories.Add(Path.GetDirectoryName(file) ?? string.Empty);
+                                        }
                                     }
                                 }
+                                catch (PdbNotFoundException)
+                                {
+                                    // If the PDB file was not found, we skip the assembly without throwing error.
+                                    _logger?.Debug($"{nameof(PdbNotFoundException)} processing file: {file}");
+                                }
+                                catch (BadImageFormatException)
+                                {
+                                    // If the Assembly has not the correct format (eg. native dll / exe)
+                                    // We skip processing the assembly.
+                                    _logger?.Debug($"{nameof(BadImageFormatException)} processing file: {file}");
+                                }
+                                catch (IOException ioException)
+                                {
+                                    // We do retries if we have an IOException.
+                                    // For cases like: `The process cannot access the file 'file path' because
+                                    // it is being used by another process`
+                                    lstExceptions ??= new List<Exception>();
+                                    lstExceptions.Add(ioException);
+                                    Thread.Sleep(1000);
+                                    goto Retry;
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger?.Error(ex);
+                                }
                             }
-                            catch (PdbNotFoundException)
+
+                            if (lstExceptions?.Count > 0)
                             {
-                                // If the PDB file was not found, we skip the assembly without throwing error.
-                                _logger?.Debug($"{nameof(PdbNotFoundException)} processing file: {file}");
-                            }
-                            catch (BadImageFormatException)
-                            {
-                                // If the Assembly has not the correct format (eg. native dll / exe)
-                                // We skip processing the assembly.
-                                _logger?.Debug($"{nameof(BadImageFormatException)} processing file: {file}");
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger?.Error(ex);
+                                _logger?.Error(new AggregateException(lstExceptions));
                             }
                         }
                     }


### PR DESCRIPTION
## Summary of changes

This PR adds support for retries on IOExceptions when processing an assembly to add coverage information.

## Reason for change

Sometimes the coverage datacollector throws an IOException because the assembly we try to modify is being used by another process. This appears to be a common problem in the coverage tool space, as we can see in the following issues:

- https://github.com/coverlet-coverage/coverlet/issues/1224
- https://github.com/coverlet-coverage/coverlet/issues/725
- https://github.com/coverlet-coverage/coverlet/issues/857

With this PR we retry at least 3 times before failing to add coverage to an assembly.

