### PR TITLE
[Profiler] Reduce memory allocation of the profiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -99,8 +99,10 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
         return false;
     }
 
-    // TODO: can we cache sysconf(_SC_CLK_TCK)? Can this value change while the app is running ?
-    cpuTime = ((userTime + kernelTime) * 1000) / sysconf(_SC_CLK_TCK);
+    // it's safe to cache it. According to the man sysconf, this value does
+    // not change during the lifetime of the process.
+    static auto ticks_per_second = sysconf(_SC_CLK_TCK);
+    cpuTime = ((userTime + kernelTime) * 1000) / ticks_per_second;
     isRunning = (state == 'R') || (state == 'D') || (state == 'W');
     return true;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -60,7 +60,7 @@ std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
 
 bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
 {
-    char statPath[64] = {'\0'};
+    char statPath[64] = {0};
     snprintf(statPath, sizeof(statPath), "/proc/self/task/%d/stat", tid);
 
     auto fd = open(statPath, O_RDONLY);
@@ -99,6 +99,7 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
         return false;
     }
 
+    // TODO: can we cache sysconf(_SC_CLK_TCK)? Can this value change while the app is running ?
     cpuTime = ((userTime + kernelTime) * 1000) / sysconf(_SC_CLK_TCK);
     isRunning = (state == 'R') || (state == 'D') || (state == 'W');
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -79,17 +79,17 @@ public:
                 break;
 
             currentIdx++;
-            if (3 == currentIdx)
+            if (currentIdx == 3)
             {
                 state = *pos;
                 nbElement++;
             }
-            else if (14 == currentIdx)
+            else if (currentIdx == 14)
             {
                 userTime = atoi(pos);
                 nbElement++;
             }
-            else if (15 == currentIdx)
+            else if (currentIdx == 15)
             {
                 kernelTime = atoi(pos);
                 nbElement++;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -58,12 +58,44 @@ public:
 
         // The thread name is in second position and wrapped by ()
         // Since the name can contain SPACE and () characters, skip it before scanning the values
-        auto pos = strrchr(line, ')');
-        pos++;
-        if (*pos == '\0')
+        auto* pos = strrchr(line, ')');
+
+        // paranoia
+        if (pos == nullptr)
             return false;
 
-        return sscanf(pos, " %c %*s %*s %*s %*s %*s %*s %*s %*s %*s %*s %d %d", &state, &userTime, &kernelTime) == 3;
+        int currentIdx = 2; // because we are currently at the thread name offset which is 2
+        int nbElement = 0;
+        while (nbElement != 3)
+        {
+            pos = strchr(pos, ' ');
+            if (pos == nullptr)
+                break;
+
+            // skip whitespaces
+            pos = pos + strspn(pos, " ");
+
+            if (*pos == '\0')
+                break;
+
+            currentIdx++;
+            if (3 == currentIdx)
+            {
+                state = *pos;
+                nbElement++;
+            }
+            else if (14 == currentIdx)
+            {
+                userTime = atoi(pos);
+                nbElement++;
+            }
+            else if (15 == currentIdx)
+            {
+                kernelTime = atoi(pos);
+                nbElement++;
+            }
+        }
+        return nbElement == 3;
     }
 #endif
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
@@ -1,11 +1,14 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
+#ifdef LINUX
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-
 #include "OpSysTools.h"
+
+#include "shared/src/native-src/dd_filesystem.hpp"
 
 // based on https://linux.die.net/man/5/proc
 // -------------------------------------------
@@ -16,7 +19,7 @@
 
 TEST(GetThreadInfoTest, Check_EmptyThreadName)
 {
-    std::string line = "377 () R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    auto const* line = "377 () R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
     char state = ' ';
     int userTime = 0;
     int kernelTime = 0;
@@ -31,7 +34,7 @@ TEST(GetThreadInfoTest, Check_EmptyThreadName)
 
 TEST(GetThreadInfoTest, Check_NoSpaceThreadName)
 {
-    std::string line = "377 (ThreadNameWithoutSpace) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    auto const* line = "377 (ThreadNameWithoutSpace) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
     char state = ' ';
     int userTime = 0;
     int kernelTime = 0;
@@ -46,7 +49,7 @@ TEST(GetThreadInfoTest, Check_NoSpaceThreadName)
 
 TEST(GetThreadInfoTest, Check_SpaceInThreadName)
 {
-    std::string line = "377 (Thread Name With Space) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    auto const* line = "377 (Thread Name With Space) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
     char state = ' ';
     int userTime = 0;
     int kernelTime = 0;
@@ -61,7 +64,7 @@ TEST(GetThreadInfoTest, Check_SpaceInThreadName)
 
 TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName)
 {
-    std::string line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    auto const* line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
     char state = ' ';
     int userTime = 0;
     int kernelTime = 0;
@@ -76,7 +79,7 @@ TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName)
 
 TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName_And_FinalParenthesis)
 {
-    std::string line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20)";
+    auto const* line = "377 (la (la) )) land) )) R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20)";
     char state = ' ';
     int userTime = 0;
     int kernelTime = 0;
@@ -88,3 +91,5 @@ TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName_And_FinalParenthes
     ASSERT_EQ(0, userTime);
     ASSERT_EQ(0, kernelTime);
 }
+
+#endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/OpSysToolsTest.cpp
@@ -92,4 +92,76 @@ TEST(GetThreadInfoTest, Check_SpaceAndParenthesisInThreadName_And_FinalParenthes
     ASSERT_EQ(0, kernelTime);
 }
 
+TEST(GetThreadInfoTest, Check_MalformedString1)
+{
+    auto const* line = "377 (dotnet)";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);;
+}
+
+TEST(GetThreadInfoTest, Check_MalformedString_NoParen_Around_ThreadName)
+{
+    auto const* line = "377 dotnet R 46 369 46 34817 369 4194368 95 0 0 0 1862 609 0 0 20 ";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+}
+
+TEST(GetThreadInfoTest, Check_EmptyString)
+{
+    auto const* line = "";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+}
+
+TEST(GetThreadInfoTest, Check_Missing_User_KernelTime)
+{
+    auto const* line = "377 (dotnet) R";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+}
+
+TEST(GetThreadInfoTest, Check_Missing_User_KernelTime2)
+{
+    auto const* line = "377 (dotnet) R 46 369 46 34817";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+}
+
+TEST(GetThreadInfoTest, Check_Missing_KernelTime)
+{
+    auto const* line = "377 (dotnet) R 46 369 46 34817 369 4194368 95 0 0 0 1862";
+    char state = ' ';
+    int userTime = 0;
+    int kernelTime = 0;
+
+    bool result = OpSysTools::ParseThreadInfo(line, state, userTime, kernelTime);
+
+    ASSERT_FALSE(result);
+}
+
 #endif


### PR DESCRIPTION
## Summary of changes

Reduce profiler memory footprint.

## Reason for change

The profiler was recently profiled by the [native profiler](https://github.com/DataDog/ddprof/). We discovered that `std::ifstream` each time it opens a file, allocates a buffer 8K. In our test, using `std::ifstream` on a hot path (CPU profiler on linux to read the thread stat file `/proc/<pid>/task/<tid>/stat`), this accounts for ~50% of the memory allocated (over the minute).

## Implementation details

Do no use `std::ifstream`, prefer the C way to read and parse `stat` file.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
