### PR TITLE
Fix ActivityContext not being honored

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -65,7 +65,6 @@ namespace Datadog.Trace.Activity.Handlers
                         Log.Information("Current ActivityMappings: {@ActivityMapping}", ActivityMappingById);
                         Log.Information("Creating a new parent for {@ActivityContext}", w3cActivity);
 
-                        // TODO issue - Activity started with default Context nested underneath previous span - I think that is expected though?
                         remoteActivityContext = true; // using this as a way to avoid ActiveSpan below for now
                         // extract parent Activity trace/span IDs TODO this is slightly duped below (but uses w3cActivity.SpanId)
                         traceId ??= Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
@@ -152,7 +151,7 @@ namespace Datadog.Trace.Activity.Handlers
                 Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 
                 // TODO this is covering for creating the parent Activity scope
-                if (parent is null || activate)
+                if (parent is null && activate)
                 {
                     Log.Information("Activating Span for {SpanName}", span.OperationName);
                     return Tracer.Instance.ActivateSpan(span, false);

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Activity.Handlers
                     else
                     {
                         // create a new parent span context for the ActivityContext
-                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, activity.ParentId, rawSpanId: w3cActivity.ParentSpanId);
+                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, rawTraceId: parentId, rawSpanId: w3cActivity.ParentSpanId);
                         isRemoteContext = true;
                     }
                 }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -86,8 +86,8 @@ namespace Datadog.Trace.Activity.Handlers
                     }
                     else
                     {
-                        // we don't have a TraceId and/or SpanId - default to the .Id
-                        if (ActivityMappingById.TryGetValue(w3cActivity.Id, out ActivityMapping mapping))
+                        // we don't have a TraceId and/or SpanId - default to the .ParentId
+                        if (ActivityMappingById.TryGetValue(w3cActivity.ParentId, out ActivityMapping mapping))
                         {
                             parent = mapping.Scope.Span.Context;
                         }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -99,12 +99,13 @@ namespace Datadog.Trace.Activity.Handlers
 
                 // We convert the activity traceId and spanId to use it in the
                 // Datadog span creation.
-                if (w3cActivity.TraceId is { } w3cTraceId && w3cActivity.SpanId is { } w3cSpanId && !remoteActivityContext)
+                if (w3cActivity.TraceId is { } w3cTraceId && w3cActivity.SpanId is { } w3cSpanId)
                 {
                     // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
                     traceId ??= Convert.ToUInt64(w3cTraceId.Substring(16), 16);
                     spanId = Convert.ToUInt64(w3cSpanId, 16);
                     rawTraceId = w3cTraceId;
+                }
             }
 
             try
@@ -121,7 +122,7 @@ namespace Datadog.Trace.Activity.Handlers
                 }
 
                 activityKey ??= activity.Id;
-                ActivityMappingById.GetOrAdd(activityKey, _ => new(activity.Instance, CreateScopeFromActivity(activity, parent, traceId, spanId, rawTraceId, rawSpanId)));
+                ActivityMappingById.GetOrAdd(activityKey, _ => new(activity.Instance!, CreateScopeFromActivity(activity, parent, traceId, spanId, rawTraceId, rawSpanId)));
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -57,8 +57,9 @@ namespace Datadog.Trace.Activity.Handlers
                     else
                     {
                         // create a new parent span context for the ActivityContext
-                        var contextSpanId = Convert.ToUInt64(w3cActivity.ParentSpanId, 16);
-                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, traceId: null, spanId: contextSpanId);
+                        var activityTraceId = Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
+                        var activitySpanId = Convert.ToUInt64(w3cActivity.ParentSpanId, 16);
+                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, traceId: activityTraceId, spanId: activitySpanId);
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Activity.Handlers
@@ -73,8 +74,13 @@ namespace Datadog.Trace.Activity.Handlers
                         else
                         {
                             // create a new parent span context for the ActivityContext
-                            var newActivityTraceId = Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
-                            var newActivitySpanId = Convert.ToUInt64(w3cActivity.ParentSpanId, 16);
+#if NETCOREAPP
+                            _ = HexString.TryParseUInt64(w3cActivity.TraceId.AsSpan(16), out var newActivityTraceId);
+                            _ = HexString.TryParseUInt64(w3cActivity.ParentSpanId, out var newActivitySpanId);
+#else
+                            _ = HexString.TryParseUInt64(w3cActivity.TraceId.Substring(16), out var newActivityTraceId);
+                            _ = HexString.TryParseUInt64(w3cActivity.ParentSpanId, out var newActivitySpanId);
+#endif
                             parent = Tracer.Instance.CreateSpanContext(SpanContext.None, traceId: newActivityTraceId, spanId: newActivitySpanId);
                         }
                     }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Activity.Handlers
                             _ = HexString.TryParseUInt64(w3cActivity.TraceId.Substring(16), out var newActivityTraceId);
                             _ = HexString.TryParseUInt64(w3cActivity.ParentSpanId, out var newActivitySpanId);
 #endif
-                            parent = Tracer.Instance.CreateSpanContext(SpanContext.None, traceId: newActivityTraceId, spanId: newActivitySpanId);
+                            parent = Tracer.Instance.CreateSpanContext(SpanContext.None, traceId: newActivityTraceId, spanId: newActivitySpanId, rawTraceId: w3cActivity.TraceId, rawSpanId: w3cActivity.ParentSpanId);
                         }
                     }
                     else

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -43,6 +43,8 @@ namespace Datadog.Trace.Activity.Handlers
             ulong? spanId = null;
             string? rawTraceId = null;
             string? rawSpanId = null;
