### PR TITLE
[Build] Add retries for build and package commands

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -6,21 +6,25 @@ parameters:
   - name: 'target'
     type: 'string'
     default: tester
-    
+
   - name: build
     type: boolean
     default: false
-    
+
   - name: command
     type: string
 
   - name: extraArgs
     type: string
     default: ''
-    
+
   - name: 'apiKey'
     type: string
     default: ''
+
+  - name: retryCountForRunCommand
+    type: number
+    default: 0
 
 steps:
 - ${{ if eq(parameters.build, true) }}:
@@ -76,5 +80,6 @@ steps:
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker
+  retryCountOnTaskFailure: ${{ parameters.retryCountForRunCommand }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -236,6 +236,7 @@ stages:
 
     - script: tracer\build.cmd BuildTracerHome BuildNativeLoader
       displayName: Build tracer home
+      retryCountOnTaskFailure: 5
 
     - publish: $(monitoringHome)
       displayName: Upload Windows tracer home directory
@@ -265,6 +266,7 @@ stages:
 
     - script: tracer\build.cmd BuildProfilerHome
       displayName: Build profiler home
+      retryCountOnTaskFailure: 5
 
     - publish: $(monitoringHome)
       displayName: Upload Windows profiler home directory
@@ -273,7 +275,7 @@ stages:
     - publish: $(symbols)
       displayName: Upload Windows profiler symbols
       artifact: windows-profiler-symbols
-      
+
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Upload Windows profiler directory
       artifact: windows-profiler-binaries
@@ -309,6 +311,7 @@ stages:
         target: builder
         baseImage: $(baseImage)
         command: "Clean CppCheckNativeSrc BuildTracerHome CppCheckNativeLoader BuildNativeLoader ExtractDebugInfoLinux"
+        retryCountForRunCommand: 2
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
@@ -353,6 +356,7 @@ stages:
         target: builder
         baseImage: $(baseImage)
         command: "Clean BuildProfilerHome ExtractDebugInfoLinux"
+        retryCountForRunCommand: 2
 
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Uploading linux profiler output build folder
@@ -410,6 +414,7 @@ stages:
         target: builder
         baseImage: $(baseImage)
         command: "ZipMonitoringHome"
+        retryCountForRunCommand: 2
 
     - publish: $(artifacts)/linux-x64
       displayName: Upload linux-x64 packages
@@ -445,6 +450,7 @@ stages:
         target: builder
         baseImage: debian
         command: "Clean CppCheckNativeSrc BuildTracerHome CppCheckNativeLoader BuildNativeLoader ExtractDebugInfoLinux"
+        retryCountForRunCommand: 2
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
@@ -484,6 +490,7 @@ stages:
         target: builder
         baseImage: debian
         command: "Clean BuildProfilerHome ExtractDebugInfoLinux"
+        retryCountForRunCommand: 2
 
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Uploading linux profiler output build folder
@@ -535,6 +542,7 @@ stages:
         target: builder
         baseImage: debian
         command: "ZipMonitoringHome"
+        retryCountForRunCommand: 2
 
     - publish: $(artifacts)/linux-arm64
       displayName: Upload arm64 packages
@@ -570,6 +578,7 @@ stages:
 
     - script: ./tracer/build.sh CppCheckNativeSrc BuildTracerHome CppCheckNativeLoader BuildNativeLoader
       displayName: Build tracer home
+      retryCountOnTaskFailure: 5
 
     - publish: $(monitoringHome)
       displayName: Uploading macos profiler artifact
@@ -607,6 +616,7 @@ stages:
 
       - script: tracer\build.cmd PackageTracerHome
         displayName: Build MSI and Tracer home
+        retryCountOnTaskFailure: 5
 
       - publish: $(artifacts)/windows-tracer-home.zip
         displayName: Publish tracer-home.zip
@@ -1186,7 +1196,7 @@ stages:
     pool:
       name: azure-windows-scale-set-3
     timeoutInMinutes: 60 #default value
-    
+
     steps:
     - powershell: |
         choco install cppcheck -y --version 2.9
@@ -2008,7 +2018,7 @@ stages:
 
   - job: Linux
     timeoutInMinutes: 60 #default value
- 
+
     pool:
       name: azure-linux-scale-set
 
@@ -2032,7 +2042,7 @@ stages:
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: false
-      
+
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [package_arm64, generate_variables, master_commit_id]
@@ -3176,7 +3186,7 @@ stages:
     - template: steps/clone-repo.yml
       parameters:
         masterCommitId: $(masterCommitId)
-        
+
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
@@ -3235,7 +3245,7 @@ stages:
         cd $(CrankDir)
         chmod +x ./run.sh
         ./run.sh "windows" "$(runExtendedThroughputTests)"
-      displayName: Crank tracer 
+      displayName: Crank tracer
       env:
         DD_SERVICE: dd-trace-dotnet
         DD_ENV: CI
@@ -3323,7 +3333,7 @@ stages:
     - template: steps/clone-repo.yml
       parameters:
         masterCommitId: $(masterCommitId)
-        
+
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:


### PR DESCRIPTION
## Summary of changes

Added 2 retries to build and package tasks in case of a build failure.

## Reason for change

Build and package commands are supposed to be deterministic, so if they fail it ought to be transient or a real build failure. In the rare scenarios where it's transient, we lose a lot of time by not retrying as no tests are ran. It happened to me on a PR yesterday, thus why I'm pushing this. 

The argument saying that we make the feedback longer in case of a real issue doesn't hold much I believe as we're used to have long pipelines so we don't check them and we're not personally notified when they fail.

## Implementation details

Added a new parameter in the run-in-docker template to apply this retry on build only. The default value is 0. 
Opted for 2 retries as we want to know fast enough if we broke the build. Arguably, 1 retry would be better maybe.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
