### PR TITLE
Remove all references to `DD_DOTNET_PROFILER_HOME`

### DIFF
--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -794,7 +794,6 @@ jobs:
           echo "COR_ENABLE_PROFILING=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
           echo "COR_PROFILER_PATH=$(Join-Path -Path $(Resolve-Path .) -ChildPath shared/bin/monitoring-home/win-${{ matrix.platform }}/Datadog.Trace.ClrProfiler.Native.dll)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
-          echo "DD_DOTNET_PROFILER_HOME=$(Join-Path -Path $(Resolve-Path .) -ChildPath shared/bin/monitoring-home)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
       - name: Run Computer01 for 2min
         shell: cmd
         run: >

--- a/profiler/build/Exceptions.linux.net60.json
+++ b/profiler/build/Exceptions.linux.net60.json
@@ -51,7 +51,6 @@
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
     "CORECLR_PROFILER_PATH_64": "$(CWD)/../../shared/bin/monitoring-home/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)/../../shared/bin/monitoring-home",
     "LD_PRELOAD": "$(CWD)/../../shared/bin/monitoring-home/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },

--- a/profiler/build/PiComputation.linux.net60.json
+++ b/profiler/build/PiComputation.linux.net60.json
@@ -58,7 +58,6 @@
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
     "CORECLR_PROFILER_PATH_64": "$(CWD)/../../shared/bin/monitoring-home/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
-    "DD_DOTNET_PROFILER_HOME": "$(CWD)/../../shared/bin/monitoring-home",
     "LD_PRELOAD": "$(CWD)/../../shared/bin/monitoring-home/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
     "DD_PROFILING_METRICS_FILEPATH": "metrics.json"
   },

--- a/shared/src/msi-installer/ContinuousProfiler/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/ContinuousProfiler/EnvironmentVariables.wxs
@@ -5,10 +5,6 @@
   <?include $(sys.CURRENTDIR)\Config.wxi?>
   <Fragment>
     <ComponentGroup Id="ContinuousProfiler.EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
-        <Component Id="ContinuousProfiler.EnvironmentVariablesShared" Guid="{9973ACAE-A4D4-495C-BD4E-FCC384C45C70}" Win64="$(var.Win64)">
-          <CreateFolder/>
-          <Environment Id="DD_DOTNET_PROFILER_HOME" Name="DD_DOTNET_PROFILER_HOME" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]" Part="all" />
-        </Component>
-      </ComponentGroup>
+    </ComponentGroup>
   </Fragment>
 </Wix>

--- a/tracer/build/crank/os.profiles.yml
+++ b/tracer/build/crank/os.profiles.yml
@@ -90,7 +90,6 @@ profiles:
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
           CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so"
           DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/tracer-home-linux"
-          DD_DOTNET_PROFILER_HOME: "{{ linuxProfilerPath }}/tracer-home-linux/linux-x64"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_ENV: throughput-adhoc


### PR DESCRIPTION
## Summary of changes

Remove all references to `DD_DOTNET_PROFILER_HOME` e.g. in the MSI

## Reason for change

This variable isn't needed and doesn't do anything any more (since #3073)

## Implementation details

Find-replace-delete

## Test coverage

N/A
