### PR TITLE
Fix `IDatadogLogger` analyzer warnings

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Datadog.Trace.Coverage.Collector
 {
@@ -47,13 +48,13 @@ namespace Datadog.Trace.Coverage.Collector
         public void Error(string? text)
         {
             _logger.LogWarning(_collectionContext, text ?? string.Empty);
-            _datadogLogger.Error(text);
+            _datadogLogger.Error("Logged coverage tool error: {Error}", text);
         }
 
         public void Error(Exception exception)
         {
             _logger.LogWarning(_collectionContext, exception.ToString());
-            _datadogLogger.Error(exception, exception.Message);
+            _datadogLogger.Error(exception, "Logged coverage tool error");
         }
 
         public void Error(Exception exception, string? text)
@@ -69,20 +70,20 @@ namespace Datadog.Trace.Coverage.Collector
             }
 
             _logger.LogWarning(_collectionContext, textToLogger);
-            _datadogLogger.Error(exception, text);
+            _datadogLogger.Error(exception, "Logged coverage tool error: {Error}", text);
         }
 
         public void Warning(string? text)
         {
             _logger.LogWarning(_collectionContext, text ?? string.Empty);
-            _datadogLogger.Warning(text);
+            _datadogLogger.Warning("Logged coverage tool warning: {Warning}", text);
         }
 
         public void Debug(string? text)
         {
             if (_isDebugEnabled)
             {
-                _datadogLogger.Debug(text);
+                _datadogLogger.Debug("Logged coverage tool debug message: {Message}", text);
             }
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -155,8 +155,8 @@ namespace Datadog.Trace.Tools.Runner
                 }
             }
 
-            Log.Debug("RunCiCommand: CodeCoverageEnabled = {value}", codeCoverageEnabled);
-            Log.Debug("RunCiCommand: TestSkippingEnabled = {value}", testSkippingEnabled);
+            Log.Debug("RunCiCommand: CodeCoverageEnabled = {Value}", codeCoverageEnabled);
+            Log.Debug("RunCiCommand: TestSkippingEnabled = {Value}", testSkippingEnabled);
             ciVisibilitySettings.SetCodeCoverageEnabled(codeCoverageEnabled);
             profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.CodeCoverage] = codeCoverageEnabled ? "1" : "0";
 
@@ -247,7 +247,7 @@ namespace Datadog.Trace.Tools.Runner
                     return 0;
                 }
 
-                Log.Debug("RunCiCommand: Launching: {value}", command);
+                Log.Debug("RunCiCommand: Launching: {Value}", command);
                 var processInfo = Utils.GetProcessStartInfo(program, Environment.CurrentDirectory, profilerEnvironmentVariables);
                 if (!string.IsNullOrEmpty(arguments))
                 {
@@ -256,7 +256,7 @@ namespace Datadog.Trace.Tools.Runner
 
                 exitCode = Utils.RunProcess(processInfo, _applicationContext.TokenSource.Token);
                 session?.SetTag(TestTags.CommandExitCode, exitCode);
-                Log.Debug<int>("RunCiCommand: Finished with exit code: {value}", exitCode);
+                Log.Debug<int>("RunCiCommand: Finished with exit code: {Value}", exitCode);
                 return exitCode;
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Activity/ActivityListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/ActivityListener.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Activity
 
             // Initialize
             var diagnosticSourceAssemblyName = diagnosticListenerType.Assembly.GetName();
-            Log.Information("DiagnosticSource: {diagnosticSourceAssemblyNameFullName}", diagnosticSourceAssemblyName.FullName);
+            Log.Information("DiagnosticSource: {DiagnosticSourceAssemblyNameFullName}", diagnosticSourceAssemblyName.FullName);
 
             var activityType = Type.GetType("System.Diagnostics.Activity, System.Diagnostics.DiagnosticSource", throwOnError: false);
             var version = diagnosticSourceAssemblyName.Version;
@@ -138,7 +138,7 @@ namespace Datadog.Trace.Activity
                 return;
             }
 
-            Log.Information("An activity listener was found but version {version} is not supported.", version?.ToString() ?? "(null)");
+            Log.Information("An activity listener was found but version {Version} is not supported.", version?.ToString() ?? "(null)");
 
             static void CreateCurrentActivityDelegates(Type activityType)
             {
@@ -197,7 +197,7 @@ namespace Datadog.Trace.Activity
             var onSampleUsingParentIdMethodInfo = typeof(ActivityListenerHandler).GetMethod("OnSampleUsingParentId", BindingFlags.Static | BindingFlags.Public)!;
             var onShouldListenToMethodInfo = typeof(ActivityListenerHandler).GetMethod("OnShouldListenTo", BindingFlags.Static | BindingFlags.Public)!;
 
-            Log.Information("Activity listener: {activityListenerType}", activityListenerType!.AssemblyQualifiedName ?? "(null)");
+            Log.Information("Activity listener: {ActivityListenerType}", activityListenerType!.AssemblyQualifiedName ?? "(null)");
 
             // Create the ActivityListener instance
             var activityListener = Activator.CreateInstance(activityListenerType);
@@ -227,7 +227,7 @@ namespace Datadog.Trace.Activity
 
         private static void CreateDiagnosticSourceListenerInstance(Type diagnosticListenerType)
         {
-            Log.Information("DiagnosticListener listener: {diagnosticListenerType}", diagnosticListenerType.AssemblyQualifiedName ?? "(null)");
+            Log.Information("DiagnosticListener listener: {DiagnosticListenerType}", diagnosticListenerType.AssemblyQualifiedName ?? "(null)");
 
             var observerDiagnosticListenerType = typeof(IObserver<>).MakeGenericType(diagnosticListenerType);
 

--- a/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
@@ -50,18 +50,18 @@ namespace Datadog.Trace.Activity
                 {
                     if (handler.ShouldListenTo(sName, activitySource.Version) && HandlerBySource.TryAdd(sName, handler))
                     {
-                        Log.Debug("ActivityListenerHandler: {sourceName} will be handled by {handler}.", sName, handler);
+                        Log.Debug("ActivityListenerHandler: {SourceName} will be handled by {Handler}.", sName, handler);
                         return true;
                     }
                 }
                 else if (handler.ShouldListenTo(sName, null) && HandlerBySource.TryAdd(sName, handler))
                 {
-                    Log.Debug("ActivityListenerHandler: {sourceName} will be handled by {handler}.", sName, handler);
+                    Log.Debug("ActivityListenerHandler: {SourceName} will be handled by {Handler}.", sName, handler);
                     return true;
                 }
             }
 
-            Log.Warning("ActivityListenerHandler: There's no handler to process the events from \"{sourceName}\".", sName);
+            Log.Warning("ActivityListenerHandler: There's no handler to process the events from \"{SourceName}\".", sName);
             return false;
         }
 
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Activity
             }
             else
             {
-                Log.Debug("ActivityListenerHandler: There's no handler to process the ActivityStarted event. [Source={sourceName}]", sName);
+                Log.Debug("ActivityListenerHandler: There's no handler to process the ActivityStarted event. [Source={SourceName}]", sName);
             }
         }
 
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Activity
             }
             else
             {
-                Log.Warning("ActivityListenerHandler: There's no handler to process the ActivityStopped event.  [Source={sourceName}]", sName);
+                Log.Warning("ActivityListenerHandler: There's no handler to process the ActivityStopped event.  [Source={SourceName}]", sName);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Activity/DiagnosticObserverListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/DiagnosticObserverListener.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Activity
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error calling OnShouldListenToDelegate");
             }
         }
 

--- a/tracer/src/Datadog.Trace/Activity/DiagnosticSourceEventListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/DiagnosticSourceEventListener.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Activity
 {
     internal class DiagnosticSourceEventListener : IObserver<KeyValuePair<string, object>>
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DiagnosticObserverListener));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DiagnosticSourceEventListener));
         private static readonly Action<string, KeyValuePair<string, object>, object?> OnNextActivityDelegate;
         private readonly string _sourceName;
 

--- a/tracer/src/Datadog.Trace/Activity/DiagnosticSourceEventListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/DiagnosticSourceEventListener.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Activity
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error handling DiagnosticSourceEventListener event with {sourceName}", sourceName);
+                Log.Error(ex, "Error handling DiagnosticSourceEventListener event with {SourceName}", sourceName);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Activity.Handlers
 {
@@ -90,7 +91,10 @@ namespace Datadog.Trace.Activity.Handlers
 
             try
             {
-                Log.Debug($"DefaultActivityHandler.ActivityStarted: [Source={sourceName}, Id={activity.Id}, RootId={activity.RootId}, OperationName={{OperationName}}, StartTimeUtc={{StartTimeUtc}}, Duration={{Duration}}]", activity.OperationName, activity.StartTimeUtc, activity.Duration);
+                if (Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    Log.Debug("DefaultActivityHandler.ActivityStarted: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
+                }
 
                 // We check if we have to ignore the activity by the operation name value
                 if (IgnoreActivityHandler.IgnoreByOperationName(activity, activeSpan))
@@ -129,7 +133,11 @@ namespace Datadog.Trace.Activity.Handlers
                     if (ActivityMappingById.TryRemove(activity.Id, out ActivityMapping value) && value.Scope?.Span is not null)
                     {
                         // We have the exact scope associated with the Activity
-                        Log.Debug($"DefaultActivityHandler.ActivityStopped: [Source={sourceName}, Id={activity.Id}, RootId={activity.RootId}, OperationName={{OperationName}}, StartTimeUtc={{StartTimeUtc}}, Duration={{Duration}}]", activity.OperationName, activity.StartTimeUtc, activity.Duration);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug("DefaultActivityHandler.ActivityStopped: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
+                        }
+
                         CloseActivityScope(sourceName, activity, value.Scope);
                         return;
                     }
@@ -140,7 +148,10 @@ namespace Datadog.Trace.Activity.Handlers
                 // has been closed and then close the associated scope.
                 if (activity.Instance is not null)
                 {
-                    Log.Information($"DefaultActivityHandler.ActivityStopped: MISSING SCOPE [Source={sourceName}, Id={activity!.Id}, RootId={activity.RootId}, OperationName={{OperationName}}, StartTimeUtc={{StartTimeUtc}}, Duration={{Duration}}]", activity.OperationName, activity.StartTimeUtc, activity.Duration);
+                    if (Log.IsEnabled(LogEventLevel.Information))
+                    {
+                        Log.Information("DefaultActivityHandler.ActivityStopped: MISSING SCOPE [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity!.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
+                    }
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
@@ -46,10 +46,7 @@ internal static class AgentTransportStrategy
         switch (strategy)
         {
             case TracesTransportType.WindowsNamedPipe:
-                // intentionally using string interpolation, as this is only called once, and avoids array allocation
-#pragma warning disable DDLOG004 // Message templates should be constant
-                Log.Information($"Using {nameof(NamedPipeClientStreamFactory)} for {productName} transport, with pipe name {settings.TracesPipeName} and timeout {settings.TracesPipeTimeoutMs}ms.");
-#pragma warning restore DDLOG004 // Message templates should be constant
+                Log.Information<string, string, int>("Using " + nameof(NamedPipeClientStreamFactory) + " for {ProductName} transport, with pipe name {TracesPipeName} and timeout {TracesPipeTimeoutMs}ms.", productName, settings.TracesPipeName, settings.TracesPipeTimeoutMs);
                 return new HttpStreamRequestFactory(
                     new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs),
                     new DatadogHttpClient(getHttpHeaderHelper()),
@@ -57,17 +54,14 @@ internal static class AgentTransportStrategy
 
             case TracesTransportType.UnixDomainSocket:
 #if NET5_0_OR_GREATER
-                Log.Information("Using {FactoryType} for {ProductName} transport, with UDS path {Path}.", nameof(SocketHandlerRequestFactory), productName, settings.TracesUnixDomainSocketPath);
+                Log.Information("Using " + nameof(SocketHandlerRequestFactory) + " for {ProductName} transport, with UDS path {Path}.", productName, settings.TracesUnixDomainSocketPath);
                 // use http://localhost as base endpoint
                 return new SocketHandlerRequestFactory(
                     new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
                     defaultAgentHeaders,
                     getBaseEndpoint(Localhost));
 #elif NETCOREAPP3_1_OR_GREATER
-                // intentionally using string interpolation, as this is only called once, and avoids array allocation
-#pragma warning disable DDLOG004 // Message templates should be constant
-                Log.Information($"Using {nameof(UnixDomainSocketStreamFactory)} for {productName} transport, with Unix Domain Sockets path {settings.TracesUnixDomainSocketPath} and timeout {settings.TracesPipeTimeoutMs}ms.");
-#pragma warning restore DDLOG004 // Message templates should be constant
+                Log.Information<string, string, int>("Using " + nameof(UnixDomainSocketStreamFactory) + " for {ProductName} transport, with Unix Domain Sockets path {TracesUnixDomainSocketPath} and timeout {TracesPipeTimeoutMs}ms.", productName, settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
                 return new HttpStreamRequestFactory(
                     new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
                     new DatadogHttpClient(getHttpHeaderHelper()),
@@ -79,10 +73,10 @@ internal static class AgentTransportStrategy
             case TracesTransportType.Default:
             default:
 #if NETCOREAPP
-                Log.Information("Using {FactoryType} for {ProductName} transport.", nameof(HttpClientRequestFactory), productName);
+                Log.Information("Using " + nameof(HttpClientRequestFactory) + " for {ProductName} transport.", productName);
                 return new HttpClientRequestFactory(getBaseEndpoint(settings.AgentUri), defaultAgentHeaders, timeout: tcpTimeout);
 #else
-                Log.Information("Using {FactoryType} for {ProductName} transport.", nameof(ApiWebRequestFactory), productName);
+                Log.Information("Using " + nameof(ApiWebRequestFactory) + " for {ProductName} transport.", productName);
                 return new ApiWebRequestFactory(getBaseEndpoint(settings.AgentUri), defaultAgentHeaders, timeout: tcpTimeout);
 #endif
         }

--- a/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentTransportStrategy.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AgentTransportStrategy.cs" company="Datadog">
+// <copyright file="AgentTransportStrategy.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -47,7 +47,9 @@ internal static class AgentTransportStrategy
         {
             case TracesTransportType.WindowsNamedPipe:
                 // intentionally using string interpolation, as this is only called once, and avoids array allocation
+#pragma warning disable DDLOG004 // Message templates should be constant
                 Log.Information($"Using {nameof(NamedPipeClientStreamFactory)} for {productName} transport, with pipe name {settings.TracesPipeName} and timeout {settings.TracesPipeTimeoutMs}ms.");
+#pragma warning restore DDLOG004 // Message templates should be constant
                 return new HttpStreamRequestFactory(
                     new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs),
                     new DatadogHttpClient(getHttpHeaderHelper()),
@@ -63,7 +65,9 @@ internal static class AgentTransportStrategy
                     getBaseEndpoint(Localhost));
 #elif NETCOREAPP3_1_OR_GREATER
                 // intentionally using string interpolation, as this is only called once, and avoids array allocation
+#pragma warning disable DDLOG004 // Message templates should be constant
                 Log.Information($"Using {nameof(UnixDomainSocketStreamFactory)} for {productName} transport, with Unix Domain Sockets path {settings.TracesUnixDomainSocketPath} and timeout {settings.TracesPipeTimeoutMs}ms.");
+#pragma warning restore DDLOG004 // Message templates should be constant
                 return new HttpStreamRequestFactory(
                     new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath),
                     new DatadogHttpClient(getHttpHeaderHelper()),

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -321,7 +321,7 @@ namespace Datadog.Trace.Agent
 
                     if (droppedSpans > 0)
                     {
-                        Log.Warning("{count} traces were dropped since the last flush operation.", droppedSpans);
+                        Log.Warning("{Count} traces were dropped since the last flush operation.", droppedSpans);
                     }
 
                     if (buffer.TraceCount > 0)
@@ -333,11 +333,11 @@ namespace Datadog.Trace.Agent
                         {
                             droppedP0Traces = Interlocked.Exchange(ref _droppedP0Traces, 0);
                             droppedP0Spans = Interlocked.Exchange(ref _droppedP0Spans, 0);
-                            Log.Debug<int, int, long, long>("Flushing {spans} spans across {traces} traces. CanComputeStats is enabled with {droppedP0Traces} droppedP0Traces and {droppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
+                            Log.Debug<int, int, long, long>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is enabled with {DroppedP0Traces} droppedP0Traces and {DroppedP0Spans} droppedP0Spans", buffer.SpanCount, buffer.TraceCount, droppedP0Traces, droppedP0Spans);
                         }
                         else
                         {
-                            Log.Debug<int, int>("Flushing {spans} spans across {traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
+                            Log.Debug<int, int>("Flushing {Spans} spans across {Traces} traces. CanComputeStats is disabled.", buffer.SpanCount, buffer.TraceCount);
                         }
 
                         var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount, CanComputeStats, droppedP0Traces, droppedP0Spans).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -95,7 +95,7 @@ namespace Datadog.Trace.Agent
                     {
                         var detectedVersion = string.IsNullOrEmpty(agentVersion) ? "{detection failed}" : agentVersion;
 
-                        _log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", detectedVersion);
+                        _log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {Version})", detectedVersion);
                         return true;
                     }
                 }

--- a/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
+++ b/tracer/src/Datadog.Trace/Agent/StatsAggregator.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, e.Message);
+                    Log.Error(e, "Error executing trace processor {TraceProcessorType}", processor?.GetType());
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Agent.Transports
                         var headers = string.Join(", ", _postRequest.Headers.Select(h => $"{h.Key}: {string.Join(", ", h.Value)}"));
 
                         var payload = await sr.ReadToEndAsync().ConfigureAwait(false);
-                        Log.Warning("AppSec event not correctly sent to backend {statusCode} by class {className} with response {responseText}, request headers: were {headers}, payload was: {payload}", new object[] { response.StatusCode, nameof(HttpClientRequest), await response.ReadAsStringAsync().ConfigureAwait(false), headers, payload });
+                        Log.Warning("AppSec event not correctly sent to backend {StatusCode} by class {ClassName} with response {ResponseText}, request headers: were {Headers}, payload was: {Payload}", new object[] { response.StatusCode, nameof(HttpClientRequest), await response.ReadAsStringAsync().ConfigureAwait(false), headers, payload });
                     }
 
                     return response;

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -374,7 +374,7 @@ namespace Datadog.Trace
                 var namedPipeIsBound = File.Exists(namedPipe);
                 if (!namedPipeIsBound)
                 {
-                    Log.Debug("NamedPipe  [{namedPipe}] is not present.", namedPipe);
+                    Log.Debug("NamedPipe  [{NamedPipe}] is not present.", namedPipe);
                 }
 
                 return namedPipeIsBound;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -63,7 +63,7 @@ internal readonly partial struct SecurityCoordinator
                 else
                 {
 #endif
-                    Log.Warning("Header {key} couldn't be added as argument to the waf", currentKey);
+                    Log.Warning("Header {Key} couldn't be added as argument to the waf", currentKey);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -248,7 +248,7 @@ internal readonly partial struct SecurityCoordinator
                 }
                 else
                 {
-                    Log.Warning("Header {key} couldn't be added as argument to the waf", keyForDictionary);
+                    Log.Warning("Header {Key} couldn't be added as argument to the waf", keyForDictionary);
                 }
             }
         }
@@ -289,7 +289,7 @@ internal readonly partial struct SecurityCoordinator
             }
             else
             {
-                Log.Warning("Query string {key} couldn't be added as argument to the waf", originalKey);
+                Log.Warning("Query string {Key} couldn't be added as argument to the waf", originalKey);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -37,7 +37,14 @@ internal readonly partial struct SecurityCoordinator
             for (var i = 0; i < results?.Length; i++)
             {
                 var match = results[i];
-                Log.Debug(blocked ? "DDAS-0012-02: Blocking current transaction (rule: {RuleId})" : "DDAS-0012-01: Detecting an attack from rule {RuleId}", match.Rule);
+                if (blocked)
+                {
+                    Log.Debug("DDAS-0012-02: Blocking current transaction (rule: {RuleId})", match.Rule);
+                }
+                else
+                {
+                    Log.Debug("DDAS-0012-01: Detecting an attack from rule {RuleId}", match.Rule);
+                }
             }
         }
     }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -360,7 +360,7 @@ namespace Datadog.Trace.AppSec
 
                 _enabled = true;
 
