### PR TITLE
Optimize startup time

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Agent
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AgentWriter>();
 
-        private static ArraySegment<byte> _emptyPayload;
+        private static readonly ArraySegment<byte> EmptyPayload = new(new byte[] { 0x90 });
 
         private readonly ConcurrentQueue<WorkItem> _pendingTraces = new ConcurrentQueue<WorkItem>();
         private readonly IDogStatsd _statsd;
@@ -106,16 +106,7 @@ namespace Datadog.Trace.Agent
 
         public bool CanComputeStats => _statsAggregator?.CanComputeStats == true;
 
-        public Task<bool> Ping()
-        {
-            if (_emptyPayload.Array == null)
-            {
-                var data = Vendors.MessagePack.MessagePackSerializer.Serialize(Array.Empty<Span[]>());
-                _emptyPayload = new ArraySegment<byte>(data);
-            }
-
-            return _api.SendTracesAsync(_emptyPayload, 0, false, 0, 0);
-        }
+        public Task<bool> Ping() => _api.SendTracesAsync(EmptyPayload, 0, false, 0, 0);
 
         public void WriteTrace(ArraySegment<Span> trace)
         {

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -92,8 +92,7 @@ namespace Datadog.Trace.Agent.MessagePack
             int originalOffset = offset;
 
             // start writing span[]
-            // offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, traceChunk.SpanCount);
-            offset += MessagePackBinary.WriteArrayHeaderForceArray32Block(ref bytes, offset, (uint)traceChunk.SpanCount);
+            offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, traceChunk.SpanCount);
             // serialize each span
             for (var i = 0; i < traceChunk.SpanCount; i++)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -440,7 +440,7 @@ namespace Datadog.Trace.ClrProfiler
 
         private static async Task<bool> WaitForDiscoveryService(IDiscoveryService discoveryService)
         {
-            var tc = new TaskCompletionSource<bool>();
+            var tc = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             // Stop waiting if we're shutting down
             LifetimeManager.Instance.AddShutdownTask(() => tc.TrySetResult(false));
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         private readonly Task _flushTask;
         private readonly Action? _disableSinkAction;
         private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource<bool> _tracerInitialized = new();
+        private readonly TaskCompletionSource<bool> _tracerInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ConcurrentQueue<TaskCompletionSource<bool>> _flushCompletionSources = new();
         private volatile bool _enqueueLogEnabled = true;
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Telemetry
         private readonly TelemetryTransportManager _transportManager;
         private readonly TimeSpan _flushInterval;
         private readonly TimeSpan _heartBeatInterval;
-        private readonly TaskCompletionSource<bool> _tracerInitialized = new();
+        private readonly TaskCompletionSource<bool> _tracerInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> _processExit = new();
         private readonly Task _flushTask;
         private readonly Task _heartbeatTask;

--- a/tracer/src/Datadog.Trace/Util/AsyncManualResetEvent.cs
+++ b/tracer/src/Datadog.Trace/Util/AsyncManualResetEvent.cs
@@ -102,7 +102,7 @@ internal class AsyncManualResetEvent
 
         static async Task DoWaitAsync(Task task, CancellationToken cancellationToken)
         {
-            var tcs = new TaskCompletionSource<object?>();
+            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
 #if NETCOREAPP2_1_OR_GREATER
             await using var reg = cancellationToken.Register(state => ((TaskCompletionSource<object?>)state!).TrySetResult(true), tcs, false).ConfigureAwait(false);
 #else


### PR DESCRIPTION
## Summary of changes

Improve the tracer startup time.

Those combined changes lower the startup time of a simple console app from 550 ms to 380 ms (on my machine). The baseline without the tracer is 80 ms.
Note that none of those changes actually reduce the amount of work done, it just moves it outside of the critical path.

## Implementation details

- In SpanMessagePackFormatter, make the SamplingPriority and ProcessId lazy so it will be initialized in the serializer thread
- In AgentWriter, make the EmptyPayload lazy so it will be initialized in the diagnostic log thread
- In TelemetryController, decorate the TaskCompletionSource with `RunContinuationsAsynchronously` because the continuation was getting inlined when calling `TrySetResult` in `Start`
