### PR TITLE
[Profiler] Improve building thread stat file path

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -59,10 +59,45 @@ std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
 //    if (clock_gettime(clockid, &cpu_time)) { ... }
 //
 
+bool BuildThreadStatPath(pid_t tid, char* statPath, int capacity)
+{
+    strncpy(statPath, "/proc/self/task/", 16);
+    int base = 1000000000;
+
+    // Adjust the base
+    while (base > tid)
+    {
+        base /= 10;
+    }
+
+    int offset = 16;
+    // Write each number to the string
+    while (base > 0 && offset < 64)
+    {
+        statPath[offset++] = (tid / base) + '0';
+        tid %= base;
+        base /= 10;
+    }
+
+    // check in case of misusage
+    if (offset >= capacity || offset + 5 >= capacity)
+    {
+        return false;
+    }
+
+    strncpy(statPath + offset, "/stat", 5);
+
+    return true;
+}
+
 bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
 {
     char statPath[64] = {0};
-    snprintf(statPath, sizeof(statPath), "/proc/self/task/%d/stat", tid);
+
+    if (!BuildThreadStatPath(tid, statPath, 64))
+    {
+        return false;
+    }
 
     auto fd = open(statPath, O_RDONLY);
 


### PR DESCRIPTION
## Summary of changes

Improve building thread stat file path

## Reason for change

`GetCpuInfo` builds the thread stat file to get its current state and the CPU it consumed. Building the thread stat file path makes a call to `snprintf` which accounts for 0.5-1% of time of the profile. 

## Implementation details

We know that a thread id cannot be higher than 2147483648, so we can build the string directly by writing the number.

## Test coverage

CPU integration tests must still pass
## Other details
<!-- Fixes #{issue} -->