-                Log.Information("AppSec is now Enabled, _settings.Enabled is {EnabledValue}, coming from remote config: {enableFromRemoteConfig}", _settings.Enabled, fromRemoteConfig);
+                Log.Information("AppSec is now Enabled, _settings.Enabled is {EnabledValue}, coming from remote config: {EnableFromRemoteConfig}", _settings.Enabled, fromRemoteConfig);
             }
         }
 
@@ -374,7 +374,7 @@ namespace Datadog.Trace.AppSec
 
                 _enabled = false;
 
-                Log.Information("AppSec is now Disabled, _settings.Enabled is {EnabledValue}, coming from remote config: {enableFromRemoteConfig}", _settings.Enabled, fromRemoteConfig);
+                Log.Information("AppSec is now Disabled, _settings.Enabled is {EnabledValue}, coming from remote config: {EnableFromRemoteConfig}", _settings.Enabled, fromRemoteConfig);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error adding CallTarget AppSec integration definitions to native library");
             }
 
             try
@@ -139,10 +139,10 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error adding CallTarget appsec derived integration definitions to native library");
             }
 
-            Log.Information($"{defs} AppSec definitions and {derived} AppSec derived definitions added to the profiler.");
+            Log.Information<int, int>("{DefinitionCount} AppSec definitions and {DerivedCount} AppSec derived definitions added to the profiler.", defs, derived);
         }
 
         private static void RemoveAppsecSpecificInstrumentations()
@@ -157,7 +157,7 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error removing CallTarget AppSec integration definitions from native library");
             }
 
             try
@@ -169,10 +169,10 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error removing CallTarget appsec derived integration definitions from native library");
             }
 
-            Log.Information($"{defs} AppSec definitions and {derived} AppSec derived definitions removed from the profiler.");
+            Log.Information<int, int>("{DefinitionCount} AppSec definitions and {DerivedCount} AppSec derived definitions removed from the profiler.", defs, derived);
         }
 
         /// <summary> Frees resources </summary>
