### PR TITLE
[Build/Test] Limit upload_container_images build stage to individual CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3165,7 +3165,7 @@ stages:
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
 - stage: upload_container_images
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
   dependsOn: [upload_to_azure]
   jobs:
     - job: upload


### PR DESCRIPTION
## Summary of changes

## Reason for change
We only want to build the container images once per commit, not on Scheduled runs like nightly or weekly.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
