### PR TITLE
[Profiler] Fix bug when retrieving number of cores

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -169,11 +169,9 @@ bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
 
 // from https://linux.die.net/man/3/get_nprocs
 //
-bool GetProcessorCount(uint32_t& processorCount)
+int32_t GetProcessorCount()
 {
-    processorCount = get_nprocs();
-
-    return true;
+    return get_nprocs();
 }
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -8,6 +8,7 @@
 #include "IApplicationStore.h"
 #include "IMetricsSender.h"
 #include "Log.h"
+#include "OsSpecificApi.h"
 #include "OpSysTools.h"
 #include "Sample.h"
 #include "dd_profiler_version.h"
@@ -509,6 +510,7 @@ bool LibddprofExporter::Export()
         additionalTags.Add("service", applicationInfo.ServiceName);
         additionalTags.Add("runtime-id", std::string(runtimeId));
         additionalTags.Add("profile_seq", std::to_string(exportsCount - 1));
+        additionalTags.Add("number_of_cpu_cores", std::to_string(OsSpecificApi::GetProcessorCount()));
 
         auto* request = CreateRequest(serializedProfile, exporter, additionalTags);
         if (request != nullptr)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -20,5 +20,5 @@ namespace OsSpecificApi
    std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
    uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
    bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
-   bool GetProcessorCount(uint32_t& processorCount);
+   int32_t GetProcessorCount();
 } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -245,9 +245,18 @@ void StackSamplerLoop::CpuProfilingIteration()
     uint32_t sampledThreads = 0;
     int32_t managedThreadsCount = _pManagedThreadList->Count();
     int32_t sampledThreadsCount = (std::min)(managedThreadsCount, _cpuThreadsThreshold);
+    static int64_t lastTime = 0;
+
+    auto firstIteration = lastTime == 0;
+
+    auto currentTimeTime = OpSysTools::GetHighPrecisionNanoseconds();
+    auto duration =  currentTimeTime - lastTime;
+    lastTime = currentTimeTime;
+    int nbThreads = 0;
 
     for (int32_t i = 0; i < sampledThreadsCount && !_shutdownRequested; i++)
     {
+        nbThreads++;
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)
         {
@@ -301,6 +310,11 @@ void StackSamplerLoop::CpuProfilingIteration()
             }
             _targetThread.reset();
         }
+    }
+
+    if (!firstIteration)
+    {
+        Log::Info("CPU iteration:\n* Wait duration: ", duration, " ns\n* Nb threads: ", nbThreads, "\n* Nb sampled threads: ", sampledThreads);
     }
 }
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="ManagedThreadListTest.cpp" />
     <ClCompile Include="MetricsRegistryTest.cpp" />
     <ClCompile Include="OpSysToolsTest.cpp" />
+    <ClCompile Include="OSpecificAPIHelper.cpp" />
     <ClCompile Include="ProfilerMockedInterface.cpp" />
     <ClCompile Include="ProfilerSignalManagerTest.cpp" />
     <ClCompile Include="RuntimeIdStoreHelper.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -107,6 +107,9 @@
     <ClCompile Include="MetricsRegistryTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="OSpecificAPIHelper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/OSpecificAPIHelper.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/OSpecificAPIHelper.cpp
@@ -1,0 +1,10 @@
+#include <cstdint>
+
+namespace OsSpecificApi {
+
+int32_t GetProcessorCount()
+{
+    return 1;
+}
+
+} // namespace OsSpecificApi

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -239,7 +239,7 @@ partial class Build
                                                                                         .EnableTrxLogOutput(ProfilerBuildDataDirectory / "results" / project.Name)
                                                                                         .WithDatadogLogger()
                                                                                         .SetProjectFile(project)),
-                        degreeOfParallelism: 1);
+                        degreeOfParallelism: 4);
         }
         finally
         {

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -239,7 +239,7 @@ partial class Build
                                                                                         .EnableTrxLogOutput(ProfilerBuildDataDirectory / "results" / project.Name)
                                                                                         .WithDatadogLogger()
                                                                                         .SetProjectFile(project)),
-                        degreeOfParallelism: 4);
+                        degreeOfParallelism: 1);
         }
         finally
         {


### PR DESCRIPTION
## Summary of changes

Fix bug when retrieving the number of cores on Windows.

## Reason for change

The way we retrieve the number of cores on Windows is a bit complex and the value is not correct (as per the description of CI runners).
Based on [Raymond Chen article](https://devblogs.microsoft.com/oldnewthing/20200824-00/?p=104116) we can use `GetActiveProcessorCount` instead.

## Implementation details

Use `GetActiveProcessorCount` for windows

## Test coverage

## Other details
<!-- Fixes #{issue} -->