@@ -303,7 +303,7 @@ namespace Datadog.Trace.AppSec
         {
             if (ruleStatus is { Count: > 0 } && !(_waf?.ToggleRules(ruleStatus) ?? false))
             {
-                Log.Debug($"_waf.ToggleRules returned false ({ruleStatus.Count} rule status entries)");
+                Log.Debug<int>("_waf.ToggleRules returned false ({Count} rule status entries)", ruleStatus.Count);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.AppSec
                 var wafTimeout = ParseWafTimeout(wafTimeoutString);
                 if (wafTimeout <= 0)
                 {
-                    Log.Warning("Ignoring '{WafTimeoutKey}' of '{wafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
+                    Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
                     wafTimeout = defaultWafTimeout;
                 }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         private static Obj EncodeUnknownType(object o, WafLibraryInvoker wafLibraryInvoker)
         {
-            Log.Warning("Couldn't encode object of unknown type {type}, falling back to ToString", o.GetType());
+            Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
 
             var s = o.ToString() ?? string.Empty;
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
@@ -144,16 +144,16 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 if (loaded)
                 {
                     success = true;
-                    Log.Information($"Loaded library '{libName}' from '{path}' with handle '{handle}'");
+                    Log.Information("Loaded library '{LibName}' from '{Path}' with handle '{Handle}'", libName, path, handle);
                     break;
                 }
 
-                Log.Warning($"Failed to load library '{libName}' from '{path}'");
+                Log.Warning("Failed to load library '{LibName}' from '{Path}'", libName, path);
             }
 
             if (!success)
             {
-                Log.Warning($"Failed to load library '{libName}' from any of the following '{string.Join(", ", paths)}'");
+                Log.Warning("Failed to load library '{LibName}' from any of the following '{Paths}'", libName, string.Join(", ", paths));
                 Log.Error("AppSec could not load libddwaf native library, as a result, AppSec could not start. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.");
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                         var idProp = ev.Value<JValue>("id") ?? emptyJValue;
                         var nameProp = ev.Value<JValue>("name") ?? emptyJValue;
                         var addresses = ev.Value<JArray>("conditions")?.SelectMany(x => x.Value<JObject>("parameters")?.Value<JArray>("inputs"));
-                        Log.Debug("DDAS-0007-00: Loaded rule: {id} - {name} on addresses: {addresses}", idProp.Value, nameProp.Value, string.Join(", ", addresses ?? Enumerable.Empty<JToken>()));
+                        Log.Debug("DDAS-0007-00: Loaded rule: {Id} - {Name} on addresses: {Addresses}", idProp.Value, nameProp.Value, string.Join(", ", addresses ?? Enumerable.Empty<JToken>()));
                     }
                 }
                 catch (Exception ex)
@@ -86,7 +86,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
         {
             if (rulesObj == null)
             {
-                Log.Error("Waf couldn't initialize properly because of an unusable rule file. If you set the environment variable {appsecrule_env}, check the path and content of the file are correct.", ConfigurationKeys.AppSec.Rules);
+                Log.Error("Waf couldn't initialize properly because of an unusable rule file. If you set the environment variable {AppsecruleEnv}, check the path and content of the file are correct.", ConfigurationKeys.AppSec.Rules);
                 return InitializationResult.FromUnusableRuleFile();
             }
 
@@ -112,11 +112,11 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 var initResult = InitializationResult.From(ruleSetInfo, wafHandle, _wafLibraryInvoker);
                 if (initResult.LoadedRules == 0)
                 {
-                    Log.Error("DDAS-0003-03: AppSec could not read the rule file {rulesFile}. Reason: All rules are invalid. AppSec will not run any protections in this application.", rulesFile);
+                    Log.Error("DDAS-0003-03: AppSec could not read the rule file {RulesFile}. Reason: All rules are invalid. AppSec will not run any protections in this application.", rulesFile);
                 }
                 else
                 {
-                    Log.Information("DDAS-0015-00: AppSec loaded {loadedRules} rules from file {rulesFile}.", initResult.LoadedRules, rulesFile);
+                    Log.Information("DDAS-0015-00: AppSec loaded {LoadedRules} rules from file {RulesFile}.", initResult.LoadedRules, rulesFile);
                 }
 
                 if (initResult.HasErrors)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 try
                 {
                     var eventsProp = root.Value<JArray>("rules");
-                    Log.Debug($"eventspropo {eventsProp.Count}");
+                    Log.Debug<int>("eventspropo {Count}", eventsProp.Count);
                     foreach (var ev in eventsProp)
                     {
                         var emptyJValue = JValue.CreateString(string.Empty);
@@ -121,15 +121,14 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
 
                 if (initResult.HasErrors)
                 {
-                    var sb = StringBuilderCache.Acquire(0);
-                    sb.Append($"WAF initialization failed. Some rules are invalid in rule file {rulesFile}:");
+                    var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
                     foreach (var item in initResult.Errors)
                     {
                         sb.Append($"{item.Key}: [{string.Join(", ", item.Value)}] ");
                     }
 
                     var errorMess = StringBuilderCache.GetStringAndRelease(sb);
-                    Log.Warning(errorMess);
+                    Log.Warning("WAF initialization failed. Some rules are invalid in rule file {RulesFile}: {ErroringRules}", rulesFile, errorMess);
                 }
 
                 return initResult;

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             {
                 // as this method is prefixed "Try" we shouldn't throw, but experience has
                 // shown that unforseen circumstance can lead to exceptions being thrown
-                Log.Error("Error occured while trying to load library from {LibraryPath}", libraryPath, ex);
+                Log.Error(ex, "Error occured while trying to load library from {LibraryPath}", libraryPath);
             }
 
             return handle != IntPtr.Zero;

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/ReducedRegistryAccess.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/ReducedRegistryAccess.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             {
                 var hresult = RegGetValue(HKEY.HKEY_LOCAL_MACHINE, key, value, RFlags.Any, out var _, pvData, ref pcbData);
 
-                Log.Debug<int>("RegGetValue - read string data: {pcbData}", pcbData);
+                Log.Debug<int>("RegGetValue - read string data: {PcbData}", pcbData);
 
                 if (hresult != 0)
                 {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -295,12 +295,12 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             funcPtr = NativeLibrary.GetExport(handle, functionName);
             if (funcPtr == IntPtr.Zero)
             {
-                _log.Error("No function of name {functionName} exists on waf object", functionName);
+                _log.Error("No function of name {FunctionName} exists on waf object", functionName);
                 ExportErrorHappened = true;
                 return null;
             }
 
-            _log.Debug("GetDelegateForNativeFunction {functionName} -  {funcPtr}: ", functionName, funcPtr);
+            _log.Debug("GetDelegateForNativeFunction {FunctionName} -  {FuncPtr}: ", functionName, funcPtr);
             return (T)Marshal.GetDelegateForFunctionPointer(funcPtr, typeof(T));
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -9,6 +9,7 @@ using Datadog.Trace.AppSec.Waf.Initialization;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Serilog;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Waf.NativeBindings
 {
@@ -265,25 +266,25 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             string message,
             ulong message_len)
         {
-            var formattedMessage = $"{level}: [{function}]{file}({line}): {message}";
+            var location = $"[{function}]{file}({line})";
             switch (level)
             {
                 case DDWAF_LOG_LEVEL.DDWAF_TRACE:
                 case DDWAF_LOG_LEVEL.DDWAF_DEBUG:
-                    _log.Debug(formattedMessage);
+                    _log.Debug("{Level}: {Location}: {Message}", level, location, message);
                     break;
                 case DDWAF_LOG_LEVEL.DDWAF_INFO:
-                    _log.Information(formattedMessage);
+                    _log.Information("{Level}: {Location}: {Message}", level, location, message);
                     break;
                 case DDWAF_LOG_LEVEL.DDWAF_WARN:
-                    _log.Warning(formattedMessage);
+                    _log.Warning("{Level}: {Location}: {Message}", level, location, message);
                     break;
                 case DDWAF_LOG_LEVEL.DDWAF_ERROR:
                 case DDWAF_LOG_LEVEL.DDWAF_AFTER_LAST:
-                    _log.Error(formattedMessage);
+                    _log.Error("{Level}: {Location}: {Message}", level, location, message);
                     break;
                 default:
-                    _log.Error("[Unknown level] " + formattedMessage);
+                    _log.Error("[Unknown level] {Level}: {Location}: {Message}", level, location, message);
                     break;
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.AppSec.Waf
             var finalRuleDatas = MergeRuleData(res);
             using var encoded = Encoder.Encode(finalRuleDatas, _wafLibraryInvoker, new List<Obj>(), false);
             var ret = _wafLibraryInvoker.UpdateRuleData(_wafHandle, encoded.RawPtr);
-            Log.Information("{number} rules have been updated and waf status is {status}", finalRuleDatas.Count, ret);
+            Log.Information("{Number} rules have been updated and waf status is {Status}", finalRuleDatas.Count, ret);
             return ret == DDWAF_RET_CODE.DDWAF_OK;
         }
 
@@ -132,7 +132,7 @@ namespace Datadog.Trace.AppSec.Waf
 
             using var encoded = Encoder.Encode(ruleStatus, _wafLibraryInvoker);
             var ret = _wafLibraryInvoker.ToggleRules(_wafHandle, encoded.RawPtr);
-            Log.Information("{number} rule status have been updated and waf status is {status}", ruleStatus.Count, ret);
+            Log.Information("{Number} rule status have been updated and waf status is {Status}", ruleStatus.Count, ret);
             return ret == DDWAF_RET_CODE.DDWAF_OK;
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace.Ci.Agent
                             // We get the countdown event and exit this loop
                             // to flush buffers (in case there's any event)
                             watermarkCountDown = watermarkEvent.Countdown;
-                            Log.Debug<int>("CIVisibilityProtocolWriter: Watermark detected on [Buffer: {bufferIndex}]", index);
+                            Log.Debug<int>("CIVisibilityProtocolWriter: Watermark detected on [Buffer: {BufferIndex}]", index);
                             break;
                         }
 
@@ -250,9 +250,9 @@ namespace Datadog.Trace.Ci.Agent
                     if (watermarkCountDown is not null)
                     {
                         watermarkCountDown.Signal();
-                        Log.Debug<int>("CIVisibilityProtocolWriter: Waiting for signals from other buffers [Buffer: {bufferIndex}]", index);
+                        Log.Debug<int>("CIVisibilityProtocolWriter: Waiting for signals from other buffers [Buffer: {BufferIndex}]", index);
                         await watermarkCountDown.WaitAsync().ConfigureAwait(false);
-                        Log.Debug<int>("CIVisibilityProtocolWriter: Signals received, continue processing.. [Buffer: {bufferIndex}]", index);
+                        Log.Debug<int>("CIVisibilityProtocolWriter: Signals received, continue processing.. [Buffer: {BufferIndex}]", index);
                     }
                 }
                 catch (ThreadAbortException ex)
@@ -269,9 +269,9 @@ namespace Datadog.Trace.Ci.Agent
                     if (watermarkCountDown is not null)
                     {
                         watermarkCountDown.Signal();
-                        Log.Debug<int>("CIVisibilityProtocolWriter: Waiting for signals from other buffers [Buffer: {bufferIndex}]", index);
+                        Log.Debug<int>("CIVisibilityProtocolWriter: Waiting for signals from other buffers [Buffer: {BufferIndex}]", index);
                         await watermarkCountDown.WaitAsync().ConfigureAwait(false);
-                        Log.Debug<int>("CIVisibilityProtocolWriter: Signals received, continue processing.. [Buffer: {bufferIndex}]", index);
+                        Log.Debug<int>("CIVisibilityProtocolWriter: Signals received, continue processing.. [Buffer: {BufferIndex}]", index);
                     }
                 }
                 finally

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Ci.Agent
                 _buffersArray[i].SetFlushTask(tskFlush);
             }
 
-            Log.Information<int>($"CIVisibilityProtocolWriter Initialized with concurrency level of: {concurrencyLevel}", concurrencyLevel);
+            Log.Information<int>("CIVisibilityProtocolWriter Initialized with concurrency level of: {ConcurrencyLevel}", concurrencyLevel);
         }
 
         public void WriteEvent(IEvent @event)

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterFileSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterFileSender.cs
@@ -45,12 +45,12 @@ namespace Datadog.Trace.Ci.Agent
             var msgPackBytes = payload.ToArray();
             var msgPackFile = str + ".mpack";
             File.WriteAllBytes(msgPackFile, msgPackBytes);
-            Log.Debug("File written: {file}", msgPackFile);
+            Log.Debug("File written: {File}", msgPackFile);
 
             var json = Vendors.MessagePack.MessagePackSerializer.ToJson(msgPackBytes);
             var jsonFile = str + ".json";
             File.WriteAllText(jsonFile, json);
-            Log.Debug("File written: {file}", jsonFile);
+            Log.Debug("File written: {File}", jsonFile);
 
             return Task.CompletedTask;
         }
@@ -77,12 +77,12 @@ namespace Datadog.Trace.Ci.Agent
                 {
                     var msgPackFile = str + $"{item.Name}.mpack";
                     File.WriteAllBytes(msgPackFile, bytes);
-                    Log.Debug("File written: {file}", msgPackFile);
+                    Log.Debug("File written: {File}", msgPackFile);
 
                     var json = Vendors.MessagePack.MessagePackSerializer.ToJson(bytes);
                     var jsonFile = str + $"{item.Name}.json";
                     File.WriteAllText(jsonFile, json);
-                    Log.Debug("File written: {file}", jsonFile);
+                    Log.Debug("File written: {File}", jsonFile);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -123,7 +123,7 @@ namespace Datadog.Trace.Ci.Agent
                 }
                 catch (MultipartApiRequestNotSupported mReqEx)
                 {
-                    Log.Error(mReqEx, "Error trying to send a multipart request to: {url}", url.ToString());
+                    Log.Error(mReqEx, "Error trying to send a multipart request to: {Url}", url.ToString());
                     return;
                 }
                 catch (Exception ex)
@@ -174,7 +174,7 @@ namespace Datadog.Trace.Ci.Agent
             var payloadArray = payload.ToArray();
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug<int, string>("Sending ({numberOfTraces} events) {bytesValue} bytes...", payload.Count, payloadArray.Length.ToString("N0"));
+                Log.Debug<int, string>("Sending ({NumberOfTraces} events) {BytesValue} bytes...", payload.Count, payloadArray.Length.ToString("N0"));
             }
 
             await SendPayloadAsync(
@@ -185,7 +185,7 @@ namespace Datadog.Trace.Ci.Agent
 
         private async Task SendPayloadAsync(MultipartPayload payload)
         {
-            Log.Debug<int>("Sending {count} multipart items...", payload.Count);
+            Log.Debug<int>("Sending {Count} multipart items...", payload.Count);
             await SendPayloadAsync(
                 payload,
                 static (request, payloadArray) =>

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIEventMessagePackFormatter.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
             }
             else
             {
-                Log.Error<int>("Error while locking the events buffer with {count} events.", value.Events.Count);
+                Log.Error<int>("Error while locking the events buffer with {Count} events.", value.Events.Count);
                 offset += MessagePackBinary.WriteNil(ref bytes, offset);
             }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityEventMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CIVisibilityEventMessagePackFormatter.cs
@@ -14,7 +14,7 @@ internal class CIVisibilityEventMessagePackFormatter<T> : EventMessagePackFormat
     {
         if (value is null)
         {
-            Log.Warning("CIVisibilityEventMessagePackFormatter<{type}>: event is null", typeof(T).Name);
+            Log.Warning("CIVisibilityEventMessagePackFormatter<{Type}>: event is null", typeof(T).Name);
             return 0;
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/CoveragePayloadMessagePackFormatter.cs
@@ -35,7 +35,7 @@ internal class CoveragePayloadMessagePackFormatter : EventMessagePackFormatter<C
         }
         else
         {
-            Log.Error<int>("Error while locking the events buffer with {count} events.", value.TestCoverageData.Count);
+            Log.Error<int>("Error while locking the events buffer with {Count} events.", value.TestCoverageData.Count);
             offset += MessagePackBinary.WriteNil(ref bytes, offset);
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Ci.Agent.Payloads
             var totalEvents = eventsBuffer.Count;
             var index = Count;
             var eventInBytes = MessagePackSerializer.Serialize(new CoveragePayload(eventsBuffer), _formatterResolver);
-            CIVisibility.Log.Debug<int, int>("CICodeCoveragePayload: Serialized {count} test code coverage as a single multipart item with {size} bytes.", eventsBuffer.Count, eventInBytes.Length);
+            CIVisibility.Log.Debug<int, int>("CICodeCoveragePayload: Serialized {Count} test code coverage as a single multipart item with {Size} bytes.", eventsBuffer.Count, eventInBytes.Length);
             return new MultipartFormItem($"coverage{index}", MimeTypes.MsgPack, $"filecoverage{index}.msgpack", new ArraySegment<byte>(eventInBytes));
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventsBuffer.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventsBuffer.cs
@@ -112,7 +112,7 @@ namespace Datadog.Trace.Ci.Agent.Payloads
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, ex.Message);
+                    Log.Error(ex, "Error serializing item to EventsBuffer");
                 }
 
                 if (_offset >= _maxBufferSize)

--- a/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -412,7 +412,7 @@ namespace Datadog.Trace.Ci
             }
             else
             {
-                Log.Warning("Git commit in .git folder is different from the one in the environment variables. [{gitCommit} != {envVarCommit}]", gitInfo.Commit, Commit);
+                Log.Warning("Git commit in .git folder is different from the one in the environment variables. [{GitCommit} != {EnvVarCommit}]", gitInfo.Commit, Commit);
             }
 
             // **********
@@ -454,7 +454,7 @@ namespace Datadog.Trace.Ci
                             }
                             else
                             {
-                                Log.Error("DD_GIT_REPOSITORY_URL is set with an empty value, defaulting to '{default}'", defaultValue);
+                                Log.Error("DD_GIT_REPOSITORY_URL is set with an empty value, defaulting to '{Default}'", defaultValue);
                             }
 
                             return false;
@@ -464,11 +464,11 @@ namespace Datadog.Trace.Ci
                         {
                             if (string.IsNullOrEmpty(defaultValue))
                             {
-                                Log.Error("DD_GIT_REPOSITORY_URL is set with an invalid value ('{value}'), and the Git repository could not be automatically extracted", value);
+                                Log.Error("DD_GIT_REPOSITORY_URL is set with an invalid value ('{Value}'), and the Git repository could not be automatically extracted", value);
                             }
                             else
                             {
-                                Log.Error("DD_GIT_REPOSITORY_URL is set with an invalid value ('{value}'), defaulting to '{default}'", value, defaultValue);
+                                Log.Error("DD_GIT_REPOSITORY_URL is set with an invalid value ('{Value}'), defaulting to '{Default}'", value, defaultValue);
                             }
 
                             return false;
@@ -502,7 +502,7 @@ namespace Datadog.Trace.Ci
                             }
                             else
                             {
-                                Log.Error("DD_GIT_COMMIT_SHA must be a full-length git SHA, defaulting to '{default}", defaultValue);
+                                Log.Error("DD_GIT_COMMIT_SHA must be a full-length git SHA, defaulting to '{Default}", defaultValue);
                             }
 
                             return false;
@@ -552,10 +552,10 @@ namespace Datadog.Trace.Ci
             {
                 foreach (var codeOwnersPath in GetCodeOwnersPaths(SourceRoot))
                 {
-                    Log.Debug("Looking for CODEOWNERS file in: {path}", codeOwnersPath);
+                    Log.Debug("Looking for CODEOWNERS file in: {Path}", codeOwnersPath);
                     if (File.Exists(codeOwnersPath))
                     {
-                        Log.Debug("CODEOWNERS file found: {path}", codeOwnersPath);
+                        Log.Debug("CODEOWNERS file found: {Path}", codeOwnersPath);
                         CodeOwners = new CodeOwners(codeOwnersPath);
                         break;
                     }

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Ci
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, e.Message);
+                    Log.Error(e, "Error executing trace processor {TraceProcessorType}", processor?.GetType());
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -430,7 +430,7 @@ namespace Datadog.Trace.Ci
                 // When is enabled by configuration we only enable it to the testhost child process if the process name is dotnet.
                 if (processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && Environment.CommandLine.IndexOf("testhost.dll", StringComparison.OrdinalIgnoreCase) == -1)
                 {
-                    Log.Information("CI Visibility disabled because the process name is 'dotnet' but the commandline doesn't contain 'testhost.dll': {cmdline}", Environment.CommandLine);
+                    Log.Information("CI Visibility disabled because the process name is 'dotnet' but the commandline doesn't contain 'testhost.dll': {Cmdline}", Environment.CommandLine);
                     return false;
                 }
 
@@ -509,13 +509,13 @@ namespace Datadog.Trace.Ci
 
                         if (_settings.CodeCoverageEnabled == null && settings.CodeCoverage.HasValue)
                         {
-                            Log.Information("ITR: Code Coverage has been changed to {value} by settings api.", settings.CodeCoverage.Value);
+                            Log.Information("ITR: Code Coverage has been changed to {Value} by settings api.", settings.CodeCoverage.Value);
                             _settings.SetCodeCoverageEnabled(settings.CodeCoverage.Value);
                         }
 
                         if (_settings.TestsSkippingEnabled == null && settings.TestsSkipping.HasValue)
                         {
-                            Log.Information("ITR: Tests Skipping has been changed to {value} by settings api.", settings.TestsSkipping.Value);
+                            Log.Information("ITR: Tests Skipping has been changed to {Value} by settings api.", settings.TestsSkipping.Value);
                             _settings.SetTestsSkippingEnabled(settings.TestsSkipping.Value);
                         }
                     }
@@ -528,7 +528,7 @@ namespace Datadog.Trace.Ci
                 if (_settings.TestsSkippingEnabled == true)
                 {
                     var skippeableTests = await lazyItrClient.Value.GetSkippableTestsAsync().ConfigureAwait(false);
-                    Log.Information<int>("ITR: SkippableTests = {length}.", skippeableTests.Length);
+                    Log.Information<int>("ITR: SkippableTests = {Length}.", skippeableTests.Length);
 
                     var skippableTestsBySuiteAndName = new Dictionary<string, Dictionary<string, IList<SkippableTest>>>();
                     foreach (var item in skippeableTests)

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -549,7 +549,7 @@ namespace Datadog.Trace.Ci
                     }
 
                     _skippableTestsBySuiteAndName = skippableTestsBySuiteAndName;
-                    Log.Debug<int>("ITR: SkippableTests dictionary has been built.", skippeableTests.Length);
+                    Log.Debug("ITR: SkippableTests dictionary has been built.");
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -186,12 +186,12 @@ namespace Datadog.Trace.Ci
                 AsyncUtil.RunSync(() => FlushAsync(), cts.Token);
                 if (cts.IsCancellationRequested)
                 {
-                    Log.Error($"Timeout occurred when flushing spans.{Environment.NewLine}{Environment.StackTrace}");
+                    Log.Error("Timeout occurred when flushing spans.{NewLine}{StackTrace}", Environment.NewLine, Environment.StackTrace);
                 }
             }
             catch (TaskCanceledException)
             {
-                Log.Error($"Timeout occurred when flushing spans.{Environment.NewLine}{Environment.StackTrace}");
+                Log.Error("Timeout occurred when flushing spans.{NewLine}{StackTrace}", Environment.NewLine, Environment.StackTrace);
             }
             finally
             {
@@ -343,7 +343,7 @@ namespace Datadog.Trace.Ci
                 if (proxyHttpsUriBuilder.Scheme == "https")
                 {
                     // HTTPS proxy is not supported by .NET BCL
-                    Log.Error($"HTTPS proxy is not supported. ({proxyHttpsUriBuilder})");
+                    Log.Error("HTTPS proxy is not supported. ({ProxyHttpsUriBuilder})", proxyHttpsUriBuilder);
                     return factory;
                 }
 
@@ -389,7 +389,7 @@ namespace Datadog.Trace.Ci
                     }
                     catch (Exception ex)
                     {
-                        Log.Warning(ex, ex.Message);
+                        Log.Warning(ex, "Error getting OS version on macOS");
                     }
                     finally
                     {
@@ -421,7 +421,7 @@ namespace Datadog.Trace.Ci
             }
             catch (Exception exception)
             {
-                Log.Warning(exception, exception.Message);
+                Log.Warning(exception, "Error getting current process name when checking CI Visibility status");
             }
 
             // By configuration
@@ -522,7 +522,7 @@ namespace Datadog.Trace.Ci
                 }
 
                 // Log code coverage status
-                Log.Information(_settings.CodeCoverageEnabled == true ? "ITR: Tests code coverage is enabled." : "ITR: Tests code coverage is disabled.");
+                Log.Information("{V}", _settings.CodeCoverageEnabled == true ? "ITR: Tests code coverage is enabled." : "ITR: Tests code coverage is disabled.");
 
                 // If the tests skipping feature is enabled we query the api for the tests we have to skip
                 if (_settings.TestsSkippingEnabled == true)

