### PR TITLE
[Profiler] Add CI visibility on profiler AzDo jobs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1835,6 +1835,8 @@ stages:
 
     - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform)
       displayName: Run Profiler Integration tests
+      env:
+        DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - publish: profiler/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -45,5 +45,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.18">
+      <CopyToOutputDirectory>lib\$(TargetFramework)\*</CopyToOutputDirectory>
+      <FolderName>datadogtestlogger</FolderName>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -37,15 +37,15 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Google.Protobuf" Version="3.20.1" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.18">
+    <PackageReference Include="DatadogTestLogger" Version="0.0.33">
       <CopyToOutputDirectory>lib\$(TargetFramework)\*</CopyToOutputDirectory>
       <FolderName>datadogtestlogger</FolderName>
     </PackageReference>

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -45,9 +45,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="DatadogTestLogger" Version="0.0.33">
-      <CopyToOutputDirectory>lib\$(TargetFramework)\*</CopyToOutputDirectory>
-      <FolderName>datadogtestlogger</FolderName>
-    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
+    <PackageReference Include="DatadogTestLogger" Version="0.0.33" ExcludeAssets="compile"/>
   </ItemGroup>
 </Project>

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SkippableTestCase.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SkippableTestCase.cs
@@ -27,7 +27,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         /// <param name="testMethod">The test method this test case belongs to.</param>
         /// <param name="testMethodArguments">The arguments for the test method.</param>
         public SkippableTestCase(string skipReason, ITestMethod testMethod, object[] testMethodArguments = null)
-            : base(TestMethodDisplay.Method, TestMethodDisplayOptions.None, testMethod, testMethodArguments)
+            : base(TestMethodDisplay.ClassAndMethod, TestMethodDisplayOptions.None, testMethod, testMethodArguments)
         {
             SkipReason = skipReason;
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFrameworkDiscover.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFrameworkDiscover.cs
@@ -54,7 +54,7 @@ namespace Datadog.Profiler.SmokeTests
                     results.Add(
                         new XunitTestCase(
                                 MessageSink,
-                                TestMethodDisplay.Method,
+                                TestMethodDisplay.ClassAndMethod,
                                 TestMethodDisplayOptions.All,
                                 testMethod,
                                 new object[] { appName, System.IO.Path.GetFileName(folder), appAssembly }));

--- a/profiler/test/Directory.Build.props
+++ b/profiler/test/Directory.Build.props
@@ -17,17 +17,4 @@
       <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
       <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>
-
-    <Target Name="PackageReferenceCopyToOutput" AfterTargets="Build">
-      <ItemGroup>
-        <PackageReferenceFiles Condition="%(PackageReference.CopyToOutputDirectory) != '' AND %(PackageReference.FolderName) != ''"
-          Include="$(NugetPackageRoot)\%(PackageReference.FolderName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory)" />
-      </ItemGroup>
-      <Message Condition="%(PackageReference.CopyToOutputDirectory) != ''" 
-               Text="> $(NugetPackageRoot) | %(PackageReference.FolderName) | %(PackageReference.Version) | %(PackageReference.CopyToOutputDirectory) [$(NugetPackageRoot)\%(PackageReference.FileName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory) | $(OutDir)]" Importance="high"/>
-      <Message Condition="%(PackageReference.CopyToOutputDirectory) != '' AND '@(PackageReferenceFiles->'%(Identity)')' != ''"
-               Text="  Copy @(PackageReferenceFiles->'%(Identity)') to $(OutDir)"
-               Importance="high"/>
-      <Copy SourceFiles="@(PackageReferenceFiles)" DestinationFolder="$(OutDir)" />
-    </Target>
 </Project>

--- a/profiler/test/Directory.Build.props
+++ b/profiler/test/Directory.Build.props
@@ -18,4 +18,16 @@
       <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>
 
+    <Target Name="PackageReferenceCopyToOutput" AfterTargets="Build">
+      <ItemGroup>
+        <PackageReferenceFiles Condition="%(PackageReference.CopyToOutputDirectory) != '' AND %(PackageReference.FolderName) != ''"
+          Include="$(NugetPackageRoot)\%(PackageReference.FolderName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory)" />
+      </ItemGroup>
+      <Message Condition="%(PackageReference.CopyToOutputDirectory) != ''" 
+               Text="> $(NugetPackageRoot) | %(PackageReference.FolderName) | %(PackageReference.Version) | %(PackageReference.CopyToOutputDirectory) [$(NugetPackageRoot)\%(PackageReference.FileName)\%(PackageReference.Version)\%(PackageReference.CopyToOutputDirectory) | $(OutDir)]" Importance="high"/>
+      <Message Condition="%(PackageReference.CopyToOutputDirectory) != '' AND '@(PackageReferenceFiles->'%(Identity)')' != ''"
+               Text="  Copy @(PackageReferenceFiles->'%(Identity)') to $(OutDir)"
+               Importance="high"/>
+      <Copy SourceFiles="@(PackageReferenceFiles)" DestinationFolder="$(OutDir)" />
+    </Target>
 </Project>

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -237,6 +237,7 @@ partial class Build
                                 .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                                 .CombineWith(integrationTestProjects, (s, project) => s
                                                                                         .EnableTrxLogOutput(ProfilerBuildDataDirectory / "results" / project.Name)
+                                                                                        .WithDatadogLogger()
                                                                                         .SetProjectFile(project)),
                         degreeOfParallelism: 4);
         }


### PR DESCRIPTION
## Summary of changes

Add profiler integration jobs to CI visibility

## Reason for change

There was a time the profiler integration tests was not running but we did not notice it (the CI status was OK).

## Implementation details

Add the datadog logger
Ensure we use the fully qualified name for the tests to avoid failing the logger

## Test coverage

## Other details
<!-- Fixes #{issue} -->
