### PR TITLE
Update telemetry-logs implementation

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
@@ -30,13 +30,15 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
     internal static class EventIdHash
     {
         /// <summary>
-        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>
+        /// and optionally a <paramref name="stackTrace"/>. The
         /// resulting hash value can be uses as an event id in lieu of transmitting the
         /// full template string.
         /// </summary>
         /// <param name="messageTemplate">A message template.</param>
+        /// <param name="stackTrace">An optional stack trace to consider in the calculation.</param>
         /// <returns>A 32-bit hash of the template.</returns>
-        public static uint Compute(string messageTemplate)
+        public static uint Compute(string messageTemplate, string? stackTrace = null)
         {
             if (messageTemplate == null)
             {
@@ -52,6 +54,16 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                     hash += messageTemplate[i];
                     hash += (hash << 10);
                     hash ^= (hash >> 6);
+                }
+
+                if (stackTrace is not null)
+                {
+                    for (var i = 0; i < stackTrace.Length; ++i)
+                    {
+                        hash += stackTrace[i];
+                        hash += (hash << 10);
+                        hash ^= (hash >> 6);
+                    }
                 }
 
                 hash += (hash << 3);

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         /// </summary>
         /// <param name="logEvent">Log event to emit.</param>
         /// <exception cref="ArgumentNullException">The event is null.</exception>
-        public void EnqueueLog(T logEvent)
+        public virtual void EnqueueLog(T logEvent)
         {
             if (logEvent == null)
             {

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/TelemetryLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/TelemetryLoggingConfiguration.cs
@@ -18,7 +18,7 @@ internal class TelemetryLoggingConfiguration
         BufferSize = bufferSize;
         BatchSize = batchSize;
         FlushPeriod = flushPeriod;
-        LogLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Debug);
+        LogLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Warning);
         TelemetrySink = new(CreateTelemetrySink);
     }
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/TelemetryLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/TelemetryLoggingConfiguration.cs
@@ -60,6 +60,7 @@ internal class TelemetryLoggingConfiguration
         return new TelemetryLogsSink(
             batchingOptions,
             () => LogLevelSwitch.MinimumLevel = LogEventLevel.Fatal,
-            DatadogSerilogLogger.NullLogger);
+            DatadogSerilogLogger.NullLogger,
+            deDuplicationEnabled: true); // This sends only messageTemplates, so may as wel dedupe
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Converters;
 
 namespace Datadog.Trace.Telemetry;
@@ -15,6 +16,7 @@ internal class LogMessageData
     {
         Message = message;
         Level = level;
+        TracerTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
     }
 
     public string Message { get; set; }
@@ -25,4 +27,9 @@ internal class LogMessageData
     public string? Tags { get; set; }
 
     public string? StackTrace { get; set; }
+
+    /// <summary>
+    /// Gets or sets unix timestamp (in seconds) of when the message is being sent
+    /// </summary>
+    public long TracerTime { get; set; }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/TelemetryLogsSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TelemetryLogsSinkTests.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using Datadog.Trace.Logging.Internal.Sinks;
 using Datadog.Trace.Telemetry;
 using FluentAssertions;
 using Xunit;
@@ -22,22 +23,24 @@ public class TelemetryLogsSinkTests
     private static readonly ApplicationTelemetryData AppData = new("my-serv", "integration-tests", TracerConstants.AssemblyVersion, "dotnet", FrameworkDescription.Instance.ProductVersion);
     private static readonly HostTelemetryData HostData = new();
 
-    [Fact]
-    public void DoesNotSendBatchesUntilInitialized()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void DoesNotSendBatchesUntilInitialized(bool deDuplicationEnabled)
     {
         var options = new BatchingSinkOptions(
             batchSizeLimit: 10,
             queueLimit: 100,
             period: TimeSpan.FromMilliseconds(100));
-        var sink = new TestTelemetryLogsSink(options);
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: deDuplicationEnabled);
 
         for (var i = 0; i < 150; i++)
         {
             // adding more logs than we're allowed
-            sink.EnqueueLog(new LogMessageData("This is my message", TelemetryLogLevel.DEBUG));
+            sink.EnqueueLog(new LogMessageData("This is my message " + i, TelemetryLogLevel.DEBUG));
         }
 
-        var wasFlushed = sink.Mutex.Wait(TimeSpan.FromSeconds(5)); // plenty of time to flush if it's going to
+        var wasFlushed = sink.BatchSentMutex.Wait(TimeSpan.FromSeconds(5)); // plenty of time to flush if it's going to
 
         wasFlushed.Should().BeFalse();
 
@@ -231,13 +234,251 @@ public class TelemetryLogsSinkTests
             .And.OnlyContain(x => x.Length == 1);
     }
 
