### PR TITLE
Add throughput tests for manual instrumentation scenarios

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2939,6 +2939,8 @@ stages:
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp tracer/tracer-home-linux/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
         cd $(CrankDir)
         chmod +x ./run.sh
         ./run.sh "linux" "$(runExtendedThroughputTests)"
@@ -2979,6 +2981,8 @@ stages:
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp tracer/tracer-home-win/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
         cd $(CrankDir)
         chmod +x ./run.sh
         ./run.sh "windows" "$(runExtendedThroughputTests)"
@@ -3019,6 +3023,8 @@ stages:
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/libddwaf.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/libddwaf.so does not exist" && exit 1
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp tracer/tracer-home-linux-arm64/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
         ./run.sh "linux_arm64" "$(runExtendedThroughputTests)"

--- a/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
+++ b/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
@@ -105,7 +105,10 @@ public class CompareThroughput
     private static string GetName(CrankScenario source) => source switch
     {
         CrankScenario.Baseline => "Baseline",
-        CrankScenario.Instrumented => "Instrumented",
+        CrankScenario.AutomaticInstrumentation => "Automatic",
+        CrankScenario.ManualInstrumentation => "Manual",
+        CrankScenario.ManualAndAutomaticInstrumentation => "Manual + Automatic",
+        CrankScenario.VersionConflict => "Version Conflict",
         CrankScenario.TraceStats => "Trace stats",
         CrankScenario.NoAttack => "No attack",
         CrankScenario.AttackNoBlocking => "Attack",
@@ -115,13 +118,43 @@ public class CompareThroughput
 
     static readonly (string Path, CrankTestSuite Type, (string Filename, CrankScenario Scenario)[] Scenarios)[] ExpectedScenarios =
     {
-        ("crank_linux_x64_1", CrankTestSuite.LinuxX64, new[] { ("baseline_linux.json", CrankScenario.Baseline), ("calltarget_ngen_linux.json", CrankScenario.Instrumented), ("trace_stats_linux.json", CrankScenario.TraceStats), }
+        ("crank_linux_x64_1", CrankTestSuite.LinuxX64, new[]
+            {
+                ("baseline_linux.json", CrankScenario.Baseline),
+                ("calltarget_ngen_linux.json", CrankScenario.AutomaticInstrumentation),
+                ("trace_stats_linux.json", CrankScenario.TraceStats),
+                ("manual_only_linux.json", CrankScenario.ManualInstrumentation),
+                ("manual_and_automatic_linux.json", CrankScenario.ManualAndAutomaticInstrumentation),
+                ("version_conflict_linux.json", CrankScenario.VersionConflict),
+            }
         ),
-        ("crank_linux_arm64_1", CrankTestSuite.LinuxArm64, new[] { ("baseline_linux_arm64.json", CrankScenario.Baseline), ("calltarget_ngen_linux_arm64.json", CrankScenario.Instrumented), ("trace_stats_linux_arm64.json", CrankScenario.TraceStats), }
+        ("crank_linux_arm64_1", CrankTestSuite.LinuxArm64, new[]
+            {
+                ("baseline_linux_arm64.json", CrankScenario.Baseline),
+                ("calltarget_ngen_linux_arm64.json", CrankScenario.AutomaticInstrumentation),
+                ("trace_stats_linux_arm64.json", CrankScenario.TraceStats),
+                ("manual_only_linux_arm64.json", CrankScenario.ManualInstrumentation),
+                ("manual_and_automatic_linux_arm64.json", CrankScenario.ManualAndAutomaticInstrumentation),
+                ("version_conflict_linux_arm64.json", CrankScenario.VersionConflict),
+            }
         ),
-        ("crank_windows_x64_1", CrankTestSuite.WindowsX64, new[] { ("baseline_windows.json", CrankScenario.Baseline), ("calltarget_ngen_windows.json", CrankScenario.Instrumented), ("trace_stats_windows.json", CrankScenario.TraceStats), }
+        ("crank_windows_x64_1", CrankTestSuite.WindowsX64, new[]
+            {
+                ("baseline_windows.json", CrankScenario.Baseline),
+                ("calltarget_ngen_windows.json", CrankScenario.AutomaticInstrumentation),
+                ("trace_stats_windows.json", CrankScenario.TraceStats),
+                ("manual_only_windows.json", CrankScenario.ManualInstrumentation),
+                ("manual_and_automatic_windows.json", CrankScenario.ManualAndAutomaticInstrumentation),
+                ("version_conflict_windows.json", CrankScenario.VersionConflict),
+            }
         ),
-        ("crank_linux_x64_asm_1", CrankTestSuite.ASMLinuxX64, new[] { ("appsec_baseline.json", CrankScenario.Baseline), ("appsec_noattack.json", CrankScenario.NoAttack), ("appsec_attack_noblocking.json", CrankScenario.AttackNoBlocking), ("appsec_attack_blocking.json", CrankScenario.AttackBlocking), }
+        ("crank_linux_x64_asm_1", CrankTestSuite.ASMLinuxX64, new[]
+            {
+                ("appsec_baseline.json", CrankScenario.Baseline),
+                ("appsec_noattack.json", CrankScenario.NoAttack),
+                ("appsec_attack_noblocking.json", CrankScenario.AttackNoBlocking),
+                ("appsec_attack_blocking.json", CrankScenario.AttackBlocking),
+            }
         ),
     };
 
@@ -161,8 +194,11 @@ public class CompareThroughput
     public enum CrankScenario
     {
         Baseline,
-        Instrumented,
+        AutomaticInstrumentation,
         TraceStats,
+        ManualInstrumentation,
+        ManualAndAutomaticInstrumentation,
+        VersionConflict,
         NoAttack,
         AttackNoBlocking,
         AttackBlocking,

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -66,3 +66,66 @@ scenarios:
         duration: 240
         serverPort: 5000
         path: /hello
+
+  manual_only:
+    application:
+      job: server
+      buildArguments: 
+      - "/p:MANUAL_INSTRUMENTATION=true"
+      environmentVariables:
+        COR_ENABLE_PROFILING: 0
+        CORECLR_ENABLE_PROFILING: 0
+      options:
+        buildFiles:
+        # Copy the dll to the project directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
+        outputFiles:
+        # Copy the dll to the publish directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello
+
+  manual_and_automatic:
+    application:
+      job: server
+      buildArguments: 
+      - "/p:MANUAL_INSTRUMENTATION=true"
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+      options:
+        buildFiles:
+        # Copy the dll to the project directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
+        outputFiles:
+        # Copy the dll to the publish directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello
+
+  version_conflict:
+    application:
+      job: server
+      buildArguments: 
+      - "/p:MANUAL_INSTRUMENTATION=true"
+      - "/p:VERSION_MISMATCH=true"
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -27,11 +27,16 @@ repository="--application.source.repository $repo"
 commit="--application.source.branchOrCommit #$commit_sha"
 
 if [ "$1" = "windows" ]; then
-    echo "Running windows throughput tests"
 
+    echo "Cleaning previous results"
     rm -f baseline_windows.json
     rm -f calltarget_ngen_windows.json
     rm -f trace_stats_windows.json
+    rm -f manual_only_windows.json
+    rm -f manual_and_automatic_windows.json
+    rm -f version_conflict_windows.json
+    
+    echo "Running windows throughput tests"
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_windows.json"
@@ -45,12 +50,29 @@ if [ "$1" = "windows" ]; then
       dd-trace --crank-import="trace_stats_windows.json"
     fi
 
-elif [ "$1" = "linux" ]; then
-    echo "Running Linux  x64 throughput tests"
+    echo "Running manual instrumentation throughput tests"
 
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile windows --json manual_only_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha 
+    dd-trace --crank-import="manual_only_windows.json"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_windows.json"
+
+    if [ "$2" = "True" ]; then
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile windows --json version_conflict_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="version_conflict_windows.json"
+    fi
+
+elif [ "$1" = "linux" ]; then
+    echo "Cleaning previous results"
     rm -f baseline_linux.json
     rm -f calltarget_ngen_linux.json
     rm -f trace_stats_linux.json
+    rm -f manual_only_linux.json
+    rm -f manual_and_automatic_linux.json
+    rm -f version_conflict_linux.json
+
+    echo "Running Linux x64 throughput tests"
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_linux.json"
@@ -64,12 +86,29 @@ elif [ "$1" = "linux" ]; then
       dd-trace --crank-import="trace_stats_linux.json"
     fi
 
-elif [ "$1" = "linux_arm64" ]; then
-    echo "Running Linux arm64 throughput tests"
+    echo "Running manual instrumentation throughput tests"
 
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux --json manual_only_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_only_linux.json"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux.json"
+
+    if [ "$2" = "True" ]; then
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux --json version_conflict_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="version_conflict_linux.json"
+    fi
+
+elif [ "$1" = "linux_arm64" ]; then
+    echo "Cleaning previous results"
     rm -f baseline_linux_arm64.json
     rm -f calltarget_ngen_linux_arm64.json
     rm -f trace_stats_linux_arm64.json
+    rm -f manual_only_linux_arm64.json
+    rm -f manual_and_automatic_linux_arm64.json
+    rm -f version_conflict_linux_arm64.json
+
+    echo "Running Linux arm64 throughput tests"
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="baseline_linux_arm64.json"
@@ -83,6 +122,18 @@ elif [ "$1" = "linux_arm64" ]; then
       dd-trace --crank-import="trace_stats_linux_arm64.json"
     fi
 
+    echo "Running manual instrumentation throughput tests"
+    
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux_arm64 --json manual_only_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_only_linux_arm64.json"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
+
+    if [ "$2" = "True" ]; then
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux_arm64 --json version_conflict_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="version_conflict_linux_arm64.json"
+    fi
 else
     echo "Unknown argument $1"
     exit 1

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -10,6 +10,7 @@ namespace Samples
 {
     public class SampleHelpers
     {
+        private static readonly Type InstrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace");
         private static readonly Type NativeMethodsType = Type.GetType("Datadog.Trace.ClrProfiler.NativeMethods, Datadog.Trace");
         private static readonly Type TracerType = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace");
         private static readonly Type ScopeType = Type.GetType("Datadog.Trace.Scope, Datadog.Trace");
@@ -19,6 +20,8 @@ namespace Samples
         private static readonly Type SpanCreationSettingsType = Type.GetType("Datadog.Trace.SpanCreationSettings, Datadog.Trace");
         private static readonly Type SpanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace");
         private static readonly Type TracerSettingsType = Type.GetType("Datadog.Trace.TracerSettings, Datadog.Trace.Configuration");
+        private static readonly Type TracerConstantsType = Type.GetType("Datadog.Trace.TracerConstants, Datadog.Trace");
+        private static readonly MethodInfo GetNativeTracerVersionMethod = InstrumentationType?.GetMethod("GetNativeTracerVersion");
         private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance")?.GetMethod;
         private static readonly MethodInfo StartActiveMethod = TracerType?.GetMethod("StartActive", types: new[] { typeof(string) });
         private static readonly MethodInfo StartActiveWithContextMethod;
@@ -36,6 +39,7 @@ namespace Samples
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
+        private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
         static SampleHelpers()
@@ -91,6 +95,32 @@ namespace Samples
         public static string GetTracerAssemblyLocation()
         {
             return NativeMethodsType?.Assembly.Location ?? "(none)";
+        }
+
+        public static string GetNativeTracerVersion()
+        {
+            try
+            {
+                return (string)GetNativeTracerVersionMethod.Invoke(null, Array.Empty<object>()) ?? "None";
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return "None";
+            }
+        }
+
+        public static string GetManagedTracerVersion()
+        {
+            try
+            {
+                return (string) TracerThreePartVersionField.GetValue(null);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                return "None";
+            }
         }
 
         public static void RunShutDownTasks(object caller)

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Controllers/HelloController.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Controllers/HelloController.cs
@@ -16,7 +16,14 @@ namespace Samples.AspNetCoreSimpleController.Controllers
         }
 
         [HttpGet]
-        public string Get() => "Hello world";
+        public string Get()
+        {
+#if MANUAL_INSTRUMENTATION
+            using var scope = Datadog.Trace.Tracer.Instance.StartActive("manual");
+            scope.Span.SetTag("location", "outer");
+#endif
+            return "Hello world";
+        }
 
         [HttpGet]
         [Route("exception")]

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -10,6 +10,9 @@ namespace Samples.AspNetCoreSimpleController
     {
         public static void Main(string[] args)
         {
+            string managedTracerVersion = "None";
+            string nativeTracerVersion = "None";
+
             if (Environment.GetEnvironmentVariable("COR_ENABLE_PROFILING") == "1" ||
                 Environment.GetEnvironmentVariable("CORECLR_ENABLE_PROFILING") == "1")
             {
@@ -39,12 +42,26 @@ namespace Samples.AspNetCoreSimpleController
                     Environment.Exit(1);
                     return;
                 }
+
+                nativeTracerVersion = SampleHelpers.GetNativeTracerVersion();
             }
             else
             {
                 Console.WriteLine(" * Running without profiler.");
             }
 
+#if MANUAL_INSTRUMENTATION
+            managedTracerVersion = SampleHelpers.GetManagedTracerVersion();
+            if(managedTracerVersion == "None")
+            {
+                Console.WriteLine("Error: Managed tracer is required and is not loaded.");
+                Environment.Exit(1);
+                return;
+            }
+#endif
+
+            Console.WriteLine(" * Using managed tracer version '{0}' and native tracer version '{1}'",
+                              managedTracerVersion, nativeTracerVersion);
             Console.WriteLine();
 
             CreateHostBuilder(args).Build().Run();

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -3,6 +3,20 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64;x86;AnyCPU</Platforms>
+    <DefineConstants Condition="'$(MANUAL_INSTRUMENTATION)' == 'true'">$(DefineConstants);MANUAL_INSTRUMENTATION</DefineConstants>
+    <DefineConstants Condition="'$(VERSION_MISMATCH)' == 'true'">$(DefineConstants);VERSION_MISMATCH</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true' AND '$(VERSION_MISMATCH)' != 'true'">
+    <!--    If you want to run the app locally, switch the reference out for this-->
+    <!--    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />-->
+    <Reference Include="Datadog.Trace">
+      <HintPath>Datadog.Trace.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true' AND '$(VERSION_MISMATCH)' == 'true'">
+    <PackageReference Include="Datadog.Trace" Version="2.22.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of changes
- Update sample to optionally create a manual span in the endpoint
- Update crank to test additional scenarios around manual instrumentation
- Add manual scenarios to comparison

## Reason for change

I am going to be making changes on critical paths and want to make sure we don't regress. Also, it's nice to have to some extra data points.

## Implementation details

Updated the existing throughput sample to look for two new MSBuild parameters:
- `MANUAL_INSTRUMENTATION`
- `VERSION_MISMATCH`

When `MANUAL_INSTRUMENTATION` is set, we create an additional span in the test endpoint. When it's _not_ set, we `#if` it away, so there should be no impact on the existing benchmark values. To use manual instrumentation we need to reference Datadog.Trace.dll; instead of reference the project (which would require re-building), we directly reference the pre-built by path, which is copied to a known location by crank.

When `VERSION_MISMATCH` is set, instead of using the pre-built dll, we reference an older version of the tracer from NuGet. 

> For .NET Core (as I understand it) it's only this "_older_ NuGet package" scenario that results in rewriting of the distributed tracer abstraction, and hence the perf hit

## Test coverage

Results should speak for themselves 🤞

## Other details

My original attempts at this were creating a separate app that was doing the automatic > manual transition both ways: automatic > manual > automatic > manual. With the updated version we only do automatic > manual, so we're not testing the manual > automatic transition. However, doing it this way means we are directly comparable with the existing benchmarks, which is nice 🙂 

The downside, is that in order to be directly comparable, we have to run on the sample agent machines, which slows down the throughput stage overall. I've kept the version mismatch as "master only" tests (or can be triggered manually) to reduce the impact.

Also: might be nice to add additional scenarios using OTel instead of Datadog.Trace.dll. Only difficulty there is further delays in the tests.
