### PR TITLE
[Dynamic Instrumentation] Support duration in debugger DSL

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/CompiledExpression.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/CompiledExpression.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Debugger.Expressions
     internal readonly record struct CompiledExpression<T>
     {
         internal CompiledExpression(
-            Func<ScopeMember, ScopeMember, Exception, ScopeMember[], T> @delegate,
+            Func<ScopeMember, ScopeMember, ScopeMember, Exception, ScopeMember[], T> @delegate,
             Expression parsedExpression,
             string rawExpression,
             EvaluationError[] errors)
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Debugger.Expressions
             Errors = errors;
         }
 
-        internal Func<ScopeMember, ScopeMember, Exception, ScopeMember[], T> Delegate { get; }
+        internal Func<ScopeMember, ScopeMember, ScopeMember, Exception, ScopeMember[], T> Delegate { get; }
 
         internal Expression ParsedExpression { get; }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/MethodScopeMembers.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/MethodScopeMembers.cs
@@ -38,6 +38,8 @@ internal class MethodScopeMembers
 
     internal ScopeMember InvocationTarget { get; set; }
 
+    internal ScopeMember Duration { get; set; }
+
     internal void AddMember(ScopeMember member)
     {
         Members[_index] = member;

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionEvaluator.cs
@@ -96,7 +96,7 @@ internal class ProbeExpressionEvaluator
                     }
                     else if (IsExpression(Templates[i]))
                     {
-                        resultBuilder.Append(compiledExpressions[i].Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Exception, scopeMembers.Members));
+                        resultBuilder.Append(compiledExpressions[i].Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Duration, scopeMembers.Exception, scopeMembers.Members));
                         if (compiledExpressions[i].Errors != null)
                         {
                             (result.Errors ??= new List<EvaluationError>()).AddRange(compiledExpressions[i].Errors);
@@ -135,7 +135,7 @@ internal class ProbeExpressionEvaluator
             }
 
             compiledExpression = _compiledCondition.Value.Value;
-            var condition = compiledExpression.Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Exception, scopeMembers.Members);
+            var condition = compiledExpression.Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Duration, scopeMembers.Exception, scopeMembers.Members);
             result.Condition = condition;
             if (compiledExpression.Errors != null)
             {
@@ -162,7 +162,7 @@ internal class ProbeExpressionEvaluator
             }
 
             compiledExpression = _compiledMetric.Value.Value;
-            var metric = compiledExpression.Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Exception, scopeMembers.Members);
+            var metric = compiledExpression.Delegate(scopeMembers.InvocationTarget, scopeMembers.Return, scopeMembers.Duration, scopeMembers.Exception, scopeMembers.Members);
             result.Metric = metric;
             if (compiledExpression.Errors != null)
             {

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -59,6 +59,8 @@ internal partial class ProbeExpressionParser<T>
                 return ReturnDefaultValueExpression();
             }
 
