### PR TITLE
Fix `otel.status_code`/`otel.library.name` from .NET Activity API

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -102,7 +102,12 @@ namespace Datadog.Trace.Activity
             // Add the library name and library version
             if (activity5 is not null)
             {
-                span.SetTag("otel.library.name", activity5.Source.Name);
+                // For .NET Activity .NET 5+ the Source.Name is only set via ActivitySource.StartActivity
+                // and not when an Activity object is created manually and having .Start() called on it
+                if (!string.IsNullOrEmpty(activity5.Source.Name))
+                {
+                    span.SetTag("otel.library.name", activity5.Source.Name);
+                }
 
                 if (!string.IsNullOrEmpty(activity5.Source.Version))
                 {

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -118,7 +118,28 @@ namespace Datadog.Trace.Activity
             // Set OTEL status code and OTEL status description
             if (span.GetTag("otel.status_code") is null)
             {
-                span.SetTag("otel.status_code", "STATUS_CODE_UNSET");
+                if (activity6 is not null)
+                {
+                    switch (activity6.Status)
+                    {
+                        case ActivityStatusCode.Unset:
+                            span.SetTag("otel.status_code", "STATUS_CODE_UNSET");
+                            break;
+                        case ActivityStatusCode.Ok:
+                            span.SetTag("otel.status_code", "STATUS_CODE_OK");
+                            break;
+                        case ActivityStatusCode.Error:
+                            span.SetTag("otel.status_code", "STATUS_CODE_ERROR");
+                            break;
+                        default:
+                            span.SetTag("otel.status_code", "STATUS_CODE_UNSET");
+                            break;
+                    }
+                }
+                else
+                {
+                    span.SetTag("otel.status_code", "STATUS_CODE_UNSET");
+                }
             }
 
             // Map the OTEL status to error tags

--- a/tracer/test/snapshots/TelemetryTests.verified.txt
+++ b/tracer/test/snapshots/TelemetryTests.verified.txt
@@ -53,7 +53,6 @@
       content: PONG,
       env: integration_tests,
       language: dotnet,
-      otel.library.name: ,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_2,
       runtime-id: Guid_1,


### PR DESCRIPTION
## Summary of changes

This adds/fixes certain information that is missing when using the `System.Diagnostics` `Activity` APIs.

## Reason for change

Expected content:

- Set `otel.status_code`
  - For later versions of the .NET Activity API this was moved to a `Status` enum so we check/set this now
- Omit `otel.library.name` when missing
  - If an `Activity` is created manually (e.g. `new Activity()` and then started via its `.Start()` function instead of through the `ActivitySource.StartActivity()` the `Source.Name` is empty. 

## Implementation details

## Test coverage

Will be in https://github.com/DataDog/dd-trace-dotnet/pull/3597, I've targeted that branch to be merged into this one.

## Other details

Had to update the snapshot for the `TelemetryTests`.

Testing these with https://github.com/DataDog/dd-trace-dotnet/pull/3597

There is an issue with how `ActivityContext` is handled in the `ActivitySource.StartActivity`. It doesn't appear to be correctly updating the ParentID within the created `Span` to match the supplied `ActivityContext`. This will be fixed in a different PR.
