### PR TITLE
first commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,10 @@ variables:
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
-    
+
+include:
+  remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
+
 build:
   only:
     - master
@@ -89,3 +92,13 @@ deploy_to_reliability_env:
     UPSTREAM_PACKAGE_JOB: build
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     FORCE_TRIGGER: $DEPLOY_TO_REL_ENV
+
+tracer-base-image:
+  extends: .ci_authenticated_job
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "robertomonteromiguel/docker_base_image_poc"'
+      when: always
+    - when: manual
+  stage: deploy
+  script:
+    - echo "Hello "


### PR DESCRIPTION
## Summary of changes

For internal tooling needs (e.g. System Tests), and for having consistent and reliable experience fetching the tracer artifacts. We can leverage a simplified approach of [OCI Artifacts](https://github.com/opencontainers/artifacts) to store the final build artifacts (e.g. dd-java-agent.jar) in GitHub Container Registry.

This PR creates a docker base image with:

Tag latest snapshot with php tracer and php appsec tracer
Tag latest release with php tracer and php appsec tracer
see also: https://docs.google.com/document/d/1HbMGgZFRnIYjfnXGJGyk0LCwWs2op12R0BE58wma448/edit#

The build process will be launched in each commit on main branch.
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
