### PR TITLE
[CI Visibility] - Extract traits recursively in NUnit

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
@@ -50,9 +50,9 @@ namespace Datadog.Trace.Ci.Agent
      *         │                         │ └──────────────────────────────┬─┘   │
      *         │                         │                                │     │
      *         │                         └────────────────────────────────┘     │
-     *         │                                   2 .. N Consumers             │
+     *         │                                   1 .. N Consumers             │
      *         │                                                                │
-     *         │                                      Max N = 6                 │
+     *         │                                      Max N = 4                 │
      *         │                                                                │
      *         └────────────────────────────────────────────────────────────────┘
      */
@@ -78,9 +78,9 @@ namespace Datadog.Trace.Ci.Agent
             _eventQueue = new BlockingCollection<IEvent>(maxItemsInQueue);
             _batchInterval = batchInterval;
 
-            // Concurrency Level is a simple algorithm where we select a number between 2 and 6 depending on the number of Logical Processor Count
+            // Concurrency Level is a simple algorithm where we select a number between 1 and 4 depending on the number of Logical Processor Count
             // To scale the number of senders with a hard limit.
-            var concurrencyLevel = concurrency ?? Math.Min(Math.Max(Environment.ProcessorCount / 2, 2), 6);
+            var concurrencyLevel = concurrency ?? Math.Min(Math.Max(Environment.ProcessorCount / 2, 1), 4);
             _buffersArray = new Buffers[concurrencyLevel];
             for (var i = 0; i < _buffersArray.Length; i++)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -87,9 +87,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             {
                 skipReason = (string)testMethodProperties.Get(SkipReasonKey);
 
-                var traits = new Dictionary<string, List<string>>();
-                ExtractTraits(currentTest, traits);
-                if (traits.Count > 0)
+                Dictionary<string, List<string>>? traits = null;
+                ExtractTraits(currentTest, ref traits);
+                if (traits?.Count > 0)
                 {
                     test.SetTraits(traits);
                 }
@@ -112,7 +112,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             return test;
         }
 