--- a/tracer/src/Datadog.Trace/Ci/Coverage/DefaultCoverageEventHandler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/DefaultCoverageEventHandler.cs
@@ -111,7 +111,7 @@ internal class DefaultCoverageEventHandler : CoverageEventHandler
 
         if (Log.IsEnabled(LogEventLevel.Debug))
         {
-            Log.Debug("Test Coverage: {json}", JsonConvert.SerializeObject(testCoverage));
+            Log.Debug("Test Coverage: {Json}", JsonConvert.SerializeObject(testCoverage));
         }
 
         return testCoverage;

--- a/tracer/src/Datadog.Trace/Ci/Coverage/DefaultWithGlobalCoverageEventHandler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/DefaultWithGlobalCoverageEventHandler.cs
@@ -145,7 +145,7 @@ internal class DefaultWithGlobalCoverageEventHandler : DefaultCoverageEventHandl
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("Global Coverage payload: {payload}", JsonConvert.SerializeObject(globalCoverage));
+                Log.Debug("Global Coverage payload: {Payload}", JsonConvert.SerializeObject(globalCoverage));
             }
 
             // Clean coverages

--- a/tracer/src/Datadog.Trace/Ci/Coverage/DefaultWithGlobalCoverageEventHandler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/DefaultWithGlobalCoverageEventHandler.cs
@@ -124,7 +124,9 @@ internal class DefaultWithGlobalCoverageEventHandler : DefaultCoverageEventHandl
                             }
                             else if (methodValue?.SequencePoints is not null)
                             {
-                                Log.Warning($"Index doesn't found: {fileCoverageInfo.Path} | {seqPoint.StartLine}:{seqPoint.StartColumn}:{seqPoint.EndLine}:{seqPoint.EndColumn} | {methodDef.FullName} | {x} | {methodValue.SequencePoints.Length}");
+                                var location = $"{seqPoint.StartLine}:{seqPoint.StartColumn}:{seqPoint.EndLine}:{seqPoint.EndColumn}";
+                                var method = $"{methodDef.FullName} | {x} | {methodValue.SequencePoints.Length}";
+                                Log.Warning("Index not found: {Path} | {Location} | {Method}", fileCoverageInfo.Path, location, method);
                             }
 
                             fileCoverageInfo.Add(new[] { (uint)seqPoint.StartLine, (uint)seqPoint.StartColumn, (uint)seqPoint.EndLine, (uint)seqPoint.EndColumn, (uint)repInSeqPoints });
@@ -154,7 +156,7 @@ internal class DefaultWithGlobalCoverageEventHandler : DefaultCoverageEventHandl
 
             GlobalContainer?.Clear();
 
-            Log.Information($"Total time to calculate global coverage: {sw.Elapsed.TotalMilliseconds}ms");
+            Log.Information("Total time to calculate global coverage: {TotalMilliseconds}ms", sw.Elapsed.TotalMilliseconds);
             return globalCoverage;
         }
     }

--- a/tracer/src/Datadog.Trace/Ci/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/GitInfo.cs
@@ -514,7 +514,7 @@ namespace Datadog.Trace.Ci
                             }
                             else
                             {
-                                Log.Warning<int>("The object size is outside of an acceptable range: {objectSize}", objectSize);
+                                Log.Warning<int>("The object size is outside of an acceptable range: {ObjectSize}", objectSize);
                             }
                         }
                     }

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -218,7 +218,7 @@ internal class IntelligentTestRunnerClient
             return 0;
         }
 
-        Log.Debug<int>("ITR: Local commits = {count}", localCommits.Length);
+        Log.Debug<int>("ITR: Local commits = {Count}", localCommits.Length);
         var remoteCommitsData = await SearchCommitAsync(localCommits).ConfigureAwait(false);
         return await SendObjectsPackFileAsync(localCommits[0], remoteCommitsData).ConfigureAwait(false);
     }
@@ -264,7 +264,7 @@ internal class IntelligentTestRunnerClient
             default);
         var jsonQuery = JsonConvert.SerializeObject(query, SerializerSettings);
         var jsonQueryBytes = Encoding.UTF8.GetBytes(jsonQuery);
-        Log.Debug("ITR: JSON RQ = {json}", jsonQuery);
+        Log.Debug("ITR: JSON RQ = {Json}", jsonQuery);
 
         return await WithRetries(InternalGetSettingsAsync, jsonQueryBytes, MaxRetries).ConfigureAwait(false);
 
@@ -275,14 +275,14 @@ internal class IntelligentTestRunnerClient
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("ITR: Getting settings from: {url}", _settingsUrl.ToString());
+                Log.Debug("ITR: Getting settings from: {Url}", _settingsUrl.ToString());
             }
 
             using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
             var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
             CheckResponseStatusCode(response, responseContent, finalTry);
 
-            Log.Debug("ITR: JSON RS = {json}", responseContent);
+            Log.Debug("ITR: JSON RS = {Json}", responseContent);
             if (string.IsNullOrEmpty(responseContent))
             {
                 return default;
@@ -332,7 +332,7 @@ internal class IntelligentTestRunnerClient
             default);
         var jsonQuery = JsonConvert.SerializeObject(query, SerializerSettings);
         var jsonQueryBytes = Encoding.UTF8.GetBytes(jsonQuery);
-        Log.Debug("ITR: JSON RQ = {json}", jsonQuery);
+        Log.Debug("ITR: JSON RQ = {Json}", jsonQuery);
 
         return await WithRetries(InternalGetSkippableTestsAsync, jsonQueryBytes, MaxRetries).ConfigureAwait(false);
 
@@ -343,14 +343,14 @@ internal class IntelligentTestRunnerClient
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("ITR: Searching skippable tests from: {url}", _skippableTestsUrl.ToString());
+                Log.Debug("ITR: Searching skippable tests from: {Url}", _skippableTestsUrl.ToString());
             }
 
             using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
             var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
             CheckResponseStatusCode(response, responseContent, finalTry);
 
-            Log.Debug("ITR: JSON RS = {json}", responseContent);
+            Log.Debug("ITR: JSON RS = {Json}", responseContent);
             if (string.IsNullOrEmpty(responseContent))
             {
                 return Array.Empty<SkippableTest>();
@@ -394,7 +394,7 @@ internal class IntelligentTestRunnerClient
 
             if (Log.IsEnabled(LogEventLevel.Debug) && deserializedResult.Data.Length != testAttributes.Count)
             {
-                Log.Debug("ITR: JSON Filtered = {json}", JsonConvert.SerializeObject(testAttributes));
+                Log.Debug("ITR: JSON Filtered = {Json}", JsonConvert.SerializeObject(testAttributes));
             }
 
             return testAttributes.ToArray();
@@ -426,7 +426,7 @@ internal class IntelligentTestRunnerClient
 
         var repository = await _getRepositoryUrlTask.ConfigureAwait(false);
         var jsonPushedSha = JsonConvert.SerializeObject(new DataArrayEnvelope<Data<object>>(commitRequests, repository), SerializerSettings);
-        Log.Debug("ITR: JSON RQ = {json}", jsonPushedSha);
+        Log.Debug("ITR: JSON RQ = {Json}", jsonPushedSha);
         var jsonPushedShaBytes = Encoding.UTF8.GetBytes(jsonPushedSha);
 
         return await WithRetries(InternalSearchCommitAsync, jsonPushedShaBytes, MaxRetries).ConfigureAwait(false);
@@ -438,14 +438,14 @@ internal class IntelligentTestRunnerClient
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("ITR: Searching commits from: {url}", _searchCommitsUrl.ToString());
+                Log.Debug("ITR: Searching commits from: {Url}", _searchCommitsUrl.ToString());
             }
 
             using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
             var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
             CheckResponseStatusCode(response, responseContent, finalTry);
 
-            Log.Debug("ITR: JSON RS = {json}", responseContent);
+            Log.Debug("ITR: JSON RS = {Json}", responseContent);
             if (string.IsNullOrEmpty(responseContent))
             {
                 return Array.Empty<string>();
@@ -488,14 +488,14 @@ internal class IntelligentTestRunnerClient
 
         var repository = await _getRepositoryUrlTask.ConfigureAwait(false);
         var jsonPushedSha = JsonConvert.SerializeObject(new DataEnvelope<Data<object>>(new Data<object>(commitSha, CommitType, default), repository), SerializerSettings);
-        Log.Debug("ITR: JSON RQ = {json}", jsonPushedSha);
+        Log.Debug("ITR: JSON RQ = {Json}", jsonPushedSha);
         var jsonPushedShaBytes = Encoding.UTF8.GetBytes(jsonPushedSha);
 
         long totalUploadSize = 0;
         foreach (var packFile in packFilesObject.Files)
         {
             // Send PackFile content
-            Log.Information("ITR: Sending {packFile}", packFile);
+            Log.Information("ITR: Sending {PackFile}", packFile);
             totalUploadSize += await WithRetries(InternalSendObjectsPackFileAsync, packFile, MaxRetries).ConfigureAwait(false);
 
             // Delete temporal pack file
@@ -505,7 +505,7 @@ internal class IntelligentTestRunnerClient
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "ITR: Error deleting pack file: '{packFile}'", packFile);
+                Log.Warning(ex, "ITR: Error deleting pack file: '{PackFile}'", packFile);
             }
         }
 
@@ -518,11 +518,11 @@ internal class IntelligentTestRunnerClient
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "ITR: Error deleting temporary folder: '{temporaryFolder}'", packFilesObject.TemporaryFolder);
+                Log.Warning(ex, "ITR: Error deleting temporary folder: '{TemporaryFolder}'", packFilesObject.TemporaryFolder);
             }
         }
 
-        Log.Information("ITR: Total pack file upload: {totalUploadSize} bytes", totalUploadSize);
+        Log.Information("ITR: Total pack file upload: {TotalUploadSize} bytes", totalUploadSize);
         return totalUploadSize;
 
         async Task<long> InternalSendObjectsPackFileAsync(string packFile, bool finalTry)
@@ -591,7 +591,7 @@ internal class IntelligentTestRunnerClient
 
             if (packObjectsResultCommand.ExitCode != 0)
             {
-                Log.Warning("ITR: 'git pack-objects...' command error: {stderr}", packObjectsResultCommand.Error);
+                Log.Warning("ITR: 'git pack-objects...' command error: {Stderr}", packObjectsResultCommand.Error);
             }
         }
 
@@ -610,7 +610,7 @@ internal class IntelligentTestRunnerClient
             }
             else
             {
-                Log.Warning("ITR: The file '{packFile}' doesn't exist.", file);
+                Log.Warning("ITR: The file '{PackFile}' doesn't exist.", file);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Processors/TestSuiteVisibilityProcessor.cs
+++ b/tracer/src/Datadog.Trace/Ci/Processors/TestSuiteVisibilityProcessor.cs
@@ -39,7 +39,7 @@ internal class TestSuiteVisibilityProcessor : ITraceProcessor
             }
             else
             {
-                Log.Warning("Span dropped because Test suite visibility is not supported without Agentless [Span.Type={type}]", span.Type);
+                Log.Warning("Span dropped because Test suite visibility is not supported without Agentless [Span.Type={Type}]", span.Type);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -48,7 +48,7 @@ public sealed class Test
         }
 
         CurrentTest.Value = this;
-        CIVisibility.Log.Debug("######### New Test Created: {name} ({suite} | {module})", Name, Suite.Name, Suite.Module.Name);
+        CIVisibility.Log.Debug("######### New Test Created: {Name} ({Suite} | {Module})", Name, Suite.Name, Suite.Module.Name);
 
         if (startDate is null)
         {
@@ -235,7 +235,7 @@ public sealed class Test
             testCoverage.SuiteId = tags.SuiteId;
             testCoverage.SpanId = _scope.Span.SpanId;
 
-            CIVisibility.Log.Debug("Coverage data for SessionId={sessionId}, SuiteId={suiteId} and SpanId={spanId} processed.", testCoverage.SessionId, testCoverage.SuiteId, testCoverage.SpanId);
+            CIVisibility.Log.Debug("Coverage data for SessionId={SessionId}, SuiteId={SuiteId} and SpanId={SpanId} processed.", testCoverage.SessionId, testCoverage.SuiteId, testCoverage.SpanId);
             CIVisibility.Manager?.WriteEvent(testCoverage);
         }
 
@@ -260,7 +260,7 @@ public sealed class Test
         scope.Dispose();
 
         Current = null;
-        CIVisibility.Log.Debug("######### Test Closed: {name} ({suite} | {module}) | {status}", Name, Suite.Name, Suite.Module.Name, tags.Status);
+        CIVisibility.Log.Debug("######### Test Closed: {Name} ({Suite} | {Module}) | {Status}", Name, Suite.Name, Suite.Module.Name, tags.Status);
     }
 
     internal void ResetStartTime()

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -164,7 +164,7 @@ public sealed class TestModule
 
         _span = span;
         Current = this;
