### PR TITLE
Prepare 2.24.1 hotfix release

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -179,9 +179,9 @@ stages:
     - checkout: none
     - bash: |
         rm -rf ./s
-        git clone --quiet --no-checkout --depth 1 --branch master $BUILD_REPOSITORY_URI ./s
+        git clone --quiet --no-checkout --depth 1 --branch hotfix/2.24.0 $BUILD_REPOSITORY_URI ./s
         cd s
-        MASTER_SHA=$(git rev-parse origin/master)
+        MASTER_SHA=$(git rev-parse origin/hotfix/2.24.0)
         rm -rf ./s
         echo "Using master commit ID $MASTER_SHA"
         echo "##vso[task.setvariable variable=master;isOutput=true]$MASTER_SHA"

--- a/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
 
@@ -16,6 +17,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
 {
     private readonly ImmutableTracerSettings _immutableTracerSettings;
     private GitMetadata? _cachedGitTags = null;
+    private int _tryCount = 0;
 
     public GitMetadataTagsProvider(ImmutableTracerSettings immutableTracerSettings)
     {
@@ -91,9 +93,20 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
         {
             // Cannot determine the entry assembly. This may mean this method was called too early.
             // Return false to indicate that we should try again later.
-            Log.Debug("Cannot extract SourceLink information as the entry assembly could not be determined.");
-            result = default;
-            return false;
+
+            var nbTries = Interlocked.Increment(ref _tryCount);
+            if (nbTries > 100)
+            {
+                Log.Debug("Tried 100 times to get the SourceLink information. Giving up.");
+                result = GitMetadata.Empty;
+                return true;
+            }
+            else
+            {
+                Log.Debug("Cannot extract SourceLink information as the entry assembly could not be determined.");
+                result = default;
+                return false;
+            }
         }
 
         if (SourceLinkInformationExtractor.TryGetSourceLinkInfo(assembly, out var commitSha, out var repositoryUrl))


### PR DESCRIPTION
## Summary of changes
Cherry picked the following:
https://github.com/DataDog/dd-trace-dotnet/pull/3835

## Reason for change
We want to release a hotfix with the aforementioned PR to mitigate any risk of any potential performance issues. 