+            bool isRemoteContext = false;
+
             if (activity is IW3CActivity w3cActivity)
             {
                 // If the user has specified a parent context, get the parent Datadog SpanContext
@@ -56,7 +58,8 @@ namespace Datadog.Trace.Activity.Handlers
                     else
                     {
                         // create a new parent span context for the ActivityContext
-                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, rawTraceId: activity.ParentId, rawSpanId: w3cActivity.ParentSpanId);
+                        parent = Tracer.Instance.CreateSpanContext(SpanContext.None, activity.ParentId, rawSpanId: w3cActivity.ParentSpanId);
+                        isRemoteContext = true;
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -86,13 +86,11 @@ namespace Datadog.Trace.Activity.Handlers
                     }
                     else
                     {
-                        // we don't have a TraceId and/or SpanId - default to the .ParentId
+                        // we have a ParentSpanId/ParentId, but no TraceId/SpanId, so default to use the ParentId for lookup
                         if (ActivityMappingById.TryGetValue(w3cActivity.ParentId, out ActivityMapping mapping))
                         {
                             parent = mapping.Scope.Span.Context;
                         }
-
-                        // TODO we have a parent ID/parent Span Id but didn't find it in the mapping
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -146,19 +146,6 @@ namespace Datadog.Trace.Activity.Handlers
                         CloseActivityScope(sourceName, activity, someValue.Scope);
                         return;
                     }
-
-                    // when we have an ActivityContext provided the ID used is the ParentID
-                    if (activity.ParentId is { } parentId && ActivityMappingById.TryRemove(parentId, out ActivityMapping parentValue) && parentValue.Scope?.Span is not null)
-                    {
-                        // We have the exact scope associated with the Activity
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            Log.Debug("DefaultActivityHandler.ActivityStopped: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
-                        }
-
-                        CloseActivityScope(sourceName, activity, parentValue.Scope);
-                        return;
-                    }
                 }
 
                 // The listener didn't send us the Activity or the scope instance was not found

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.Activity.Handlers
                         Log.Information("Current ActivityMappings: {@ActivityMapping}", ActivityMappingById);
                         Log.Information("Creating a new parent for {@ActivityContext}", w3cActivity);
 
+                        // TODO issue - Activity started with default Context nested underneath previous span - I think that is expected though?
                         remoteActivityContext = true; // using this as a way to avoid ActiveSpan below for now
                         // extract parent Activity trace/span IDs TODO this is slightly duped below (but uses w3cActivity.SpanId)
                         traceId ??= Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
@@ -199,18 +200,6 @@ namespace Datadog.Trace.Activity.Handlers
                         CloseActivityScope(sourceName, activity, parentValue.Scope);
                         return;
                     }
-
-                    // if (ActivityMappingById.TryRemove(activity.Id, out ActivityMapping value) && value.Scope?.Span is not null)
-                    // {
-                    //     // We have the exact scope associated with the Activity
-                    //     if (Log.IsEnabled(LogEventLevel.Debug))
-                    //     {
-                    //         Log.Debug("DefaultActivityHandler.ActivityStopped: [Source={SourceName}, Id={Id}, RootId={RootId}, OperationName={OperationName}, StartTimeUtc={StartTimeUtc}, Duration={Duration}]", new object[] { sourceName, activity.Id, activity.RootId, activity.OperationName!, activity.StartTimeUtc, activity.Duration });
-                    //     }
-                    //
-                    //     CloseActivityScope(sourceName, activity, value.Scope);
-                    //     return;
-                    // }
                 }
 
                 // The listener didn't send us the Activity or the scope instance was not found

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Activity.Handlers
                 Log.Error(ex, "Error processing the OnActivityStarted callback");
             }
 
-            static Scope CreateScopeFromActivity(T activity, ISpanContext? parent, ulong? traceId, ulong? spanId, string? rawTraceId, string? rawSpanId)
+            static Scope CreateScopeFromActivity(T activity, SpanContext? parent, ulong? traceId, ulong? spanId, string? rawTraceId, string? rawSpanId)
             {
                 var span = Tracer.Instance.StartSpan(activity.OperationName, parent: parent, startTime: activity.StartTimeUtc, traceId: traceId, spanId: spanId, rawTraceId: rawTraceId, rawSpanId: rawSpanId);
                 Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -171,13 +171,13 @@ namespace Datadog.Trace.Activity.Handlers
                     }
 
                     string key;
-                    if (activity is not IW3CActivity w3cActivity)
+                    if (activity is IW3CActivity w3cActivity)
                     {
-                        key = activity.Id;
+                        key = w3cActivity.TraceId + w3cActivity.SpanId;
                     }
                     else
                     {
-                        key = w3cActivity.TraceId + w3cActivity.SpanId;
+                        key = activity.Id;
                     }
 
                     if (ActivityMappingById.TryRemove(key, out ActivityMapping someValue) && someValue.Scope?.Span is not null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -31,7 +31,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
                 return;
             }
 