-        CIVisibility.Log.Debug("### Test Module Created: {name}", name);
+        CIVisibility.Log.Debug("### Test Module Created: {Name}", name);
 
         if (startDate is null)
         {
@@ -299,7 +299,7 @@ public sealed class TestModule
     {
         if (InternalClose(duration))
         {
-            CIVisibility.Log.Debug("### Test Module Flushing after close: {name}", Name);
+            CIVisibility.Log.Debug("### Test Module Flushing after close: {Name}", Name);
             CIVisibility.Flush();
         }
     }
@@ -322,7 +322,7 @@ public sealed class TestModule
     {
         if (InternalClose(duration))
         {
-            CIVisibility.Log.Debug("### Test Module Flushing after close: {name}", Name);
+            CIVisibility.Log.Debug("### Test Module Flushing after close: {Name}", Name);
             return CIVisibility.FlushAsync();
         }
 
@@ -404,7 +404,7 @@ public sealed class TestModule
         span.Finish(duration.Value);
 
         Current = null;
-        CIVisibility.Log.Debug("### Test Module Closed: {name} | {status}", Name, Tags.Status);
+        CIVisibility.Log.Debug("### Test Module Closed: {Name} | {Status}", Name, Tags.Status);
 
         if (_fakeSession is { } fakeSession)
         {

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -74,7 +74,7 @@ public sealed class TestSession
         }
 
         Current = this;
-        CIVisibility.Log.Debug("### Test Session Created: {command}", command);
+        CIVisibility.Log.Debug("### Test Session Created: {Command}", command);
 
         if (startDate is null)
         {
@@ -264,7 +264,7 @@ public sealed class TestSession
     {
         if (InternalClose(status, duration))
         {
-            CIVisibility.Log.Debug("### Test Session Flushing after close: {command}", Command);
+            CIVisibility.Log.Debug("### Test Session Flushing after close: {Command}", Command);
             CIVisibility.Flush();
         }
     }
@@ -289,7 +289,7 @@ public sealed class TestSession
     {
         if (InternalClose(status, duration))
         {
-            CIVisibility.Log.Debug("### Test Session Flushing after close: {command}", Command);
+            CIVisibility.Log.Debug("### Test Session Flushing after close: {Command}", Command);
             return CIVisibility.FlushAsync();
         }
 
@@ -338,7 +338,7 @@ public sealed class TestSession
         }
 
         Current = null;
-        CIVisibility.Log.Debug("### Test Session Closed: {command} | {status}", Command, Tags.Status);
+        CIVisibility.Log.Debug("### Test Session Closed: {Command} | {Status}", Command, Tags.Status);
         return true;
     }
 

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -40,7 +40,7 @@ public sealed class TestSuite
 
         _span = span;
         Current = this;
-        CIVisibility.Log.Debug("###### New Test Suite Created: {name} ({module})", Name, Module.Name);
+        CIVisibility.Log.Debug("###### New Test Suite Created: {Name} ({Module})", Name, Module.Name);
 
         if (startDate is null)
         {
@@ -163,7 +163,7 @@ public sealed class TestSuite
 
         Current = null;
         Module.RemoveSuite(Name);
-        CIVisibility.Log.Debug("###### Test Suite Closed: {name} ({module}) | {status}", Name, Module.Name, Tags.Status);
+        CIVisibility.Log.Debug("###### Test Suite Closed: {Name} ({Module}) | {Status}", Name, Module.Name, Tags.Status);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHeadersCollectionAdapter.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
                 catch (Exception ex)
                 {
-                    Logger.Information(ex, "Could not deserialize Kafka header {headerName}", name);
+                    Logger.Information(ex, "Could not deserialize Kafka header {HeaderName}", name);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LoggerFactoryIntegrationCommon.cs" company="Datadog">
+// <copyright file="LoggerFactoryIntegrationCommon.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Error loading logger factory types for " + typeof(TLoggerFactory));
+                Log.Warning(ex, "Error loading logger factory types for {LoggerFactoryType}", typeof(TLoggerFactory));
                 ProviderInterfaces = null;
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
@@ -109,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug($"Unknown Serilog LogEventPropertyValue '{value.GetType()}': skipping in log message");
+                Log.Debug("Unknown Serilog LogEventPropertyValue '{Type}': skipping in log message", value.GetType());
                 LogFormatter.WriteValue(writer, value: null);
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -141,7 +141,7 @@ internal static class MsTestIntegration
         }
         catch (Exception ex)
         {
-            Log.Error(ex, ex.Message);
+            Log.Error(ex, "Error reading MSTest traits");
         }
 
         return testProperties;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitTestCommandExecuteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitTestCommandExecuteIntegration.cs
@@ -47,7 +47,7 @@ public static class NUnitTestCommandExecuteIntegration
         var testResult = executionContext.CurrentResult;
         if (testResult.ResultState.Status == TestStatus.Failed && executionContext.CurrentTest.TestType == NUnitIntegration.TestSuiteConst)
         {
-            CIVisibility.Log.Warning($"{typeof(TTarget).FullName} | {executionContext.CurrentTest.TestType} | {executionContext.CurrentTest.FullName} | {executionContext.CurrentResult.Message} | {executionContext.CurrentResult.ResultState.Status} | {executionContext.CurrentResult.ResultState.Site}");
+            CIVisibility.Log.Warning("{FullName} | {TestType} | {TestName} | {Message} | {Status} | {Site}", new object[] { typeof(TTarget).FullName, executionContext.CurrentTest.TestType, executionContext.CurrentTest.FullName, executionContext.CurrentResult.Message, executionContext.CurrentResult.ResultState.Status, executionContext.CurrentResult.ResultState.Site });
 
             if (NUnitIntegration.GetTestSuiteFrom(executionContext.CurrentTest) is { } suite)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemPerformWorkIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemPerformWorkIntegration.cs
@@ -51,7 +51,7 @@ public static class NUnitWorkItemPerformWorkIntegration
                     break;
                 case "TestMethod" when NUnitIntegration.ShouldSkip(item):
                     var testMethod = item.Method.MethodInfo;
-                    Common.Log.Debug("ITR: Test skipped: {class}.{name}", testMethod.DeclaringType?.FullName, testMethod.Name);
+                    Common.Log.Debug("ITR: Test skipped: {Class}.{Name}", testMethod.DeclaringType?.FullName, testMethod.Name);
                     item.RunState = RunState.Ignored;
                     item.Properties.Set(NUnitIntegration.SkipReasonKey, "Skipped by the Intelligent Test Runner");
                     break;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
@@ -40,7 +40,7 @@ public static class XUnitTestRunnerRunAsyncIntegration
             // Check if the test should be skipped by the ITR
             if (XUnitIntegration.ShouldSkip(ref runnerInstance) && instance.TryDuckCast<ITestRunnerSkippable>(out var skippableRunnerInstance))
             {
-                Common.Log.Debug("ITR: Test skipped: {class}.{name}", runnerInstance.TestClass?.FullName ?? string.Empty, runnerInstance.TestMethod?.Name ?? string.Empty);
+                Common.Log.Debug("ITR: Test skipped: {Class}.{Name}", runnerInstance.TestClass?.FullName ?? string.Empty, runnerInstance.TestMethod?.Name ?? string.Empty);
                 skippableRunnerInstance.SkipReason = "Skipped by the Intelligent Test Runner";
             }
             else if (runnerInstance.SkipReason is not null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
     {
         private const string HttpRequestMessagePropertyTypeName = "System.ServiceModel.Channels.HttpRequestMessageProperty";
         private static readonly Lazy<Func<object>> _getCurrentOperationContext = new Lazy<Func<object>>(CreateGetCurrentOperationContextDelegate, isThreadSafe: true);
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ChannelHandlerIntegration));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(WcfCommon));
 
         internal const string IntegrationName = nameof(IntegrationId.Wcf);
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.Wcf;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler
 
         public void Register(object manualTracer)
         {
-            Log.Information("Registering {child} as child tracer", manualTracer.GetType());
+            Log.Information("Registering {Child} as child tracer", manualTracer.GetType());
             _child = manualTracer.DuckCast<ICommonTracer>();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 {
     internal abstract class ContinuationGenerator<TTarget, TReturn>
     {
-        internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContinuationGenerator<TTarget, TTarget>));
+        internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ContinuationGenerator<TTarget, TReturn>));
 
         internal delegate object ObjectContinuationMethodDelegate(TTarget target, object returnValue, Exception exception, in CallTargetState state);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
@@ -38,7 +38,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug($"== TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}> using Resolver: {Resolver.GetType().FullName}");
+                Log.Debug(
+                    "== {TaskContinuationGenerator} using Resolver: {Resolver}",
+                    $"TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}>",
+                    Resolver.GetType().FullName);
             }
         }
 
@@ -111,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(ex, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(ex);
                 }
 
                 // *
@@ -177,7 +180,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(ex, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(ex);
                 }
 
                 // *

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs
@@ -40,7 +40,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug($"== TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}, {typeof(TResult).FullName}> using Resolver: {Resolver.GetType().FullName}");
+                Log.Debug(
+                    "== {TaskContinuationGenerator} using Resolver: {Resolver}",
+                    $"TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}, {typeof(TResult).FullName}>",
+                    Resolver.GetType().FullName);
             }
         }
 
@@ -118,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(ex, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(ex);
                 }
 
                 // *
@@ -192,7 +195,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(ex, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(ex);
                 }
 
                 // *

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
@@ -38,7 +38,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug($"== TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}> using Resolver: {Resolver.GetType().FullName}");
+                Log.Debug(
+                    "== {TaskContinuationGenerator} using Resolver: {Resolver}",
+                    $"TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}>",
+                    Resolver.GetType().FullName);
             }
         }
 
@@ -87,7 +90,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     }
                     catch (Exception contEx)
                     {
-                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                     }
 
                     throw;
@@ -102,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception contEx)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                 }
             }
         }
@@ -146,7 +149,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     }
                     catch (Exception contEx)
                     {
-                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                     }
 
                     throw;
@@ -161,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception contEx)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
@@ -40,7 +40,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug($"== TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}> using Resolver: {Resolver.GetType().FullName}");
+                Log.Debug(
+                    "== {TaskContinuationGenerator} using Resolver: {Resolver}",
+                    $"TaskContinuationGenerator<{typeof(TIntegration).FullName}, {typeof(TTarget).FullName}, {typeof(TReturn).FullName}>",
+                    Resolver.GetType().FullName);
             }
         }
 
@@ -90,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     }
                     catch (Exception contEx)
                     {
-                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                     }
 
                     throw;
@@ -105,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception contEx)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                 }
 
                 return result;
@@ -152,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                     }
                     catch (Exception contEx)
                     {
-                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                     }
 
                     throw;
@@ -167,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception contEx)
                 {
-                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx);
                 }
 
                 return result;

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -42,11 +42,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
              *
              */
 
-            Log.Debug($"Creating BeginMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Creating BeginMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             MethodInfo onMethodBeginMethodInfo = integrationType.GetMethod(BeginMethodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (onMethodBeginMethodInfo is null)
             {
-                Log.Debug($"'{BeginMethodName}' method was not found in integration type: '{integrationType.FullName}'.");
+                Log.Debug("'{BeginMethodName}' method was not found in integration type: '{IntegrationType}'.", BeginMethodName, integrationType.FullName);
                 return null;
             }
 
@@ -186,7 +186,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             ilWriter.EmitCall(OpCodes.Call, onMethodBeginMethodInfo, null);
             ilWriter.Emit(OpCodes.Ret);
 
-            Log.Debug($"Created BeginMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Created BeginMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             return callMethod;
         }
 
@@ -205,11 +205,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
              *
              */
 
-            Log.Debug($"Creating SlowBeginMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Creating SlowBeginMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             MethodInfo onMethodBeginMethodInfo = integrationType.GetMethod(BeginMethodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (onMethodBeginMethodInfo is null)
             {
-                Log.Debug($"'{BeginMethodName}' method was not found in integration type: '{integrationType.FullName}'.");
+                Log.Debug("'{BeginMethodName}' method was not found in integration type: '{IntegrationType}'.", BeginMethodName, integrationType.FullName);
                 return null;
             }
 
@@ -304,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             ilWriter.EmitCall(OpCodes.Call, onMethodBeginMethodInfo, null);
             ilWriter.Emit(OpCodes.Ret);
 
-            Log.Debug($"Created SlowBeginMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Created SlowBeginMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             return callMethod;
         }
 
@@ -318,12 +318,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
              *      - CallTargetReturn OnMethodEnd<TTarget>(Exception exception, in CallTargetState state);
              */
 
-            Log.Debug($"Creating EndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Creating EndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             MethodInfo onMethodEndMethodInfo = GetOnMethodEndMethodInfo(integrationType, "CallTargetReturn");
 
             if (onMethodEndMethodInfo is null)
             {
-                Log.Debug($"'{EndMethodName}' method was not found in integration type: '{integrationType.FullName}'.");
+                Log.Debug("'{EndMethodName}' method was not found in integration type: '{IntegrationType}'.", EndMethodName, integrationType.FullName);
                 return null;
             }
 
@@ -415,7 +415,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
             ilWriter.Emit(OpCodes.Ret);
 
-            Log.Debug($"Created EndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}]");
+            Log.Debug("Created EndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}]", integrationType.FullName, targetType.FullName);
             return callMethod;
         }
 
@@ -432,12 +432,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
              *
              */
 
-            Log.Debug($"Creating EndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}, ReturnType={returnType.FullName}]");
+            Log.Debug("Creating EndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}, ReturnType={ReturnType}]", integrationType.FullName, targetType.FullName, returnType.FullName);
             MethodInfo onMethodEndMethodInfo = GetOnMethodEndMethodInfo(integrationType, "CallTargetReturn`1");
 
             if (onMethodEndMethodInfo is null)
             {
-                Log.Debug($"'{EndMethodName}' method was not found in integration type: '{integrationType.FullName}'.");
+                Log.Debug("'{EndMethodName}' method was not found in integration type: '{IntegrationType}'.", EndMethodName, integrationType.FullName);
                 return null;
             }
 
@@ -568,7 +568,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
             ilWriter.Emit(OpCodes.Ret);
 
-            Log.Debug($"Created EndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}, ReturnType={returnType.FullName}]");
+            Log.Debug("Created EndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}, ReturnType={ReturnType}]", integrationType.FullName, targetType.FullName, returnType.FullName);
             return callMethod;
         }
 
@@ -593,11 +593,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
              *      [Type] represents a type that we can reference directly, instead of using generics.
              */
 
-            Log.Debug($"Creating AsyncEndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}, ReturnType={returnType.FullName}]");
+            Log.Debug("Creating AsyncEndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}, ReturnType={ReturnType}]", integrationType.FullName, targetType.FullName, returnType.FullName);
             MethodInfo onAsyncMethodEndMethodInfo = integrationType.GetMethod(EndAsyncMethodName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
             if (onAsyncMethodEndMethodInfo is null)
             {
-                Log.Debug($"'{EndAsyncMethodName}' method was not found in integration type: '{integrationType.FullName}'.");
+                Log.Debug("'{EndAsyncMethodName}' method was not found in integration type: '{IntegrationType}'.", EndAsyncMethodName, integrationType.FullName);
                 return default;
             }
 
@@ -759,7 +759,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
             ilWriter.Emit(OpCodes.Ret);
 
-            Log.Debug($"Created AsyncEndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}, ReturnType={returnType.FullName}]");
+            Log.Debug("Created AsyncEndMethod Dynamic Method for '{IntegrationType}' integration. [Target={TargetType}, ReturnType={ReturnType}]", integrationType.FullName, targetType.FullName, returnType.FullName);
             return new CreateAsyncEndMethodResult(callMethod, preserveContext);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
@@ -25,13 +25,13 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         internal static void DisableIntegration() => _disableIntegration = true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void LogException(Exception exception, string message = null)
+        internal static void LogException(Exception exception)
         {
             // ReSharper disable twice ExplicitCallerInfoArgument
-            Log.Error(exception, message ?? exception?.Message);
+            Log.Error(exception, "Exception occurred when calling the CallTarget integration continuation.");
             if (exception is DuckTypeException or TargetInvocationException { InnerException: DuckTypeException })
             {
-                Log.Warning($"DuckTypeException has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");
+                Log.Warning("DuckTypeException has been detected, the integration <{TIntegration}, {TTarget}> will be disabled.", typeof(TIntegration), typeof(TTarget));
                 if (_integrationId.Value is not null)
                 {
                     Tracer.Instance.TracerManager.Telemetry.IntegrationDisabledDueToError(_integrationId.Value.Value, nameof(DuckTypeException));
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             }
             else if (exception is CallTargetInvokerException)
             {
-                Log.Warning($"CallTargetInvokerException has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");
+                Log.Warning("CallTargetInvokerException has been detected, the integration <{TIntegration}, {TTarget}> will be disabled.", typeof(TIntegration), typeof(TTarget));
                 if (_integrationId.Value is not null)
                 {
                     Tracer.Instance.TracerManager.Telemetry.IntegrationDisabledDueToError(_integrationId.Value.Value, nameof(CallTargetInvokerException));

--- a/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler
                 {
                     var parentTracer = parent.DuckCast<IAutomaticTracer>();
 
-                    Log.Information("Building manual tracer, connected to {assembly}", parent.GetType().Assembly);
+                    Log.Information("Building manual tracer, connected to {Assembly}", parent.GetType().Assembly);
 
                     Instance = new ManualTracer(parentTracer);
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.ClrProfiler
                 var payload = InstrumentationDefinitions.GetAllDefinitions();
                 NativeMethods.InitializeProfiler(payload.DefinitionsId, payload.Definitions);
 
-                Log.Information<int>("The profiler has been initialized with {count} definitions.", payload.Definitions.Length);
+                Log.Information<int>("The profiler has been initialized with {Count} definitions.", payload.Definitions.Length);
             }
             catch (Exception ex)
             {
@@ -155,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler
                 var payload = InstrumentationDefinitions.GetDerivedDefinitions();
                 NativeMethods.AddDerivedInstrumentations(payload.DefinitionsId, payload.Definitions);
 
-                Log.Information<int>("The profiler has been initialized with {count} derived definitions.", payload.Definitions.Length);
+                Log.Information<int>("The profiler has been initialized with {Count} derived definitions.", payload.Definitions.Length);
             }
             catch (Exception ex)
             {
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler
                 var payload = InstrumentationDefinitions.GetInterfaceDefinitions();
                 NativeMethods.AddInterfaceInstrumentations(payload.DefinitionsId, payload.Definitions);
 
-                Log.Information<int>("The profiler has been initialized with {count} interface definitions.", payload.Definitions.Length);
+                Log.Information<int>("The profiler has been initialized with {Count} interface definitions.", payload.Definitions.Length);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -196,7 +196,7 @@ namespace Datadog.Trace.ClrProfiler
                     var traceMethodsConfiguration = tracer.Settings.TraceMethods;
                     var payload = InstrumentationDefinitions.GetTraceMethodDefinitions();
                     NativeMethods.InitializeTraceMethods(payload.DefinitionsId, payload.AssemblyName, payload.TypeName, traceMethodsConfiguration);
-                    Log.Information("TraceMethods instrumentation enabled with Assembly={AssemblyName}, Type={TypeName}, and Configuration={}.", payload.AssemblyName, payload.TypeName, traceMethodsConfiguration);
+                    Log.Information("TraceMethods instrumentation enabled with Assembly={AssemblyName}, Type={TypeName}, and Configuration={Configuration}.", payload.AssemblyName, payload.TypeName, traceMethodsConfiguration);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error initializing TraceAttribute instrumentation");
             }
 
             InitializeNoNativeParts();
@@ -137,7 +137,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error sending CallTarget integration definitions to native library");
             }
 
             try
@@ -159,7 +159,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error sending CallTarget derived integration definitions to native library");
             }
 
             try
@@ -172,7 +172,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error sending CallTarget interface integration definitions to native library");
             }
 
             if (tracer is null)
@@ -200,7 +200,7 @@ namespace Datadog.Trace.ClrProfiler
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, ex.Message);
+                    Log.Error(ex, "Error initializing TraceMethods instrumentation");
                 }
             }
 
