### PR TITLE
[Build/Test] Add system tests for the library injection images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3165,7 +3165,7 @@ stages:
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
 - stage: upload_container_images
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
   dependsOn: [upload_to_azure]
   jobs:
     - job: upload

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3165,7 +3165,7 @@ stages:
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
 - stage: upload_container_images
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true))
   dependsOn: [upload_to_azure]
   jobs:
     - job: upload

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -121,6 +121,7 @@ jobs:
         lib-injection-connection: ['network','uds']
         lib-injection-use-admission-controller: ['', 'use-admission-controller']
         weblog-variant: ['dd-lib-dotnet-init-test-app']
+        runtime: ['bullseye-slim','alpine']
       fail-fast: false
     env:
       TEST_LIBRARY: dotnet
@@ -129,11 +130,13 @@ jobs:
       LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
       DOCKER_IMAGE_TAG: ${{ github.sha }}
-      BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8 
+      DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}-${{ matrix.runtime }}
+      RUNTIME: ${{ matrix.runtime }}
+      BUILDX_PLATFORMS: linux/amd64
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@b3ca75b6ce109a349f7390a9f111e6b3ef3c97ef
+        uses: DataDog/system-tests/lib-injection/runner@1282714bfd25baae821f10cf6f1e77f990a82a89 # zach/lib-injection-dotnet
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.repository_owner }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -48,13 +48,6 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: lib-injection-tags
-      id: lib-injection-tags
-      uses: DataDog/system-tests/lib-injection/docker-tags@main
-      with:
-        init-image-name: 'dd-lib-dotnet-init'
-        main-branch-name: 'master'
-
     - name: Login to Docker
       run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -108,3 +108,34 @@ jobs:
         # When we actually produce linux-musl-arm64 binaries, use that instead of the placeholder 'linux-musl-arm' directory
         build-args: |
           LINUX_PACKAGE=linux-musl-arm
+
+  test:
+    needs:
+      - build-and-publish-init-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        lib-injection-connection: ['network','uds']
+        lib-injection-use-admission-controller: ['', 'use-admission-controller']
+        weblog-variant: ['dd-lib-dotnet-init-test-app']
+      fail-fast: false
+    env:
+      TEST_LIBRARY: dotnet
+      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
+      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
+      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
+      DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
+      DOCKER_IMAGE_TAG: ${{ github.sha }}
+      BUILDX_PLATFORMS: linux/amd64,linux/arm64/v8 
+    steps:
+      - name: lib-injection test runner
+        id: lib-injection-test-runner
+        uses: DataDog/system-tests/lib-injection/runner@b3ca75b6ce109a349f7390a9f111e6b3ef3c97ef
+        with:
+          docker-registry: ghcr.io
+          docker-registry-username: ${{ github.repository_owner }}
+          docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          test-script: ./lib-injection/run-manual-lib-injection.sh

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -59,40 +59,44 @@ jobs:
       run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
     - name: Build and push dd-lib-dotnet-init:<SHA>-amd64
+      id: build-image-amd64
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-amd64'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}'
         platforms: 'linux/amd64' # for windows, we can run windows/amd64,windows/386,windows/arm64
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}.tar.gz
 
     - name: Build and push dd-lib-dotnet-init:<SHA>-arm64v8
+      id: build-image-arm64v8
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-arm64v8'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}.arm64.tar.gz
 
     - name: Build and push dd-lib-dotnet-init:<SHA>-musl-amd64
+      id: build-image-musl-amd64
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-amd64'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl'
         platforms: 'linux/amd64'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}-musl.tar.gz
 
     - name: Build and push dd-lib-dotnet-init:<SHA>-musl-arm64v8
+      id: build-image-musl-arm64v8
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-arm64v8'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         # When we actually produce linux-musl-arm64 binaries, use that instead of the placeholder 'linux-musl-arm' directory
@@ -105,15 +109,15 @@ jobs:
         # Create multiarch image for dd-lib-dotnet-init:<SHA>
         docker manifest create \
           ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }} \
-          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-amd64 \
-          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-arm64v8
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-amd64.outputs.digest}}" \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}
 
         # Create multiarch image for dd-lib-dotnet-init:<SHA>-musl
         docker manifest create \
           ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl \
-          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-amd64 \
-          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-arm64v8
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-amd64.outputs.digest}}" \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl
 
   test:

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@1282714bfd25baae821f10cf6f1e77f990a82a89 # zach/lib-injection-dotnet
+        uses: DataDog/system-tests/lib-injection/runner@69336117276b3ef31f2594d20cbd8cd8a7d26396 # zach/lib-injection-dotnet
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.repository_owner }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@69336117276b3ef31f2594d20cbd8cd8a7d26396 # zach/lib-injection-dotnet
+        uses: DataDog/system-tests/lib-injection/runner@main
         with:
           docker-registry: ghcr.io
           docker-registry-username: ${{ github.repository_owner }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -48,66 +48,73 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Generate libc image tags
+    - name: lib-injection-tags
       id: lib-injection-tags
       uses: DataDog/system-tests/lib-injection/docker-tags@main
       with:
         init-image-name: 'dd-lib-dotnet-init'
         main-branch-name: 'master'
 
-    - name: Generate musl image tags
-      id: generate-musl-tags
-      shell: pwsh
-      run: |
-        $input = "${{ steps.lib-injection-tags.outputs.tag-names }}"
-        $muslTagNames = @($input.Split(",") | ForEach-Object { $_ + "-musl" }) -join ","
-
-        echo "Generated musl tag names '$muslTagNames'"
-        echo "::set-output name=musl-tag-names::$muslTagNames"
-
     - name: Login to Docker
       run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
-    - name: Docker Build linux-x64 image
+    - name: Build and push dd-lib-dotnet-init:<SHA>-amd64
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.lib-injection-tags.outputs.tag-names }}
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-amd64'
         platforms: 'linux/amd64' # for windows, we can run windows/amd64,windows/386,windows/arm64
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}.tar.gz
 