-            if (DefaultActivityHandler.ActivityMappingById.TryGetValue(activity.Id, out var activityMapping))
+            string key;
+            if (activityData.TryDuckCast<IW3CActivity>(out var w3cActivity))
+            {
+                key = w3cActivity.TraceId + w3cActivity.SpanId;
+            }
+            else
+            {
+                key = activity.Id;
+            }
+
+            if (DefaultActivityHandler.ActivityMappingById.TryGetValue(key, out var activityMapping))
             {
                 if (baseProcessor.ParentProvider is not null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/ResourceAttributeProcessorHelper.cs
@@ -32,9 +32,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
             }
 
             string key;
-            if (activityData.TryDuckCast<IW3CActivity>(out var w3cActivity))
+            if (activityData.TryDuckCast<IW3CActivity>(out var w3cActivity) && w3cActivity.TraceId is { } traceId && w3cActivity.SpanId is { } spanId)
             {
-                key = w3cActivity.TraceId + w3cActivity.SpanId;
+                key = traceId + spanId;
             }
             else
             {

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -39,6 +39,7 @@
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
+      runtime-id: Guid_2,
       span.kind: server,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -46,6 +47,7 @@
     Metrics: {
       process_id: 0,
       _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
     }
@@ -57,7 +59,7 @@
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_7,
+    ParentId: Id_4,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -66,20 +68,15 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
       span.kind: server,
-      version: 1.0.0,
-      _dd.p.dm: -0
+      version: 1.0.0
     },
     Metrics: {
-      attribute-int: 1.0,
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
+      attribute-int: 1.0
     }
   },
   {
     TraceId: Id_3,
-    SpanId: Id_8,
+    SpanId: Id_7,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor4,
     Service: Samples.NetActivitySdk,
@@ -100,8 +97,8 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_10,
+    TraceId: Id_8,
+    SpanId: Id_9,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -128,13 +125,13 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_11,
+    TraceId: Id_8,
+    SpanId: Id_10,
     Name: Samples.NetActivitySdk.internal,
     Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_10,
+    ParentId: Id_9,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -146,10 +143,28 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_12,
+    TraceId: Id_8,
+    SpanId: Id_11,
     Name: Samples.NetActivitySdk.internal,
     Resource: UnsetStatusSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_10,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_12,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: ParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_11,
@@ -164,10 +179,27 @@
     }
   },
   {
-    TraceId: Id_9,
+    TraceId: Id_8,
     SpanId: Id_13,
+    Name: opentelemetry.internal,
+    Resource: ChildSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_12,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_14,
     Name: Samples.NetActivitySdk.internal,
-    Resource: ParentSpan,
+    Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_12,
@@ -182,43 +214,8 @@
     }
   },
   {
-    TraceId: Id_9,
-    SpanId: Id_14,
-    Name: opentelemetry.internal,
-    Resource: ChildSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_13,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_9,
+    TraceId: Id_8,
     SpanId: Id_15,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: W3CParentSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_13,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_9,
-    SpanId: Id_16,
     Name: opentelemetry.internal,
     Resource: Parent-NonW3CId,
     Service: Samples.NetActivitySdk,
@@ -247,7 +244,7 @@
     Resource: Child-NonW3CId,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_17,
+    ParentId: Id_16,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -257,8 +254,8 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_20,
+    TraceId: Id_18,
+    SpanId: Id_19,
     Name: Samples.NetActivitySdk.internal,
     Resource: RootSpan,
     Service: Samples.NetActivitySdk,
@@ -283,13 +280,13 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_21,
+    TraceId: Id_18,
+    SpanId: Id_20,
     Name: Saying hello!,
     Resource: AddTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_20,
+    ParentId: Id_19,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -315,13 +312,13 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_22,
+    TraceId: Id_18,
+    SpanId: Id_21,
     Name: Samples.NetActivitySdk.internal,
     Resource: SetTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_20,
+    ParentId: Id_19,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -348,13 +345,13 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_23,
+    TraceId: Id_18,
+    SpanId: Id_22,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_20,
+    ParentId: Id_19,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -366,13 +363,13 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_24,
+    TraceId: Id_18,
+    SpanId: Id_23,
     Name: Samples.NetActivitySdk.internal,
     Resource: AddBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_20,
+    ParentId: Id_19,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -384,10 +381,28 @@
     }
   },
   {
-    TraceId: Id_19,
-    SpanId: Id_25,
+    TraceId: Id_18,
+    SpanId: Id_24,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameDateEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_22,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_18,
+    SpanId: Id_25,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: SetBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_23,
@@ -402,10 +417,10 @@
     }
   },
   {
-    TraceId: Id_19,
+    TraceId: Id_18,
     SpanId: Id_26,
     Name: Samples.NetActivitySdk.internal,
-    Resource: SetBaggage,
+    Resource: EmptyTagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_25,
@@ -420,10 +435,10 @@
     }
   },
   {
-    TraceId: Id_19,
+    TraceId: Id_18,
     SpanId: Id_27,
     Name: Samples.NetActivitySdk.internal,
-    Resource: EmptyTagsEvent,
+    Resource: TagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_28,
@@ -456,10 +471,10 @@
     }
   },
   {
-    TraceId: Id_19,
+    TraceId: Id_18,
     SpanId: Id_28,
     Name: Samples.NetActivitySdk.internal,
-    Resource: TagsEvent,
+    Resource: MultipleEvents,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_27,

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -26,13 +26,35 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_4,
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: Samples.NetActivitySdk.server,
+    Resource: Ctor4,
+    Service: Samples.NetActivitySdk,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      attribute-string: str,
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_3,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      attribute-int: 1.0
+    }
+  },
+  {
+    TraceId: Id_4,
+    SpanId: Id_5,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_5,
+    ParentId: Id_6,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -51,35 +73,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_6,
+    TraceId: Id_4,
+    SpanId: Id_7,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_4,
-    Tags: {
-      attribute-string: str,
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
-      span.kind: server,
-      version: 1.0.0
-    },
-    Metrics: {
-      attribute-int: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_7,
-    Name: Samples.NetActivitySdk.server,
-    Resource: Ctor4,
-    Service: Samples.NetActivitySdk,
-    Type: web,
-    ParentId: Id_6,
+    ParentId: Id_5,
     Tags: {
       attribute-string: str,
       env: integration_tests,

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -2,18 +2,16 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Samples.NetActivitySdk.server,
-    Resource: Ctor1,
+    Name: opentelemetry.internal,
+    Resource: Child-NonW3CId,
     Service: Samples.NetActivitySdk,
-    Type: web,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
-      runtime-id: Guid_2,
-      span.kind: server,
+      runtime-id: Guid_1,
+      span.kind: internal,
       version: 1.0.0,
       _dd.p.dm: -0
     },
@@ -29,10 +27,36 @@
     TraceId: Id_3,
     SpanId: Id_4,
     Name: Samples.NetActivitySdk.server,
+    Resource: Ctor1,
+    Service: Samples.NetActivitySdk,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: Samples.NetActivitySdk.server,
     Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_5,
+    ParentId: Id_7,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -51,13 +75,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_6,
+    TraceId: Id_5,
+    SpanId: Id_8,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_5,
+    ParentId: Id_7,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -78,13 +102,13 @@
     }
   },
   {
-    TraceId: Id_3,
-    SpanId: Id_7,
+    TraceId: Id_5,
+    SpanId: Id_9,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor4,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_6,
+    ParentId: Id_8,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -100,8 +124,8 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_9,
+    TraceId: Id_10,
+    SpanId: Id_11,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -114,7 +138,7 @@
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_ERROR,
       otel.trace_id: Guid_4,
-      runtime-id: Guid_2,
+      runtime-id: Guid_1,
       span.kind: internal,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -128,13 +152,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_10,
+    TraceId: Id_10,
+    SpanId: Id_12,
     Name: Samples.NetActivitySdk.internal,
     Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_9,
+    ParentId: Id_11,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -146,13 +170,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_11,
+    TraceId: Id_10,
+    SpanId: Id_13,
     Name: Samples.NetActivitySdk.internal,
     Resource: UnsetStatusSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_10,
+    ParentId: Id_12,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -164,13 +188,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_12,
+    TraceId: Id_10,
+    SpanId: Id_14,
     Name: Samples.NetActivitySdk.internal,
     Resource: ParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_11,
+    ParentId: Id_13,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -182,13 +206,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_13,
+    TraceId: Id_10,
+    SpanId: Id_15,
     Name: opentelemetry.internal,
     Resource: ChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_12,
+    ParentId: Id_14,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -199,13 +223,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_14,
+    TraceId: Id_10,
+    SpanId: Id_16,
     Name: Samples.NetActivitySdk.internal,
     Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_12,
+    ParentId: Id_14,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -217,34 +241,10 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_15,
+    TraceId: Id_10,
+    SpanId: Id_17,
     Name: opentelemetry.internal,
-    Resource: Parent-NonW3CId,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      runtime-id: Guid_2,
-      span.kind: internal,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_16,
-    SpanId: Id_18,
-    Name: opentelemetry.internal,
-    Resource: Child-NonW3CId,
+    Resource: W3CChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_16,
@@ -252,13 +252,49 @@
       env: integration_tests,
       language: dotnet,
       otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_18,
+    TraceId: Id_10,
+    SpanId: Id_18,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: IAmMiscSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_16,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_10,
     SpanId: Id_19,
+    Name: opentelemetry.internal,
+    Resource: MiscSpan2,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_18,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_20,
+    SpanId: Id_21,
     Name: Samples.NetActivitySdk.internal,
     Resource: RootSpan,
     Service: Samples.NetActivitySdk,
@@ -269,7 +305,7 @@
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_5,
-      runtime-id: Guid_2,
+      runtime-id: Guid_1,
       span.kind: internal,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -283,13 +319,13 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_20,
+    TraceId: Id_20,
+    SpanId: Id_22,
     Name: Saying hello!,
     Resource: AddTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_19,
+    ParentId: Id_21,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -315,13 +351,13 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_21,
+    TraceId: Id_20,
+    SpanId: Id_23,
     Name: Samples.NetActivitySdk.internal,
     Resource: SetTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_19,
+    ParentId: Id_21,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -348,31 +384,31 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_22,
+    TraceId: Id_20,
+    SpanId: Id_24,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_19,
+    ParentId: Id_21,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_23,
+    TraceId: Id_20,
+    SpanId: Id_25,
     Name: Samples.NetActivitySdk.internal,
     Resource: AddBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_19,
+    ParentId: Id_21,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -384,13 +420,13 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_24,
+    TraceId: Id_20,
+    SpanId: Id_26,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameDateEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_22,
+    ParentId: Id_24,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -402,28 +438,10 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_25,
+    TraceId: Id_20,
+    SpanId: Id_27,
     Name: Samples.NetActivitySdk.internal,
     Resource: SetBaggage,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_23,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_18,
-    SpanId: Id_26,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: EmptyTagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_25,
@@ -438,8 +456,26 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_27,
+    TraceId: Id_20,
+    SpanId: Id_28,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: EmptyTagsEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_26,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_20,
+    SpanId: Id_29,
     Name: Samples.NetActivitySdk.internal,
     Resource: TagsEvent,
     Service: Samples.NetActivitySdk,
@@ -456,55 +492,19 @@
     }
   },
   {
-    TraceId: Id_18,
-    SpanId: Id_28,
+    TraceId: Id_20,
+    SpanId: Id_30,
     Name: Samples.NetActivitySdk.internal,
     Resource: MultipleEvents,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_27,
+    ParentId: Id_29,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_5,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_18,
-    SpanId: Id_28,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: MultipleEvents,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_27,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_19,
-    SpanId: Id_29,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: MultipleEvents,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_28,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -32,13 +32,13 @@
     Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
+    ParentId: Id_5,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
-      runtime-id: Guid_2,
       span.kind: server,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -46,19 +46,18 @@
     Metrics: {
       process_id: 0,
       _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_3,
-    SpanId: Id_5,
+    SpanId: Id_6,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_4,
+    ParentId: Id_7,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -67,20 +66,25 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
       span.kind: server,
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.p.dm: -0
     },
     Metrics: {
-      attribute-int: 1.0
+      attribute-int: 1.0,
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
     TraceId: Id_3,
-    SpanId: Id_6,
+    SpanId: Id_8,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor4,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_5,
+    ParentId: Id_6,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -96,8 +100,8 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_8,
+    TraceId: Id_9,
+    SpanId: Id_10,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -124,13 +128,13 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_9,
+    TraceId: Id_9,
+    SpanId: Id_11,
     Name: Samples.NetActivitySdk.internal,
     Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_8,
+    ParentId: Id_10,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -142,13 +146,13 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_10,
+    TraceId: Id_9,
+    SpanId: Id_12,
     Name: Samples.NetActivitySdk.internal,
     Resource: UnsetStatusSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_9,
+    ParentId: Id_11,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -160,13 +164,13 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_11,
+    TraceId: Id_9,
+    SpanId: Id_13,
     Name: Samples.NetActivitySdk.internal,
     Resource: ParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_10,
+    ParentId: Id_12,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -178,13 +182,13 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_12,
+    TraceId: Id_9,
+    SpanId: Id_14,
     Name: opentelemetry.internal,
     Resource: ChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_11,
+    ParentId: Id_13,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -195,47 +199,12 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_13,
+    TraceId: Id_9,
+    SpanId: Id_15,
     Name: Samples.NetActivitySdk.internal,
     Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_11,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_7,
-    SpanId: Id_14,
-    Name: opentelemetry.internal,
-    Resource: W3CChildSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_13,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_7,
-    SpanId: Id_15,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: IAmMiscSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
     ParentId: Id_13,
     Tags: {
       env: integration_tests,
@@ -248,7 +217,7 @@
     }
   },
   {
-    TraceId: Id_7,
+    TraceId: Id_9,
     SpanId: Id_16,
     Name: opentelemetry.internal,
     Resource: Parent-NonW3CId,
@@ -457,7 +426,7 @@
     Resource: EmptyTagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_26,
+    ParentId: Id_28,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -39,7 +39,6 @@
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
-      runtime-id: Guid_2,
       span.kind: server,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -47,7 +46,6 @@
     Metrics: {
       process_id: 0,
       _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0
     }

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -26,50 +26,35 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_3,
+    TraceId: Id_3,
+    SpanId: Id_4,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_2,
+    ParentId: Id_5,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
+      otel.trace_id: Guid_3,
       span.kind: server,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_4,
-    Name: Samples.NetActivitySdk.server,
-    Resource: Ctor3,
-    Service: Samples.NetActivitySdk,
-    Type: web,
-    ParentId: Id_3,
-    Tags: {
-      attribute-string: str,
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
-      span.kind: server,
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.p.dm: -0
     },
     Metrics: {
-      attribute-int: 1.0
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_5,
+    TraceId: Id_3,
+    SpanId: Id_6,
     Name: Samples.NetActivitySdk.server,
-    Resource: Ctor4,
+    Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
     ParentId: Id_4,
@@ -79,7 +64,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
+      otel.trace_id: Guid_3,
       span.kind: server,
       version: 1.0.0
     },
@@ -88,8 +73,30 @@
     }
   },
   {
-    TraceId: Id_6,
+    TraceId: Id_3,
     SpanId: Id_7,
+    Name: Samples.NetActivitySdk.server,
+    Resource: Ctor4,
+    Service: Samples.NetActivitySdk,
+    Type: web,
+    ParentId: Id_6,
+    Tags: {
+      attribute-string: str,
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_3,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      attribute-int: 1.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_9,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -101,7 +108,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_ERROR,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       runtime-id: Guid_2,
       span.kind: internal,
       version: 1.0.0,
@@ -116,46 +123,10 @@
     }
   },
   {
-    TraceId: Id_6,
-    SpanId: Id_8,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: OkSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_7,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_OK,
-      otel.trace_id: Guid_3,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_6,
-    SpanId: Id_9,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: UnsetStatusSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_8,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_6,
+    TraceId: Id_8,
     SpanId: Id_10,
     Name: Samples.NetActivitySdk.internal,
-    Resource: ParentSpan,
+    Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_9,
@@ -163,87 +134,88 @@
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.status_code: STATUS_CODE_OK,
+      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_6,
+    TraceId: Id_8,
     SpanId: Id_11,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: UnsetStatusSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_10,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_12,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: ParentSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_11,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_13,
     Name: opentelemetry.internal,
     Resource: ChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_10,
+    ParentId: Id_12,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_6,
-    SpanId: Id_12,
+    TraceId: Id_8,
+    SpanId: Id_14,
     Name: Samples.NetActivitySdk.internal,
     Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_10,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_6,
-    SpanId: Id_13,
-    Name: opentelemetry.internal,
-    Resource: W3CChildSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_12,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_6,
-    SpanId: Id_14,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: IAmMiscSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
     ParentId: Id_12,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_6,
+    TraceId: Id_8,
     SpanId: Id_15,
     Name: opentelemetry.internal,
-    Resource: MiscSpan2,
+    Resource: W3CChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_14,
@@ -251,13 +223,31 @@
       env: integration_tests,
       language: dotnet,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
+      otel.trace_id: Guid_4,
       span.kind: internal,
       version: 1.0.0
     }
   },
   {
-    TraceId: Id_16,
+    TraceId: Id_8,
+    SpanId: Id_16,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: IAmMiscSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_14,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
     SpanId: Id_17,
     Name: opentelemetry.internal,
     Resource: Parent-NonW3CId,
@@ -308,7 +298,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       runtime-id: Guid_2,
       span.kind: internal,
       version: 1.0.0,
@@ -345,7 +335,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       span.kind: internal,
       version: 1.0.0
     },
