### PR TITLE
[ASM] Add valueparts without source in vulnerability Json

### DIFF
--- a/tracer/src/Datadog.Trace/IAST/Evidence.cs
+++ b/tracer/src/Datadog.Trace/IAST/Evidence.cs
@@ -38,10 +38,10 @@ internal readonly struct Evidence
         var rangeList = _ranges.ToList();
         rangeList.Sort();
         int currentIndex = 0;
-        var valueLenght = _value.Length;
+        var valueLength = _value.Length;
         foreach (var range in rangeList)
         {
-            if (!range.IsEmpty() && range.Source != null && range.Start >= 0 && range.Start + range.Length <= valueLenght && currentIndex <= range.Start)
+            if (!range.IsEmpty() && range.Source != null && range.Start >= 0 && range.Start + range.Length <= valueLength && currentIndex <= range.Start)
             {
                 if (currentIndex != range.Start)
                 {

--- a/tracer/src/Datadog.Trace/IAST/Evidence.cs
+++ b/tracer/src/Datadog.Trace/IAST/Evidence.cs
@@ -13,14 +13,16 @@ namespace Datadog.Trace.Iast;
 internal readonly struct Evidence
 {
     private readonly Range[]? _ranges;
+    private readonly string _value;
 
     public Evidence(string value, Range[]? ranges = null)
     {
-        this.Value = value;
+        this._value = value;
         this._ranges = ranges;
     }
 
-    public string Value { get; }
+    // We only show value in the json when there are no valueParts
+    public string? Value => _ranges?.Length > 0 ? null : _value;
 
     // This method is only used once when serializing to json (and it is also called from unit tests)
     public List<ValuePart>? ValueParts => GetValuePartsFromRanges();
@@ -36,24 +38,24 @@ internal readonly struct Evidence
         var rangeList = _ranges.ToList();
         rangeList.Sort();
         int currentIndex = 0;
-        var valueLenght = Value.Length;
+        var valueLenght = _value.Length;
         foreach (var range in rangeList)
         {
             if (!range.IsEmpty() && range.Source != null && range.Start >= 0 && range.Start + range.Length <= valueLenght && currentIndex <= range.Start)
             {
                 if (currentIndex != range.Start)
                 {
-                    valueParts.Add(new ValuePart(Value.Substring(currentIndex, range.Start - currentIndex), null));
+                    valueParts.Add(new ValuePart(_value.Substring(currentIndex, range.Start - currentIndex), null));
                 }
 
-                valueParts.Add(new ValuePart(Value.Substring(range.Start, range.Length), range.Source.GetInternalId()));
+                valueParts.Add(new ValuePart(_value.Substring(range.Start, range.Length), range.Source.GetInternalId()));
                 currentIndex = range.Start + range.Length;
             }
         }
 
-        if (valueParts.Count > 0 && currentIndex < Value.Length)
+        if (valueParts.Count > 0 && currentIndex < _value.Length)
         {
-            valueParts.Add(new ValuePart(Value.Substring(currentIndex), null));
+            valueParts.Add(new ValuePart(_value.Substring(currentIndex), null));
         }
 
         return valueParts.Count > 0 ? valueParts : null;
@@ -66,6 +68,6 @@ internal readonly struct Evidence
 
     public override int GetHashCode()
     {
-        return IastUtils.GetHashCode(Value, _ranges);
+        return IastUtils.GetHashCode(_value, _ranges);
     }
 }

--- a/tracer/src/Datadog.Trace/IAST/Range.cs
+++ b/tracer/src/Datadog.Trace/IAST/Range.cs
@@ -5,9 +5,12 @@
 
 #nullable enable
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+
 namespace Datadog.Trace.Iast;
 
-internal readonly struct Range
+internal readonly struct Range : IComparable<Range>
 {
     public Range(int start, int length, Source source)
     {
@@ -30,5 +33,10 @@ internal readonly struct Range
     public override int GetHashCode()
     {
         return IastUtils.GetHashCode(Start, Length, Source);
+    }
+
+    public int CompareTo([AllowNull] Range other)
+    {
+        return this.Start.CompareTo(other.Start);
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/EvidenceTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/EvidenceTests.cs
@@ -20,11 +20,13 @@ public class EvidenceTests
         source2.SetInternalId(1);
         var ranges = new Range[] { new Range(0, 2, source), new Range(2, 2, source2) };
         var ev = new Evidence("sql_query", ranges);
-        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts.Count.Should().Be(3);
         ev.ValueParts[0].Source.Should().Be(0);
         ev.ValueParts[1].Source.Should().Be(1);
+        ev.ValueParts[2].Source.Should().BeNull();
         ev.ValueParts[0].Value.Should().Be("sq");
         ev.ValueParts[1].Value.Should().Be("l_");
+        ev.ValueParts[2].Value.Should().Be("query");
     }
 
     [Fact]
@@ -32,13 +34,19 @@ public class EvidenceTests
     {
         var source = new Source(2, "name", "value");
         source.SetInternalId(0);
-        var ranges = new Range[] { new Range(0, 2, source), new Range(2, 2, source) };
+        var ranges = new Range[] { new Range(2, 2, source), new Range(6, 2, source) };
         var ev = new Evidence("sql_query", ranges);
-        ev.ValueParts.Count.Should().Be(2);
-        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts.Count.Should().Be(5);
+        ev.ValueParts[0].Source.Should().BeNull();
         ev.ValueParts[1].Source.Should().Be(0);
+        ev.ValueParts[2].Source.Should().BeNull();
+        ev.ValueParts[3].Source.Should().Be(0);
+        ev.ValueParts[4].Source.Should().BeNull();
         ev.ValueParts[0].Value.Should().Be("sq");
         ev.ValueParts[1].Value.Should().Be("l_");
+        ev.ValueParts[2].Value.Should().Be("qu");
+        ev.ValueParts[3].Value.Should().Be("er");
+        ev.ValueParts[4].Value.Should().Be("y");
     }
 
     [Fact]
@@ -74,8 +82,128 @@ public class EvidenceTests
         source.SetInternalId(0);
         var ranges = new Range[] { new Range(0, 2, null), new Range(2, 2, source) };
         var ev = new Evidence("sql_query", ranges);
-        ev.ValueParts.Count.Should().Be(1);
+        ev.ValueParts.Count.Should().Be(3);
+        ev.ValueParts[0].Source.Should().BeNull();
+        ev.ValueParts[1].Source.Should().Be(0);
+        ev.ValueParts[2].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sq");
+        ev.ValueParts[1].Value.Should().Be("l_");
+        ev.ValueParts[2].Value.Should().Be("query");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect7()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(1, 1, source), new Range(2, 2, source2) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(4);
+        ev.ValueParts[0].Source.Should().BeNull();
+        ev.ValueParts[1].Source.Should().Be(0);
+        ev.ValueParts[2].Source.Should().Be(1);
+        ev.ValueParts[3].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("s");
+        ev.ValueParts[1].Value.Should().Be("q");
+        ev.ValueParts[2].Value.Should().Be("l_");
+        ev.ValueParts[3].Value.Should().Be("query");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect8()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(0, 5, source), new Range(5, 4, source2) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
         ev.ValueParts[0].Source.Should().Be(0);
-        ev.ValueParts[0].Value.Should().Be("l_");
+        ev.ValueParts[1].Source.Should().Be(1);
+        ev.ValueParts[0].Value.Should().Be("sql_q");
+        ev.ValueParts[1].Value.Should().Be("uery");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect9()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(6, 44, source2), new Range(0, 5, source) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts[1].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sql_q");
+        ev.ValueParts[1].Value.Should().Be("uery");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect10()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(0, 5, source), new Range(1, 2, source2) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts[1].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sql_q");
+        ev.ValueParts[1].Value.Should().Be("uery");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect11()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(0, 5, source), new Range(6, 0, source2) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts[1].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sql_q");
+        ev.ValueParts[1].Value.Should().Be("uery");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect12()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(0, 5, source), new Range(6, 1, null) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts[1].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sql_q");
+        ev.ValueParts[1].Value.Should().Be("uery");
+    }
+
+    [Fact]
+    public void GivenAnEvidence_WhenGetValueParts_ValuePartsIsCorrect13()
+    {
+        var source = new Source(2, "name", "value");
+        source.SetInternalId(0);
+        var source2 = new Source(3, "name2", "value2");
+        source2.SetInternalId(1);
+        var ranges = new Range[] { new Range(0, 3, source), new Range(2, 2, source2) };
+        var ev = new Evidence("sql_query", ranges);
+        ev.ValueParts.Count.Should().Be(2);
+        ev.ValueParts[0].Source.Should().Be(0);
+        ev.ValueParts[1].Source.Should().BeNull();
+        ev.ValueParts[0].Value.Should().Be("sql");
+        ev.ValueParts[1].Value.Should().Be("_query");
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -5,9 +5,6 @@
 
 using System.Text.RegularExpressions;
 using Datadog.Trace.Iast;
-using Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
 using Xunit;
 
@@ -38,8 +35,9 @@ public class VulnerabilityBatchTests
                 {
                     ValueParts = new[]
                     {
-                        new { Source = 0, Value = "sq" },
-                        new { Source = 1, Value = "l_" },
+                        new { Source = (int?)0, Value = "sq" },
+                        new { Source = (int?)1, Value = "l_" },
+                        new { Source = (int?)null, Value = "query" },
                     }
                 }
             }
@@ -51,7 +49,7 @@ public class VulnerabilityBatchTests
     {
         var batch = new VulnerabilityBatch();
         var source = new Source(2, "name", "value");
-        var ranges = new Range[] { new Range(0, 2, source), new Range(2, 2, source) };
+        var ranges = new Range[] { new Range(1, 1, source), new Range(2, 2, source) };
         var evidence = new Evidence("sql_query", ranges);
         var vulnerability = new Vulnerability("sqli", new Location(), evidence);
         batch.Add(vulnerability);
@@ -67,8 +65,10 @@ public class VulnerabilityBatchTests
                 {
                     ValueParts = new[]
                     {
-                        new { Source = 0, Value = "sq" },
-                        new { Source = 0, Value = "l_" },
+                        new { Source = (int?)null, Value = "s" },
+                        new { Source = (int?)0, Value = "q" },
+                        new { Source = (int?)0, Value = "l_" },
+                        new { Source = (int?)null, Value = "query" },
                     }
                 }
             }
@@ -97,8 +97,9 @@ public class VulnerabilityBatchTests
                 {
                     ValueParts = new[]
                     {
-                        new { Source = 0, Value = "sq" },
-                        new { Source = 0, Value = "l_" },
+                        new { Source = (int?)0, Value = "sq" },
+                        new { Source = (int?)0, Value = "l_" },
+                        new { Source = (int?)null, Value = "query" },
                     }
                 }
             }
@@ -133,8 +134,9 @@ public class VulnerabilityBatchTests
                 {
                     ValueParts = new[]
                     {
-                        new { Source = 0, Value = "sq" },
-                        new { Source = 1, Value = "l_" },
+                        new { Source = (int?)0, Value = "sq" },
+                        new { Source = (int?)1, Value = "l_" },
+                        new { Source = (int?)null, Value = "query" },
                     }
                 }
             },
@@ -144,7 +146,9 @@ public class VulnerabilityBatchTests
                 {
                     ValueParts = new[]
                     {
-                        new { Source = 1, Value = "le" },
+                        new { Source = (int?)null, Value = "fi" },
+                        new { Source = (int?)1, Value = "le" },
+                        new { Source = (int?)null, Value = "name" },
                     }
                 }
             }
@@ -184,6 +188,9 @@ public class VulnerabilityBatchTests
 					        {
 						        ""value"": ""l_"",
 						        ""source"": 1
+					        },
+					        {
+						        ""value"": ""query""
 					        }
 				        ]
 			        }
