### PR TITLE
Record the MVID of a loaded assembly in dependency telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/DependencyTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/DependencyTelemetryData.cs
@@ -19,5 +19,7 @@ namespace Datadog.Trace.Telemetry
         public string Name { get; set; }
 
         public string? Version { get; set; }
+
+        public string? Hash { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     {
                         new(name: "pg") { Version = "8.6.0" },
                         new(name: "express") { Version = "4.17.1" },
-                        new(name: "body-parser") { Version = "1.19.0" },
+                        new(name: "body-parser") { Version = "1.19.0", Hash = "646DF3C3-959F-4011-8673-EE58BD9291E2" },
                     },
                     configuration: new List<TelemetryValue>())
                     {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
@@ -46,7 +46,8 @@
       },
       {
         "name": "body-parser",
-        "version": "1.19.0"
+        "version": "1.19.0",
+        "hash": "646DF3C3-959F-4011-8673-EE58BD9291E2"
       }
     ],
     "configuration": [],


### PR DESCRIPTION
## Summary of changes

Adds the MVID of an assembly to the dependency version telemetry

## Reason for change

Multiple assemblies can have the same name+version combination, where one version is vulnerable, and another isn't.

## Implementation details

Send the `Assembly.ManifestModule.ModuleVersionId` for the dependency. There's always guaranteed to be exactly one manifest `Module` in the assembly, so solves the "multiple module" issue.

## Test coverage

Added tests that:
 - The MVID is added
 - MVID contributes towards "uniqueness" tracking of the dependency
 - It's serialized correctly to JSON
 - It's retrieved from the assembly correctly

## Other details
cc @anderruiz 
