### PR TITLE
[Profiler] Improve Linux stackwalker deadlock detection

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -121,14 +121,6 @@ int dladdr(const void* addr_arg, Dl_info* info)
     return result;
 }
 
-__thread int _dd_in_pthread_create = 0;
-
-// this function is called in by the profiler
-int dd_IsInPthreadCreate()
-{
-    return _dd_in_pthread_create;
-}
-
 #ifdef DD_ALPINE
 
 /* Function pointers to hold the value of the glibc functions */

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -52,7 +52,7 @@ enum FUNCTION_ID
 __thread unsigned long long functions_entered_counter = 0;
 
 // this function is called by the profiler
-unsigned long long dd_can_be_profiled()
+unsigned long long dd_inside_wrapped_functions()
 {
     return functions_entered_counter;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -32,7 +32,7 @@ When finished, we put back the previous block signals. (This is done by libunwin
 
 But this has a non-negligible overhead. Instead, we will incr/decr a counter per function
 each time the thread enters/exits from it.
-The profiler will just have to check if this counter is equla to 0 to profiler or not.
+The profiler will just have to check if this counter is equal to 0 to profiler or not.
 
 */
 
@@ -51,7 +51,7 @@ enum FUNCTION_ID
 // counters: one byte per function
 __thread unsigned long long functions_entered_counter = 0;
 
-// this function is called in by the profiler
+// this function is called by the profiler
 unsigned long long dd_can_be_profiled()
 {
     return functions_entered_counter;

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -24,14 +24,38 @@ The hijacked thread will start walking its callstack and a call to dl_iterate_ph
 dl_iterate_phdr is not recursive and the thread is blocked.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%% Fix
+One way is to use the LD_PRELOAD trick:
 We will rely on LD_PRELOAD mechanism to inject our own implementation of dl_iterate_phdr.
 Before calling the real dl_iterate_phdr, we block all signals that would intefere with the thread.
 Then will call the real dl_iterate_phdr.
-When finished, we put back the previous block signals.
+When finished, we put back the previous block signals. (This is done by libunwind, just taking advantage of it.)
 
-This is done by libunwind, just taking advantage of it.
+But this has a non-negligible overhead. Instead, we will incr/decr a counter per function
+each time the thread enters/exits from it.
+The profiler will just have to check if this counter is equla to 0 to profiler or not.
 
 */
+
+enum FUNCTION_ID
+{
+    ENTERED_DL_ITERATE_PHDR = 0,
+    ENTERED_DL_OPEN = 1,
+    ENTERED_DL_ADDR = 2,
+    ENTERED_PTHREAD_CREATE = 3,
+    ENTERED_PTHREAD_ATTR_INIT = 4,
+    ENTERED_PTHREAD_GETATTR_DEFAULT_NP = 5,
+    ENTERED_PTHREAD_SETATTR_DEFAULT_NP = 6,
+    ENTERED_FORK = 7
+};
+
+// counters: one byte per function
+__thread unsigned long long functions_entered_counter = 0;
+
+// this function is called in by the profiler
+unsigned long long dd_can_be_profiled()
+{
+    return functions_entered_counter;
+}
 
 /* Function pointers to hold the value of the glibc functions */
 static int (*__real_dl_iterate_phdr)(int (*callback)(struct dl_phdr_info* info, size_t size, void* data), void* data) = NULL;
@@ -43,20 +67,12 @@ int dl_iterate_phdr(int (*callback)(struct dl_phdr_info* info, size_t size, void
         __real_dl_iterate_phdr = dlsym(RTLD_NEXT, "dl_iterate_phdr");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dl_iterate_phdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_DL_ITERATE_PHDR]++;
 
     // call the real dl_iterate_phdr (libc)
     int result = __real_dl_iterate_phdr(callback, data);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_DL_ITERATE_PHDR]--;
 
     return result;
 }
@@ -75,20 +91,12 @@ void* dlopen(const char* file, int mode)
         __real_dlopen = dlsym(RTLD_NEXT, "dlopen");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dlopen
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_DL_OPEN]++;
 
     // call the real dlopen (libc/musl-libc)
     void* result = __real_dlopen(file, mode);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_DL_OPEN]--;
 
     return result;
 }
