### PR TITLE
Sorted and encoded tags and added new tests

### DIFF
--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -25,16 +25,18 @@ namespace Datadog.Trace.DatabaseMonitoring
             }
 
             var propagatorSringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-            propagatorSringBuilder.Append($"/*{SqlCommentRootService}='{configuredServiceName}',{SqlCommentSpanService}='{context.ServiceName}'");
-
-            if (context.TraceContext?.ServiceVersion is { } versionTag)
-            {
-                propagatorSringBuilder.Append($",{SqlCommentVersion}='{versionTag}'");
-            }
+            propagatorSringBuilder.Append($"/*{SqlCommentSpanService}='{Uri.EscapeDataString(context.ServiceName)}'");
 
             if (context.TraceContext?.Environment is { } envTag)
             {
-                propagatorSringBuilder.Append($",{SqlCommentEnv}='{envTag}'");
+                propagatorSringBuilder.Append($",{SqlCommentEnv}='{Uri.EscapeDataString(envTag)}'");
+            }
+
+            propagatorSringBuilder.Append($",{SqlCommentRootService}='{Uri.EscapeDataString(configuredServiceName)}'");
+
+            if (context.TraceContext?.ServiceVersion is { } versionTag)
+            {
+                propagatorSringBuilder.Append($",{SqlCommentVersion}='{Uri.EscapeDataString(versionTag)}'");
             }
 
             if (propagationStyle == DbmPropagationLevel.Full)


### PR DESCRIPTION
## Summary of changes
Correcting feature implemented in https://github.com/DataDog/dd-trace-dotnet/pull/3784 , the comment DBM comment needs to be injected in a specific order plus I wasn't encoding the tags as expected, this PR does both and adds tests for that as well.

## Reason for change
The comment wasn't structure as the feature specified.

## Test coverage
Added some new UTests.

The new order is:
```
/*dddbs='Samples.MySql-mysql',dde='testing',ddps='Samples.MySql,ddpv='1.0.0',traceparent='00-00000000000000005a8b821223980484-3fc7937f5046bdbc-01'*/
```
**Note**: Value of the tags is an example based on static test values