### PR TITLE
[CI Visibility] - Ensure dd-trace uses same settings as target process

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -48,6 +48,11 @@ namespace Datadog.Trace.Tools.Runner
                 }
             }
 
+            if (Program.CallbackForTests is null)
+            {
+                Utils.SetCommonTracerSettingsToCurrentProcess(settings);
+            }
+
             var arguments = args.Count > 1 ? Utils.GetArgumentsAsString(args.Skip(1).ToArray()) : null;
 
             // CI Visibility mode is enabled.

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -36,29 +36,21 @@ namespace Datadog.Trace.Tools.Runner
             if (!string.IsNullOrWhiteSpace(options.Environment))
             {
                 envVars[ConfigurationKeys.Environment] = options.Environment;
-                // Settings back DD_ENV to use it in the current process (eg for CIVisibility's TestSession)
-                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.Environment, options.Environment);
             }
 
             if (!string.IsNullOrWhiteSpace(options.Service))
             {
                 envVars[ConfigurationKeys.ServiceName] = options.Service;
-                // Settings back DD_SERVICE to use it in the current process (eg for CIVisibility's TestSession)
-                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceName, options.Service);
             }
 
             if (!string.IsNullOrWhiteSpace(options.Version))
             {
                 envVars[ConfigurationKeys.ServiceVersion] = options.Version;
-                // Settings back DD_VERSION to use it in the current process (eg for CIVisibility's TestSession)
-                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceVersion, options.Version);
             }
 
             if (!string.IsNullOrWhiteSpace(options.AgentUrl))
             {
                 envVars[ConfigurationKeys.AgentUri] = options.AgentUrl;
-                // Settings back DD_TRACE_AGENT_URL to use it in the current process (eg for CIVisibility's TestSession)
-                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.AgentUri, options.AgentUrl);
             }
 
             return envVars;
@@ -104,6 +96,33 @@ namespace Datadog.Trace.Tools.Runner
             }
 
             return envVars;
+        }
+
+        public static void SetCommonTracerSettingsToCurrentProcess(CommonTracerSettings options)
+        {
+            // Settings back DD_ENV to use it in the current process (eg for CIVisibility's TestSession)
+            if (!string.IsNullOrWhiteSpace(options.Environment))
+            {
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.Environment, options.Environment);
+            }
+
+            // Settings back DD_SERVICE to use it in the current process (eg for CIVisibility's TestSession)
+            if (!string.IsNullOrWhiteSpace(options.Service))
+            {
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceName, options.Service);
+            }
+
+            // Settings back DD_VERSION to use it in the current process (eg for CIVisibility's TestSession)
+            if (!string.IsNullOrWhiteSpace(options.Version))
+            {
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceVersion, options.Version);
+            }
+
+            // Settings back DD_TRACE_AGENT_URL to use it in the current process (eg for CIVisibility's TestSession)
+            if (!string.IsNullOrWhiteSpace(options.AgentUrl))
+            {
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.AgentUri, options.AgentUrl);
+            }
         }
 
         public static string DirectoryExists(string name, params string[] paths)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -35,22 +35,30 @@ namespace Datadog.Trace.Tools.Runner
 
             if (!string.IsNullOrWhiteSpace(options.Environment))
             {
-                envVars["DD_ENV"] = options.Environment;
+                envVars[ConfigurationKeys.Environment] = options.Environment;
+                // Settings back DD_ENV to use it in the current process (eg for CIVisibility's TestSession)
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.Environment, options.Environment);
             }
 
             if (!string.IsNullOrWhiteSpace(options.Service))
             {
-                envVars["DD_SERVICE"] = options.Service;
+                envVars[ConfigurationKeys.ServiceName] = options.Service;
+                // Settings back DD_SERVICE to use it in the current process (eg for CIVisibility's TestSession)
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceName, options.Service);
             }
 
             if (!string.IsNullOrWhiteSpace(options.Version))
             {
-                envVars["DD_VERSION"] = options.Version;
+                envVars[ConfigurationKeys.ServiceVersion] = options.Version;
+                // Settings back DD_VERSION to use it in the current process (eg for CIVisibility's TestSession)
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.ServiceVersion, options.Version);
             }
 
             if (!string.IsNullOrWhiteSpace(options.AgentUrl))
             {
-                envVars["DD_TRACE_AGENT_URL"] = options.AgentUrl;
+                envVars[ConfigurationKeys.AgentUri] = options.AgentUrl;
+                // Settings back DD_TRACE_AGENT_URL to use it in the current process (eg for CIVisibility's TestSession)
+                EnvironmentHelpers.SetEnvironmentVariable(ConfigurationKeys.AgentUri, options.AgentUrl);
             }
 
             return envVars;


### PR DESCRIPTION
## Summary of changes

This PR uses the options from the command line to set the environment variables for the wrapper process, so the wrapper and the target process uses the same values.

## Reason for change

We have seen some inconsistency in CI Visibility when a customer uses the `--dd-service` arguments to set the test service name, where Modules, Suites and Tests have the same service name set by the user, but the Test Session doesn't.

If a customer set these parameters we want to keep those values on every span / session / module / suite and test we send to the backend.