@@ -377,7 +367,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       set-string: str,
       span.kind: internal,
       version: 1.0.0
@@ -418,7 +408,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       span.kind: internal,
       version: 1.0.0
     }
@@ -454,7 +444,7 @@
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
       span.kind: internal,
       version: 1.0.0
     }
@@ -466,13 +456,31 @@
     Resource: EmptyTagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_25,
+    ParentId: Id_26,
     Tags: {
       env: integration_tests,
       language: dotnet,
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
+      otel.trace_id: Guid_5,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_18,
+    SpanId: Id_28,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: MultipleEvents,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_27,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
       span.kind: internal,
       version: 1.0.0
     }

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -2,16 +2,18 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: opentelemetry.internal,
-    Resource: Child-NonW3CId,
+    Name: Samples.NetActivitySdk.server,
+    Resource: Ctor1,
     Service: Samples.NetActivitySdk,
-    Type: custom,
+    Type: web,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      runtime-id: Guid_1,
-      span.kind: internal,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: server,
       version: 1.0.0,
       _dd.p.dm: -0
     },
@@ -27,36 +29,10 @@
     TraceId: Id_3,
     SpanId: Id_4,
     Name: Samples.NetActivitySdk.server,
-    Resource: Ctor1,
-    Service: Samples.NetActivitySdk,
-    Type: web,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_2,
-      runtime-id: Guid_1,
-      span.kind: server,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_6,
-    Name: Samples.NetActivitySdk.server,
     Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_7,
