### PR TITLE
Add a size limit to the serialization temp buffer

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Agent
         private long _droppedP0Traces;
         private long _droppedP0Spans;
 
-        private long _droppedSpans;
+        private long _droppedTraces;
 
         public AgentWriter(IApi api, IStatsAggregator statsAggregator, IDogStatsd statsd, ISpanSampler spanSampler, bool automaticFlush = true, int maxBufferSize = 1024 * 1024 * 10, int batchInterval = 100)
         : this(api, statsAggregator, statsd, spanSampler, MovingAverageKeepRateCalculator.CreateDefaultKeepRateCalculator(), automaticFlush, maxBufferSize, batchInterval)
@@ -308,11 +308,11 @@ namespace Datadog.Trace.Agent
                         _statsd.Increment(TracerMetricNames.Queue.DequeuedSpans, buffer.SpanCount);
                     }
 
-                    var droppedSpans = Interlocked.Exchange(ref _droppedSpans, 0);
+                    var droppedTraces = Interlocked.Exchange(ref _droppedTraces, 0);
 
-                    if (droppedSpans > 0)
+                    if (droppedTraces > 0)
                     {
-                        Log.Warning("{Count} traces were dropped since the last flush operation.", droppedSpans);
+                        Log.Warning("{Count} traces were dropped since the last flush operation.", droppedTraces);
                     }
 
                     if (buffer.TraceCount > 0)
@@ -484,7 +484,7 @@ namespace Datadog.Trace.Agent
 
         private void DropTrace(ArraySegment<Span> spans)
         {
-            Interlocked.Increment(ref _droppedSpans);
+            Interlocked.Increment(ref _droppedTraces);
             _traceKeepRateCalculator.IncrementDrops(1);
 
             if (_statsd != null)

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -454,6 +454,13 @@ namespace Datadog.Trace.Agent
                 return;
             }
 
+            if (!buffer.IsFull)
+            {
+                // If the serialization failed even though the buffer isn't full, there's no point in trying again
+                DropTrace(spans);
+                return;
+            }
+
             // Active buffer is full, swap them
             buffer = SwapBuffers();
 
@@ -470,6 +477,11 @@ namespace Datadog.Trace.Agent
             }
 
             // All the buffers are full :( drop the trace
+            DropTrace(spans);
+        }
+
+        private void DropTrace(ArraySegment<Span> spans)
+        {
             Interlocked.Increment(ref _droppedSpans);
             _traceKeepRateCalculator.IncrementDrops(1);
 

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Agent.MessagePack
         }
 
         // overload of IMessagePackFormatter<TraceChunkModel>.Serialize() with `in` modifier on `TraceChunkModel` parameter
-        public int Serialize(ref byte[] bytes, int offset, in TraceChunkModel traceChunk, IFormatterResolver formatterResolver)
+        public int Serialize(ref byte[] bytes, int offset, in TraceChunkModel traceChunk, IFormatterResolver formatterResolver, int? maxSize = null)
         {
             int originalOffset = offset;
 
@@ -96,6 +96,12 @@ namespace Datadog.Trace.Agent.MessagePack
             // serialize each span
             for (var i = 0; i < traceChunk.SpanCount; i++)
             {
+                if (maxSize != null && offset - originalOffset >= maxSize)
+                {
+                    // We've already reached the maximum size, give up
+                    return 0;
+                }
+
                 // when serializing each span, we need additional information that is not
                 // available in the span object itself, like its position in the trace chunk
                 // or if its parent can also be found in the same chunk, so we use SpanModel

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Agent
                 if (!_locked)
                 {
                     // Sanity check - headers are written when the buffer is locked
-                    // ThrowHelper.ThrowInvalidOperationException("Data was extracted from the buffer without locking");
+                    ThrowHelper.ThrowInvalidOperationException("Data was extracted from the buffer without locking");
                 }
 
                 return new ArraySegment<byte>(_buffer, 0, _offset);

--- a/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/tracer/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -92,11 +92,17 @@ namespace Datadog.Trace.Agent
 
                 if (_formatter is SpanMessagePackFormatter spanFormatter)
                 {
-                    size = spanFormatter.Serialize(ref temporaryBuffer, 0, in traceChunk, _formatterResolver);
+                    size = spanFormatter.Serialize(ref temporaryBuffer, 0, in traceChunk, _formatterResolver, maxSize: _maxBufferSize);
                 }
                 else
                 {
                     size = _formatter.Serialize(ref temporaryBuffer, 0, traceChunk, _formatterResolver);
+                }
+
+                if (size == 0)
+                {
+                    // Serialization failed because the trace is too big
+                    return false;
                 }
 
                 if (!EnsureCapacity(size + _offset))

--- a/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Tests.Agent
             for (int i = 0; i < traceCount; i++)
             {
                 var spans = CreateTraceChunk(spanCount);
-                buffer.TryWrite(spans, ref _temporaryBuffer).Should().BeTrue();
+                buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
             }
 
             buffer.Lock();
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests.Agent
             var spans = CreateTraceChunk(1);
             var result = buffer.TryWrite(spans, ref _temporaryBuffer);
 
-            result.Should().BeFalse();
+            result.Should().Be(SpanBuffer.WriteStatus.Full);
             buffer.TraceCount.Should().Be(0);
             buffer.IsFull.Should().BeTrue();
 
@@ -78,11 +78,11 @@ namespace Datadog.Trace.Tests.Agent
             var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
             var spans = CreateTraceChunk(1);
 
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().BeTrue();
+            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
             buffer.Lock();
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().BeFalse();
+            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Full);
             buffer.Clear();
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().BeTrue();
+            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tests.Agent
             var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
             var spans = CreateTraceChunk(3);
 
-            buffer.TryWrite(spans, ref _temporaryBuffer).Should().BeTrue();
+            buffer.TryWrite(spans, ref _temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Success);
             buffer.TraceCount.Should().Be(1);
             buffer.SpanCount.Should().Be(3);
 
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tests.Agent
             var temporaryBuffer = new byte[256];
             var spans = CreateTraceChunk(10);
 
-            buffer.TryWrite(spans, ref temporaryBuffer).Should().BeFalse();
+            buffer.TryWrite(spans, ref temporaryBuffer).Should().Be(SpanBuffer.WriteStatus.Overflow);
             buffer.IsFull.Should().BeFalse();
             buffer.SpanCount.Should().Be(0);
             buffer.TraceCount.Should().Be(0);


### PR DESCRIPTION
## Summary of changes

Cap the maximum size of the temporary buffer used to serialize traces.

## Reason for change

We serialize each trace to the temporary buffer before checking if it can fit in the send buffer. It means that the temporary buffer can grow arbitrarily large if the app has huge traces, even if in the end the trace is going to be discarded because it's bigger than the buffer size limit. In one case we've seen a 180 MB temporary buffer.

## Implementation details

The temporary buffer is resized directly by the MessagePack library. In a perfect world the library would allow to set a size limit but that's not the case.
Instead, we take advantage of the fact that traces are serialized span by span. We stop the serialization of the next span if the temporary buffer has reached the limit. Since we only check for each span, it means we can go over the limit, but in practice the size of the temporary buffer should never exceed twice the limit (the size is double with every resize).

## Test coverage

A unit test has been added to verify the behavior when serializing a trace that is too big.

