### PR TITLE
Handle multiple empty `tracestate` headers in `W3CTraceContextPropagator`

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -741,6 +741,12 @@ namespace Datadog.Trace.Propagators
                     break;
             }
 
+            if (sb.Length == 0)
+            {
+                StringBuilderCache.GetStringAndRelease(sb);
+                return string.Empty;
+            }
+
             // remove trailing ","
             if (sb[sb.Length - 1] == TraceStateHeaderValuesSeparator)
             {


### PR DESCRIPTION
## Summary of changes

Fixes a bug that throws an exception when there are multiple, _empty_ `tracestate` headers in a request.

## Reason for change

Without the fix `W3CPropagator.Extract` throws an `IndexOutOfRangeException`

## Implementation details

Check the length of the `StringBuilder` before removing the final character (it has length 0 if there are multiple empty `tracestate` headers).

## Test coverage

Added repro tests. The multi-header versions all fail without the fix, and pass with it.
