### PR TITLE
[CI Visibility] - Defer await for git upload task

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -244,17 +244,17 @@ namespace Datadog.Trace.Tools.Runner
             {
                 AnsiConsole.WriteLine("Running: " + command);
 
-                if (Program.CallbackForTests != null)
-                {
-                    Program.CallbackForTests(program, arguments, profilerEnvironmentVariables);
-                    return 0;
-                }
-
-                if (ciVisibilitySettings.IntelligentTestRunnerEnabled)
+                if (ciVisibilitySettings.IntelligentTestRunnerEnabled || Program.CallbackForTests is not null)
                 {
                     // Awaiting git repository task before running the command if ITR is enabled.
                     Log.Debug("RunCiCommand: Awaiting for the Git repository upload.");
                     await uploadRepositoryChangesTask.ConfigureAwait(false);
+                }
+
+                if (Program.CallbackForTests is { } callbackForTests)
+                {
+                    callbackForTests(program, arguments, profilerEnvironmentVariables);
+                    return 0;
                 }
 
                 Log.Debug("RunCiCommand: Launching: {Value}", command);


### PR DESCRIPTION
## Summary of changes

This PR defers the await for the git upload task depending on the configuration. While with ITR enabled we need to send the metadata before asking the tests to skip, when ITR is disabled we can defer that until the process termination.

## Reason for change

Performance / startup improvements.