+    [Fact]
+    public void WhenDeDupeEnabled_OnlySendsSingleLog()
+    {
+        var options = new BatchingSinkOptions(
+            batchSizeLimit: 10,
+            queueLimit: 100,
+            period: TimeSpan.FromMilliseconds(100));
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: true);
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            sink.EnqueueLog(new LogMessageData("This is my message", TelemetryLogLevel.DEBUG));
+        }
+
+        // Now initialize
+        sink.Initialize(
+            AppData,
+            HostData,
+            new TelemetryDataBuilder(),
+            new ITelemetryTransport[] { new TestTransport(TelemetryPushResult.Success) });
+
+        WaitForBatchCount(sink, count: 1);
+
+        sink.Batches.Should()
+            .HaveCount(1)
+            .And.ContainSingle()
+            .Subject.Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be("This is my message. 4 additional messages skipped.");
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndIncludesExceptionFromSameLocation_OnlySendsSingleLog()
+    {
+        const string message = "This is my message";
+        var options = new BatchingSinkOptions(
+            batchSizeLimit: 10,
+            queueLimit: 100,
+            period: TimeSpan.FromMilliseconds(100));
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: true);
+
+        // Add multiple identical messages with exception from same location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException1();
+            sink.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.DEBUG) { StackTrace = ExceptionRedactor.Redact(ex) });
+        }
+
+        // Now initialize
+        sink.Initialize(
+            AppData,
+            HostData,
+            new TelemetryDataBuilder(),
+            new ITelemetryTransport[] { new TestTransport(TelemetryPushResult.Success) });
+
+        WaitForBatchCount(sink, count: 1);
+
+        sink.Batches.Should()
+            .HaveCount(1)
+            .And.ContainSingle()
+            .Subject.Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be("This is my message. 4 additional messages skipped.");
+
+        Exception GetException1()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndIncludesExceptionFromDifferentLocation_SendsDifferentLog()
+    {
+        const string message = "This is my message";
+        var options = new BatchingSinkOptions(
+            batchSizeLimit: 10,
+            queueLimit: 100,
+            period: TimeSpan.FromMilliseconds(100));
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: true);
+
+        // Add multiple identical messages with exception from same location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException1();
+            sink.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.DEBUG) { StackTrace = ExceptionRedactor.Redact(ex) });
+        }
+
+        // Add multiple identical messages with exception from different location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException2();
+            sink.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.DEBUG) { StackTrace = ExceptionRedactor.Redact(ex) });
+        }
+
+        // Now initialize
+        sink.Initialize(
+            AppData,
+            HostData,
+            new TelemetryDataBuilder(),
+            new ITelemetryTransport[] { new TestTransport(TelemetryPushResult.Success) });
+
+        WaitForBatchCount(sink, count: 1);
+
+        var batch = sink.Batches.Should()
+            .HaveCount(1)
+            .And.ContainSingle()
+            .Subject;
+        batch.Should().HaveCount(2);
+        batch[0].Message.Should().Be("This is my message. 4 additional messages skipped.");
+        batch[1].Message.Should().Be("This is my message. 4 additional messages skipped.");
+
+        Exception GetException1()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+
+        Exception GetException2()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndSendsBatchInBetween_SendsSingleLogPerBatch()
+    {
+        var sendingBatchMutex = new ManualResetEventSlim();
+        var options = new BatchingSinkOptions(
+            batchSizeLimit: 10,
+            queueLimit: 100,
+            period: TimeSpan.FromMilliseconds(100));
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: true);
+        sink.SendingBatch = _ =>
+        {
+            if (sendingBatchMutex is not null && !sendingBatchMutex.Wait(TimeSpan.FromSeconds(5)))
+            {
+                throw new Exception("Timeout waiting for send batch signal");
+            }
+
+            return Task.CompletedTask;
+        };
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            sink.EnqueueLog(new LogMessageData("This is my message", TelemetryLogLevel.DEBUG));
+        }
+
+        // Now initialize
+        sink.Initialize(
+            AppData,
+            HostData,
+            new TelemetryDataBuilder(),
+            new ITelemetryTransport[] { new TestTransport(TelemetryPushResult.Success) });
+
+        sendingBatchMutex.Set();
+        WaitForBatchCount(sink, count: 1);
+        sendingBatchMutex = null;
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            sink.EnqueueLog(new LogMessageData("This is my second message", TelemetryLogLevel.DEBUG));
+        }
+
+        WaitForBatchCount(sink, count: 2);
+
+        var batches = sink.Batches.ToArray();
+        batches.Should().HaveCount(2);
+
+        batches[0].Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be("This is my message. 4 additional messages skipped.");
+
+        batches[1].Should()
+                  .ContainSingle()
+                  .Subject.Message.Should()
+                  .Be("This is my second message. 4 additional messages skipped.");
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndOverfills_GroupsAllIntoSingleBatch()
+    {
+        const int batchSizeLimit = 10;
+        var options = new BatchingSinkOptions(
+            batchSizeLimit: batchSizeLimit,
+            queueLimit: 100,
+            period: TimeSpan.FromMilliseconds(100));
+        var sink = new TestTelemetryLogsSink(options, deDuplicationEnabled: true);
+
+        // Add too many identical messages
+        for (var i = 0; i < batchSizeLimit * 2; i++)
+        {
+            sink.EnqueueLog(new LogMessageData("This is my message", TelemetryLogLevel.DEBUG));
+        }
+
+        // Now initialize
+        sink.Initialize(
+            AppData,
+            HostData,
+            new TelemetryDataBuilder(),
+            new ITelemetryTransport[] { new TestTransport(TelemetryPushResult.Success) });
+
+        WaitForBatchCount(sink, count: 1);
+
+        var batches = sink.Batches
+                          .Should()
+                          .ContainSingle()
+                          .Subject.Should()
+                          .ContainSingle()
+                          .Subject.Message.Should()
+                          .Be("This is my message. 19 additional messages skipped.");
+    }
+
     private static void WaitForBatchCount(TestTelemetryLogsSink sink, int count, int seconds = 10)
     {
         var deadline = DateTime.UtcNow.AddSeconds(seconds);
         while (sink.Batches.Count < count && deadline > DateTime.UtcNow)
         {
-            sink.Mutex.Wait(TimeSpan.FromSeconds(1));
-            sink.Mutex.Reset();
+            sink.BatchSentMutex.Wait(TimeSpan.FromSeconds(1));
+            sink.BatchSentMutex.Reset();
         }
     }
 
