### PR TITLE
Stop extracting SourceLink after 100 tries

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
 
@@ -16,6 +17,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
 {
     private readonly ImmutableTracerSettings _immutableTracerSettings;
     private GitMetadata? _cachedGitTags = null;
+    private int _tryCount = 0;
 
     public GitMetadataTagsProvider(ImmutableTracerSettings immutableTracerSettings)
     {
@@ -91,9 +93,20 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
         {
             // Cannot determine the entry assembly. This may mean this method was called too early.
             // Return false to indicate that we should try again later.
-            Log.Debug("Cannot extract SourceLink information as the entry assembly could not be determined.");
-            result = default;
-            return false;
+
+            var nbTries = Interlocked.Increment(ref _tryCount);
+            if (nbTries > 100)
+            {
+                Log.Debug("Tried 100 times to get the SourceLink information. Giving up.");
+                result = GitMetadata.Empty;
+                return true;
+            }
+            else
+            {
+                Log.Debug("Cannot extract SourceLink information as the entry assembly could not be determined.");
+                result = default;
+                return false;
+            }
         }
 
         if (SourceLinkInformationExtractor.TryGetSourceLinkInfo(assembly, out var commitSha, out var repositoryUrl))


### PR DESCRIPTION
## Summary of changes

Quick and dirty implementation to give up on extracting the SourceLink info after 100 tries.

## Reason for change

In tests (and I hope only in tests), we can extract try extracting `SourceLink` info indefinitely. I believe this is causing decreasing performances in our tests, to a point some other tests, non resilient to this, were failing. The NetFx implementation in particular seem way more impactful as the .NET Core one, maybe explaining why the other tests were failling on NET461. 