+    ParentId: Id_5,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -75,13 +51,13 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_8,
+    TraceId: Id_3,
+    SpanId: Id_6,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_7,
+    ParentId: Id_5,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -102,13 +78,13 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_9,
+    TraceId: Id_3,
+    SpanId: Id_7,
     Name: Samples.NetActivitySdk.server,
     Resource: Ctor4,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_8,
+    ParentId: Id_6,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -124,8 +100,8 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_11,
+    TraceId: Id_8,
+    SpanId: Id_9,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -138,7 +114,7 @@
       otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_ERROR,
       otel.trace_id: Guid_4,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: internal,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -152,13 +128,13 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_12,
+    TraceId: Id_8,
+    SpanId: Id_10,
     Name: Samples.NetActivitySdk.internal,
     Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_11,
+    ParentId: Id_9,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -170,10 +146,63 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_13,
+    TraceId: Id_8,
+    SpanId: Id_11,
     Name: Samples.NetActivitySdk.internal,
     Resource: UnsetStatusSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_10,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_12,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: ParentSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_11,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_13,
+    Name: opentelemetry.internal,
+    Resource: ChildSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_12,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_8,
+    SpanId: Id_14,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_12,
@@ -188,66 +217,13 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_14,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: ParentSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_13,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_10,
+    TraceId: Id_8,
     SpanId: Id_15,
