### PR TITLE
Fix test trigger on scheduled builds

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -50,7 +50,7 @@ partial class Build : NukeBuild
                     bool isChanged;
                     var forceExplorationTestsWithVariableName = $"force_exploration_tests_with_{variableName}";
 
-                    if (Environment.GetEnvironmentVariable("Build.Reason") == "Schedule" && bool.Parse(Environment.GetEnvironmentVariable("isMainBranch") ?? "false"))
+                    if (Environment.GetEnvironmentVariable("BUILD_REASON") == "Schedule" && bool.Parse(Environment.GetEnvironmentVariable("isMainBranch") ?? "false"))
                     {
                         Logger.Info("Running scheduled build on master, forcing all tests to run regardless of whether there has been a change.");
                         isChanged = true;


### PR DESCRIPTION
## Summary of changes
Small fix for tests not being triggered on scheduled builds.

## Implementation details
Rename reading environment variable from `Build.Reason` to `BUILD_REASON`

