### PR TITLE
Wrap DbCommand.Connection getter with a try/catch

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -224,7 +224,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
             private static DbCommandCache.TagsCacheItem GetTagsFromConnectionString(IDbCommand command)
             {
-                var connectionString = command.Connection?.ConnectionString;
+                IDbConnection dbConnection = null;
+                try
+                {
+                    dbConnection = command.Connection;
+                }
+                catch (NotSupportedException nsException)
+                {
+                    Log.Debug(nsException, "Connection cannot be retrieved from the command.");
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug(ex, "Error trying to retrieve the connection from the command.");
+                }
+
+                var connectionString = dbConnection?.ConnectionString;
 
                 // Check if the connection string is the one in the cache
                 var tagsByConnectionString = _tagsByConnectionStringCache;


### PR DESCRIPTION
## Summary of changes

This PR is a continuation of #3693 where we have to catchthe exception thrown when extracting the connection from a DbCommand created by DbDataSource ([source](https://source.dot.net/#System.Data.Common/System/Data/Common/DbDataSource.cs,342))
