### PR TITLE
[Profiler] Fix CppCheck version when installing

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1189,7 +1189,7 @@ stages:
     
     steps:
     - powershell: |
-        choco install cppcheck -y
+        choco install cppcheck -y --version 2.9
         Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\Program Files\Cppcheck";
         refreshenv
       displayName: Install CppCheck

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -895,7 +895,7 @@ jobs:
       - name: Install CppCheck
         shell: pwsh
         run: |
-          choco install cppcheck -y
+          choco install cppcheck -y --version 2.9
           refreshenv
           echo "C:\Program Files\Cppcheck" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
       


### PR DESCRIPTION
## Summary of changes

Install CppCheck 2.9 to avoid job failure.

## Reason for change

CppCheck was upgraded to 2.10 but this version fails on with an internal error when parsing `0ns` line.
Until it's fixed, we will use the 2.9 version.

## Implementation details

Fix Cppcheck version to 2.9

## Test coverage

## Other details
<!-- Fixes #{issue} -->
