### PR TITLE
[Profiler] New scenario: Add endpoint with dots

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/EndpointsCountController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/EndpointsCountController.cs
@@ -1,0 +1,22 @@
+// <copyright file="EndpointsCountController.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BuggyBits.Controllers
+{
+    public class EndpointsCountController : Controller
+    {
+        [Route("End.Point.With.Dots")]
+        public async Task<IActionResult> Index()
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            return Redirect("/");
+        }
+    }
+}

--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/ReviewsController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/ReviewsController.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ReviewsController.cs" company="Datadog">
+// <copyright file="ReviewsController.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -23,7 +23,8 @@ namespace BuggyBits
         Async = 8,             // using async code
         FormatExceptions = 16, // generating FormatExceptions for prices
         ParallelLock = 32,     // using parallel code with lock
-        MemoryLeak = 64 // keep a controller in memory due to instance callback passed to a cache
+        MemoryLeak = 64, // keep a controller in memory due to instance callback passed to a cache
+        EndpointsCount = 128 // Specific test with '.' in endpoint name
     }
 
     public class Program

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -136,7 +136,7 @@ namespace BuggyBits
 
                 if ((_scenario & Scenario.EndpointsCount) == Scenario.EndpointsCount)
                 {
-                    urls.Add($"{rootUrl}/End.Point.With.Dots.js");
+                    urls.Add($"{rootUrl}/End.Point.With.Dots");
                 }
             }
 

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -133,6 +133,11 @@ namespace BuggyBits
                 {
                     urls.Add($"{rootUrl}/News");
                 }
+
+                if ((_scenario & Scenario.EndpointsCount) == Scenario.EndpointsCount)
+                {
+                    urls.Add($"{rootUrl}/End.Point.With.Dots.js");
+                }
             }
 
             return urls;


### PR DESCRIPTION
## Summary of changes

Add a new scenario with '.' in the endpoint name.

## Reason for change

The profiling faced an issue recently with endpoints containing '.'. This test will continuously run in the `prof-dotnet` app and the data will be checked by the profiling backend.

## Implementation details

Add a new controller with an endpoint with '.' inside.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
