### PR TITLE
[Profiler] Fix integration tests not running

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1822,20 +1822,20 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildProfilerLinuxIntegrationTests"
+        command: "BuildProfilerSamplesLinux"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - template: steps/run-in-docker.yml
       parameters:
         baseImage: $(baseImage)
-        command: "RunProfilerCpuLimitTests"
+        command: "BuildAndRunProfilerCpuLimitTests"
         extraArgs: "--cpus 2 --env CONTAINER_CPUS=1"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - template: steps/run-in-docker.yml
       parameters:
         baseImage: $(baseImage)
-        command: "RunProfilerCpuLimitTests"
+        command: "BuildAndRunProfilerCpuLimitTests"
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,7 +349,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-7.0.101}
     image: dd-trace-dotnet/${baseImage:-centos7}-tester
-    command: dotnet /build/bin/Debug/_build.dll RunProfilerLinuxIntegrationTests
+    command: dotnet /build/bin/Debug/_build.dll BuildAndRunProfilerLinuxIntegrationTests
     volumes:
       - ./:/project
     cap_add:


### PR DESCRIPTION
## Summary of changes

Fix the profiler linux integration tests job which was not running correctly since a while

## Reason for change

After a dotnet sdk upgrade in the [CI](https://github.com/DataDog/dd-trace-dotnet/pull/3633), profiler integration tests assembly was not recognized as a test library (probably a regression in the dotnet testing SDK) and the job was still running successfully. The library was run but not tests => successful job.

## Implementation details

Build and Run the integration test from the same target.

## Test coverage

The job itself.

## Other details
<!-- Fixes #{issue} -->