@@ -196,8 +203,14 @@ public class VulnerabilityBatchTests
 				        ""value"": ""filename"",
 				        ""valueParts"": [
 					        {
+						        ""value"": ""fi""
+					        },
+					        {
 						        ""value"": ""le"",
 						        ""source"": 1
+					        },
+					        {
+						        ""value"": ""name""
 					        }
 				        ]
 			        }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -179,7 +179,6 @@ public class VulnerabilityBatchTests
 			        ""hash"": -507016161,
 			        ""location"": {},
 			        ""evidence"": {
-				        ""value"": ""sql_query"",
 				        ""valueParts"": [
 					        {
 						        ""value"": ""sq"",
@@ -200,7 +199,6 @@ public class VulnerabilityBatchTests
 			        ""hash"": -1083869249,
 			        ""location"": {},
 			        ""evidence"": {
-				        ""value"": ""filename"",
 				        ""valueParts"": [
 					        {
 						        ""value"": ""fi""

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
@@ -27,7 +27,6 @@
       "type": "SQL_INJECTION",
       
       "evidence": {
-        "value": "SELECT Surname from Persons where name = 'Vicent'",
         "valueParts": [
           {
             "value": "SELECT Surname from Persons where name = 'Vicent'",

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -28,7 +28,6 @@
       "type": "SQL_INJECTION",
       
       "evidence": {
-        "value": "SELECT Surname from Persons where name = 'Vicent'",
         "valueParts": [
           {
             "value": "SELECT Surname from Persons where name = 'Vicent'",

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -25,7 +25,6 @@
       "type": "SQL_INJECTION",
       
       "evidence": {
-        "value": "SELECT Surname from Persons where name = 'Vicent'",
         "valueParts": [
           {
             "value": "SELECT Surname from Persons where name = 'Vicent'",


### PR DESCRIPTION
## Summary of changes

In order to comply with the latest vulnerability json format, we need to add value parts not associated with a source.
https://github.com/DataDog/experimental/blob/main/teams/asm/vulnerability_schema/vulnerability_schema.json
https://github.com/DataDog/experimental/blob/main/teams/asm/vulnerability_schema/vulnerability_example.json

## Reason for change

To comply with the latest json format.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
