### PR TITLE
Fix osx folder in GetNativeLoaderPath()

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -130,8 +130,7 @@ namespace Datadog.Trace.TestHelpers
                 ("linux", "Arm64", _, _) => ("so", "linux-arm64"),
                 ("linux", "X64", _, false) => ("so", "linux-x64"),
                 ("linux", "X64", _, true) => ("so", "linux-musl-x64"),
-                ("osx", "X64", _, _) => ("dylib", "osx-x64"),
-                ("osx", "Arm64", _, _) => ("dylib", "osx-arm64"),
+                ("osx", _, _, _) => ("dylib", "osx"),
                 _ => throw new PlatformNotSupportedException()
             };
 


### PR DESCRIPTION
## Summary of changes

Fix OSX folder path in `Datadog.Trace.TestHelpers.EnvironmentHelper.GetNativeLoaderPath()` 