@@ -103,20 +111,12 @@ int dladdr(const void* addr_arg, Dl_info* info)
         __real_dladdr = dlsym(RTLD_NEXT, "dladdr");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dladdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_DL_ADDR]++;
 
     // call the real dladdr (libc/musl-libc)
     int result = __real_dladdr(addr_arg, info);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_DL_ADDR]--;
 
     return result;
 }
@@ -141,11 +141,12 @@ int __pthread_create(pthread_t* restrict res, const pthread_attr_t* restrict att
         __real___pthread_create = dlsym(RTLD_NEXT, "__pthread_create");
     }
 
-    _dd_in_pthread_create = 1;
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_CREATE]++;
+
     // call the real __pthread_create (libc/musl-libc)
     int result = __real___pthread_create(res, attrp, entry, arg);
 
-    _dd_in_pthread_create = 0;
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_CREATE]--;
 
     return result;
 }
@@ -160,20 +161,12 @@ int pthread_attr_init(pthread_attr_t* a)
         __real_pthread_attr_init = dlsym(RTLD_NEXT, "pthread_attr_init");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dladdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_ATTR_INIT]++;
 
     // call the real pthread_attr_init (libc/musl-libc)
     int result = __real_pthread_attr_init(a);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_ATTR_INIT]--;
 
     return result;
 }
@@ -188,20 +181,12 @@ int pthread_getattr_default_np(pthread_attr_t* a)
         __real_pthread_getattr_default_np = dlsym(RTLD_NEXT, "pthread_getattr_default_np");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dladdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_GETATTR_DEFAULT_NP]++;
 
     // call the real pthread_getattr_default_np (libc/musl-libc)
     int result = __real_pthread_getattr_default_np(a);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_GETATTR_DEFAULT_NP]--;
 
     return result;
 }
@@ -216,20 +201,12 @@ int pthread_setattr_default_np(const pthread_attr_t* a)
         __real_pthread_setattr_default_np = dlsym(RTLD_NEXT, "pthread_setattr_default_np");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dladdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_SETATTR_DEFAULT_NP]++;
 
     // call the real pthread_setattr_default_np (libc/musl-libc)
     int result = __real_pthread_setattr_default_np(a);
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_PTHREAD_SETATTR_DEFAULT_NP]--;
 
     return result;
 }
@@ -244,20 +221,12 @@ pid_t fork()
         __real_fork = dlsym(RTLD_NEXT, "fork");
     }
 
-    sigset_t oldOne;
-    sigset_t newOne;
-
-    // initialize the set to all signals
-    sigfillset(&newOne);
-
-    // prevent any signals from interrupting the execution of the real dladdr
-    pthread_sigmask(SIG_SETMASK, &newOne, &oldOne);
+    ((char*)&functions_entered_counter)[ENTERED_FORK]++;
 
     // call the real fork (libc/musl-libc)
     pid_t result = __real_fork();
 
