### PR TITLE
[AAS]Bail out from starting processes if API_KEY isn't present

### DIFF
--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -66,6 +66,11 @@ namespace Datadog.Trace
                 }
 
                 var azureAppServiceSettings = new ImmutableAzureAppServiceSettings(GlobalConfigurationSource.Instance);
+                if (azureAppServiceSettings.IsUnsafeToTrace)
+                {
+                    Log.Error("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is certainly missing. The trace_agent and dogstatsd process will not be started. Add the API key in the app configuration and restart it.");
+                    return;
+                }
 
                 var automaticTraceEnabled = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.TraceEnabled, string.Empty)?.ToBoolean() ?? true;
                 var automaticProfilingEnabled = EnvironmentHelpers.GetEnvironmentVariable(ContinuousProfiler.ConfigurationKeys.ProfilingEnabled)?.ToBoolean() ?? false;
@@ -344,7 +349,7 @@ namespace Datadog.Trace
                         return true;
                     }
 
-                    Log.Debug("Program [{Process}] is no longer running", ProcessPath);
+                    Log.Information("Program [{Process}] is no longer running", ProcessPath);
 
                     return false;
                 }
@@ -365,7 +370,14 @@ namespace Datadog.Trace
 
             private bool NamedPipeIsBound()
             {
-                return File.Exists($"\\\\.\\pipe\\{PipeName}");
+                var namedPipe = $"\\\\.\\pipe\\{PipeName}";
+                var namedPipeIsBound = File.Exists(namedPipe);
+                if (namedPipeIsBound)
+                {
+                    Log.Debug("NamedPipe  [{namedPipe}] is not present.", namedPipe);
+                }
+
+                return namedPipeIsBound;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace
                 var azureAppServiceSettings = new ImmutableAzureAppServiceSettings(GlobalConfigurationSource.Instance);
                 if (azureAppServiceSettings.IsUnsafeToTrace)
                 {
-                    Log.Error("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is certainly missing. The trace_agent and dogstatsd process will not be started. Add the API key in the app configuration and restart it.");
+                    Log.Error("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is likely missing. The trace_agent and dogstatsd process will not be started. Check your app configuration and restart the app service to try again.");
                     return;
                 }
 
@@ -372,7 +372,7 @@ namespace Datadog.Trace
             {
                 var namedPipe = $"\\\\.\\pipe\\{PipeName}";
                 var namedPipeIsBound = File.Exists(namedPipe);
-                if (namedPipeIsBound)
+                if (!namedPipeIsBound)
                 {
                     Log.Debug("NamedPipe  [{namedPipe}] is not present.", namedPipe);
                 }


### PR DESCRIPTION
## Summary of changes

If the API_KEY isn't present, we still try to start the trace_agent and dogstatsd which do not make sense. If they were to die because of that, we would in addition be entering in an infinite loop of restarts. 

## Reason for change

Saw this while investigating an escalation. While I'm not sure yet it's the root cause, I think this sould be changed either way. 

## Implementation details

Just add a quick check before starting processes

## Test coverage

## Other details
<!-- Fixes #{issue} -->
