### PR TITLE
[Profiler] Improve .NET exception profiler

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -9,6 +9,7 @@
 #include "IConfiguration.h"
 #include "Log.h"
 #include "OsSpecificApi.h"
+#include "ScopeFinalizer.h"
 #include "shared/src/native-src/com_ptr.h"
 #include "shared/src/native-src/string.h"
 
@@ -231,6 +232,10 @@ bool ExceptionsProvider::LoadExceptionMetadata()
         if (fields[i].ridOfField == messageFieldDef)
         {
             _messageFieldOffset = fields[i];
+            // Set the _exceptionClassId field to notify that we found
+            // the message field offset.
+            // So we do not enter this method anymore
+            _exceptionClassId = exceptionClassId;
             return true;
         }
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GroupSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GroupSampler.h
@@ -26,7 +26,7 @@ public:
     {
         std::unique_lock lock(_knownGroupsMutex);
 
-        auto [it, inserted] = _knownGroups.insert(group);
+        auto [it, inserted] = _knownGroups.insert(std::move(group));
         if (inserted)
         {
             // This is the first time we see this group in this time window,


### PR DESCRIPTION
## Summary of changes

Improve .NET exception profiler performance.

## Reason for change

Too slow. In my test, without the fix, ~8% of the CPU is spent in `LoadExceptionMetadata`. With this fix, we reduce it to a few percent for the first calls. Once initialized correctly, `LoadExceptionMetadata` does not show up anymore.


## Implementation details

`LoadMetadataException` was called at each exception and this incurred a significant performance hit. This method was meant to be called a few times (at the beginning) but not all the time.
The call is guarded by a check to the `_exceptionClassId` to notify that we have the offset of the message field. But this field was never set.

## Test coverage

The current tests we have
## Other details
<!-- Fixes #{issue} -->