-    - name: Docker Build linux-arm64 image
+    - name: Build and push dd-lib-dotnet-init:<SHA>-arm64v8
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.lib-injection-tags.outputs.tag-names }}
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-arm64v8'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}.arm64.tar.gz
 
-    - name: Docker Build linux-musl-x64 image
+    - name: Build and push dd-lib-dotnet-init:<SHA>-musl-amd64
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.generate-musl-tags.outputs.musl-tag-names }}
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-amd64'
         platforms: 'linux/amd64'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
           LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}-musl.tar.gz
 
-    - name: Docker Build linux-musl-arm64 image
+    - name: Build and push dd-lib-dotnet-init:<SHA>-musl-arm64v8
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.generate-musl-tags.outputs.musl-tag-names }}
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-arm64v8'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         # When we actually produce linux-musl-arm64 binaries, use that instead of the placeholder 'linux-musl-arm' directory
         build-args: |
           LINUX_PACKAGE=linux-musl-arm
+
+    - name: Publish multiarch images for <SHA> and <SHA>-musl tags
+      shell: bash
+      run: |
+        # Create multiarch image for dd-lib-dotnet-init:<SHA>
+        docker manifest create \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }} \
+          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-amd64 \
+          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-arm64v8
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}
+
+        # Create multiarch image for dd-lib-dotnet-init:<SHA>-musl
+        docker manifest create \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl \
+          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-amd64 \
+          --amend ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl-arm64v8
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl
 
   test:
     needs:
@@ -122,6 +129,11 @@ jobs:
         lib-injection-use-admission-controller: ['', 'use-admission-controller']
         weblog-variant: ['dd-lib-dotnet-init-test-app']
         runtime: ['bullseye-slim','alpine']
+        include:
+          - runtime: 'bullseye-slim'
+            init-tag-suffix: ''
+          - runtime: 'alpine'
+            init-tag-suffix: '-musl'
       fail-fast: false
     env:
       TEST_LIBRARY: dotnet
@@ -129,7 +141,7 @@ jobs:
       LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
       LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
-      DOCKER_IMAGE_TAG: ${{ github.sha }}
+      DOCKER_IMAGE_TAG: ${{ github.sha }}${{ matrix.init-tag-suffix }}
       DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}-${{ matrix.runtime }}
       RUNTIME: ${{ matrix.runtime }}
       BUILDX_PLATFORMS: linux/amd64

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -103,17 +103,21 @@ jobs:
         build-args: |
           LINUX_PACKAGE=linux-musl-arm
 
-    - name: Publish multiarch images for <SHA> and <SHA>-musl tags
+    - name: Publish multiarch images with all platforms
       shell: bash
       run: |
-        # Create multiarch image for dd-lib-dotnet-init:<SHA>
+        # Issue: The above 'docker buildx build' commands only create an image for one platform at a time because we have different build-args for each invocation.
+        # This results in the 'dd-lib-dotnet-init:<SHA>[-musl]' tag being overwritten by the latest build command, so the result is not a multiarch image
+
+        # Fix: The following lines create and publish a new manifest to overwrite the 'dd-lib-dotnet-init:<SHA>[-musl]' tag.
+        # In the new manifest we directly reference each platform-specific image, so the tag becomes a multiarch image.
+        
         docker manifest create \
           ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }} \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-amd64.outputs.digest}}" \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}
 
-        # Create multiarch image for dd-lib-dotnet-init:<SHA>-musl
         docker manifest create \
           ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-amd64.outputs.digest}}" \


### PR DESCRIPTION
## Summary of changes
Invokes the system tests to validate the library injection images for .NET

## Reason for change
We need tests for this, and in doing so it found an issue with the existing GHCR images 😅 

## Implementation details
- Removes the `latest` and `latest-snapshot` tags, so now we only build images with the following tags:
  - `dd-lib-dotnet-init:<SHA>`
  - `dd-lib-dotnet-init:<SHA>-musl`
- Fixes an issue where the last `docker build buildx` command would overwrite the tag in GHCR. Since the ARM64 image builds were run last, this resulted in the `dd-lib-dotnet-init:<SHA>` and `dd-lib-dotnet-init:<SHA>-musl` tags referencing only the ARM64-platform image. The fix is to create and upload a new manifest at the end of the build that directly references all of the platform images that belong to that tag.
- Invokes the system-tests to run the lib-injection test suite with the following parameters
  - Test app name: `dd-lib-dotnet-init-test-app`
  - .NET Core runtimes: `7.0-bullseye-slim` and `7.0-alpine`

## Test coverage
The tests succeed! See the latest [GitHub Actions test run](https://github.com/DataDog/dd-trace-dotnet/actions/runs/4199663351/jobs/7284816400)

## Other details
Note: Waiting on the .NET test code to be merged in the system-tests repo via https://github.com/DataDog/system-tests/pull/880