-    // restore the previous state for signals
-    pthread_sigmask(SIG_SETMASK, &oldOne, NULL);
+    ((char*)&functions_entered_counter)[ENTERED_FORK]--;
 
     return result;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -160,11 +160,11 @@ void LinuxStackFramesCollector::NotifyStackWalkCompleted(std::int32_t resultErro
 
 // This symbol is defined in the Datadog.Linux.ApiWrapper. It allows us to check if the thread to be profiled
 // contains a frame of a function that might cause a deadlock.
-extern "C" unsigned long long dd_can_be_profiled() __attribute__((weak));
+extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak));
 
 std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
 {
-    if (dd_can_be_profiled != nullptr && dd_can_be_profiled() != 0)
+    if (dd_inside_wrapped_functions != nullptr && dd_inside_wrapped_functions() != 0)
     {
         return E_ABORT;
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -158,16 +158,13 @@ void LinuxStackFramesCollector::NotifyStackWalkCompleted(std::int32_t resultErro
     _stackWalkInProgressWaiter.notify_one();
 }
 
-// This symbol is defined in the Datadog.Linux.ApiWrapper to handle the special case of __pthread_create
-// For __pthread_create we cannot block the signals while calling the *real* pthread_create and restore it after,
-// because the newly created thread will inherit the signal mask from its parent (which will be "block all signals").
-// So to prevent it, dd_IsInPthreadCreate will indicate if the current callstack is executing __pthread_create.
-// If it's the case, we just bail, otherwise we stackwalk the current thread.
-extern "C" int dd_IsInPthreadCreate() __attribute__((weak));
+// This symbol is defined in the Datadog.Linux.ApiWrapper. It allows us to check if the thread to be profiled
+// contains a frame of a function that might cause a deadlock.
+extern "C" unsigned long long dd_can_be_profiled() __attribute__((weak));
 
 std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
 {
-    if (dd_IsInPthreadCreate != nullptr && dd_IsInPthreadCreate() == 1)
+    if (dd_can_be_profiled != nullptr && dd_can_be_profiled() != 0)
     {
         return E_ABORT;
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -30,10 +30,10 @@ using ::testing::Return;
 
 // This global variable and function are use defined/declared for the test only
 // In production, those symbols will be defined in the Wrapper library
-int dd_IsPthreadCreateCall = 0;
-extern "C" int dd_can_be_profiled()
+int profile_or_not = 0;
+extern "C" long long dd_can_be_profiled()
 {
-    return dd_IsPthreadCreateCall;
+    return profile_or_not;
 }
 
 #define ASSERT_DURATION_LE(secs, stmt)                                            \
@@ -153,7 +153,7 @@ public:
 
         _processId = OpSysTools::GetProcId();
         SignalHandlerForTest::_instance = std::make_unique<SignalHandlerForTest>();
-        dd_IsPthreadCreateCall = 0;
+        profile_or_not = 0;
     }
 
     void TearDown() override
@@ -165,7 +165,7 @@ public:
 
         SignalHandlerForTest::_instance.reset();
         sigaction(SIGUSR1, &_oldAction, nullptr);
-        dd_IsPthreadCreateCall = 0;
+        profile_or_not = 0;
     }
 
     void StopTest()
@@ -179,7 +179,7 @@ public:
 
     static void SimulateInPthreadCreate()
     {
-        dd_IsPthreadCreateCall = 1;
+        profile_or_not = 1; // do not profile
     }
 
     pid_t GetWorkerThreadId()

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -31,7 +31,7 @@ using ::testing::Return;
 // This global variable and function are use defined/declared for the test only
 // In production, those symbols will be defined in the Wrapper library
 int dd_IsPthreadCreateCall = 0;
-extern "C" int dd_IsInPthreadCreate()
+extern "C" int dd_can_be_profiled()
 {
     return dd_IsPthreadCreateCall;
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -177,7 +177,7 @@ public:
         _stopWorker = true;
     }
 
-    static void SimulateInPthreadCreate()
+    static void SimulateDeadlock()
     {
         profile_or_not = 1; // do not profile
     }
@@ -340,7 +340,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckSamplingThreadCollectCallStackWith
 
 TEST_F(LinuxStackFramesCollectorFixture, CheckCollectionAbortIfInPthreadCreateCall)
 {
-    SimulateInPthreadCreate();
+    SimulateDeadlock();
 
     auto* signalManager = ProfilerSignalManager::Get();
 


### PR DESCRIPTION
## Summary of changes

Improve linux stackwalker deadlock detection.

## Reason for change

It can happen that the application calls our wrapped functions often. For example, when there is a burst of exceptions the CLR will call `dl_iterate_phdr` and each call will make 2 calls to `pthread_sigmask` which will increase the overhead on the application.

To avoid that, we reuse the `pthread_create` strategy.

## Implementation details

Use a counter per function to know if the thread called a function which might cause a deadlock.

## Test coverage

The current test we have.
## Other details
<!-- Fixes #{issue} -->