-    Name: opentelemetry.internal,
-    Resource: ChildSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_14,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_10,
-    SpanId: Id_16,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: W3CParentSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_14,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_10,
-    SpanId: Id_17,
     Name: opentelemetry.internal,
     Resource: W3CChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_16,
+    ParentId: Id_14,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -258,13 +234,13 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_18,
+    TraceId: Id_8,
+    SpanId: Id_16,
     Name: Samples.NetActivitySdk.internal,
     Resource: IAmMiscSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_16,
+    ParentId: Id_14,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -276,13 +252,13 @@
     }
   },
   {
-    TraceId: Id_10,
-    SpanId: Id_19,
+    TraceId: Id_8,
+    SpanId: Id_17,
     Name: opentelemetry.internal,
     Resource: MiscSpan2,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_18,
+    ParentId: Id_16,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -293,19 +269,17 @@
     }
   },
   {
-    TraceId: Id_20,
-    SpanId: Id_21,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: RootSpan,
+    TraceId: Id_18,
+    SpanId: Id_19,
+    Name: opentelemetry.internal,
+    Resource: Parent-NonW3CId,
     Service: Samples.NetActivitySdk,
     Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
       otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_5,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: internal,
       version: 1.0.0,
       _dd.p.dm: -0
@@ -319,13 +293,55 @@
     }
   },
   {
-    TraceId: Id_20,
+    TraceId: Id_18,
+    SpanId: Id_20,
+    Name: opentelemetry.internal,
+    Resource: Child-NonW3CId,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_19,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_21,
     SpanId: Id_22,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: RootSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_21,
+    SpanId: Id_23,
     Name: Saying hello!,
     Resource: AddTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_21,
+    ParentId: Id_22,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -351,13 +367,13 @@
     }
   },
   {
-    TraceId: Id_20,
-    SpanId: Id_23,
+    TraceId: Id_21,
+    SpanId: Id_24,
     Name: Samples.NetActivitySdk.internal,
     Resource: SetTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_21,
+    ParentId: Id_22,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -384,13 +400,13 @@
     }
   },
   {
-    TraceId: Id_20,
-    SpanId: Id_24,
+    TraceId: Id_21,
+    SpanId: Id_25,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_21,
+    ParentId: Id_22,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -402,13 +418,13 @@
     }
   },
   {
-    TraceId: Id_20,
-    SpanId: Id_25,
+    TraceId: Id_21,
+    SpanId: Id_26,
     Name: Samples.NetActivitySdk.internal,
     Resource: AddBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_21,
+    ParentId: Id_22,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -420,28 +436,10 @@
     }
   },
   {
-    TraceId: Id_20,
-    SpanId: Id_26,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: NameDateEvent,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_24,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_5,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_20,
+    TraceId: Id_21,
     SpanId: Id_27,
     Name: Samples.NetActivitySdk.internal,
-    Resource: SetBaggage,
+    Resource: NameDateEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_25,
@@ -456,10 +454,10 @@
     }
   },
   {
-    TraceId: Id_20,
+    TraceId: Id_21,
     SpanId: Id_28,
     Name: Samples.NetActivitySdk.internal,
-    Resource: EmptyTagsEvent,
+    Resource: SetBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_26,
@@ -474,13 +472,13 @@
     }
   },
   {
-    TraceId: Id_20,
+    TraceId: Id_21,
     SpanId: Id_29,
     Name: Samples.NetActivitySdk.internal,
-    Resource: TagsEvent,
+    Resource: EmptyTagsEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_28,
+    ParentId: Id_27,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -492,13 +490,31 @@
     }
   },
   {
-    TraceId: Id_20,
+    TraceId: Id_21,
     SpanId: Id_30,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: TagsEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_29,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_21,
+    SpanId: Id_31,
     Name: Samples.NetActivitySdk.internal,
     Resource: MultipleEvents,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_29,
+    ParentId: Id_30,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -57,7 +57,7 @@
     Resource: Ctor3,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_4,
+    ParentId: Id_5,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -66,10 +66,15 @@
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_3,
       span.kind: server,
-      version: 1.0.0
+      version: 1.0.0,
+      _dd.p.dm: -0
     },
     Metrics: {
-      attribute-int: 1.0
+      attribute-int: 1.0,
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
     }
   },
   {

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -26,13 +26,39 @@
     }
   },
   {
-    TraceId: Id_1,
-    SpanId: Id_3,
+    TraceId: Id_3,
+    SpanId: Id_4,
     Name: Samples.NetActivitySdk.server,
-    Resource: Ctor4,
+    Resource: Ctor2,
     Service: Samples.NetActivitySdk,
     Type: web,
-    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_3,
+      runtime-id: Guid_2,
+      span.kind: server,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_5,
+    Name: Samples.NetActivitySdk.server,
+    Resource: Ctor3,
+    Service: Samples.NetActivitySdk,
+    Type: web,
+    ParentId: Id_4,
     Tags: {
       attribute-string: str,
       env: integration_tests,
@@ -48,35 +74,10 @@
     }
   },
   {
-    TraceId: Id_4,
-    SpanId: Id_5,
+    TraceId: Id_3,
+    SpanId: Id_6,
     Name: Samples.NetActivitySdk.server,
-    Resource: Ctor2,
-    Service: Samples.NetActivitySdk,
-    Type: web,
-    ParentId: Id_6,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_3,
-      span.kind: server,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_4,
-    SpanId: Id_7,
-    Name: Samples.NetActivitySdk.server,
-    Resource: Ctor3,
+    Resource: Ctor4,
     Service: Samples.NetActivitySdk,
     Type: web,
     ParentId: Id_5,
@@ -95,8 +96,8 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_9,
+    TraceId: Id_7,
+    SpanId: Id_8,
     Name: Samples.NetActivitySdk.internal,
     Resource: ErrorSpan,
     Service: Samples.NetActivitySdk,
@@ -123,13 +124,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_10,
+    TraceId: Id_7,
+    SpanId: Id_9,
     Name: Samples.NetActivitySdk.internal,
     Resource: OkSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_9,
+    ParentId: Id_8,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -141,10 +142,28 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_11,
+    TraceId: Id_7,
+    SpanId: Id_10,
     Name: Samples.NetActivitySdk.internal,
     Resource: UnsetStatusSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_9,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_11,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: ParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_10,
@@ -159,10 +178,27 @@
     }
   },
   {
-    TraceId: Id_8,
+    TraceId: Id_7,
     SpanId: Id_12,
+    Name: opentelemetry.internal,
+    Resource: ChildSpan,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_11,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_13,
     Name: Samples.NetActivitySdk.internal,
-    Resource: ParentSpan,
+    Resource: W3CParentSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_11,
@@ -177,48 +213,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_13,
-    Name: opentelemetry.internal,
-    Resource: ChildSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_12,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_8,
+    TraceId: Id_7,
     SpanId: Id_14,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: W3CParentSpan,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_12,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_8,
-    SpanId: Id_15,
     Name: opentelemetry.internal,
     Resource: W3CChildSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_14,
+    ParentId: Id_13,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -229,13 +230,13 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_16,
+    TraceId: Id_7,
+    SpanId: Id_15,
     Name: Samples.NetActivitySdk.internal,
     Resource: IAmMiscSpan,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_14,
+    ParentId: Id_13,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -247,8 +248,8 @@
     }
   },
   {
-    TraceId: Id_8,
-    SpanId: Id_17,
+    TraceId: Id_7,
+    SpanId: Id_16,
     Name: opentelemetry.internal,
     Resource: Parent-NonW3CId,
     Service: Samples.NetActivitySdk,
@@ -438,7 +439,7 @@
     Resource: SetBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_24,
+    ParentId: Id_25,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -103,26 +103,6 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: MyServiceName.internal,
-    Resource: StartActiveSpan.Child,
-    Service: MyServiceName,
-    Type: custom,
-    ParentId: Id_2,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
-      service.instance.id: Guid_3,
-      service.name: MyServiceName,
-      service.version: 1.0.x,
-      span.kind: internal
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_7,
-    Name: MyServiceName.internal,
     Resource: InnerSpanOk,
     Service: MyServiceName,
     Type: custom,
@@ -141,7 +121,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_8,
+    SpanId: Id_7,
     Name: MyServiceName.internal,
     Resource: InnerSpanError,
     Service: MyServiceName,
@@ -164,7 +144,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_9,
+    SpanId: Id_8,
     Name: MyServiceName.internal,
     Resource: InnerSpanUpdated,
     Service: MyServiceName,
@@ -184,7 +164,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_10,
+    SpanId: Id_9,
     Name: OtherLibrary.internal,
     Resource: Response,
     Service: MyServiceName,
@@ -195,6 +175,26 @@
       language: dotnet,
       otel.library.name: OtherLibrary,
       otel.library.version: 4.0.0,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
+      span.kind: internal
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: MyServiceName.internal,
+    Resource: StartActiveSpan.Child,
+    Service: MyServiceName,
+    Type: custom,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -103,26 +103,6 @@
     TraceId: Id_1,
     SpanId: Id_6,
     Name: MyServiceName.internal,
-    Resource: StartActiveSpan.Child,
-    Service: MyServiceName,
-    Type: custom,
-    ParentId: Id_2,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_1,
-      service.instance.id: Guid_3,
-      service.name: MyServiceName,
-      service.version: 1.0.x,
-      span.kind: internal
-    }
-  },
-  {
-    TraceId: Id_1,
-    SpanId: Id_7,
-    Name: MyServiceName.internal,
     Resource: InnerSpanOk,
     Service: MyServiceName,
     Type: custom,
@@ -141,7 +121,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_8,
+    SpanId: Id_7,
     Name: MyServiceName.internal,
     Resource: InnerSpanError,
     Service: MyServiceName,
@@ -164,7 +144,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_9,
+    SpanId: Id_8,
     Name: MyServiceName.internal,
     Resource: InnerSpanUpdated,
     Service: MyServiceName,
@@ -184,7 +164,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_10,
+    SpanId: Id_9,
     Name: OtherLibrary.internal,
     Resource: Response,
     Service: MyServiceName,
@@ -195,6 +175,26 @@
       language: dotnet,
       otel.library.name: OtherLibrary,
       otel.library.version: 4.0.0,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
+      span.kind: internal
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: MyServiceName.internal,
+    Resource: StartActiveSpan.Child,
+    Service: MyServiceName,
+    Type: custom,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,


### PR DESCRIPTION
## Summary of changes

When using the .NET `Activity` API, any `Activity` object started with a `ActivityContext` isn't honored by the tracer.
It's expected that the TraceID of that started `Activity` would map to the TraceID within the `ActivityContext`.

This PR fixes that.

Some pseudocode to better explain:

```csharp
ActivitySource source  = new ActivitySource("Name");

// this will become our Active Span
using var firstActivity = source.StartActivity("First", ActivityKind.Server);

// Create some random context that we'll provide to another Activity
var someContext = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None);
// Start a new activity, this should map to the "someContext" remote trace
using var secondActivity = source.StartActivity("Second", ActivityKind.Server, someContext);
```

What happens currently is that `secondActivity` gets mapped to the `firstActivity` trace as we don't handle unknown/remote `ActivityContext`.

## Reason for change

We'd expect the `Activity` to map to the supplied `ActivityContext`, but it doesn't, so it's a bug.

## Implementation details

Now the `secondActivity` will be mapped to its own trace, based on the `someContext`, instead of being a child of `firstActivity`.

Within the `DefaultActivityHandler` we check the activity mappings either by the `Activity.Id` or the `Activity.ParentId` -> the `ParentId` is what handles this case.

## Test coverage

- Snapshots from the `Samples.NetActivitySdk` tests updated.
