### PR TITLE
[Build/Test] Publish official dd-lib-dotnet-init images on tagged commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ deploy_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
       when: on_success
     - when: manual
       allow_failure: true
@@ -113,7 +113,7 @@ deploy_musl_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
       when: on_success
     - when: manual
       allow_failure: true
@@ -131,7 +131,7 @@ deploy_latest_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
       when: on_success
     - when: manual
       allow_failure: true
@@ -149,7 +149,7 @@ deploy_latest_musl_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
       when: on_success
     - when: manual
       allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,3 +89,75 @@ deploy_to_reliability_env:
     UPSTREAM_PACKAGE_JOB: build
     UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
     FORCE_TRIGGER: $DEPLOY_TO_REL_ENV
+
+deploy_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-lib-dotnet-init:$CI_COMMIT_TAG
+    IMG_SIGNING: "false"
+
+deploy_musl_tag_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA-musl
+    IMG_DESTINATIONS: dd-lib-dotnet-init:$CI_COMMIT_TAG-musl
+    IMG_SIGNING: "false"
+
+deploy_latest_tag_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA
+    IMG_DESTINATIONS: dd-lib-dotnet-init:latest
+    IMG_SIGNING: "false"
+
+deploy_latest_musl_tag_to_docker_registries:
+  stage: deploy
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    - if: '$CI_COMMIT_TAG =~ /^v.*/'
+      when: on_success
+    - when: manual
+      allow_failure: true
+  trigger:
+    project: DataDog/public-images
+    branch: main
+    strategy: depend
+  variables:
+    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA-musl
+    IMG_DESTINATIONS: dd-lib-dotnet-init:latest-musl
+    IMG_SIGNING: "false"


### PR DESCRIPTION
## Summary of changes
Update GitLab CI to only publish the dd-lib-dotnet-init images from the GitHub Container Registry to the official Datadog repositories when a tag is added.

Note: This configuration is nearly identical to the Java GitLab pipeline so it seems like pretty reasonable logic.

## Reason for change
This publishes official container images to support Kubernetes Admission Controller library injection for .NET.

## Implementation details
When a commit is tagged, the new GitLab jobs will run in CI. The dd-lib-dotnet-init image with the tags `<SHA>` and `<SHA>-musl` are pulled from the [GitHub container registry](https://github.com/DataDog/dd-trace-dotnet/pkgs/container/dd-trace-dotnet%2Fdd-lib-dotnet-init) and republished to the production Datadog repositories using the pipeline from the DataDog/public-images repo.

## Test coverage
Tested by running the GitLab pipeline on this branch and the new jobs were skipped.

## Other details
N/A