+            HandleDurationBinaryOperation(ref left, ref right);
+
             switch (operand)
             {
                 case ">":
@@ -81,6 +83,19 @@ internal partial class ProbeExpressionParser<T>
         {
             AddError($"{left?.ToString() ?? "N/A"} {operand} {right?.ToString() ?? "N/A"}", e.Message);
             return ReturnDefaultValueExpression();
+        }
+    }
+
+    private void HandleDurationBinaryOperation(ref Expression left, ref Expression right)
+    {
+        if (left is ParameterExpression { Name: Duration } && IsIntegralNumericType(right.Type))
+        {
+            right = CallTimeSpanConstructor(right);
+        }
+
+        if (right is ParameterExpression { Name: Duration } && IsIntegralNumericType(right.Type))
+        {
+            left = CallTimeSpanConstructor(left);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -530,11 +530,6 @@ internal partial class ProbeExpressionParser<T>
     private ParameterExpression AddParameterAndVariable(ScopeMember scopeMember, Type type, string name, List<Expression> expressions, List<ParameterExpression> scopeMembers)
     {
         var parameterExpression = Expression.Parameter(scopeMember.GetType());
-        if (type == null)
-        {
-            return parameterExpression;
-        }
-
         var variable = Expression.Variable(type, name);
         expressions.Add(Expression.Assign(variable, Expression.Convert(Expression.Field(parameterExpression, "Value"), type)));
         scopeMembers.Add(variable);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -530,6 +530,11 @@ internal partial class ProbeExpressionParser<T>
     private ParameterExpression AddParameterAndVariable(ScopeMember scopeMember, Type type, string name, List<Expression> expressions, List<ParameterExpression> scopeMembers)
     {
         var parameterExpression = Expression.Parameter(scopeMember.GetType());
+        if (type == null)
+        {
+            return parameterExpression;
+        }
+
         var variable = Expression.Variable(type, name);
         expressions.Add(Expression.Assign(variable, Expression.Convert(Expression.Field(parameterExpression, "Value"), type)));
         scopeMembers.Add(variable);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParserHelper.cs
@@ -61,12 +61,14 @@ internal static class ProbeExpressionParserHelper
             Expression body,
             ParameterExpression thisParameterExpression,
             ParameterExpression returnParameterExpression,
+            ParameterExpression durationParameterExpression,
             ParameterExpression exceptionParameterExpression,
             ParameterExpression argsOrLocalsParameterExpression)
         {
             ExpressionBody = body;
             ThisParameterExpression = thisParameterExpression;
             ReturnParameterExpression = returnParameterExpression;
+            DurationParameterExpression = durationParameterExpression;
             ExceptionParameterExpression = exceptionParameterExpression;
             ArgsAndLocalsParameterExpression = argsOrLocalsParameterExpression;
         }
@@ -76,6 +78,8 @@ internal static class ProbeExpressionParserHelper
         internal ParameterExpression ThisParameterExpression { get; }
 
         internal ParameterExpression ReturnParameterExpression { get; }
+
+        internal ParameterExpression DurationParameterExpression { get; }
 
         internal ParameterExpression ExceptionParameterExpression { get; }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -224,8 +224,12 @@ namespace Datadog.Trace.Debugger.Expressions
             shouldStopCapture = false;
             try
             {
-                // we always taking the duration at the evaluation time - this might be different from what we have in the snapshot
-                snapshotCreator.SetDuration();
+                if (ProbeInfo.ProbeType == ProbeType.Metric)
+                {
+                    // we always taking the duration at the evaluation time - this might be different from what we have in the snapshot
+                    snapshotCreator.SetDuration();
+                }
+
                 evaluationResult = GetOrCreateEvaluator().Evaluate(snapshotCreator.MethodScopeMembers);
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -224,9 +224,9 @@ namespace Datadog.Trace.Debugger.Expressions
             shouldStopCapture = false;
             try
             {
-                if (ProbeInfo.ProbeType == ProbeType.Metric)
+                if (ProbeInfo.ProbeType != ProbeType.Metric)
                 {
-                    // we always taking the duration at the evaluation time - this might be different from what we have in the snapshot
+                    // we taking the duration at the evaluation time - this might be different from what we have in the snapshot
                     snapshotCreator.SetDuration();
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -224,6 +224,8 @@ namespace Datadog.Trace.Debugger.Expressions
             shouldStopCapture = false;
             try
             {
+                // we always taking the duration at the evaluation time - this might be different from what we have in the snapshot
+                snapshotCreator.SetDuration();
                 evaluationResult = GetOrCreateEvaluator().Evaluate(snapshotCreator.MethodScopeMembers);
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ScopeMember.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ScopeMember.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.Debugger.Expressions
         This,
         Return,
         Exception,
+        Duration,
         None
     }
 

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -190,6 +190,12 @@ namespace Datadog.Trace.Debugger.Snapshots
             MethodScopeMembers.AddMember(new ScopeMember(name, type, value, memberKind));
         }
 
+        internal void SetDuration()
+        {
+            var duration = DateTimeOffset.UtcNow - _startTime;
+            MethodScopeMembers.Duration = new ScopeMember("duration", duration.GetType(), duration, ScopeMemberKind.Duration);
+        }
+
         internal void Initialize()
         {
             _jsonWriter.WriteStartObject();

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThenDuration.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThenDuration.verified.txt
@@ -1,0 +1,63 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "return": {
+            "arguments": {
+              "intArg": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "this": {
+                "type": "GreaterThenDuration",
+                "value": "GreaterThenDuration"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "String",
+                "value": "Arg is: 3"
+              }
+            },
+            "staticFields": {
+              "Dsl": {
+                "type": "String",
+                "value": "{\r\n  \"dsl\": \"ref @duration > 0\"\r\n}"
+              },
+              "Json": {
+                "type": "String",
+                "value": "{\r\n    \"gt\": [\r\n      {\"ref\": \"@duration\"},\r\n      0\r\n    ]\r\n}"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThenDuration"
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.GreaterThenDuration",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
@@ -1,0 +1,89 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "seed": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "this": {
+                "type": "TemplateWithDurationAtEntry",
+                "value": "TemplateWithDurationAtEntry"
+              }
+            },
+            "staticFields": {
+              "Dsl": {
+                "type": "String",
+                "value": "{\r\n  \"dsl\": \"Result is {ref @duration}\"\r\n}"
+              },
+              "Json": {
+                "type": "String",
+                "value": "{\r\n        \"ref\": \"@duration\"\r\n}"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "seed": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "this": {
+                "type": "TemplateWithDurationAtEntry",
+                "value": "TemplateWithDurationAtEntry"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "i": {
+                "type": "Int32",
+                "value": "6"
+              }
+            },
+            "staticFields": {
+              "Dsl": {
+                "type": "String",
+                "value": "{\r\n  \"dsl\": \"Result is {ref @duration}\"\r\n}"
+              },
+              "Json": {
+                "type": "String",
+                "value": "{\r\n        \"ref\": \"@duration\"\r\n}"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateWithDurationAtEntry"
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.ExpressionTests.TemplateWithDurationAtEntry",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GreaterThenDuration.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.GreaterThenDuration.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TemplateWithDurationAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TemplateWithDurationAtEntry.verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
@@ -13,11 +13,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
@@ -12,11 +12,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
@@ -13,11 +13,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
@@ -13,11 +13,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;
@@ -37,4 +39,4 @@ Expressions:
 }
 Result: The result of the expression is: 
 Errors:
-EvaluationError { Expression = Convert(CollectionLocal.get_Item(100), String)), Message = Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index') }
+EvaluationError { Expression = Convert(CollectionLocal.get_Item(100))), Message = Index was out of range. Must be non-negative and less than the size of the collection. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
@@ -2,12 +2,7 @@
 Segments: 
 
 {
-    "index": [
-        {
-            "ref": "DictionaryLocal"
-        },
-        "hello"
-    ]
+    "ref": "@duration"
 }
 Expressions: 
 (
@@ -33,8 +28,8 @@ Expressions:
     var StringArg = (string)scopeMemberArray[9].Value;
     var CollectionArg = (List<string>)scopeMemberArray[10].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
-    var $dd_el_result = (string)DictionaryLocal["hello"];
+    var $dd_el_result = @duration.ToString();
 
     return $dd_el_result;
 }
-Result: The result of the expression is: world
+Result: The result of the expression is: 00:00:00.0200000

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
@@ -11,6 +11,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
@@ -17,6 +17,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
@@ -14,6 +14,7 @@ Expressions:
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
@@ -8,6 +8,7 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
@@ -31,6 +31,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
@@ -25,6 +25,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
@@ -11,6 +11,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
@@ -17,6 +17,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
@@ -15,6 +15,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
@@ -21,6 +21,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
@@ -11,6 +11,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
@@ -17,6 +17,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
@@ -11,6 +11,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
@@ -17,6 +17,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
@@ -24,6 +24,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
@@ -18,6 +18,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
@@ -22,6 +22,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
@@ -16,6 +16,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
@@ -10,6 +10,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
@@ -17,6 +17,7 @@ Expression: (
     bool $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
@@ -11,12 +11,14 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     string $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
@@ -10,12 +10,14 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     string $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
@@ -37,6 +37,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
@@ -31,6 +31,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
@@ -66,6 +66,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
@@ -60,6 +60,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
@@ -37,6 +37,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
@@ -31,6 +31,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -20,6 +20,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -26,6 +26,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
@@ -22,6 +22,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
@@ -16,6 +16,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -21,6 +21,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -27,6 +27,7 @@ Expression: (
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
@@ -8,11 +8,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
@@ -8,11 +8,13 @@ Expressions:
 (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
@@ -20,6 +20,7 @@ Expression: (
     bool $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
     var @exception = exception;
     var IntLocal = (int)scopeMemberArray[0].Value;
     var DoubleLocal = (double)scopeMemberArray[1].Value;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
@@ -13,6 +13,7 @@ Json:
 Expression: (
     scopeMember,
     scopeMember,
+    scopeMember,
     exception,
     scopeMemberArray) =>
 {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/Duration.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/Duration.json
@@ -1,0 +1,4 @@
+{
+    "dsl": "{@duration}",
+    "ref": "@duration"
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/GreaterThenDuration.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/GreaterThenDuration.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class GreaterThenDuration : IRun
+    {
+        private const string Dsl = @"{
+  ""dsl"": ""ref @duration > 0""
+}";
+
+        private const string Json = @"{
+    ""gt"": [
+      {""ref"": ""@duration""},
+      0
+    ]
+}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodProbeTestData(
+            conditionDsl: Dsl,
+            conditionJson: Json,
+            captureSnapshot: true,
+            evaluateAt: 1,
+            returnTypeName: "System.String",
+            parametersTypeName: new[] { "System.Int32" })]
+        public string Method(int intArg)
+        {
+            Console.WriteLine(intArg);
+            return $"Arg is: {intArg}";
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateWithDurationAtEntry.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateWithDurationAtEntry.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Samples.Probes.TestRuns.ExpressionTests
+{
+    public class TemplateWithDurationAtEntry : IRun
+    {
+        private const string Dsl = @"{
+  ""dsl"": ""Result is {ref @duration}""
+}";
+
+        private const string Json = @"{
+        ""ref"": ""@duration""
+}";
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            Method(3);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodProbeTestData(
+            templateDsl: Dsl,
+            templateJson: Json,
+            templateStr: "Result is: ",
+            captureSnapshot: true,
+            evaluateAt: 0,
+            returnTypeName: "System.Int32",
+            parametersTypeName: new[] { "System.Int32" })]
+        public int Method(int seed)
+        {
+            int i = 5;
+            Console.Write(seed + i);
+            i++;
+            Console.Write(seed + i);
+            return seed + i;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Support @duration in debugger DSL

## Reason for change
To be aligned with our internal DSL RFC

## Implementation details

## Test coverage
TemplateWithDuration
ConditionWithDuration