@@ -223,11 +223,11 @@ namespace Datadog.Trace.ClrProfiler
                     NativeMethods.InitializeProfiler(payload.DefinitionsId, payload.Definitions);
                     derived = payload.Definitions.Length;
 
-                    Log.Information($"{defs} IAST definitions and {derived} IAST derived definitions added to the profiler.");
+                    Log.Information<int, int>("{Defs} IAST definitions and {Derived} IAST derived definitions added to the profiler.", defs, derived);
 
                     Log.Debug("Registering IAST Callsite Dataflow Aspects into native library.");
                     var aspects = NativeMethods.RegisterIastAspects(AspectDefinitions.Aspects);
-                    Log.Information($"{aspects} IAST Callsite Dataflow Aspects added to the profiler.");
+                    Log.Information<int>("{Aspects} IAST Callsite Dataflow Aspects added to the profiler.", aspects);
                 }
                 catch (Exception ex)
                 {
@@ -275,16 +275,19 @@ namespace Datadog.Trace.ClrProfiler
             try
             {
                 var asm = typeof(Instrumentation).Assembly;
+                // intentionally using string interpolation, as this is only called once, and avoids array allocation
+#pragma warning disable DDLOG004 // Message templates should be constant
 #if NET5_0_OR_GREATER
                 // Can't use asm.CodeBase or asm.GlobalAssemblyCache in .NET 5+
                 Log.Information($"[Assembly metadata] Location: {asm.Location}, HostContext: {asm.HostContext}, SecurityRuleSet: {asm.SecurityRuleSet}");
 #else
                 Log.Information($"[Assembly metadata] Location: {asm.Location}, CodeBase: {asm.CodeBase}, GAC: {asm.GlobalAssemblyCache}, HostContext: {asm.HostContext}, SecurityRuleSet: {asm.SecurityRuleSet}");
 #endif
+#pragma warning restore DDLOG004 // Message templates should be constant
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error printing assembly metadata");
             }
 
             try
@@ -301,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error initializing CIVisibility");
             }
 
             try
@@ -311,7 +314,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error initializing Security");
             }
 
 #if !NETFRAMEWORK

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettingsCollection.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettingsCollection.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public class ImmutableIntegrationSettingsCollection
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<IntegrationSettingsCollection>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ImmutableIntegrationSettingsCollection>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableIntegrationSettingsCollection"/> class.

--- a/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
+++ b/tracer/src/Datadog.Trace/ContinuousProfiler/ContextTracker.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ContinuousProfiler
                 {
                     if (_firstEndpointFailure)
                     {
-                        Log.Warning(e, "Unable to set the endpoint for span {spanId}", localRootSpanId);
+                        Log.Warning(e, "Unable to set the endpoint for span {SpanId}", localRootSpanId);
                         _firstEndpointFailure = false;
                     }
                 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -150,7 +150,7 @@ internal class DataStreamsManager
         }
         catch (Exception ex)
         {
-            Log.Error("Error setting a data streams checkpoint. Disabling data streams monitoring", ex);
+            Log.Error(ex, "Error setting a data streams checkpoint. Disabling data streams monitoring");
             // Set this to false out of an abundance of caution.
             // We will look at being less conservative in the future
             // if we see intermittent errors for some reason.

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
             catch (Exception e)
             {
-                Log.Error(e, $"Failed to create probe processor for probe: {probe.Id}");
+                Log.Error(e, "Failed to create probe processor for probe: {Id}", probe.Id);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.Debugger.Expressions
             }
             catch (Exception e)
             {
-                Log.Error(e, "Failed to process probe. Probe Id: " + ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to process probe. Probe Id: {ProbeId}", ProbeInfo.ProbeId);
                 return false;
             }
         }
@@ -235,7 +235,7 @@ namespace Datadog.Trace.Debugger.Expressions
             catch (Exception e)
             {
                 // if the evaluation failed stop capturing
-                Log.Error(e, "Failed to evaluate expression for probe: " + ProbeInfo.ProbeId);
+                Log.Error(e, "Failed to evaluate expression for probe: {ProbeId}", ProbeInfo.ProbeId);
                 snapshotCreator.Stop();
                 shouldStopCapture = true;
                 return evaluationResult;

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/AsyncHelper.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/AsyncHelper.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Debugger.Helpers
         {
             if (field.Name.StartsWith(StateMachineFieldsNamePrefix))
             {
-                Log.Debug("Ignoring local (state machine field): " + field.FieldType.Name + " " + field.DeclaringType?.Name + " " + field.Name);
+                Log.Debug("Ignoring local (state machine field): {FieldType} {DeclaringType} {FieldName}", field.FieldType.Name, field.DeclaringType?.Name, field.Name);
                 return true;
             }
 
@@ -154,7 +154,7 @@ namespace Datadog.Trace.Debugger.Helpers
                 }
                 else
                 {
-                    AsyncMethodDebuggerInvoker.Log.Information($"Ignoring local {field.FieldType.Name} {field.DeclaringType?.Name}.{field.Name}");
+                    AsyncMethodDebuggerInvoker.Log.Information("Ignoring local {FieldType} {DeclaringType}.{FieldName}", field.FieldType.Name, field.DeclaringType?.Name, field.Name);
                     return true;
                 }
             }

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
@@ -137,19 +137,19 @@ namespace Datadog.Trace.Debugger.Instrumentation
                     var kickoffInfo = AsyncHelper.GetAsyncKickoffMethodInfo(instance, stateMachineType);
                     if (kickoffInfo.KickoffParentObject == null && kickoffInfo.KickoffMethod.IsStatic == false)
                     {
-                        Log.Warning($"{nameof(BeginLine)}: hoisted 'this' has not found. {kickoffInfo.KickoffParentType.Name}.{kickoffInfo.KickoffMethod.Name}");
+                        Log.Warning(nameof(BeginLine) + ": hoisted 'this' was not found. {KickoffParentType}.{KickoffMethod}", kickoffInfo.KickoffParentType.Name, kickoffInfo.KickoffMethod.Name);
                     }
 
                     if (!MethodMetadataCollection.Instance.TryCreateAsyncMethodMetadataIfNotExists(instance, methodMetadataIndex, in methodHandle, in typeHandle, kickoffInfo))
                     {
-                        Log.Warning($"([Async]BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {typeof(TTarget)}, instance type name = {instance.GetType().Name}, methodMetadataId = {methodMetadataIndex}, probeId = {probeId}");
+                        Log.Warning("([Async]BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId);
                         return CreateInvalidatedAsyncLineDebuggerState();
                     }
                 }
 
                 if (!ProbeMetadataCollection.Instance.TryCreateProbeMetadataIfNotExists(probeMetadataIndex, probeId))
                 {
-                    Log.Warning($"[Async]BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, probeMetadataIndex = {probeMetadataIndex}, probeId = {probeId}");
+                    Log.Warning("[Async]BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
                     return CreateInvalidatedAsyncLineDebuggerState();
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class AsyncLineDebuggerInvoker
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(LineDebuggerInvoker));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AsyncLineDebuggerInvoker));
 
         private static AsyncLineDebuggerState CreateInvalidatedAsyncLineDebuggerState()
         {

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
@@ -99,18 +99,18 @@ namespace Datadog.Trace.Debugger.Instrumentation
             var kickoffInfo = AsyncHelper.GetAsyncKickoffMethodInfo(instance, stateMachineType);
             if (kickoffInfo.KickoffParentObject == null && kickoffInfo.KickoffMethod.IsStatic == false)
             {
-                Log.Warning($"{nameof(BeginMethod)}: hoisted 'this' has not found. {kickoffInfo.KickoffParentType.Name}.{kickoffInfo.KickoffMethod.Name}");
+                Log.Warning(nameof(BeginMethod) + ": hoisted 'this' has not found. {KickoffParentType}.{KickoffMethod}", kickoffInfo.KickoffParentType.Name, kickoffInfo.KickoffMethod.Name);
             }
 
             if (!MethodMetadataCollection.Instance.TryCreateAsyncMethodMetadataIfNotExists(instance, methodMetadataIndex, in methodHandle, in typeHandle, kickoffInfo))
             {
-                Log.Warning($"BeginMethod: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {typeof(TTarget)}, instance type name = {instance.GetType().Name}, methodMetadataId = {methodMetadataIndex}, probeId = {probeId}");
+                Log.Warning("BeginMethod: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId);
                 return AsyncMethodDebuggerState.CreateInvalidatedDebuggerState();
             }
 
             if (!ProbeMetadataCollection.Instance.TryCreateProbeMetadataIfNotExists(probeMetadataIndex, probeId))
             {
-                Log.Warning($"BeginMethod: Failed to receive the ProbeData associated with the executing probe. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, probeMetadataIndex = {probeMetadataIndex}, probeId = {probeId}");
+                Log.Warning("BeginMethod: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
                 return AsyncMethodDebuggerState.CreateInvalidatedDebuggerState();
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
@@ -153,13 +153,13 @@ namespace Datadog.Trace.Debugger.Instrumentation
             {
                 if (!MethodMetadataCollection.Instance.TryCreateNonAsyncMethodMetadataIfNotExists(methodMetadataIndex, in methodHandle, in typeHandle))
                 {
-                    Log.Warning($"BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, methodMetadataId = {methodMetadataIndex}, probeId = {probeId}");
+                    Log.Warning("BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId);
                     return CreateInvalidatedLineDebuggerState();
                 }
 
                 if (!ProbeMetadataCollection.Instance.TryCreateProbeMetadataIfNotExists(probeMetadataIndex, probeId))
                 {
-                    Log.Warning($"BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, probeMetadataIndex = {probeMetadataIndex}, probeId = {probeId}");
+                    Log.Warning("BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
                     return CreateInvalidatedLineDebuggerState();
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
@@ -39,13 +39,13 @@ namespace Datadog.Trace.Debugger.Instrumentation
         {
             if (!MethodMetadataCollection.Instance.TryCreateNonAsyncMethodMetadataIfNotExists(methodMetadataIndex, in methodHandle, in typeHandle))
             {
-                Log.Warning($"BeginMethod_StartMarker: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, methodMetadaId = {methodMetadataIndex}, probeId = {probeId}");
+                Log.Warning("BeginMethod_StartMarker: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadaId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId);
                 return CreateInvalidatedDebuggerState();
             }
 
             if (!ProbeMetadataCollection.Instance.TryCreateProbeMetadataIfNotExists(probeMetadataIndex, probeId))
             {
-                Log.Warning($"BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe. type = {typeof(TTarget)}, instance type name = {instance?.GetType().Name}, probeMetadataIndex = {probeMetadataIndex}, probeId = {probeId}");
+                Log.Warning("BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
                 return CreateInvalidatedDebuggerState();
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodMetadataInfoFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodMetadataInfoFactory.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             }
             catch (Exception e)
             {
-                Log.Error(e, $"Failed to obtain local variable names from PDB for {method.Name}");
+                Log.Error(e, "Failed to obtain local variable names from PDB for {Name}", method.Name);
                 return null;
             }
         }

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodMetadataInfoFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodMetadataInfoFactory.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
     /// </summary>
     internal static class MethodMetadataInfoFactory
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<MethodMetadataInfo>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(MethodMetadataInfoFactory));
 
         public static MethodMetadataInfo Create(MethodBase method, Type type)
         {

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/Registry/MethodMetadataCollection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/Registry/MethodMetadataCollection.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Debugger.Instrumentation.Registry
 
                 if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
                 {
-                    Log.Debug($"{nameof(MethodMetadataCollection)}.{nameof(TryCreateAsyncMethodMetadataIfNotExists)}: Creating a new metadata info for Async method = {method}, index = {index}, Items.Length = {Items.Length}");
+                    Log.Debug<MethodBase, int, int>(nameof(MethodMetadataCollection) + "." + nameof(TryCreateAsyncMethodMetadataIfNotExists) + ": Creating a new metadata info for Async method = {Method}, index = {Index}, Items.Length = {Length}",  method, index, Items.Length);
                 }
 
                 if (method == null)
@@ -113,7 +113,7 @@ namespace Datadog.Trace.Debugger.Instrumentation.Registry
 
                 if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
                 {
-                    Log.Debug($"{nameof(MethodMetadataCollection)}.{nameof(TryCreateNonAsyncMethodMetadataIfNotExists)}: Creating a new metadata info for Non-Async method = {method}, index = {index}, Items.Length = {Items.Length}");
+                    Log.Debug<MethodBase, int, int>(nameof(MethodMetadataCollection) + "." + nameof(TryCreateNonAsyncMethodMetadataIfNotExists) + ": Creating a new metadata info for Non-Async method = {Method}, index = {Index}, Items.Length = {Length}",  method, index, Items.Length);
                 }
 
                 if (method == null)

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/Registry/ProbeMetadataCollection.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/Registry/ProbeMetadataCollection.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Debugger.Instrumentation.Registry
 
                 if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
                 {
-                    Log.Debug($"{nameof(ProbeMetadataCollection)}.{nameof(TryCreateProbeMetadataIfNotExists)}: Creating a new probe metadata info for index = {index}, Items.Length = {Items.Length}");
+                    Log.Debug<int, int>(nameof(ProbeMetadataCollection) + "." + nameof(TryCreateProbeMetadataIfNotExists) + " Creating a new probe metadata info for index = {Index}, Items.Length = {Length}", index, Items.Length);
                 }
 
                 var processor = ProbeExpressionsProcessor.Instance.Get(probeId);

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -163,7 +163,7 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                Log.Information($"Live Debugger.InstrumentProbes: Request to instrument {addedProbes.Count} probes definitions");
+                Log.Information<int>("Live Debugger.InstrumentProbes: Request to instrument {Count} probes definitions", addedProbes.Count);
 
                 var methodProbes = new List<NativeMethodProbeDefinition>();
                 var lineProbes = new List<NativeLineProbeDefinition>();
@@ -235,7 +235,7 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                Log.Information($"Live Debugger.InstrumentProbes: Request to remove {removedProbesIds.Length} probes.");
+                Log.Information<int>("Live Debugger.InstrumentProbes: Request to remove {Length} probes.", removedProbesIds.Length);
 
                 RemoveUnboundProbes(removedProbesIds);
 
@@ -335,7 +335,7 @@ namespace Datadog.Trace.Debugger
                 }
                 catch (Exception exception)
                 {
-                    Log.Warning($"Failed to deserialize configuration with path {configContent.Path.Path}", exception);
+                    Log.Warning(exception, "Failed to deserialize configuration with path {Path}", configContent.Path.Path);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -176,7 +176,7 @@ namespace Datadog.Trace.Debugger
                             var status = lineProbeResult.Status;
                             var message = lineProbeResult.Message;
 
-                            Log.Information("Finished resolving line probe for ProbeID {ProbeID}. Result was '{Status}'. Message was: '{Message}'", probe.Id, status);
+                            Log.Information("Finished resolving line probe for ProbeID {ProbeID}. Result was '{Status}'. Message was: '{Message}'", probe.Id, status, message);
                             switch (status)
                             {
                                 case LiveProbeResolveStatus.Bound:

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/ProbeRateLimiter.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Debugger.RateLimiting
             var adaptiveSampler = CreateSampler(samplesPerSecond);
             if (!_samplers.TryAdd(probeId, adaptiveSampler))
             {
-                Log.Warning($"Failed to add sampler for probe {probeId}");
+                Log.Warning("Failed to add sampler for probe {ProbeId}", probeId);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Debugger.Sink
 
             if (newInterval != currentInterval)
             {
-                Log.Debug($"Changing flush interval. Remaining available capacity in upload queue {remainingPercent * 100}%, new flush interval {newInterval}ms");
+                Log.Debug<double, int>("Changing flush interval. Remaining available capacity in upload queue {Remaining}%, new flush interval {NewInterval}ms", remainingPercent * 100, newInterval);
             }
 
             return newInterval;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             }
             catch (Exception e)
             {
-                Log.Error(e.ToString());
+                Log.Error(e, "Error serializing object {VariableName} Depth={CurrentDepth} FieldsOnly={FieldsOnly}", variableName, currentDepth, fieldsOnly);
             }
 
             return false;
@@ -136,7 +136,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             }
             catch (Exception e)
             {
-                Log.Error(e.ToString());
+                Log.Error(e, "Error serializing object {VariableName} Depth={CurrentDepth} FieldsOnly={FieldsOnly}", variableName, currentDepth, fieldsOnly);
             }
 
             return false;
@@ -326,12 +326,12 @@ namespace Datadog.Trace.Debugger.Snapshots
             catch (InvalidOperationException e)
             {
                 // Collection was modified, enumeration operation may not execute
-                Log.Error(e.ToString());
+                Log.Error<int>(e, "Error serializing enumerable (Collection was modified) Depth={CurrentDepth}", currentDepth);
                 jsonWriter.WriteEndArray();
             }
             catch (Exception e)
             {
-                Log.Error(e.ToString());
+                Log.Error<int>(e, "Error serializing enumerable Depth={CurrentDepth}", currentDepth);
             }
         }
 
@@ -406,14 +406,14 @@ namespace Datadog.Trace.Debugger.Snapshots
 
                     default:
                         {
-                            Log.Error($"{nameof(DebuggerSnapshotSerializer)}.{nameof(TryGetValue)}: Can't get value of {fieldOrProp.Name}. Unsupported member info {fieldOrProp.GetType()}");
+                            Log.Error(nameof(DebuggerSnapshotSerializer) + "." + nameof(TryGetValue) + ": Can't get value of {Name}. Unsupported member info {Type}", fieldOrProp.Name, fieldOrProp.GetType());
                             break;
                         }
                 }
             }
             catch (Exception e)
             {
-                Log.Error($"{nameof(DebuggerSnapshotSerializer)}.{nameof(TryGetValue)}: {e}");
+                Log.Error(e, nameof(DebuggerSnapshotSerializer) + "." + nameof(TryGetValue));
             }
 
             return false;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 {
     internal class SnapshotSlicer
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebuggerSink));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SnapshotSlicer));
 
         private readonly int _maxDepth;
         private readonly int _maxSnapshotSize;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotSlicer.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             }
             catch (Exception e)
             {
-                Log.Warning($"Failed to fit snapshot with probe id {probeId} due to exception", e);
+                Log.Warning(e, "Failed to fit snapshot with probe id {ProbeId} due to exception", probeId);
                 return snapshot;
             }
         }
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
             while (maxDepth > 0 && payloadSize >= _maxSnapshotSize)
             {
-                Log.Information($"Trying to slice snapshot with probe id {probeId} by removing {maxDepth} `field` depth property");
+                Log.Information<string, int>("Trying to slice snapshot with probe id {ProbeId} by removing {MaxDepth} `field` depth property", probeId, maxDepth);
 
                 var fieldDepth = 0;
                 var skipFields = false;
@@ -102,10 +102,14 @@ namespace Datadog.Trace.Debugger.Snapshots
                 maxDepth = Math.Min(maxFieldDepth, maxDepth - 1);
             }
 
-            Log.Information(
+#pragma warning disable DDLOG004 // Message templates should be constant - It's constant enough!
+            Log.Information<string, int>(
                 payloadSize >= _maxSnapshotSize
-                    ? $"Failed to fit snapshot with probe id {probeId} size to the {_maxSnapshotSize}"
-                    : $"Succeed to fit snapshot with probe id {probeId} size to the {_maxSnapshotSize}");
+                    ? "Failed to fit snapshot with probe id {ProbeId} size to the {MaxSnapshotSize}"
+                    : "Succeed to fit snapshot with probe id {ProbeId} size to the {MaxSnapshotSize}",
+                probeId,
+                _maxSnapshotSize);
+#pragma warning restore DDLOG004 // Message templates should be constant
 
             return snapshot;
         }

--- a/tracer/src/Datadog.Trace/Headers/Ip/RequestIpExtractor.cs
+++ b/tracer/src/Datadog.Trace/Headers/Ip/RequestIpExtractor.cs
@@ -26,13 +26,13 @@ namespace Datadog.Trace.Headers.Ip
                     extractedCustomIp = IpExtractor.RealIpFromValue(value, isSecureConnection);
                     if (extractedCustomIp == null)
                     {
-                        Log.Warning("A custom header for ip with value {value} was configured but no correct ip could be extracted", value);
+                        Log.Warning("A custom header for ip with value {Value} was configured but no correct ip could be extracted", value);
                     }
 
                     return extractedCustomIp;
                 }
 