@@ -254,20 +495,27 @@ public class TelemetryLogsSinkTests
 
     internal class TestTelemetryLogsSink : TelemetryLogsSink
     {
-        public TestTelemetryLogsSink(BatchingSinkOptions sinkOptions, Action disableSinkAction = null, IDatadogLogger log = null)
-            : base(sinkOptions, disableSinkAction ?? (() => { }), log ?? DatadogSerilogLogger.NullLogger)
+        public TestTelemetryLogsSink(
+            BatchingSinkOptions sinkOptions,
+            Action disableSinkAction = null,
+            IDatadogLogger log = null,
+            bool deDuplicationEnabled = false)
+            : base(sinkOptions, disableSinkAction ?? (() => { }), log ?? DatadogSerilogLogger.NullLogger, deDuplicationEnabled)
         {
         }
 
-        public ManualResetEventSlim Mutex { get; } = new();
+        public Func<Queue<LogMessageData>, Task> SendingBatch { get; set; } = _ => Task.CompletedTask;
+
+        public ManualResetEventSlim BatchSentMutex { get; } = new();
 
         public ConcurrentQueue<LogMessageData[]> Batches { get; } = new();
 
         protected override async Task<bool> EmitBatch(Queue<LogMessageData> events)
         {
+            await SendingBatch.Invoke(events);
             Batches.Enqueue(events.ToArray());
             var result = await base.EmitBatch(events);
-            Mutex.Set();
+            BatchSentMutex.Set();
             return result;
         }
     }


### PR DESCRIPTION
## Summary of changes

- Add de-duplication of telemetry logs
- Update minimum log verbosity to Warn
- Add timestamp to log messages (otherwise uses the timestamp in the batch)

## Reason for change

We want to make sure we don't overwhelm the intake. As these are sanitised logs (message templates only) there should be huge savings by deduplicating.

## Implementation details

Uses the message template (+ stack trace if present) to generate a hash. Check if the hash has already been seen before writing the log message). 

Similar to the log-rate-limiting that we already have (disabled by default), we append an "additional messages skipped" count to each log message. 

When a new batch is emitted, we reset the log count. Technically I think there's a small race condition which would cause a duplicate log message to be "dropped" entirely under the following conditions:

- The log message (`MESSAGE`) has been previously seen `3` times (it's present in the `logCounts` dictionary).
- `EnqueueLog` is called at `EmitBatch` with the message `MESSAGE`.
- `EnqueueLog` takes a reference to the dictionary
- `EmitBatch` swaps out the dictionary, and starts processing the log messages in the batch, adding the counts. It updates the log message for `MESSAGE` with the existing count (`3`)
- `EnqueueLog` checks its `logCounts` dictionary, updates the count to `4`, and discards the log
- The "wrong" count is sent

_Ideally_ we would either send the correct count, `4`, or we would emit the log in the next batch. However, I don't think this is a big enough issue to worry about (unless there's an easy solution I'm missing)! 

## Test coverage

Added unit tests for the de-dupe behaviour

## Other details
Awaiting final verification on whether we want to append the the `"{x} additional messages skipped"` message at all. If not, then the above concern is moot and we can skip it. Note that AFAICT, in Java's proposed implementation, they _don't_ add the extra message https://github.com/DataDog/dd-trace-java/pull/4521