### PR TITLE
bug fix for request blocking

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -395,28 +395,22 @@ namespace Datadog.Trace.AppSec
                 }
             }
 
-            if (_remoteConfigurationStatus.RulesOverrides is { Count: > 0 })
-            {
-                var result = _waf.UpdateRulesStatus(_remoteConfigurationStatus.RulesOverrides, _remoteConfigurationStatus.Exclusions);
-                Log.Debug<bool, int>("_waf.Update was updated: {Success}, ({Count} rule status entries)", result, _remoteConfigurationStatus.RulesOverrides.Count);
+            var result = _waf.UpdateRulesStatus(_remoteConfigurationStatus.RulesOverrides, _remoteConfigurationStatus.Exclusions);
+            Log.Debug<bool, int, int>(
+                "_waf.Update was updated: {Success}, ({RulesOverridesCount} rule status entries), ({ExclusionsCount} exclusion filters)",
+                result,
+                _remoteConfigurationStatus.RulesOverrides.Count,
+                _remoteConfigurationStatus.Exclusions.Count);
 
-                foreach (var asmConfig in asmConfigs)
-                {
-                    if (result)
-                    {
-                        e.Acknowledge(asmConfig.Name);
-                    }
-                    else
-                    {
-                        e.Error(asmConfig.Name, "waf couldn't be updated with rule overrides");
-                    }
-                }
-            }
-            else
+            foreach (var asmConfig in asmConfigs)
             {
-                foreach (var asmConfig in asmConfigs)
+                if (result)
                 {
                     e.Acknowledge(asmConfig.Name);
+                }
+                else
+                {
+                    e.Error(asmConfig.Name, "waf couldn't be updated with rule overrides");
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -167,11 +167,6 @@ namespace Datadog.Trace.AppSec.Waf
                 return false;
             }
 
-            if (rulesData.Count == 0)
-            {
-                return true;
-            }
-
             var argsToDispose = new List<Obj>();
             var mergedRuleData = MergeRuleData(rulesData);
             var rulesDataEncoded = mergedRuleData.Encode(_wafLibraryInvoker, argsToDispose);
@@ -192,11 +187,6 @@ namespace Datadog.Trace.AppSec.Waf
             {
                 Log.Warning("Waf instance has been disposed when trying to toggle rules");
                 return false;
-            }
-
-            if (ruleStatus.Count == 0)
-            {
-                return true;
             }
 
             var argsToDispose = new List<Obj>();


### PR DESCRIPTION
## Summary of changes

Need to always call the WAF update, even with an empty list, to ensure rules overrides get turned off.