### PR TITLE
Update log message with minimum datadog-agent version required for RCM

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.Debugger
 
                 if (!Volatile.Read(ref _isRcmAvailable))
                 {
-                    Log.Warning("Live Debugger could not be enabled because Remote Configuration Management is not available. Please ensure that you are using datadog-agent version 7.38.0 or higher, and that Remote Configuration Management is enabled in datadog-agent's yaml configuration file.");
+                    Log.Warning("Live Debugger could not be enabled because Remote Configuration Management is not available. Please ensure that you are using datadog-agent version 7.41.1 or higher, and that Remote Configuration Management is enabled in datadog-agent's yaml configuration file.");
                     return false;
                 }
 


### PR DESCRIPTION
## Summary of changes
Update log message with minimum datadog-agent version required for Remote Configuration from v7.38 to 7.41.1

## Reason for change
We've seen a lot of strange issues come up when using RCM with `datadog-agent` versions ealier than `v7.41.1`
