### PR TITLE
[CI Visibility] - Improve test source start line for CI Visibility UI

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -136,9 +136,20 @@ public sealed class Test
     {
         if (MethodSymbolResolver.Instance.TryGetMethodSymbol(methodInfo, out var methodSymbol))
         {
+            var startLine = methodSymbol.StartLine;
+            // startline refers to the first instruction of method body.
+            // In order to improve the source code in the CI Visibility UI, we decrease
+            // this value by 2 so <bold>most of the time</bold> will show the missing
+            // `{` char and the method signature.
+            // There's no an easy way to extract the correct startline number.
+            if (startLine > 1)
+            {
+                startLine -= 2;
+            }
+
             var tags = (TestSpanTags)_scope.Span.Tags;
             tags.SourceFile = CIEnvironmentValues.Instance.MakeRelativePathFromSourceRoot(methodSymbol.File, false);
-            tags.SourceStart = methodSymbol.StartLine;
+            tags.SourceStart = startLine;
             tags.SourceEnd = methodSymbol.EndLine;
 
             if (CIEnvironmentValues.Instance.CodeOwners is { } codeOwners)


### PR DESCRIPTION
## Summary of changes

This PR improves the source code visibility in the CI Visibility UI.

## Reason for change

The current source code highlight doesn't include the signature and first `{` token of the test method:
<img width="409" alt="image" src="https://user-images.githubusercontent.com/69803/216671449-6de8de62-79cd-4130-8047-ad6b022e1086.png">

There's no an easy way to calculate the method signature line without involving some kind of AST, this is just a best effort approach improvements for the most common cases.

There's known cases were this fix doesn't work, like:
- Multiline method signature
- Methods with comments in the top part. (not included in the symbols).

