### PR TITLE
[Build/Test] Small integration test cleanup

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -39,16 +39,14 @@ namespace Datadog.Trace.Security.IntegrationTests
         private static readonly Regex AppSecErrorCount = new(@"\s*_dd.appsec.event_rules.error_count: 0.0,?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private readonly string _testName;
         private readonly HttpClient _httpClient;
-        private readonly string _shutdownPath;
         private readonly JsonSerializerSettings _jsonSerializerSettingsOrderProperty;
         private int _httpPort;
 
-        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null)
+        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string samplesDir = null, string testName = null)
             : base(Prefix + sampleName, samplesDir ?? "test/test-applications/security", outputHelper)
         {
             _testName = Prefix + (testName ?? sampleName);
             _httpClient = new HttpClient();
-            _shutdownPath = shutdownPath;
 
             // adding these header so we can later assert it was collected properly
             _httpClient.DefaultRequestHeaders.Add(XffHeader, MainIp);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore2TestsSecurityDisabled : AspNetCoreBase
     {
         public AspNetCore2TestsSecurityDisabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore2", fixture, outputHelper, "/shutdown", enableSecurity: false, testName: "AspNetCore2.SecurityDisabled")
+            : base("AspNetCore2", fixture, outputHelper, enableSecurity: false, testName: "AspNetCore2.SecurityDisabled")
         {
         }
     }
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore2TestsSecurityEnabled : AspNetCoreBase
     {
         public AspNetCore2TestsSecurityEnabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore2", fixture, outputHelper, "/shutdown", enableSecurity: true, testName: "AspNetCore2.SecurityEnabled")
+            : base("AspNetCore2", fixture, outputHelper, enableSecurity: true, testName: "AspNetCore2.SecurityEnabled")
         {
         }
     }
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore2TestsSecurityDisabledWithDefaultExternalRulesFile : AspNetCoreSecurityDisabledWithExternalRulesFile
     {
         public AspNetCore2TestsSecurityDisabledWithDefaultExternalRulesFile(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore2", fixture, outputHelper, "/shutdown", ruleFile: DefaultRuleFile, testName: "AspNetCore2.SecurityDisabled")
+            : base("AspNetCore2", fixture, outputHelper, ruleFile: DefaultRuleFile, testName: "AspNetCore2.SecurityDisabled")
         {
         }
     }
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore2TestsSecurityEnabledWithDefaultExternalRulesFile : AspNetCoreSecurityEnabledWithExternalRulesFile
     {
         public AspNetCore2TestsSecurityEnabledWithDefaultExternalRulesFile(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore2", fixture, outputHelper, "/shutdown", ruleFile: DefaultRuleFile, testName: "AspNetCore2.SecurityEnabled")
+            : base("AspNetCore2", fixture, outputHelper, ruleFile: DefaultRuleFile, testName: "AspNetCore2.SecurityEnabled")
         {
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly AspNetCoreTestFixture fixture;
 
         public AspNetCore2RateLimiter(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore2", outputHelper, "/shutdown")
+            : base("AspNetCore2", outputHelper)
         {
             this.fixture = fixture;
             this.fixture.SetOutput(outputHelper);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public abstract class AspNetCore5TestsWithoutExternalRulesFile : AspNetCoreBase
     {
         public AspNetCore5TestsWithoutExternalRulesFile(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableSecurity, string testName)
-            : base("AspNetCore5", fixture, outputHelper, "/shutdown", enableSecurity: enableSecurity, testName: testName)
+            : base("AspNetCore5", fixture, outputHelper, enableSecurity: enableSecurity, testName: testName)
         {
             SetEnvironmentVariable(Configuration.ConfigurationKeys.DebugEnabled, "true");
         }
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore5TestsSecurityDisabledWithDefaultExternalRulesFile : AspNetCoreSecurityDisabledWithExternalRulesFile
     {
         public AspNetCore5TestsSecurityDisabledWithDefaultExternalRulesFile(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", fixture, outputHelper, "/shutdown", ruleFile: DefaultRuleFile, testName: "AspNetCore5.SecurityDisabled")
+            : base("AspNetCore5", fixture, outputHelper, ruleFile: DefaultRuleFile, testName: "AspNetCore5.SecurityDisabled")
         {
         }
     }
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore5TestsSecurityEnabledWithDefaultExternalRulesFile : AspNetCoreSecurityEnabledWithExternalRulesFile
     {
         public AspNetCore5TestsSecurityEnabledWithDefaultExternalRulesFile(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", fixture, outputHelper, "/shutdown", ruleFile: DefaultRuleFile, testName: "AspNetCore5.SecurityEnabled")
+            : base("AspNetCore5", fixture, outputHelper, ruleFile: DefaultRuleFile, testName: "AspNetCore5.SecurityEnabled")
         {
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AsmInitialization.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public abstract class AspNetCore5AsmInitialization : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         public AspNetCore5AsmInitialization(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableSecurity, string ruleset, string testName)
-            : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
+            : base("AspNetCore5", outputHelper, testName: testName)
         {
             Fixture = fixture;
             Fixture.SetOutput(outputHelper);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5ExternalRules.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore5ExternalRules : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         public AspNetCore5ExternalRules(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", outputHelper, "/shutdown", testName: nameof(AspNetCore5ExternalRules))
+            : base("AspNetCore5", outputHelper, testName: nameof(AspNetCore5ExternalRules))
         {
             Fixture = fixture;
             Fixture.SetOutput(outputHelper);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly AspNetCoreTestFixture fixture;
 
         public AspNetCore5RateLimiter(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCore5", outputHelper, "/shutdown")
+            : base("AspNetCore5", outputHelper)
         {
             this.fixture = fixture;
             this.fixture.SetOutput(outputHelper);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly AspNetCoreTestFixture fixture;
 
         public AspNetCoreBare(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
-            : base("AspNetCoreBare", outputHelper, "/shutdown")
+            : base("AspNetCoreBare", outputHelper)
         {
             this.fixture = fixture;
             this.fixture.SetOutput(outputHelper);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -19,7 +19,6 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             EnableSecurity = enableSecurity;
             Fixture = fixture;
-            Fixture.ShutdownPath = "/shutdown";
             Fixture.SetOutput(outputHelper);
         }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -14,11 +14,12 @@ namespace Datadog.Trace.Security.IntegrationTests
 {
     public abstract class AspNetCoreBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
-        public AspNetCoreBase(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string shutdownPath, bool enableSecurity = true, string testName = null)
-            : base(sampleName, outputHelper, shutdownPath ?? "/shutdown", testName: testName)
+        public AspNetCoreBase(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableSecurity = true, string testName = null)
+            : base(sampleName, outputHelper, testName: testName)
         {
             EnableSecurity = enableSecurity;
             Fixture = fixture;
+            Fixture.ShutdownPath = "/shutdown";
             Fixture.SetOutput(outputHelper);
         }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
@@ -17,16 +17,16 @@ namespace Datadog.Trace.Security.IntegrationTests
 {
     public abstract class AspNetCoreSecurityDisabledWithExternalRulesFile : AspNetCoreWithExternalRulesFileBase
     {
-        public AspNetCoreSecurityDisabledWithExternalRulesFile(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string shutdownPath, string ruleFile = null, string testName = null)
-            : base(sampleName, fixture, outputHelper, shutdownPath, enableSecurity: false, ruleFile: ruleFile, testName: testName)
+        public AspNetCoreSecurityDisabledWithExternalRulesFile(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string ruleFile = null, string testName = null)
+            : base(sampleName, fixture, outputHelper, enableSecurity: false, ruleFile: ruleFile, testName: testName)
         {
         }
     }
 
     public abstract class AspNetCoreSecurityEnabledWithExternalRulesFile : AspNetCoreWithExternalRulesFileBase
     {
-        public AspNetCoreSecurityEnabledWithExternalRulesFile(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string shutdownPath, string ruleFile = null, string testName = null)
-            : base(sampleName, fixture, outputHelper, shutdownPath, enableSecurity: true, ruleFile: ruleFile, testName: testName)
+        public AspNetCoreSecurityEnabledWithExternalRulesFile(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string ruleFile = null, string testName = null)
+            : base(sampleName, fixture, outputHelper, enableSecurity: true, ruleFile: ruleFile, testName: testName)
         {
         }
 
@@ -54,11 +54,12 @@ namespace Datadog.Trace.Security.IntegrationTests
 
     public abstract class AspNetCoreWithExternalRulesFileBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
-        public AspNetCoreWithExternalRulesFileBase(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, string shutdownPath, bool enableSecurity = true, string ruleFile = null, string testName = null)
-            : base(sampleName, outputHelper, shutdownPath ?? "/shutdown", testName: testName)
+        public AspNetCoreWithExternalRulesFileBase(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableSecurity = true, string ruleFile = null, string testName = null)
+            : base(sampleName, outputHelper, testName: testName)
         {
             EnableSecurity = enableSecurity;
             Fixture = fixture;
+            Fixture.ShutdownPath = "/shutdown";
             Fixture.SetOutput(outputHelper);
             RuleFile = ruleFile;
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
@@ -59,7 +59,6 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             EnableSecurity = enableSecurity;
             Fixture = fixture;
-            Fixture.ShutdownPath = "/shutdown";
             Fixture.SetOutput(outputHelper);
             RuleFile = ruleFile;
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -58,12 +58,13 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly string _testName;
 
         public AspNetMvc5(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-            : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
+            : base(nameof(AspNetMvc5), output, @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = "Security." + nameof(AspNetMvc5)
                      + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly bool _enableSecurity;
 
         public AspNetMvc5RateLimiter(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity, int? traceRateLimit)
-            : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
+            : base(nameof(AspNetMvc5), output, @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
@@ -109,6 +109,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                 SetEnvironmentVariable(ConfigurationKeys.AppSec.TraceRateLimit, _traceRateLimit.ToString());
             }
 
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             SetHttpPort(iisFixture.HttpPort);
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -58,12 +58,13 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly string _testName;
 
         public AspNetWebApi(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-            : base("WebApi", output, "/api/home/shutdown", @"test\test-applications\security\aspnet")
+            : base("WebApi", output, @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/api/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = "Security." + nameof(AspNetWebApi)
                      + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -59,12 +59,13 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly string _testName;
 
         public AspNetWebForms(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-            : base("WebForms", output, "/home/shutdown", @"test\test-applications\security\aspnet")
+            : base("WebForms", output, @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _enableSecurity = enableSecurity;
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = "Security." + nameof(AspNetWebForms)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -163,7 +163,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
     public abstract class AspNetCore2IastTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         public AspNetCore2IastTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableIast, string testName, bool? isIastDeduplicationEnabled = null, int? samplingRate = null, int? vulnerabilitiesPerRequest = null)
-            : base("AspNetCore2", outputHelper, "/shutdown", testName: testName)
+            : base("AspNetCore2", outputHelper, testName: testName)
         {
             Fixture = fixture;
             IastEnabled = enableIast;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -186,7 +186,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
     public abstract class AspNetCore5IastTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         public AspNetCore5IastTests(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableIast, string testName, bool? isIastDeduplicationEnabled = null, int? samplingRate = null, int? vulnerabilitiesPerRequest = null)
-            : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
+            : base("AspNetCore5", outputHelper, testName: testName)
         {
             Fixture = fixture;
             IastEnabled = enableIast;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
         private readonly bool _enableIast;
 
         public AspNetMvc5IastTests(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableIast)
-            : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
+            : base(nameof(AspNetMvc5), output, @"test\test-applications\security\aspnet")
         {
             EnableIast(enableIast);
             SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
@@ -70,6 +70,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
 
             _iisFixture = iisFixture;
             _enableIast = enableIast;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = "Security." + nameof(AspNetMvc5)
                      + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmBlockingActions.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmBlockingActions.cs
@@ -64,12 +64,13 @@ public abstract class AspNetMvc5AsmBlockingActions : RcmBaseFramework, IClassFix
     private readonly string _testName;
 
     public AspNetMvc5AsmBlockingActions(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-        : base("AspNetMvc5", output, "/home/shutdown", @"test\test-applications\security\aspnet")
+        : base("AspNetMvc5", output, @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
         SetEnvironmentVariable(ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
         _iisFixture = iisFixture;
+        _iisFixture.ShutdownPath = "/home/shutdown";
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5AsmBlockingActions)
                                 + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
@@ -64,11 +64,12 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
     private readonly string _testName;
 
     public AspNetMvc5AsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-        : base("AspNetMvc5", output, "/home/shutdown", @"test\test-applications\security\aspnet")
+        : base("AspNetMvc5", output, @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
         _iisFixture = iisFixture;
+        _iisFixture.ShutdownPath = "/home/shutdown";
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5AsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmRulesToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmRulesToggle.cs
@@ -65,11 +65,12 @@ public abstract class AspNetMvc5AsmRulesToggle : RcmBaseFramework, IClassFixture
     private readonly string _testName;
 
     public AspNetMvc5AsmRulesToggle(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-        : base("AspNetMvc5", output, "/home/shutdown", @"test\test-applications\security\aspnet")
+        : base("AspNetMvc5", output, @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
         _iisFixture = iisFixture;
+        _iisFixture.ShutdownPath = "/home/shutdown";
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5AsmRulesToggle)
                                 + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
@@ -62,11 +62,12 @@ public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisF
     private readonly string _testName;
 
     public AspNetWebApiAsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-        : base("WebApi", output, "/api/home/shutdown", @"test\test-applications\security\aspnet")
+        : base("WebApi", output, @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
         _iisFixture = iisFixture;
+        _iisFixture.ShutdownPath = "/api/home/shutdown";
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetWebApiAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
@@ -64,11 +64,12 @@ public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<Ii
     private readonly string _testName;
 
     public AspNetWebFormsAsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
-        : base("WebForms", output, "/home/shutdown", @"test\test-applications\security\aspnet")
+        : base("WebForms", output, @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
         _iisFixture = iisFixture;
+        _iisFixture.ShutdownPath = "/home/shutdown";
         _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetWebFormsAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -23,7 +23,7 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     protected const string LogFileNamePrefix = "dotnet-tracer-managed-";
 
     protected RcmBase(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool? enableSecurity, string testName)
-        : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
+        : base("AspNetCore5", outputHelper, testName: testName)
     {
         Fixture = fixture;
         EnableSecurity = enableSecurity;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RcmBaseFramework.cs" company="Datadog">
+// <copyright file="RcmBaseFramework.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -14,8 +14,8 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm;
 
 public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
-    public RcmBaseFramework(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null)
-        : base(sampleName, outputHelper,  shutdownPath, samplesDir, testName)
+    public RcmBaseFramework(string sampleName, ITestOutputHelper outputHelper, string samplesDir = null, string testName = null)
+        : base(sampleName, outputHelper, samplesDir, testName)
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -45,6 +45,8 @@ namespace Datadog.Trace.TestHelpers
 
         public int HttpPort { get; private set; }
 
+        public string ShutdownPath { get; set; }
+
         public void SetOutput(ITestOutputHelper output)
         {
             lock (_outputLock)
@@ -139,9 +141,9 @@ namespace Datadog.Trace.TestHelpers
 
         public void Dispose()
         {
-            if (HttpPort is not 0)
+            if (HttpPort is not 0 && ShutdownPath is not null)
             {
-                var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}/shutdown");
+                var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
                 request.GetResponse().Close();
             }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.TestHelpers
 
         public int HttpPort { get; private set; }
 
-        public string ShutdownPath { get; set; } = "/home/shutdown";
+        public string ShutdownPath { get; set; } = "/shutdown";
 
         public void SetOutput(ITestOutputHelper output)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.TestHelpers
 
         public int HttpPort { get; private set; }
 
-        public string ShutdownPath { get; set; }
+        public string ShutdownPath { get; set; } = "/home/shutdown";
 
         public void SetOutput(ITestOutputHelper output)
         {


### PR DESCRIPTION
## Summary of changes
Small cleanup in test projects

## Reason for change
Tidying up

## Implementation details
- Remove the `_shutdownPath` field from Datadog.Trace.Security.IntegrationTests.AspNetBase and add a `ShutdownPath` property on `AspNetCoreTestFixture`
- Remove unused members in Datadog.Trace.TestHelpers.TestHelper

## Test coverage

## Other details