-                Log.Warning("A custom header for ip {customIpHeader} was configured but there was no such header in the request", customIpHeader);
+                Log.Warning("A custom header for ip {CustomIpHeader} was configured but there was no such header in the request", customIpHeader);
             }
 
             string potentialIp = null;

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Logging
         public static IDatadogLogger GetLoggerFor(Type classType)
         {
             // Tells us which types are loaded, when, and how often.
-            SharedLogger.Debug($"Logger retrieved for: {classType.AssemblyQualifiedName}");
+            SharedLogger.Debug("Logger retrieved for: {AssemblyQualifiedName}", classType.AssemblyQualifiedName);
             return SharedLogger;
         }
 

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.PlatformHelpers
             }
             catch (Exception ex)
             {
-                Log.Warning("Error reading cgroup file. Will not report container id.", ex);
+                Log.Warning(ex, "Error reading cgroup file. Will not report container id.");
             }
 
             return null;

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.Processors
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L89-L93
             if (string.IsNullOrEmpty(span.ResourceName))
             {
-                Log.Debug("Fixing malformed trace. Resource is empty (reason:resource_empty), setting span.resource={name}: {span}", span.OperationName, span);
+                Log.Debug("Fixing malformed trace. Resource is empty (reason:resource_empty), setting span.resource={Name}: {Span}", span.OperationName, span);
                 span.ResourceName = span.OperationName;
             }
 
@@ -91,21 +91,21 @@ namespace Datadog.Trace.Processors
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L108-L112
             if (span.Duration < TimeSpan.Zero)
             {
-                Log.Debug("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0: {span}", span);
+                Log.Debug("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0: {Span}", span);
                 span.SetDuration(TimeSpan.Zero);
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L113-L117
             if (span.Duration.ToNanoseconds() > long.MaxValue - span.StartTime.ToUnixTimeNanoseconds())
             {
-                Log.Debug("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0: {span}", span);
+                Log.Debug("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0: {Span}", span);
                 span.SetDuration(TimeSpan.Zero);
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L118-L126
             if (span.StartTime < Year2000Time)
             {
-                Log.Debug("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now(): {span}", span);
+                Log.Debug("Fixing malformed trace. Start date is invalid (reason:invalid_start_date), setting span.start=time.now(): {Span}", span);
                 var now = span.Context.TraceContext.UtcNow;
                 var start = now - span.Duration;
                 if (start.ToUnixTimeNanoseconds() < 0)
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Processors
             if (TraceUtil.TruncateUTF8(ref type, MaxTypeLen))
             {
                 span.Type = type;
-                Log.Debug("Fixing malformed trace. Type is too long (reason:type_truncate), truncating span.type to length={maxServiceLen}: {span}", MaxTypeLen, span);
+                Log.Debug("Fixing malformed trace. Type is too long (reason:type_truncate), truncating span.type to length={MaxServiceLen}: {Span}", MaxTypeLen, span);
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L133-L135
@@ -132,7 +132,7 @@ namespace Datadog.Trace.Processors
             {
                 if (!TraceUtil.IsValidStatusCode(statusCodeTags.HttpStatusCode))
                 {
-                    Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={invalidStatusCode}: {span}", statusCodeTags.HttpStatusCode, span);
+                    Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={InvalidStatusCode}: {Span}", statusCodeTags.HttpStatusCode, span);
                     statusCodeTags.HttpStatusCode = string.Empty;
                 }
             }
@@ -141,7 +141,7 @@ namespace Datadog.Trace.Processors
                 string httpStatusCode = span.GetTag(Tags.HttpStatusCode);
                 if (!string.IsNullOrEmpty(httpStatusCode) && !TraceUtil.IsValidStatusCode(httpStatusCode))
                 {
-                    Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={invalidStatusCode}: {span}", httpStatusCode, span);
+                    Log.Debug("Fixing malformed trace. HTTP status code is invalid (reason:invalid_http_status_code), dropping invalid http.status_code={InvalidStatusCode}: {Span}", httpStatusCode, span);
                     span.Tags.SetTag(Tags.HttpStatusCode, null);
                 }
             }
@@ -159,14 +159,14 @@ namespace Datadog.Trace.Processors
         {
             if (string.IsNullOrEmpty(svc))
             {
-                Log.Debug("Fixing malformed trace. Service  is empty (reason:service_empty), setting span.service={serviceName}.", svc);
+                Log.Debug("Fixing malformed trace. Service  is empty (reason:service_empty), setting span.service={ServiceName}.", svc);
                 return DefaultServiceName;
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/traceutil/normalize.go#L59-L73
             if (TraceUtil.TruncateUTF8(ref svc, MaxServiceLen))
             {
-                Log.Debug<int>("Fixing malformed trace. Service is too long (reason:service_truncate), truncating span.service to length={maxServiceLen}.", MaxServiceLen);
+                Log.Debug<int>("Fixing malformed trace. Service is too long (reason:service_truncate), truncating span.service to length={MaxServiceLen}.", MaxServiceLen);
             }
 
             return TraceUtil.NormalizeTag(svc);
@@ -177,13 +177,13 @@ namespace Datadog.Trace.Processors
         {
             if (string.IsNullOrEmpty(name))
             {
-                Log.Debug("Fixing malformed trace. Name is empty (reason:span_name_empty), setting span.name={name}.", name);
+                Log.Debug("Fixing malformed trace. Name is empty (reason:span_name_empty), setting span.name={Name}.", name);
                 return DefaultSpanName;
             }
 
             if (TraceUtil.TruncateUTF8(ref name, MaxNameLen))
             {
-                Log.Debug<int>("Fixing malformed trace. Name is too long (reason:span_name_truncate), truncating span.name to length={maxServiceLen}.", MaxNameLen);
+                Log.Debug<int>("Fixing malformed trace. Name is too long (reason:span_name_truncate), truncating span.name to length={MaxServiceLen}.", MaxNameLen);
             }
 
             name = TraceUtil.NormalizeMetricName(name, MaxNameLen);

--- a/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/NormalizerTraceProcessor.cs
@@ -91,14 +91,14 @@ namespace Datadog.Trace.Processors
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L108-L112
             if (span.Duration < TimeSpan.Zero)
             {
-                Log.Debug("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0: {span}", span.OperationName, span);
+                Log.Debug("Fixing malformed trace. Duration is invalid (reason:invalid_duration), setting span.duration=0: {span}", span);
                 span.SetDuration(TimeSpan.Zero);
             }
 
             // https://github.com/DataDog/datadog-agent/blob/eac2327c5574da7f225f9ef0f89eaeb05ed10382/pkg/trace/agent/normalizer.go#L113-L117
             if (span.Duration.ToNanoseconds() > long.MaxValue - span.StartTime.ToUnixTimeNanoseconds())
             {
-                Log.Debug("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0: {span}", span.OperationName, span);
+                Log.Debug("Fixing malformed trace. Duration is too large and causes overflow (reason:invalid_duration), setting span.duration=0: {span}", span);
                 span.SetDuration(TimeSpan.Zero);
             }
 

--- a/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/ObfuscatorTraceProcessor.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.Processors
             }
             catch (Exception ex)
             {
-                Log.Debug("Error obfuscating sql {}", sqlQuery, ex);
+                Log.Debug(ex, "Error obfuscating sql {Query}", sqlQuery);
             }
 
             return sqlQuery;

--- a/tracer/src/Datadog.Trace/Processors/TruncatorTagsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/TruncatorTagsProcessor.cs
@@ -26,13 +26,13 @@ namespace Datadog.Trace.Processors
             if (TraceUtil.TruncateUTF8(ref key, MaxMetaKeyLen))
             {
                 key += "...";
-                Log.Debug("span.truncate: truncating `Meta` key (max {maxMetaKeyLen} chars): {key}", MaxMetaKeyLen, key);
+                Log.Debug("span.truncate: truncating `Meta` key (max {MaxMetaKeyLen} chars): {Key}", MaxMetaKeyLen, key);
             }
 
             if (TraceUtil.TruncateUTF8(ref value, MaxMetaValLen))
             {
                 value += "...";
-                Log.Debug("span.truncate: truncating `Meta` value (max {maxMetaValLen} chars): {value}", MaxMetaValLen, value);
+                Log.Debug("span.truncate: truncating `Meta` value (max {MaxMetaValLen} chars): {Value}", MaxMetaValLen, value);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Processors
             if (TraceUtil.TruncateUTF8(ref key, MaxMetricsKeyLen))
             {
                 key += "...";
-                Log.Debug("span.truncate: truncating `Metrics` key (max {maxMetricsKeyLen} chars): {key}", MaxMetricsKeyLen, key);
+                Log.Debug("span.truncate: truncating `Metrics` key (max {MaxMetricsKeyLen} chars): {Key}", MaxMetricsKeyLen, key);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Processors/TruncatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/TruncatorTraceProcessor.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Processors
         {
             if (TraceUtil.TruncateUTF8(ref r, MaxResourceLen))
             {
-                Log.Debug("span.truncate: truncated `Resource` (max {maxResourceLen} chars): {resource}", MaxResourceLen, r);
+                Log.Debug("span.truncate: truncated `Resource` (max {MaxResourceLen} chars): {Resource}", MaxResourceLen, r);
             }
 
             return r;

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -257,7 +257,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 }
                 catch (Exception e)
                 {
-                    Log.Warning($"Failed to apply remote configurations {e.Message}");
+                    Log.Warning(e, "Failed to apply remote configurations for product {Product}", product?.Name);
                 }
             }
 
@@ -279,7 +279,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 }
                 catch (Exception e)
                 {
-                    Log.Warning($"Failed to remove remote configurations {e.Message}");
+                    Log.Warning(e, "Failed to remove remote configurations");
                 }
             }
 

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen1Count = gen1;
             _previousGen2Count = gen2;
 
-            Log.Debug("Sent the following metrics to the DD agent: {metrics}", GarbageCollectionMetrics);
+            Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
         }
 
         private class PerformanceCountersValue

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.RuntimeMetrics
     {
         private const string GarbageCollectionMetrics = $"{MetricsNames.Gen0HeapSize}, {MetricsNames.Gen1HeapSize}, {MetricsNames.Gen2HeapSize}, {MetricsNames.LohSize}, {MetricsNames.ContentionCount}, {MetricsNames.Gen0CollectionsCount}, {MetricsNames.Gen1CollectionsCount}, {MetricsNames.Gen2CollectionsCount}";
 
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<PerformanceCountersListener>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<MemoryMappedCounters>();
 
         private readonly IDogStatsd _statsd;
         private readonly int _processId;

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/MemoryMappedCounters.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen1Count = gen1;
             _previousGen2Count = gen2;
 
-            Log.Debug("Sent the following metrics to the DD agent: {metrics}", GarbageCollectionMetrics);
+            Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -109,7 +109,7 @@ namespace Datadog.Trace.RuntimeMetrics
             _previousGen1Count = gen1;
             _previousGen2Count = gen2;
 
-            Log.Debug("Sent the following metrics to the DD agent: {metrics}", GarbageCollectionMetrics);
+            Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GarbageCollectionMetrics);
         }
 
         protected virtual void InitializePerformanceCounters()

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
             _statsd.Gauge(MetricsNames.ThreadPoolWorkersCount, ThreadPool.ThreadCount);
 
-            Log.Debug("Sent the following metrics to the DD agent: {metrics}", ThreadStatsMetrics);
+            Log.Debug("Sent the following metrics to the DD agent: {Metrics}", ThreadStatsMetrics);
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
@@ -109,7 +109,7 @@ namespace Datadog.Trace.RuntimeMetrics
                     if (start != null)
                     {
                         _statsd.Timer(MetricsNames.GcPauseTime, (eventData.TimeStamp - start.Value).TotalMilliseconds);
-                        Log.Debug("Sent the following metrics to the DD agent: {metrics}", MetricsNames.GcPauseTime);
+                        Log.Debug("Sent the following metrics to the DD agent: {Metrics}", MetricsNames.GcPauseTime);
                     }
                 }
                 else
@@ -123,7 +123,7 @@ namespace Datadog.Trace.RuntimeMetrics
                         _statsd.Gauge(MetricsNames.Gen2HeapSize, stats.Gen2Size);
                         _statsd.Gauge(MetricsNames.LohSize, stats.LohSize);
 
-                        Log.Debug("Sent the following metrics to the DD agent: {metrics}", GcHeapStatsMetrics);
+                        Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GcHeapStatsMetrics);
                     }
                     else if (eventData.EventId == EventContentionStop)
                     {
@@ -142,7 +142,7 @@ namespace Datadog.Trace.RuntimeMetrics
                         }
 
                         _statsd.Increment(GcCountMetricNames[heapHistory.Generation], 1, tags: heapHistory.Compacting ? CompactingGcTags : NotCompactingGcTags);