-        private static void ExtractTraits(ITest currentTest, Dictionary<string, List<string>> traits)
+        private static void ExtractTraits(ITest currentTest, ref Dictionary<string, List<string>>? traits)
         {
             if (currentTest.Instance is null)
             {
@@ -121,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
             if (currentTest.Parent is { Instance: { } })
             {
-                ExtractTraits(currentTest.Parent, traits);
+                ExtractTraits(currentTest.Parent, ref traits);
             }
 
             if (currentTest.Properties is { Keys: { Count: > 0 } } properties)
@@ -136,6 +136,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                     var value = properties[key];
                     if (value is not null)
                     {
+                        traits ??= new();
                         if (!traits.TryGetValue(key, out var lstValues))
                         {
                             lstValues = new List<string>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -85,33 +85,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             // Get traits
             if (testMethodProperties != null)
             {
-                var traits = new Dictionary<string, List<string>>();
                 skipReason = (string)testMethodProperties.Get(SkipReasonKey);
-                foreach (var key in testMethodProperties.Keys)
-                {
-                    if (key == SkipReasonKey || key == "_JOINTYPE")
-                    {
-                        continue;
-                    }
 
-                    var value = testMethodProperties[key];
-                    if (value != null)
-                    {
-                        var lstValues = new List<string>();
-                        foreach (var valObj in value)
-                        {
-                            if (valObj is null)
-                            {
-                                continue;
-                            }
-
-                            lstValues.Add(valObj.ToString() ?? string.Empty);
-                        }
-
-                        traits[key] = lstValues;
-                    }
-                }
-
+                var traits = new Dictionary<string, List<string>>();
+                ExtractTraits(currentTest, traits);
                 if (traits.Count > 0)
                 {
                     test.SetTraits(traits);
@@ -133,6 +110,50 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
             test.ResetStartTime();
             return test;
+        }
+
+        private static void ExtractTraits(ITest currentTest, Dictionary<string, List<string>> traits)
+        {
+            if (currentTest.Instance is null)
+            {
+                return;
+            }
+
+            if (currentTest.Parent is { Instance: { } })
+            {
+                ExtractTraits(currentTest.Parent, traits);
+            }
+
+            if (currentTest.Properties is { Keys: { Count: > 0 } } properties)
+            {
+                foreach (var key in properties.Keys)
+                {
+                    if (key is SkipReasonKey or "_APPDOMAIN" or "_JOINTYPE" or "_PID" or "_PROVIDERSTACKTRACE")
+                    {
+                        continue;
+                    }
+
+                    var value = properties[key];
+                    if (value is not null)
+                    {
+                        if (!traits.TryGetValue(key, out var lstValues))
+                        {
+                            lstValues = new List<string>();
+                            traits[key] = lstValues;
+                        }
+
+                        foreach (var valObj in value)
+                        {
+                            if (valObj is null)
+                            {
+                                continue;
+                            }
+
+                            lstValues.Add(valObj.ToString() ?? string.Empty);
+                        }
+                    }
+                }
+            }
         }
 
         internal static void FinishTest(Test test, Exception? ex)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -246,6 +246,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                                 case "SimpleParameterizedTest":
                                     CheckSimpleTestSpan(targetTest);
+                                    CheckParametrizedTraitsValues(targetTest);
                                     AssertTargetSpanAnyOf(
                                         targetTest,
                                         TestTags.Parameters,
@@ -404,6 +405,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the traits tag value
             AssertTargetSpanEqual(targetTest, TestTags.Traits, "{\"Category\":[\"Category01\"],\"Compatibility\":[\"Windows\",\"Linux\"]}");
+        }
+
+        private static void CheckParametrizedTraitsValues(MockCIVisibilityTest targetTest)
+        {
+            // Check the traits tag value
+            AssertTargetSpanAnyOf(
+                targetTest,
+                TestTags.Traits,
+                "{\"Category\":[\"ParemeterizedTest\",\"FirstCase\"]}",
+                "{\"Category\":[\"ParemeterizedTest\",\"SecondCase\"]}",
+                "{\"Category\":[\"ParemeterizedTest\",\"ThirdCase\"]}");
         }
 
         private static void CheckOriginTag(MockCIVisibilityTest targetTest)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -168,6 +168,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                                 case "SimpleParameterizedTest":
                                     CheckSimpleTestSpan(targetSpan);
+                                    CheckParametrizedTraitsValues(targetSpan);
                                     AssertTargetSpanAnyOf(
                                         targetSpan,
                                         TestTags.Parameters,
@@ -349,6 +350,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the traits tag value
             AssertTargetSpanEqual(targetSpan, TestTags.Traits, "{\"Category\":[\"Category01\"],\"Compatibility\":[\"Windows\",\"Linux\"]}");
+        }
+
+        private static void CheckParametrizedTraitsValues(MockSpan targetTest)
+        {
+            // Check the traits tag value
+            AssertTargetSpanAnyOf(
+                targetTest,
+                TestTags.Traits,
+                "{\"Category\":[\"ParemeterizedTest\",\"FirstCase\"]}",
+                "{\"Category\":[\"ParemeterizedTest\",\"SecondCase\"]}",
+                "{\"Category\":[\"ParemeterizedTest\",\"ThirdCase\"]}");
         }
 
         private static void CheckOriginTag(MockSpan targetSpan)

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -71,9 +71,10 @@ namespace Samples.NUnitTests
         // **********************************************************************************
 
         [Theory]
-        [TestCase(1, 1, 2)]
-        [TestCase(2, 2, 4)]
-        [TestCase(3, 3, 6)]
+        [Category("ParemeterizedTest")]
+        [TestCase(1, 1, 2, Category = "FirstCase")]
+        [TestCase(2, 2, 4, Category = "SecondCase")]
+        [TestCase(3, 3, 6, Category = "ThirdCase")]
         public void SimpleParameterizedTest(int xValue, int yValue, int expectedResult)
         {
             Assert.AreEqual(expectedResult, xValue + yValue);


### PR DESCRIPTION
## Summary of changes

This PR add support to extract multiple traits recursively  in NUnit enabling the following scenario:

```csharp
        [Theory]
        [Category("ParemeterizedTest")]
        [TestCase(1, 1, 2, Category = "FirstCase")]
        [TestCase(2, 2, 4, Category = "SecondCase")]
        [TestCase(3, 3, 6, Category = "ThirdCase")]
        public void SimpleParameterizedTest(int xValue, int yValue, int expectedResult) {}
```

#### Resulting in:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/69803/217897756-8b860515-bdfc-413d-abbe-0e88cb625078.png">


## Reason for change

Customer asked the support for these cases.

## Test coverage

Test suite was updated adding this scenario.