### PR TITLE
[CI Visibility] - Avoid sending the global code coverage tag if we have ITR enabled

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -151,6 +151,8 @@ namespace Datadog.Trace.Tools.Runner
 
                 Log.Debug("RunHelper: CodeCoverageEnabled = {value}", codeCoverageEnabled);
                 Log.Debug("RunHelper: TestSkippingEnabled = {value}", testSkippingEnabled);
+                ciVisibilitySettings.SetCodeCoverageEnabled(codeCoverageEnabled);
+                profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.CodeCoverage] = codeCoverageEnabled ? "1" : "0";
 
                 if (codeCoverageEnabled)
                 {

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -365,8 +365,12 @@ public sealed class TestModule
         if (CoverageReporter.Handler is DefaultWithGlobalCoverageEventHandler coverageHandler &&
             coverageHandler.GetCodeCoveragePercentage() is { } globalCoverage)
         {
-            // Adds the global code coverage percentage to the module
-            span.SetTag(CommonTags.CodeCoverageTotalLines, globalCoverage.Data[0].ToString(CultureInfo.InvariantCulture));
+            // We only report global code coverage if we don't skip any test
+            if (!CIVisibility.HasSkippableTests())
+            {
+                // Adds the global code coverage percentage to the module
+                span.SetTag(CommonTags.CodeCoverageTotalLines, globalCoverage.Data[0].ToString(CultureInfo.InvariantCulture));
+            }
 
             // If the code coverage path environment variable is set, we store the json file
             if (!string.IsNullOrWhiteSpace(CIVisibility.Settings.CodeCoveragePath))
@@ -383,6 +387,17 @@ public sealed class TestModule
                     CIVisibility.Log.Error(ex, "Error writing global code coverage.");
                 }
             }
+        }
+
+        if (CIVisibility.Settings.TestsSkippingEnabled.HasValue)
+        {
+            span.SetTag(CommonTags.TestsSkippingEnabled, CIVisibility.Settings.TestsSkippingEnabled.Value ? "true" : "false");
+            span.SetTag(CommonTags.TestsSkipped, CIVisibility.HasSkippableTests() ? "true" : "false");
+        }
+
+        if (CIVisibility.Settings.CodeCoverageEnabled.HasValue)
+        {
+            span.SetTag(CommonTags.CodeCoverageEnabled, CIVisibility.Settings.CodeCoverageEnabled.Value ? "true" : "false");
         }
 
         span.Finish(duration.Value);


### PR DESCRIPTION
## Summary of changes

This PR add the test skipping and coverage enable tags at module level (requirement from UI) and avoid to send the global test code coverage tag if we are skipping tests due to ITR. (Because the coverage in this case has a misleading value).

## Reason for change

These changes were decided in the last ci visibility libraries meeting.