-                        Log.Debug("Sent the following metrics to the DD agent: {metrics}", GcGlobalHeapMetrics);
+                        Log.Debug("Sent the following metrics to the DD agent: {Metrics}", GcGlobalHeapMetrics);
                     }
                 }
             }
@@ -192,7 +192,7 @@ namespace Datadog.Trace.RuntimeMetrics
                     var value = (double)rawValue;
 
                     _statsd.Gauge(statName, value);
-                    Log.Debug("Sent the following metrics to the DD agent: {metrics}", statName);
+                    Log.Debug("Sent the following metrics to the DD agent: {Metrics}", statName);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
                     _statsd.Gauge(MetricsNames.CpuPercentage, Math.Round(totalCpu.TotalMilliseconds * 100 / maximumCpu, 1, MidpointRounding.AwayFromZero));
 
-                    Log.Debug("Sent the following metrics to the DD agent: {metrics}", ProcessMetrics);
+                    Log.Debug("Sent the following metrics to the DD agent: {Metrics}", ProcessMetrics);
                 }
 
                 if (!_exceptionCounts.IsEmpty)
@@ -138,11 +138,11 @@ namespace Datadog.Trace.RuntimeMetrics
                     // Having an exact exception count is probably not worth the overhead required to fix it
                     _exceptionCounts.Clear();
 
-                    Log.Debug("Sent the following metrics to the DD agent: {metrics}", MetricsNames.ExceptionsCount);
+                    Log.Debug("Sent the following metrics to the DD agent: {Metrics}", MetricsNames.ExceptionsCount);
                 }
                 else
                 {
-                    Log.Debug("Did not send the following metrics to the DD agent: {metrics}", MetricsNames.ExceptionsCount);
+                    Log.Debug("Did not send the following metrics to the DD agent: {Metrics}", MetricsNames.ExceptionsCount);
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Sampling
             }
             catch (ArgumentException e)
             {
-                Log.Error("Custom sampling rule regex for service name was invalid.", e);
+                Log.Error(e, "Custom sampling rule regex for service name was invalid.");
                 throw;
             }
 
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Sampling
             }
             catch (ArgumentException e)
             {
-                Log.Error("Custom sampling rule regex for operation name was invalid.", e);
+                Log.Error(e, "Custom sampling rule regex for operation name was invalid.");
                 throw;
             }
 

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Sampling
                 return sampleRate;
             }
 
-            Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {rate}", span.TraceId, _defaultSamplingRate);
+            Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.TraceId, _defaultSamplingRate);
 
             defaultRate = _defaultSamplingRate ?? 1;
             span.SetMetric(Metrics.SamplingAgentDecision, defaultRate);

--- a/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Sampling
 {
     internal class TracerRateLimiter : RateLimiter
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RateLimiter>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerRateLimiter>();
 
         public TracerRateLimiter(int? maxTracesPerInterval)
             : base(maxTracesPerInterval)

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ServiceFabric
                 {
                     if (PlatformHelpers.ServiceFabric.IsRunningInServiceFabric())
                     {
-                        Log.Warning("Could not get type {typeName}.", typeName);
+                        Log.Warning("Could not get type {TypeName}.", typeName);
                     }
 
                     return false;
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ServiceFabric
                 {
                     if (PlatformHelpers.ServiceFabric.IsRunningInServiceFabric())
                     {
-                        Log.Warning("Could not get event {eventName}.", fullEventName);
+                        Log.Warning("Could not get event {EventName}.", fullEventName);
                     }
 
                     return false;
@@ -50,12 +50,12 @@ namespace Datadog.Trace.ServiceFabric
 
                 // use null target because event is static
                 eventInfo.AddEventHandler(target: null, eventHandler);
-                Log.Debug("Subscribed to event {eventName}.", fullEventName);
+                Log.Debug("Subscribed to event {EventName}.", fullEventName);
                 return true;
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error adding event handler to {eventName}.", fullEventName);
+                Log.Error(ex, "Error adding event handler to {EventName}.", fullEventName);
                 return false;
             }
         }
@@ -160,7 +160,7 @@ namespace Datadog.Trace.ServiceFabric
 
                 if (expectedSpanName != scope.Span.OperationName)
                 {
-                    Log.Warning("Expected span name {expectedSpanName}, but found {actualSpanName} instead.", expectedSpanName, scope.Span.OperationName);
+                    Log.Warning("Expected span name {ExpectedSpanName}, but found {ActualSpanName} instead.", expectedSpanName, scope.Span.OperationName);
                     return;
                 }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -44,10 +44,10 @@ namespace Datadog.Trace
                 var tagsType = Tags.GetType();
 
                 Log.Debug(
-                    "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type: [{tagsType}])",
+                    "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type: [{TagsType}])",
                     new object[] { SpanId, Context.ParentId, TraceId, Tags, tagsType });
             }
-         }
+        }
 
         /// <summary>
         /// Gets or sets operation name
@@ -165,7 +165,7 @@ namespace Datadog.Trace
 
             static void LogMissingTraceContext(string key, string value)
             {
-                Log.Warning("Ignoring ISpan.SetTag({key}, {value}) because the span is not associated to a TraceContext.", key, value);
+                Log.Warning("Ignoring ISpan.SetTag({Key}, {Value}) because the span is not associated to a TraceContext.", key, value);
             }
 
             // since we don't expose a public API for setting trace-level attributes yet,

--- a/tracer/src/Datadog.Trace/Tagging/TagPropagation.cs
+++ b/tracer/src/Datadog.Trace/Tagging/TagPropagation.cs
@@ -157,7 +157,7 @@ internal static class TagPropagation
             {
                 if (!IsValid(tag.Key, tag.Value))
                 {
-                    Log.Debug("Propagated tag is not valid. Key: \"{key}\", Value: \"{value}\"", tag.Key, tag.Value);
+                    Log.Debug("Propagated tag is not valid. Key: \"{Key}\", Value: \"{Value}\"", tag.Key, tag.Value);
 
                     // if tag contains invalid chars,
                     // set tag "_dd.propagation_error:encoding_error"...

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Telemetry
 {
     internal class TelemetryFactory
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Datadog.Trace.Telemetry.TelemetryFactory>();
 
         private static readonly ConfigurationTelemetryCollector Configuration = new();
         private static readonly DependencyTelemetryCollector Dependencies = new();

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryTransportStrategy.cs" company="Datadog">
+// <copyright file="TelemetryTransportStrategy.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Telemetry.Transports;
 
 internal static class TelemetryTransportStrategy
 {
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TelemetryTransportStrategy));
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
 
     public static IApiRequestFactory GetDirectIntakeFactory(Uri baseEndpoint, string apiKey)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -146,7 +146,7 @@ namespace Datadog.Trace
                 else if (ShouldTriggerPartialFlush())
                 {
                     Log.Debug<ulong, ulong, int>(
-                        "Closing span {spanId} triggered a partial flush of trace {traceId} with {spanCount} pending spans",
+                        "Closing span {SpanId} triggered a partial flush of trace {TraceId} with {SpanCount} pending spans",
                         span.SpanId,
                         span.TraceId,
                         _spans.Count);

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -616,7 +616,7 @@ namespace Datadog.Trace
                     }
                     catch (Exception e)
                     {
-                        Log.Error(e, e.Message);
+                        Log.Error(e, "Error executing trace processor {TraceProcessorType}", processor?.GetType());
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Util
                 // Use atomic operation to log only once
                 if (Interlocked.Exchange(ref _cache, null) != null)
                 {
-                    Log.Information($"More than {MaxConnectionStrings} different connection strings were used, disabling cache");
+                    Log.Information<int>("More than {MaxConnectionStrings} different connection strings were used, disabling cache", MaxConnectionStrings);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
             }
             catch (RegexMatchTimeoutException exception)
             {
-                _logger.Error(exception, "Query string obfuscation timed out with timeout value of {TotalMilliseconds} ms and regex pattern {pattern}", _timeout.TotalMilliseconds, _regex.ToString());
+                _logger.Error(exception, "Query string obfuscation timed out with timeout value of {TotalMilliseconds} ms and regex pattern {Pattern}", _timeout.TotalMilliseconds, _regex.ToString());
             }
 
             return string.Empty;

--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Util
         /// <returns>Task with the output of the command</returns>
         public static async Task<CommandOutput?> RunCommandAsync(Command command, string? input = null)
         {
-            Log.Debug("Running command: {command} {args}", command.Cmd, command.Arguments);
+            Log.Debug("Running command: {Command} {Args}", command.Cmd, command.Arguments);
             var processStartInfo = GetProcessStartInfo(command);
             if (input is not null)
             {
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Util
             outputStringBuilder.Append(await processInfo.StandardOutput.ReadToEndAsync().ConfigureAwait(false));
             errorStringBuilder.Append(await processInfo.StandardError.ReadToEndAsync().ConfigureAwait(false));
 
-            Log.Debug<int>("Process finished with exit code: {value}.", processInfo.ExitCode);
+            Log.Debug<int>("Process finished with exit code: {Value}.", processInfo.ExitCode);
             return new CommandOutput(outputStringBuilder.ToString(), errorStringBuilder.ToString(), processInfo.ExitCode);
         }
 

--- a/tracer/src/Datadog.Trace/Util/RuntimeId.cs
+++ b/tracer/src/Datadog.Trace/Util/RuntimeId.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Util
         {
             if (NativeLoader.TryGetRuntimeIdFromNative(out var runtimeId))
             {
-                Log.Information("Runtime id retrieved from native loader: " + runtimeId);
+                Log.Information("Runtime id retrieved from native loader: {RuntimeId}", runtimeId);
                 return runtimeId;
             }
 

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -7,5 +7,3 @@
     "StyleCop.CSharp.OrderingRules",
     "SA1202:Elements must be ordered by access",
     Justification = "Allow custom ordering in integrations.")]
-
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG006", Justification = "Will fix in a subsequent PR")]

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -8,8 +8,5 @@
     "SA1202:Elements must be ordered by access",
     Justification = "Allow custom ordering in integrations.")]
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG003", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG004", Justification = "Will fix in a subsequent PR")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG005", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG006", Justification = "Will fix in a subsequent PR")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG007", Justification = "Will fix in a subsequent PR")]

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -15,5 +15,3 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG005", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG006", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG007", Justification = "Will fix in a subsequent PR")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG008", Justification = "Will fix in a subsequent PR")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG009", Justification = "Will fix in a subsequent PR")]

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -8,5 +8,4 @@
     "SA1202:Elements must be ordered by access",
     Justification = "Allow custom ordering in integrations.")]
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG004", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG006", Justification = "Will fix in a subsequent PR")]

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -8,7 +8,6 @@
     "SA1202:Elements must be ordered by access",
     Justification = "Allow custom ordering in integrations.")]
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG001", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG003", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG004", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG005", Justification = "Will fix in a subsequent PR")]

--- a/tracer/src/GlobalSuppressions.cs
+++ b/tracer/src/GlobalSuppressions.cs
@@ -9,7 +9,6 @@
     Justification = "Allow custom ordering in integrations.")]
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG001", Justification = "Will fix in a subsequent PR")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG002", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG003", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG004", Justification = "Will fix in a subsequent PR")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DDLOG005", Justification = "Will fix in a subsequent PR")]


### PR DESCRIPTION
## Summary of changes

Fixes all the incorrect usages flagged by the analyzers. There's&hellip;a lot&hellip;

## Reason for change

#3781 introduced several analyzers for how we create log messages with `IDatadogLogger`. These are necessary both for performance reasons (using interpolated strings breaks Serilog's message cache) and audit/redaction purposes (in the future, so we can scrub exceptions, for example). This PR fixes all the highlighted issues 

## Implementation details

Each commit in this PR removes one or more of the analyzer suppressions, and then fixes all the errors that produces. In many cases I could use, Visual Studio's "bulk fix" feature (which is awesome), but checked them all by hand, and updated them where necessary.

One of the most important commits also introduces the biggest changes: [Fix non-constant message template](https://github.com/DataDog/dd-trace-dotnet/commit/0c21f4e87911be6ef73f60a49095c6c238e79019). We have many cases where we unnecessarily using interpolation or writing exception messages as the log message. This is where most 👀 are needed to ensure the changes make sense.

## Test coverage

It builds without warnings and tests pass, so 🎉 

## Other details
Depends on https://github.com/DataDog/dd-trace-dotnet/pull/3781

Also, this will likely be a merge-conflict-heavy PR, so I'd like to get it merged ASAP 🙏 
