### PR TITLE
[Profiler] Bucketize contention events by duration

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -7,6 +7,7 @@
 #include "IContentionListener.h"
 #include "RawContentionSample.h"
 #include "GenericSampler.h"
+#include "GroupSampler.h"
 #include "MetricsRegistry.h"
 #include "CounterMetric.h"
 #include "MeanMaxMetric.h"
@@ -36,12 +37,14 @@ public:
         IConfiguration* pConfiguration,
         MetricsRegistry& metricsRegistry);
 
-    void OnContention(double contentionDuration) override;
+    void OnContention(double contentionDurationNs) override;
 
 private:
+    static std::string GetBucket(double contentionDurationNs);
+
     ICorProfilerInfo4* _pCorProfilerInfo;
     IManagedThreadList* _pManagedThreadList;
-    GenericSampler _sampler;
+    GroupSampler<std::string> _sampler;
     int32_t _contentionDurationThreshold;
     int32_t _sampleLimit;
     IConfiguration const* const _pConfiguration;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -4,18 +4,24 @@
 #pragma once
 
 #include "RawSample.h"
+#include "Sample.h"
 
 class RawContentionSample : public RawSample
 {
+private:
+    const std::string BucketLabelName = "Duration bucket";
+
 public:
     void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
     {
         uint32_t contentionCountIndex = valueOffset;
         uint32_t contentionDurationIndex = valueOffset + 1;
 
+        sample->AddLabel(Label(BucketLabelName, Bucket));
         sample->AddValue(1, contentionCountIndex);
         sample->AddValue(static_cast<std::int64_t>(ContentionDuration), contentionDurationIndex);
     }
 
     double ContentionDuration;
+    std::string Bucket;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -9,7 +9,7 @@
 class RawContentionSample : public RawSample
 {
 private:
-    const std::string BucketLabelName = "Duration bucket";
+    inline static const std::string BucketLabelName = "Duration bucket";
 
 public:
     void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
@@ -17,7 +17,7 @@ public:
         uint32_t contentionCountIndex = valueOffset;
         uint32_t contentionDurationIndex = valueOffset + 1;
 
-        sample->AddLabel(Label(BucketLabelName, Bucket));
+        sample->AddLabel(Label{BucketLabelName, std::move(Bucket)});
         sample->AddValue(1, contentionCountIndex);
         sample->AddValue(static_cast<std::int64_t>(ContentionDuration), contentionDurationIndex);
     }


### PR DESCRIPTION
## Summary of changes

Bucketize contention events when sampling them.

## Reason for change

As of today, we sample contention events  without taking into account their duration. The issue is that we could lost an interesting information which is `What is the distribution of those events`. In other words, did we got a lot of short contention events, or large ones...

## Implementation details

Use `GroupSampler` to categorize them.
For now there is only 5 buckets ("0-9ms", "10-49ms", "50-99ms", "100-499ms", "+500ms"). We'll see how it goes and change it.
We use the bucket as string instead of as int to :
- upscaling by label will be easy
- smart filter in a near/far future.

## Test coverage

The current test should still work.

## Other details
<!-- Fixes #{issue} -->
