### PR TITLE
[Trace] DD_DBM_PROPAGATION_MODE enables commenting spans with service & trace data.

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
+{
+    internal static class DatabaseMonitoringPropagator
+    {
+        private const string SqlCommentSpanService = "dddbs";
+        private const string SqlCommentRootService = "ddps";
+        private const string SqlCommentVersion = "ddpv";
+        private const string SqlCommentEnv = "dde";
+
+        private const string SqlCommentTraceParent = "traceparent";
+
+        internal static string PropagateSpanData(string propagationStyle, string configuredServiceName, string sqlCommand, Scope scope)
+        {
+            var propgationComment =
+                $"{SqlCommentRootService}='{configuredServiceName}'," +
+                $"{SqlCommentSpanService}='{scope.Span.ServiceName}'," +
+                $"{SqlCommentVersion}='{scope.Span.GetTag(Tags.Version)}'," +
+                $"{SqlCommentEnv}='{scope.Span.GetTag(Tags.Env)}'";
+
+            if (propagationStyle == "full")
+            {
+                propgationComment = propgationComment + CreateTraceParent(scope.Span.TraceId, scope.Span.SpanId, scope.Span.GetMetric(Tags.SamplingPriority));
+            }
+
+            return $"/*{propgationComment}*/ {sqlCommand}";
+        }
+
+        internal static string CreateTraceParent(ulong traceId, ulong spanId, double? samplingProprity)
+        {
+            samplingProprity = samplingProprity > 0 ? 01 : 00;
+
+            return $",{SqlCommentTraceParent}='00-{traceId.ToString("X32")}-{spanId.ToString("X16")}-{samplingProprity}'";
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 {
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         {
             samplingProprity = samplingProprity > 0 ? 01 : 00;
 
-            return $",{SqlCommentTraceParent}='00-{traceId.ToString("X32")}-{spanId.ToString("X16")}-{samplingProprity}'";
+            return $",{SqlCommentTraceParent}='00-{traceId.ToString("x32")}-{spanId.ToString("x16")}-{samplingProprity}'";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DatabaseMonitoringPropagator.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
         internal static string CreateTraceParent(ulong traceId, ulong spanId, double? samplingProprity)
         {
-            string sampling = samplingProprity >= 1.0 ? "01" : "00";
+            string sampling = samplingProprity > 0.0 ? "01" : "00";
 
             return $"{SqlCommentTraceParent}='00-{traceId.ToString("x32")}-{spanId.ToString("x16")}-{sampling}'";
         }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -372,6 +372,13 @@ namespace Datadog.Trace.Configuration
         public const string QueryStringReportingEnabled = "DD_HTTP_SERVER_TAG_QUERY_STRING";
 
         /// <summary>
+        /// Configuration key for setting DBM propagation mode
+        /// Default value is disabled
+        /// </summary>
+        /// <seealso cref="TracerSettings.DbmPropagationMode"/>
+        public const string DbmPropagationMode = "DD_DBM_PROPAGATION_MODE";
+
+        /// <summary>
         /// String constants for CI Visibility configuration keys.
         /// </summary>
         public static class CIVisibility

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -133,6 +133,8 @@ namespace Datadog.Trace.Configuration
 
             IsRunningInAzureAppService = settings.IsRunningInAzureAppService;
             AzureAppServiceMetadata = settings.AzureAppServiceMetadata;
+
+            DbmPropagationMode = settings.DbmPropagationMode;
         }
 
         /// <summary>
@@ -396,6 +398,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the tracer is running in AAS
         /// </summary>
         internal bool IsRunningInAzureAppService { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tracer should propagate service data in db queries
+        /// </summary>
+        internal string DbmPropagationMode { get; }
 
         /// <summary>
         /// Gets the AAS settings

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -400,7 +400,7 @@ namespace Datadog.Trace.Configuration
         internal bool IsRunningInAzureAppService { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the tracer should propagate service data in db queries
+        /// Gets a value indicating whether the tracer should propagate service data in db queries
         /// </summary>
         internal string DbmPropagationMode { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -271,7 +271,24 @@ namespace Datadog.Trace.Configuration
                 HttpClientExcludedUrlSubstrings = TrimSplitString(urlSubstringSkips.ToUpperInvariant(), commaSeparator);
             }
 
-            DbmPropagationMode = CheckDbmPropagationInput(source?.GetString(ConfigurationKeys.DbmPropagationMode) ?? "disabled");
+            DbmPropagationLevel dbmPropagationValue;
+            DbmPropagationMode = Enum.TryParse(source?.GetString(ConfigurationKeys.DbmPropagationMode), true, out dbmPropagationValue) ?
+                $"{dbmPropagationValue}".ToLower() : "disabled";
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tracer should propagate service data in db queries
+        /// </summary>
+        public enum DbmPropagationLevel
+        {
+            /// <summary>Nothing should be propagated</summary>
+            Disabled,
+
+            /// <summary>Only service tags should be injected</summary>
+            Service,
+
+            /// <summary>Both service details and span traceparent should be injected</summary>
+            Full
         }
 
         /// <summary>
@@ -737,17 +754,6 @@ namespace Datadog.Trace.Configuration
             }
 
             return httpErrorCodesArray;
-        }
-
-        internal static string CheckDbmPropagationInput(string mode)
-        {
-            if (mode != null && mode != "disabled" && mode != "service" && mode != "full")
-            {
-                Log.Warning("Wrong format '{0}' for DD_DBM_PROPAGATION_MODE configuration, expected: disabled, service or full.", mode);
-                return "disabled";
-            }
-
-            return mode;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -270,6 +270,8 @@ namespace Datadog.Trace.Configuration
             {
                 HttpClientExcludedUrlSubstrings = TrimSplitString(urlSubstringSkips.ToUpperInvariant(), commaSeparator);
             }
+
+            DbmPropagationMode = CheckDbmPropagationInput(source?.GetString(ConfigurationKeys.DbmPropagationMode) ?? "disabled");
         }
 
         /// <summary>
@@ -563,6 +565,11 @@ namespace Datadog.Trace.Configuration
         internal bool IsRunningInAzureAppService { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the tracer should propagate service data in db queries
+        /// </summary>
+        internal string DbmPropagationMode { get; set; }
+
+        /// <summary>
         /// Gets or sets the AAS settings
         /// </summary>
         internal ImmutableAzureAppServiceSettings AzureAppServiceMetadata { get; set; }
@@ -730,6 +737,17 @@ namespace Datadog.Trace.Configuration
             }
 
             return httpErrorCodesArray;
+        }
+
+        internal static string CheckDbmPropagationInput(string mode)
+        {
+            if (mode != null && mode != "disabled" && mode != "service" && mode != "full")
+            {
+                Log.Warning("Wrong format '{0}' for DD_DBM_PROPAGATION_MODE configuration, expected: disabled, service or full.", mode);
+                return "disabled";
+            }
+
+            return mode;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -529,6 +529,11 @@ namespace Datadog.Trace
 
         internal const string TagPropagationError = "_dd.propagation_error";
 
+        /// <summary>
+        /// Marks a span as when dmb needed data was injected
+        /// </summary>
+        internal const string DbmDataPropagated = "_dd.dbm_trace_injected";
+
         internal static class AppSec
         {
             internal const string Events = "appsec.events.";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DatabaseMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DatabaseMonitoringTests.cs
@@ -1,0 +1,108 @@
+// <copyright file="DatabaseMonitoringTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
+{
+    [Trait("RequiresDockerDependency", "true")]
+    public class DatabaseMonitoringTests : TracingIntegrationTest
+    {
+        public DatabaseMonitoringTests(ITestOutputHelper output)
+            : base("MySql", output)
+        {
+            SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_ENV", "testing");
+            SetEnvironmentVariable("DD_DBM_PROPAGATION_MODE", "full");
+        }
+
+        public static IEnumerable<object[]> GetMySql8Data()
+        {
+            foreach (object[] item in PackageVersions.MySqlData)
+            {
+                if (!((string)item[0]).StartsWith("8") && !string.IsNullOrEmpty((string)item[0]))
+                {
+                    continue;
+                }
+
+                yield return item;
+            }
+        }
+
+        public override Result ValidateIntegrationSpan(MockSpan span) => span.IsMySql();
+
+        // Check that the span has been tagged after the comment was propagated
+        private void ValidateDbmTaggedSpans(IEnumerable<MockSpan> spans)
+        {
+            foreach (var span in spans)
+            {
+                Console.WriteLine(span.ToString());
+                Assert.True(span.Tags?.ContainsKey(Tags.DbmDataPropagated));
+            }
+        }
+
+        [Fact]
+        private void ConfirmDbmPropagateSpanData()
+        {
+            const string expectedServiceComment = "/*ddps='Test.Service',dddbs='Test.Service-mysql',ddpv='1.0.0',dde='testing'*/";
+            const string expectedTraceParent = "traceparent='00-00000000000000006172c1c9a829c71c-05a5f7b5320d6e4d-01'";
+            const string expectedFullComment = "/*ddps='Test.Service',dddbs='Test.Service-mysql',ddpv='1.0.0',dde='testing',traceparent='00-00000000000000006172c1c9a829c71c-05a5f7b5320d6e4d-01'*/";
+
+            Span span = Tracer.Instance.StartSpan("mysql.query", null, null, "Test.Service-mysql", null, 7021887840877922076, 407003698947780173);
+            span.SetTag(Tags.Env, "testing");
+            span.SetTag(Tags.Version, "1.0.0");
+            span.SetMetric(Tags.SamplingPriority, 0.5);
+
+            var currentServiceComment = DatabaseMonitoringPropagator.PropagateSpanData("service", "Test.Service", span);
+            var currentServiceTraceParent = DatabaseMonitoringPropagator.CreateTraceParent(span.TraceId, span.SpanId, span.GetMetric(Tags.SamplingPriority));
+            var currentFullComment = DatabaseMonitoringPropagator.PropagateSpanData("full", "Test.Service", span);
+
+            Assert.Equal(expectedServiceComment, currentServiceComment);
+            Assert.Equal(expectedTraceParent, currentServiceTraceParent);
+            Assert.Equal(expectedFullComment, currentFullComment);
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [MemberData(nameof(GetMySql8Data))]
+        private void SubmitDbmCommentedSpans(string packageVersion)
+        {
+            // ALWAYS: 75 spans
+            // - MySqlCommand: 19 spans (3 groups * 7 spans - 2 missing spans)
+            // - DbCommand:  42 spans (6 groups * 7 spans)
+            // - IDbCommand: 14 spans (2 groups * 7 spans)
+            //
+            // NETSTANDARD: +56 spans
+            // - DbCommand-netstandard:  42 spans (6 groups * 7 spans)
+            // - IDbCommand-netstandard: 14 spans (2 groups * 7 spans)
+            //
+            // CALLTARGET: +9 spans
+            // - MySqlCommand: 2 additional spans
+            // - IDbCommandGenericConstrant<MySqlCommand>: 7 spans (1 group * 7 spans)
+            //
+            // NETSTANDARD + CALLTARGET: +7 spans
+            // - IDbCommandGenericConstrant<MySqlCommand>-netstandard: 7 spans (1 group * 7 spans)
+            var expectedSpanCount = 147;
+
+            const string dbType = "mysql";
+            const string expectedOperationName = dbType + ".query";
+
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
+            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+            int actualSpanCount = spans.Count(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)); // Remove unexpected DB spans from the calculation
+
+            Assert.Equal(expectedSpanCount, actualSpanCount);
+            ValidateDbmTaggedSpans(spans);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Adds DBM related classes and methods so that linking APM and DBM is configurable for **MySql** and **Postgres** when setting `DD_DBM_PROPAGATION_MODE`, the accepted values are `service`, `full` and the default value of `disabled` .

## Reason for change
Part of the effort to link traces and DBM queries in the UI.

## Implementation details
Created `DatabaseMonitoringPropagator`  and `DatabaseMonitoringTests` classes to generate and test that the new `commandText` is being set correctly after the spans are started.

## Test coverage
Added tests to confirm that the `DatabaseMonitoringPropagator` class methods return the correct string, and other to confirm spans are marked as expected and their amount stays as expected.
