### PR TITLE
Improve OSX dev experience

### DIFF
--- a/Datadog.Trace.OSX.sln
+++ b/Datadog.Trace.OSX.sln
@@ -1,0 +1,1260 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.31903.286
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace", "tracer\src\Datadog.Trace\Datadog.Trace.csproj", "{5DFDF781-F24C-45B1-82EF-9125875A80A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tests", "tracer\test\Datadog.Trace.Tests\Datadog.Trace.Tests.csproj", "{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.IntegrationTests", "tracer\test\Datadog.Trace.IntegrationTests\Datadog.Trace.IntegrationTests.csproj", "{0434F813-5F94-4195-8A2C-E2E755513822}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.OpenTracing", "tracer\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj", "{188219D1-D123-46C9-B905-A9ED30E6AAA7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.OpenTracing.Tests", "tracer\test\Datadog.Trace.OpenTracing.Tests\Datadog.Trace.OpenTracing.Tests.csproj", "{3BCE5D99-147B-4305-9970-AB0F683A6E8D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.OpenTracing.IntegrationTests", "tracer\test\Datadog.Trace.OpenTracing.IntegrationTests\Datadog.Trace.OpenTracing.IntegrationTests.csproj", "{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.TestHelpers", "tracer\test\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj", "{237A1C92-DE9E-4649-961B-BBB7CF0DFE01}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FEBCE7DC-9FD1-48A6-B911-71ABB240A030}"
+	ProjectSection(SolutionItems) = preProject
+		.dockerignore = .dockerignore
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		tracer\Datadog.Trace.proj = tracer\Datadog.Trace.proj
+		Datadog.Trace.snk = Datadog.Trace.snk
+		tracer\Directory.Build.props = tracer\Directory.Build.props
+		docker-compose.yml = docker-compose.yml
+		tracer\GlobalSuppressions.cs = tracer\GlobalSuppressions.cs
+		LICENSE = LICENSE
+		LICENSE-3rdparty.csv = LICENSE-3rdparty.csv
+		docs\README.md = docs\README.md
+		tracer\stylecop.json = tracer\stylecop.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9E5F0022-0A50-40BF-AC6A-C3078585ECAB}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\src\Directory.Build.props = tracer\src\Directory.Build.props
+		tracer\src\GlobalSuppressions.cs = tracer\src\GlobalSuppressions.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8CEC2042-F11C-49F5-A674-2355793B600A}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\Directory.Build.props = tracer\test\Directory.Build.props
+		tracer\test\GlobalSuppressions.cs = tracer\test\GlobalSuppressions.cs
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ExampleLibrary", "tracer\test\test-applications\integrations\dependency-libs\Samples.ExampleLibrary\Samples.ExampleLibrary.csproj", "{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ExampleLibraryTracer", "tracer\test\test-applications\integrations\dependency-libs\Samples.ExampleLibraryTracer\Samples.ExampleLibraryTracer.csproj", "{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.IntegrationTests", "tracer\test\Datadog.Trace.ClrProfiler.IntegrationTests\Datadog.Trace.ClrProfiler.IntegrationTests.csproj", "{0D546118-B70A-44D0-B675-39EDB99FCEEE}"
+	ProjectSection(ProjectDependencies) = postProject
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9} = {AD119B05-A092-41AD-B68E-4AE2DB5A96D9}
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4} = {D141BD06-DD95-4CAF-85CD-657116E0DAD4}
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410} = {C1210E08-58E5-44D4-BE6F-634C3FC5E410}
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992} = {DC7D131A-AF99-46AB-9AA6-463443E3B992}
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1} = {AA88952E-9393-4A4B-85B5-CC7F03629CE1}
+		{43782238-E7BB-49D0-9541-1121DACA6EB5} = {43782238-E7BB-49D0-9541-1121DACA6EB5}
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3} = {1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}
+		{303F8E41-691F-4453-AB7D-88A0036C0465} = {303F8E41-691F-4453-AB7D-88A0036C0465}
+		{3493346B-44F6-4F50-8FB4-51D0090DF544} = {3493346B-44F6-4F50-8FB4-51D0090DF544}
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC} = {F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32} = {8276E670-FC3F-4EDE-9D51-6DAD90336C32}
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A} = {2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37} = {8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE} = {FA487690-E88C-4A57-9187-B71CB70C1AAE}
+		{086FF8A0-9CEE-470A-9751-78B0F1340649} = {086FF8A0-9CEE-470A-9751-78B0F1340649}
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275} = {BF1E5BA6-C0E5-4472-9D5D-2622231DD275}
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084} = {3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B} = {C98950B1-DC4B-43DA-974F-EF2CF325EC2B}
+		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {C41023C9-65C3-4FB3-9053-4DE963A81500}
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028} = {EEA89ACD-CFBB-4F60-A150-74F0A84DF028}
+		{8E1555D1-13D5-4DBF-9631-117D840C3158} = {8E1555D1-13D5-4DBF-9631-117D840C3158}
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0} = {DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4} = {42FA33DD-AEA3-4FF3-8319-F30244A666A4}
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360} = {5EE6B6EB-B768-47EC-882B-8DCACA2B1360}
+		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {7B0822F6-80DE-4B49-8125-93975678D0D5}
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6} = {DA0A44FB-D562-4776-AAFB-8266E78AA1A6}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SqlServer", "tracer\test\test-applications\integrations\Samples.SqlServer\Samples.SqlServer.csproj", "{086FF8A0-9CEE-470A-9751-78B0F1340649}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Elasticsearch", "tracer\test\test-applications\integrations\Samples.Elasticsearch\Samples.Elasticsearch.csproj", "{C98950B1-DC4B-43DA-974F-EF2CF325EC2B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.Managed.Tests", "tracer\test\Datadog.Trace.ClrProfiler.Managed.Tests\Datadog.Trace.ClrProfiler.Managed.Tests.csproj", "{5B52C0C0-A554-4E53-9D17-B121E78FF919}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MongoDB", "tracer\test\test-applications\integrations\Samples.MongoDB\Samples.MongoDB.csproj", "{3493346B-44F6-4F50-8FB4-51D0090DF544}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Npgsql", "tracer\test\test-applications\integrations\Samples.Npgsql\Samples.Npgsql.csproj", "{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Elasticsearch.V5", "tracer\test\test-applications\integrations\Samples.Elasticsearch.V5\Samples.Elasticsearch.V5.csproj", "{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HttpMessageHandler.StackOverflowException", "tracer\test\test-applications\regression\HttpMessageHandler.StackOverflowException\HttpMessageHandler.StackOverflowException.csproj", "{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ServiceStack.Redis", "tracer\test\test-applications\integrations\Samples.ServiceStack.Redis\Samples.ServiceStack.Redis.csproj", "{8E1555D1-13D5-4DBF-9631-117D840C3158}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.StackExchange.Redis", "tracer\test\test-applications\integrations\Samples.StackExchange.Redis\Samples.StackExchange.Redis.csproj", "{DC7D131A-AF99-46AB-9AA6-463443E3B992}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Wcf", "tracer\test\test-applications\integrations\Samples.Wcf\Samples.Wcf.csproj", "{DA0A44FB-D562-4776-AAFB-8266E78AA1A6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDogThreadTest", "tracer\test\test-applications\regression\DataDogThreadTest\DataDogThreadTest.csproj", "{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GraphQL", "tracer\test\test-applications\integrations\Samples.GraphQL\Samples.GraphQL.csproj", "{43782238-E7BB-49D0-9541-1121DACA6EB5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.StackOverflowException", "tracer\test\test-applications\regression\StackExchange.Redis.StackOverflowException\StackExchange.Redis.StackOverflowException.csproj", "{FA487690-E88C-4A57-9187-B71CB70C1AAE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AppDomainInstance", "tracer\test\test-applications\regression\dependency-libs\AppDomainInstance\AppDomainInstance.csproj", "{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.Managed.Loader", "tracer\src\Datadog.Trace.ClrProfiler.Managed.Loader\Datadog.Trace.ClrProfiler.Managed.Loader.csproj", "{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyLoad.FileNotFoundException", "tracer\test\test-applications\regression\AssemblyLoad.FileNotFoundException\AssemblyLoad.FileNotFoundException.csproj", "{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MySql", "tracer\test\test-applications\integrations\Samples.MySql\Samples.MySql.csproj", "{42FA33DD-AEA3-4FF3-8319-F30244A666A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.DatabaseHelper", "tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj", "{472DBA92-4FEA-4B9A-BA70-0E97B942E12D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyResolveMscorlibResources.InfiniteRecursionCrash", "tracer\test\test-applications\regression\AssemblyResolveMscorlibResources.InfiniteRecursionCrash\AssemblyResolveMscorlibResources.InfiniteRecursionCrash.csproj", "{EEA89ACD-CFBB-4F60-A150-74F0A84DF028}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.TracingWithoutLimits", "tracer\test\test-applications\integrations\Samples.TracingWithoutLimits\Samples.TracingWithoutLimits.csproj", "{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.RateLimiter", "tracer\test\test-applications\integrations\Samples.RateLimiter\Samples.RateLimiter.csproj", "{EF718502-7760-45B5-A563-5F1B22A6B840}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMvc30", "tracer\test\test-applications\integrations\Samples.AspNetCoreMvc30\Samples.AspNetCoreMvc30.csproj", "{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMvc31", "tracer\test\test-applications\integrations\Samples.AspNetCoreMvc31\Samples.AspNetCoreMvc31.csproj", "{303F8E41-691F-4453-AB7D-88A0036C0465}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMvc21", "tracer\test\test-applications\integrations\Samples.AspNetCoreMvc21\Samples.AspNetCoreMvc21.csproj", "{D141BD06-DD95-4CAF-85CD-657116E0DAD4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis.Abstractions", "tracer\test\test-applications\regression\dependency-libs\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj", "{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis", "tracer\test\test-applications\regression\dependency-libs\Datadog.StackExchange.Redis\Datadog.StackExchange.Redis.csproj", "{EB0B88E2-589A-4F65-8F98-D5B958D8104F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis.StrongName", "tracer\test\test-applications\regression\dependency-libs\Datadog.StackExchange.Redis.StrongName\Datadog.StackExchange.Redis.StrongName.csproj", "{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.AssemblyConflict.LegacyProject", "tracer\test\test-applications\regression\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj", "{7B0822F6-80DE-4B49-8125-93975678D0D5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "tracer\test\test-applications\regression\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Dapper", "tracer\test\test-applications\integrations\Samples.Dapper\Samples.Dapper.csproj", "{7E563BF6-47F2-4531-A1CE-FB9445DF3253}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DogStatsD.RaceCondition", "tracer\test\test-applications\regression\DogStatsD.RaceCondition\DogStatsD.RaceCondition.csproj", "{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.DatabaseHelper.netstandard", "tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj", "{8D949A40-5F4B-4EB0-B8FD-301B472C96AE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.MSBuild", "tracer\src\Datadog.Trace.MSBuild\Datadog.Trace.MSBuild.csproj", "{E02B141F-E7C0-46CF-B9F6-39427218E714}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.BenchmarkDotNet", "tracer\src\Datadog.Trace.BenchmarkDotNet\Datadog.Trace.BenchmarkDotNet.csproj", "{C00D8070-A38A-4267-9730-E9985CAE77DF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.Trace", "tracer\test\benchmarks\Benchmarks.Trace\Benchmarks.Trace.csproj", "{B8D132F6-43E3-44D9-902C-78051DBAD01C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.HttpMessageHandler", "tracer\test\test-applications\integrations\Samples.HttpMessageHandler\Samples.HttpMessageHandler.csproj", "{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test-applications", "test-applications", "{9518425A-36A5-4B8F-B0B8-6137DB88441D}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\test-applications\Directory.Build.props = tracer\test\test-applications\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "regression", "regression", "{498A300E-D036-49B7-A43D-821D1CAF11A5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependency-libs", "dependency-libs", "{EFE48691-1FBA-41D5-9BFD-676771973F0C}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\test-applications\regression\dependency-libs\Directory.Build.props = tracer\test\test-applications\regression\dependency-libs\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "integrations", "integrations", "{BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependency-libs", "dependency-libs", "{8683D82A-2BBE-4199-9C36-C59F48804F90}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\test-applications\integrations\dependency-libs\Directory.Build.props = tracer\test\test-applications\integrations\dependency-libs\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.DuckTyping.Tests", "tracer\test\Datadog.Trace.DuckTyping.Tests\Datadog.Trace.DuckTyping.Tests.csproj", "{91E50134-0E55-4D22-B180-6967174FCE0B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{A0C5FBBB-CFB2-4FB9-B8F0-55676E9DCF06}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\build\PackageVersionsGeneratorDefinitions.json = tracer\build\PackageVersionsGeneratorDefinitions.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "artifacts", "artifacts", "{CC53E5C5-9D3E-4AD9-A9CA-D2190463EB5B}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\build\artifacts\createLogPath.sh = tracer\build\artifacts\createLogPath.sh
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{E5439139-6F94-44FA-9590-C32FCC1C7A93}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreAssemblyLoadFailureOlderNuGet", "tracer\test\test-applications\regression\NetCoreAssemblyLoadFailureOlderNuGet\NetCoreAssemblyLoadFailureOlderNuGet.csproj", "{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "instrumentation", "instrumentation", "{933F1D4B-1216-4BC1-956E-8C30818BAA0F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.ManualTracing", "tracer\test\test-applications\regression\Sandbox.ManualTracing\Sandbox.ManualTracing.csproj", "{6DF72F24-D842-4F1E-948C-ED89093325D6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SqlServer.NetFramework20", "tracer\test\test-applications\integrations\Samples.SqlServer.NetFramework20\Samples.SqlServer.NetFramework20.csproj", "{8276E670-FC3F-4EDE-9D51-6DAD90336C32}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.DatabaseHelper.NetFramework20", "tracer\test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper.NetFramework20\Samples.DatabaseHelper.NetFramework20.csproj", "{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CallTargetNativeTest", "tracer\test\test-applications\instrumentation\CallTargetNativeTest\CallTargetNativeTest.csproj", "{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Microsoft.Data.SqlClient", "tracer\test\test-applications\integrations\Samples.Microsoft.Data.SqlClient\Samples.Microsoft.Data.SqlClient.csproj", "{AA88952E-9393-4A4B-85B5-CC7F03629CE1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NoMultiLoader", "tracer\test\test-applications\integrations\Samples.NoMultiLoader\Samples.NoMultiLoader.csproj", "{472B69A0-956F-42C0-9CB8-30107821C43B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NoMultiLoader.Deps", "tracer\test\test-applications\integrations\dependency-libs\Samples.NoMultiLoader.Deps\Samples.NoMultiLoader.Deps.csproj", "{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.WebRequest.NetFramework20", "tracer\test\test-applications\integrations\Samples.WebRequest.NetFramework20\Samples.WebRequest.NetFramework20.csproj", "{5EE6B6EB-B768-47EC-882B-8DCACA2B1360}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.WebRequestHelper.NetFramework20", "tracer\test\test-applications\integrations\dependency-libs\Samples.WebRequestHelper.NetFramework20\Samples.WebRequestHelper.NetFramework20.csproj", "{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.RabbitMQ", "tracer\test\test-applications\integrations\Samples.RabbitMQ\Samples.RabbitMQ.csproj", "{C1210E08-58E5-44D4-BE6F-634C3FC5E410}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.RuntimeMetrics", "tracer\test\test-applications\integrations\Samples.RuntimeMetrics\Samples.RuntimeMetrics.csproj", "{600953C4-BD8F-4A4B-A275-6D6F9EF48342}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.WebRequest", "tracer\test\test-applications\integrations\Samples.WebRequest\Samples.WebRequest.csproj", "{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493}"
+EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Samples.SqlServer.Vb", "tracer\test\test-applications\integrations\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj", "{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.FakeDbCommand", "tracer\test\test-applications\integrations\Samples.FakeDbCommand\Samples.FakeDbCommand.csproj", "{0E036453-2C80-4FC9-A517-771F0071734B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Microsoft.Data.Sqlite", "tracer\test\test-applications\integrations\Samples.Microsoft.Data.Sqlite\Samples.Microsoft.Data.Sqlite.csproj", "{061AB58B-8235-4DAE-8D56-5F081DD78F5E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SQLite.Core", "tracer\test\test-applications\integrations\Samples.SQLite.Core\Samples.SQLite.Core.csproj", "{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA", "tracer\test\test-applications\integrations\Samples.OracleMDA\Samples.OracleMDA.csproj", "{BD46EFCC-177C-466E-81DF-39314B780ADA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA.Core", "tracer\test\test-applications\integrations\Samples.OracleMDA.Core\Samples.OracleMDA.Core.csproj", "{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crank", "crank", "{E3FB283A-B766-4887-95E1-329667671921}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\build\crank\os.profiles.yml = tracer\build\crank\os.profiles.yml
+		tracer\build\crank\run.sh = tracer\build\crank\run.sh
+		tracer\build\crank\Samples.AspNetCoreSimpleController.yml = tracer\build\crank\Samples.AspNetCoreSimpleController.yml
+		tracer\build\crank\Security.Samples.AspNetCoreSimpleController.yml = tracer\build\crank\Security.Samples.AspNetCoreSimpleController.yml
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "tracer\test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreRazorPages", "tracer\test\test-applications\integrations\Samples.AspNetCoreRazorPages\Samples.AspNetCoreRazorPages.csproj", "{1B9E6BF4-9D48-4988-9945-248096119E46}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AWS.SQS", "tracer\test\test-applications\integrations\Samples.AWS.SQS\Samples.AWS.SQS.csproj", "{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.XUnitTests", "tracer\test\test-applications\integrations\Samples.XUnitTests\Samples.XUnitTests.csproj", "{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NUnitTests", "tracer\test\test-applications\integrations\Samples.NUnitTests\Samples.NUnitTests.csproj", "{BC998ACD-353B-4A56-8A56-DF6200E141B6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MSTestTests", "tracer\test\test-applications\integrations\Samples.MSTestTests\Samples.MSTestTests.csproj", "{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Msmq", "tracer\test\test-applications\integrations\Samples.Msmq\Samples.Msmq.csproj", "{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Kafka", "tracer\test\test-applications\integrations\Samples.Kafka\Samples.Kafka.csproj", "{94B50277-FB50-4B42-BA79-770ADB24CB80}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.CosmosDb", "tracer\test\test-applications\integrations\Samples.CosmosDb\Samples.CosmosDb.csproj", "{95613224-C1D7-4D4A-8926-F70DA26371CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "tracer\build\_build\_build.csproj", "{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Owin.WebApi2", "tracer\test\test-applications\integrations\Samples.Owin.WebApi2\Samples.Owin.WebApi2.csproj", "{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Analyzers", "tracer\src\Datadog.Trace.Tools.Analyzers\Datadog.Trace.Tools.Analyzers.csproj", "{5450EA0B-56D3-4E29-932E-094AD037B345}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Analyzers.Tests", "tracer\test\Datadog.Trace.Tools.Analyzers.Tests\Datadog.Trace.Tools.Analyzers.Tests.csproj", "{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Log4Net", "tracer\test\test-applications\integrations\LogsInjection.Log4Net\LogsInjection.Log4Net.csproj", "{B93AD901-B761-486D-80AE-443742DB65E0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog", "tracer\test\test-applications\integrations\LogsInjection.NLog\LogsInjection.NLog.csproj", "{7203DD2B-739F-4223-AE50-D26A7FEEE1A4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog", "tracer\test\test-applications\integrations\LogsInjection.Serilog\LogsInjection.Serilog.csproj", "{83290961-40BF-48CB-B925-FBBE48E629F3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PluginApplication", "tracer\test\test-applications\integrations\dependency-libs\PluginApplication\PluginApplication.csproj", "{6E8D73F3-082C-455B-BBD5-03A156DCDD0F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjectionHelper", "tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper\LogsInjectionHelper.csproj", "{65492DD4-CCD9-437A-B383-E7EB7AB872D2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.AspNet", "tracer\src\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj", "{04B3C44A-D21B-40A8-A167-CB6C035D613B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "security", "security", "{0972AD57-B16B-494F-AE0A-091DD6F3B42B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Security.AspNetCore5", "tracer\test\test-applications\security\Samples.Security.AspNetCore5\Samples.Security.AspNetCore5.csproj", "{AF000E79-8F94-4F52-A7EE-52781C958DCB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Security.IntegrationTests", "tracer\test\Datadog.Trace.Security.IntegrationTests\Datadog.Trace.Security.IntegrationTests.csproj", "{7C66569C-1174-49AF-8DA7-8B216685C1D4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Security.Unit.Tests", "tracer\test\Datadog.Trace.Security.Unit.Tests\Datadog.Trace.Security.Unit.Tests.csproj", "{EE45C020-5EC5-4722-9E35-BC5CC62D2722}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Security.AspNetCore2", "tracer\test\test-applications\security\Samples.Security.AspNetCore2\Samples.Security.AspNetCore2.csproj", "{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Bundle", "tracer\src\Datadog.Trace.Bundle\Datadog.Trace.Bundle.csproj", "{CF364E70-F5B5-4D44-B29E-2165525D3A69}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.ILogger", "tracer\test\test-applications\integrations\LogsInjection.ILogger\LogsInjection.ILogger.csproj", "{463A6FB2-1ABE-4B92-A470-97134D0BBC7E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Aerospike", "tracer\test\test-applications\integrations\Samples.Aerospike\Samples.Aerospike.csproj", "{7471A7A8-B89C-4C94-8EB1-24180E71CA1F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceBus.Minimal.NServiceBus", "tracer\test\test-applications\regression\ServiceBus.Minimal.NServiceBus\ServiceBus.Minimal.NServiceBus.csproj", "{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceBus.Minimal.Rebus", "tracer\test\test-applications\regression\ServiceBus.Minimal.Rebus\ServiceBus.Minimal.Rebus.csproj", "{6C599D79-87D0-476B-9CBA-F731E5627622}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceBus.Minimal.MassTransit", "tracer\test\test-applications\regression\ServiceBus.Minimal.MassTransit\ServiceBus.Minimal.MassTransit.csproj", "{B0E671B9-78DE-410F-A0AA-612FF1F900F2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GraphQL3", "tracer\test\test-applications\integrations\Samples.GraphQL3\Samples.GraphQL3.csproj", "{CA3D605F-8DD7-4041-B024-70A24036AFA1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GraphQL4", "tracer\test\test-applications\integrations\Samples.GraphQL4\Samples.GraphQL4.csproj", "{DA81EF3E-FDB3-417F-AA20-60FC495E3596}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Elasticsearch.V7", "tracer\test\test-applications\integrations\Samples.Elasticsearch.V7\Samples.Elasticsearch.V7.csproj", "{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EnumerateAssemblyReferences", "tracer\test\test-applications\regression\EnumerateAssemblyReferences\EnumerateAssemblyReferences.csproj", "{B22311CE-EC71-4ADD-ADC6-C466B2D10230}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "azure-functions", "azure-functions", "{C4C1E313-C7C1-4490-AECE-0DD0062380A4}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\test-applications\azure-functions\Directory.Build.props = tracer\test\test-applications\azure-functions\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AzureFunctions.V3InProcess", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V3InProcess\Samples.AzureFunctions.V3InProcess.csproj", "{536F1D82-D40C-4E33-B7FA-76A0F17BF672}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Samples.Shared", "tracer\test\test-applications\Samples.Shared\Samples.Shared.shproj", "{5A806F4B-39E7-4F38-B36F-F5CFC4F8760A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Tracer.Native.Checks", "tracer\test\test-applications\instrumentation\Datadog.Tracer.Native.Checks\Datadog.Tracer.Native.Checks.csproj", "{7DFDD339-30C5-4C1D-AB07-F9106256AF77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MySqlConnector", "tracer\test\test-applications\integrations\Samples.MySqlConnector\Samples.MySqlConnector.csproj", "{73252693-2563-4B20-A2F5-F8DB37B91DBE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Couchbase", "tracer\test\test-applications\integrations\Samples.Couchbase\Samples.Couchbase.csproj", "{6F38B456-1D16-4842-AEE5-E74564FB506A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Couchbase3", "tracer\test\test-applications\integrations\Samples.Couchbase3\Samples.Couchbase3.csproj", "{65A66859-2735-4DD6-A927-B416B7A62D0F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMinimalApis", "tracer\test\test-applications\integrations\Samples.AspNetCoreMinimalApis\Samples.AspNetCoreMinimalApis.csproj", "{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreSmokeTest", "tracer\test\test-applications\regression\AspNetCoreSmokeTest\AspNetCoreSmokeTest.csproj", "{BED94A61-6FD9-4103-BD35-70B4798C301C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.SourceGenerators", "tracer\src\Datadog.Trace.SourceGenerators\Datadog.Trace.SourceGenerators.csproj", "{C49095FE-A186-4DED-8DC1-02CE8A42F56B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.SourceGenerators.Tests", "tracer\test\Datadog.Trace.SourceGenerators.Tests\Datadog.Trace.SourceGenerators.Tests.csproj", "{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.1x", "tracer\test\test-applications\integrations\Samples.VersionConflict.1x\Samples.VersionConflict.1x.csproj", "{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.2x", "tracer\test\test-applications\integrations\Samples.VersionConflict.2x\Samples.VersionConflict.2x.csproj", "{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Data.DB2.DBCommand", "tracer\test\test-applications\regression\IBM.Data.DB2.DBCommand\IBM.Data.DB2.DBCommand.csproj", "{E961D189-3EF9-4D79-95A1-78D825B73B01}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Devart.Data.DBCommand", "tracer\test\test-applications\regression\Devart.Data.DBCommand\Devart.Data.DBCommand.csproj", "{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjectionHelper.VersionConflict", "tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj", "{E9D55D41-B161-492F-9EC7-FF2F2231A587}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Serilog.VersionConflict.2x\LogsInjection.Serilog.VersionConflict.2x.csproj", "{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog14.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Serilog14.VersionConflict.2x\LogsInjection.Serilog14.VersionConflict.2x.csproj", "{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Log4Net.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Log4Net.VersionConflict.2x\LogsInjection.Log4Net.VersionConflict.2x.csproj", "{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog.VersionConflict.2x\LogsInjection.NLog.VersionConflict.2x.csproj", "{F19B5109-36AC-4A64-AFE6-FAF9E831C528}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog20.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog20.VersionConflict.2x\LogsInjection.NLog20.VersionConflict.2x.csproj", "{0980BCDD-A231-42D1-B689-41A41BBA161A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog10.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog10.VersionConflict.2x\LogsInjection.NLog10.VersionConflict.2x.csproj", "{D00DDBDA-66F5-490D-8C1C-16CC5E142170}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.ILogger.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.ILogger.VersionConflict.2x\LogsInjection.ILogger.VersionConflict.2x.csproj", "{238F67DB-1E48-447C-B1B8-BDC692103791}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner", "tracer\src\Datadog.Trace.Tools.Runner\Datadog.Trace.Tools.Runner.csproj", "{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.IntegrationTests", "tracer\test\Datadog.Trace.Tools.Runner.IntegrationTests\Datadog.Trace.Tools.Runner.IntegrationTests.csproj", "{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.ArtifactTests", "tracer\test\Datadog.Trace.Tools.Runner.ArtifactTests\Datadog.Trace.Tools.Runner.ArtifactTests.csproj", "{8D4DA889-124E-4164-AD90-F9480E43F685}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.LargePayload", "tracer\test\test-applications\integrations\Samples.LargePayload\Samples.LargePayload.csproj", "{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AWS.Lambda", "tracer\test\test-applications\integrations\Samples.AWS.Lambda\Samples.AWS.Lambda.csproj", "{31D192AF-5454-4D91-97E1-889723AAD309}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Console", "tracer\test\test-applications\integrations\Samples.Console\Samples.Console.csproj", "{887AC8BA-35A6-4646-BF9A-59357155805E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.Tests", "tracer\test\Datadog.Trace.Tools.Runner.Tests\Datadog.Trace.Tools.Runner.Tests.csproj", "{595BB494-CD26-4A51-8E5B-009219E3F2AE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Telemetry", "tracer\test\test-applications\integrations\Samples.Telemetry\Samples.Telemetry.csproj", "{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.AutomaticInstrumentation", "tracer\test\test-applications\regression\Sandbox.AutomaticInstrumentation\Sandbox.AutomaticInstrumentation.csproj", "{10619BA2-AED1-482A-8570-BB7C7B83DDDC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Coverage.collector", "tracer\src\Datadog.Trace.Coverage.collector\Datadog.Trace.Coverage.collector.csproj", "{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.TraceAnnotations", "tracer\test\test-applications\integrations\Samples.TraceAnnotations\Samples.TraceAnnotations.csproj", "{230A9B80-E1AA-469F-86F2-B7E257F14E66}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.TraceAnnotations.VersionMismatch.BeforeFeature", "tracer\test\test-applications\integrations\Samples.TraceAnnotations.VersionMismatch.BeforeFeature\Samples.TraceAnnotations.VersionMismatch.BeforeFeature.csproj", "{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.TraceAnnotations.VersionMismatch.AfterFeature", "tracer\test\test-applications\integrations\Samples.TraceAnnotations.VersionMismatch.AfterFeature\Samples.TraceAnnotations.VersionMismatch.AfterFeature.csproj", "{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.TraceAnnotations.VersionMismatch.NewerNuGet", "tracer\test\test-applications\integrations\Samples.TraceAnnotations.VersionMismatch.NewerNuGet\Samples.TraceAnnotations.VersionMismatch.NewerNuGet.csproj", "{2CC63AEB-0098-4D3B-9606-F07692C03E90}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GrpcDotNet", "tracer\test\test-applications\integrations\Samples.GrpcDotNet\Samples.GrpcDotNet.csproj", "{DEACDE01-95FE-4777-B70A-F20A96AABEA7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GrpcLegacy", "tracer\test\test-applications\integrations\Samples.GrpcLegacy\Samples.GrpcLegacy.csproj", "{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Security.AspNetCoreBare", "tracer\test\test-applications\security\Samples.Security.AspNetCoreBare\Samples.Security.AspNetCoreBare.csproj", "{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Annotations", "tracer\src\Datadog.Trace.Annotations\Datadog.Trace.Annotations.csproj", "{4067EAF6-28C5-4B04-9C8A-80720C0541E6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyLoadContextRedirect", "tracer\test\test-applications\regression\AssemblyLoadContextRedirect\AssemblyLoadContextRedirect.csproj", "{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.InstrumentedAssemblyGenerator", "tracer\src\Datadog.InstrumentedAssemblyGenerator\Datadog.InstrumentedAssemblyGenerator.csproj", "{CD816C0C-D116-49A1-93A7-8095594224EB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.InstrumentedAssemblyVerification", "tracer\src\Datadog.InstrumentedAssemblyVerification\Datadog.InstrumentedAssemblyVerification.csproj", "{FCE813DE-7BF2-4F63-8303-E92F90780C81}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "debugger", "debugger", "{16427BFB-B4C6-46A9-A290-8EA51FF73FEA}"
+	ProjectSection(SolutionItems) = preProject
+		tracer\test\test-applications\debugger\Directory.Build.props = tracer\test\test-applications\debugger\Directory.Build.props
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes", "tracer\test\test-applications\debugger\Samples.Probes\Samples.Probes.csproj", "{2BED2D88-0B51-468B-A559-DA7B4BACA00B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ProcessStart", "tracer\test\test-applications\integrations\Samples.ProcessStart\Samples.ProcessStart.csproj", "{B1F9F419-87E1-4B59-A954-9895FCD7949E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.HotChocolate", "tracer\test\test-applications\integrations\Samples.HotChocolate\Samples.HotChocolate.csproj", "{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.TestHelpers.AutoInstrumentation", "tracer\test\Datadog.Trace.TestHelpers.AutoInstrumentation\Datadog.Trace.TestHelpers.AutoInstrumentation.csproj", "{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependency-libs", "dependency-libs", "{0884B566-D22E-498C-BAA9-26D50ABCAE3A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes.External", "tracer\test\test-applications\debugger\dependency-libs\Samples.Probes.External\Samples.Probes.External.csproj", "{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.DataStreams.Kafka", "tracer\test\test-applications\integrations\Samples.DataStreams.Kafka\Samples.DataStreams.Kafka.csproj", "{7415B0FB-A446-41D6-A0CD-D64B703F15AD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.WeakHashing", "tracer\test\test-applications\integrations\Samples.WeakHashing\Samples.WeakHashing.csproj", "{8C615906-AA60-4BA7-9B04-6A4E20969D6D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.WeakCipher", "tracer\test\test-applications\integrations\Samples.WeakCipher\Samples.WeakCipher.csproj", "{43C696FA-3812-4312-9529-98CECCD32A81}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Deduplication", "tracer\test\test-applications\integrations\Samples.Deduplication\Samples.Deduplication.csproj", "{63B3A841-F3E0-4D60-B85D-156D7251FFDF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AzureFunctions.V4InProcess", "tracer\test\test-applications\azure-functions\Samples.AzureFunctions.V4InProcess\Samples.AzureFunctions.V4InProcess.csproj", "{0F0F7D45-0E13-42B0-A158-8F303BBE8358}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Debugger.IntegrationTests", "tracer\test\Datadog.Trace.Debugger.IntegrationTests\Datadog.Trace.Debugger.IntegrationTests.csproj", "{BB2D2ED3-4378-4B44-974E-8BE80F0021EF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes.TestRuns", "tracer\test\test-applications\debugger\dependency-libs\Samples.Probes.TestRuns\Samples.Probes.TestRuns.csproj", "{4F377216-3D76-4169-BE2B-8DA3A653DD5E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OpenTelemetrySdk", "tracer\test\test-applications\integrations\Samples.OpenTelemetrySdk\Samples.OpenTelemetrySdk.csproj", "{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.NetActivitySdk", "tracer\test\test-applications\integrations\Samples.NetActivitySdk\Samples.NetActivitySdk.csproj", "{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.Trace.BenchmarkDotNet.Tests", "tracer\test\Datadog.Trace.BenchmarkDotNet.Tests\Datadog.Trace.BenchmarkDotNet.Tests.csproj", "{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.InstrumentedTests", "tracer\test\test-applications\integrations\Samples.InstrumentedTests\Samples.InstrumentedTests.csproj", "{64E32F7A-8989-480E-AFE7-3BD343424F6A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5DFDF781-F24C-45B1-82EF-9125875A80A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DFDF781-F24C-45B1-82EF-9125875A80A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DFDF781-F24C-45B1-82EF-9125875A80A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DFDF781-F24C-45B1-82EF-9125875A80A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0434F813-5F94-4195-8A2C-E2E755513822}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0434F813-5F94-4195-8A2C-E2E755513822}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0434F813-5F94-4195-8A2C-E2E755513822}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0434F813-5F94-4195-8A2C-E2E755513822}.Release|Any CPU.Build.0 = Release|Any CPU
+		{188219D1-D123-46C9-B905-A9ED30E6AAA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{188219D1-D123-46C9-B905-A9ED30E6AAA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{188219D1-D123-46C9-B905-A9ED30E6AAA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{188219D1-D123-46C9-B905-A9ED30E6AAA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BCE5D99-147B-4305-9970-AB0F683A6E8D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BCE5D99-147B-4305-9970-AB0F683A6E8D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BCE5D99-147B-4305-9970-AB0F683A6E8D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BCE5D99-147B-4305-9970-AB0F683A6E8D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{237A1C92-DE9E-4649-961B-BBB7CF0DFE01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{237A1C92-DE9E-4649-961B-BBB7CF0DFE01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{237A1C92-DE9E-4649-961B-BBB7CF0DFE01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{237A1C92-DE9E-4649-961B-BBB7CF0DFE01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B52C0C0-A554-4E53-9D17-B121E78FF919}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B52C0C0-A554-4E53-9D17-B121E78FF919}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B52C0C0-A554-4E53-9D17-B121E78FF919}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B52C0C0-A554-4E53-9D17-B121E78FF919}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{472DBA92-4FEA-4B9A-BA70-0E97B942E12D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{472DBA92-4FEA-4B9A-BA70-0E97B942E12D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{472DBA92-4FEA-4B9A-BA70-0E97B942E12D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{472DBA92-4FEA-4B9A-BA70-0E97B942E12D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D949A40-5F4B-4EB0-B8FD-301B472C96AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D949A40-5F4B-4EB0-B8FD-301B472C96AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D949A40-5F4B-4EB0-B8FD-301B472C96AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D949A40-5F4B-4EB0-B8FD-301B472C96AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E02B141F-E7C0-46CF-B9F6-39427218E714}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E02B141F-E7C0-46CF-B9F6-39427218E714}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E02B141F-E7C0-46CF-B9F6-39427218E714}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E02B141F-E7C0-46CF-B9F6-39427218E714}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C00D8070-A38A-4267-9730-E9985CAE77DF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C00D8070-A38A-4267-9730-E9985CAE77DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C00D8070-A38A-4267-9730-E9985CAE77DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C00D8070-A38A-4267-9730-E9985CAE77DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8D132F6-43E3-44D9-902C-78051DBAD01C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8D132F6-43E3-44D9-902C-78051DBAD01C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8D132F6-43E3-44D9-902C-78051DBAD01C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8D132F6-43E3-44D9-902C-78051DBAD01C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91E50134-0E55-4D22-B180-6967174FCE0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91E50134-0E55-4D22-B180-6967174FCE0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91E50134-0E55-4D22-B180-6967174FCE0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91E50134-0E55-4D22-B180-6967174FCE0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B9E6BF4-9D48-4988-9945-248096119E46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B9E6BF4-9D48-4988-9945-248096119E46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B9E6BF4-9D48-4988-9945-248096119E46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B9E6BF4-9D48-4988-9945-248096119E46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B50277-FB50-4B42-BA79-770ADB24CB80}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94B50277-FB50-4B42-BA79-770ADB24CB80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B50277-FB50-4B42-BA79-770ADB24CB80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94B50277-FB50-4B42-BA79-770ADB24CB80}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5450EA0B-56D3-4E29-932E-094AD037B345}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5450EA0B-56D3-4E29-932E-094AD037B345}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5450EA0B-56D3-4E29-932E-094AD037B345}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5450EA0B-56D3-4E29-932E-094AD037B345}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E8D73F3-082C-455B-BBD5-03A156DCDD0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E8D73F3-082C-455B-BBD5-03A156DCDD0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E8D73F3-082C-455B-BBD5-03A156DCDD0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E8D73F3-082C-455B-BBD5-03A156DCDD0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65492DD4-CCD9-437A-B383-E7EB7AB872D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65492DD4-CCD9-437A-B383-E7EB7AB872D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65492DD4-CCD9-437A-B383-E7EB7AB872D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65492DD4-CCD9-437A-B383-E7EB7AB872D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C66569C-1174-49AF-8DA7-8B216685C1D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C66569C-1174-49AF-8DA7-8B216685C1D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C66569C-1174-49AF-8DA7-8B216685C1D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C66569C-1174-49AF-8DA7-8B216685C1D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE45C020-5EC5-4722-9E35-BC5CC62D2722}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE45C020-5EC5-4722-9E35-BC5CC62D2722}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE45C020-5EC5-4722-9E35-BC5CC62D2722}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE45C020-5EC5-4722-9E35-BC5CC62D2722}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF364E70-F5B5-4D44-B29E-2165525D3A69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF364E70-F5B5-4D44-B29E-2165525D3A69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF364E70-F5B5-4D44-B29E-2165525D3A69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF364E70-F5B5-4D44-B29E-2165525D3A69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C49095FE-A186-4DED-8DC1-02CE8A42F56B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C49095FE-A186-4DED-8DC1-02CE8A42F56B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C49095FE-A186-4DED-8DC1-02CE8A42F56B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C49095FE-A186-4DED-8DC1-02CE8A42F56B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D4DA889-124E-4164-AD90-F9480E43F685}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D4DA889-124E-4164-AD90-F9480E43F685}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D4DA889-124E-4164-AD90-F9480E43F685}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D4DA889-124E-4164-AD90-F9480E43F685}.Release|Any CPU.Build.0 = Release|Any CPU
+		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{595BB494-CD26-4A51-8E5B-009219E3F2AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4067EAF6-28C5-4B04-9C8A-80720C0541E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4067EAF6-28C5-4B04-9C8A-80720C0541E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4067EAF6-28C5-4B04-9C8A-80720C0541E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4067EAF6-28C5-4B04-9C8A-80720C0541E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD816C0C-D116-49A1-93A7-8095594224EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD816C0C-D116-49A1-93A7-8095594224EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD816C0C-D116-49A1-93A7-8095594224EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD816C0C-D116-49A1-93A7-8095594224EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCE813DE-7BF2-4F63-8303-E92F90780C81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCE813DE-7BF2-4F63-8303-E92F90780C81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCE813DE-7BF2-4F63-8303-E92F90780C81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCE813DE-7BF2-4F63-8303-E92F90780C81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F0F7D45-0E13-42B0-A158-8F303BBE8358}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F0F7D45-0E13-42B0-A158-8F303BBE8358}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F377216-3D76-4169-BE2B-8DA3A653DD5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F377216-3D76-4169-BE2B-8DA3A653DD5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F377216-3D76-4169-BE2B-8DA3A653DD5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F377216-3D76-4169-BE2B-8DA3A653DD5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028}.Release|Any CPU.Build.0 = Release|Any CPU
+		{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DFDD339-30C5-4C1D-AB07-F9106256AF77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DFDD339-30C5-4C1D-AB07-F9106256AF77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DFDD339-30C5-4C1D-AB07-F9106256AF77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DFDD339-30C5-4C1D-AB07-F9106256AF77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B22311CE-EC71-4ADD-ADC6-C466B2D10230}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B22311CE-EC71-4ADD-ADC6-C466B2D10230}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B22311CE-EC71-4ADD-ADC6-C466B2D10230}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B22311CE-EC71-4ADD-ADC6-C466B2D10230}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E961D189-3EF9-4D79-95A1-78D825B73B01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E961D189-3EF9-4D79-95A1-78D825B73B01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E961D189-3EF9-4D79-95A1-78D825B73B01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E961D189-3EF9-4D79-95A1-78D825B73B01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{463A6FB2-1ABE-4B92-A470-97134D0BBC7E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{463A6FB2-1ABE-4B92-A470-97134D0BBC7E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{463A6FB2-1ABE-4B92-A470-97134D0BBC7E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{463A6FB2-1ABE-4B92-A470-97134D0BBC7E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B93AD901-B761-486D-80AE-443742DB65E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B93AD901-B761-486D-80AE-443742DB65E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B93AD901-B761-486D-80AE-443742DB65E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B93AD901-B761-486D-80AE-443742DB65E0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7203DD2B-739F-4223-AE50-D26A7FEEE1A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7203DD2B-739F-4223-AE50-D26A7FEEE1A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7203DD2B-739F-4223-AE50-D26A7FEEE1A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7203DD2B-739F-4223-AE50-D26A7FEEE1A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{83290961-40BF-48CB-B925-FBBE48E629F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83290961-40BF-48CB-B925-FBBE48E629F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83290961-40BF-48CB-B925-FBBE48E629F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83290961-40BF-48CB-B925-FBBE48E629F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7471A7A8-B89C-4C94-8EB1-24180E71CA1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7471A7A8-B89C-4C94-8EB1-24180E71CA1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7471A7A8-B89C-4C94-8EB1-24180E71CA1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7471A7A8-B89C-4C94-8EB1-24180E71CA1F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{303F8E41-691F-4453-AB7D-88A0036C0465}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{303F8E41-691F-4453-AB7D-88A0036C0465}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{303F8E41-691F-4453-AB7D-88A0036C0465}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{303F8E41-691F-4453-AB7D-88A0036C0465}.Release|Any CPU.Build.0 = Release|Any CPU
+		{31D192AF-5454-4D91-97E1-889723AAD309}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{31D192AF-5454-4D91-97E1-889723AAD309}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{31D192AF-5454-4D91-97E1-889723AAD309}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{31D192AF-5454-4D91-97E1-889723AAD309}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{536F1D82-D40C-4E33-B7FA-76A0F17BF672}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{536F1D82-D40C-4E33-B7FA-76A0F17BF672}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{887AC8BA-35A6-4646-BF9A-59357155805E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{887AC8BA-35A6-4646-BF9A-59357155805E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{887AC8BA-35A6-4646-BF9A-59357155805E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{887AC8BA-35A6-4646-BF9A-59357155805E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95613224-C1D7-4D4A-8926-F70DA26371CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95613224-C1D7-4D4A-8926-F70DA26371CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95613224-C1D7-4D4A-8926-F70DA26371CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95613224-C1D7-4D4A-8926-F70DA26371CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F38B456-1D16-4842-AEE5-E74564FB506A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F38B456-1D16-4842-AEE5-E74564FB506A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F38B456-1D16-4842-AEE5-E74564FB506A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F38B456-1D16-4842-AEE5-E74564FB506A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65A66859-2735-4DD6-A927-B416B7A62D0F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65A66859-2735-4DD6-A927-B416B7A62D0F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65A66859-2735-4DD6-A927-B416B7A62D0F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65A66859-2735-4DD6-A927-B416B7A62D0F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63B3A841-F3E0-4D60-B85D-156D7251FFDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63B3A841-F3E0-4D60-B85D-156D7251FFDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63B3A841-F3E0-4D60-B85D-156D7251FFDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63B3A841-F3E0-4D60-B85D-156D7251FFDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA3D605F-8DD7-4041-B024-70A24036AFA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA3D605F-8DD7-4041-B024-70A24036AFA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA3D605F-8DD7-4041-B024-70A24036AFA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA3D605F-8DD7-4041-B024-70A24036AFA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA81EF3E-FDB3-417F-AA20-60FC495E3596}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA81EF3E-FDB3-417F-AA20-60FC495E3596}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA81EF3E-FDB3-417F-AA20-60FC495E3596}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA81EF3E-FDB3-417F-AA20-60FC495E3596}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DEACDE01-95FE-4777-B70A-F20A96AABEA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DEACDE01-95FE-4777-B70A-F20A96AABEA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DEACDE01-95FE-4777-B70A-F20A96AABEA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DEACDE01-95FE-4777-B70A-F20A96AABEA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{061AB58B-8235-4DAE-8D56-5F081DD78F5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{061AB58B-8235-4DAE-8D56-5F081DD78F5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{061AB58B-8235-4DAE-8D56-5F081DD78F5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{061AB58B-8235-4DAE-8D56-5F081DD78F5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3493346B-44F6-4F50-8FB4-51D0090DF544}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3493346B-44F6-4F50-8FB4-51D0090DF544}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3493346B-44F6-4F50-8FB4-51D0090DF544}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3493346B-44F6-4F50-8FB4-51D0090DF544}.Release|Any CPU.Build.0 = Release|Any CPU
+		{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC998ACD-353B-4A56-8A56-DF6200E141B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC998ACD-353B-4A56-8A56-DF6200E141B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC998ACD-353B-4A56-8A56-DF6200E141B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC998ACD-353B-4A56-8A56-DF6200E141B6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD46EFCC-177C-466E-81DF-39314B780ADA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD46EFCC-177C-466E-81DF-39314B780ADA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD46EFCC-177C-466E-81DF-39314B780ADA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD46EFCC-177C-466E-81DF-39314B780ADA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2BED2D88-0B51-468B-A559-DA7B4BACA00B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2BED2D88-0B51-468B-A559-DA7B4BACA00B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2BED2D88-0B51-468B-A559-DA7B4BACA00B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2BED2D88-0B51-468B-A559-DA7B4BACA00B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1F9F419-87E1-4B59-A954-9895FCD7949E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1F9F419-87E1-4B59-A954-9895FCD7949E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1F9F419-87E1-4B59-A954-9895FCD7949E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1F9F419-87E1-4B59-A954-9895FCD7949E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EF718502-7760-45B5-A563-5F1B22A6B840}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EF718502-7760-45B5-A563-5F1B22A6B840}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EF718502-7760-45B5-A563-5F1B22A6B840}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EF718502-7760-45B5-A563-5F1B22A6B840}.Release|Any CPU.Build.0 = Release|Any CPU
+		{600953C4-BD8F-4A4B-A275-6D6F9EF48342}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{600953C4-BD8F-4A4B-A275-6D6F9EF48342}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{600953C4-BD8F-4A4B-A275-6D6F9EF48342}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{600953C4-BD8F-4A4B-A275-6D6F9EF48342}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E1555D1-13D5-4DBF-9631-117D840C3158}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E1555D1-13D5-4DBF-9631-117D840C3158}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E1555D1-13D5-4DBF-9631-117D840C3158}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E1555D1-13D5-4DBF-9631-117D840C3158}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{086FF8A0-9CEE-470A-9751-78B0F1340649}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{086FF8A0-9CEE-470A-9751-78B0F1340649}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{086FF8A0-9CEE-470A-9751-78B0F1340649}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{086FF8A0-9CEE-470A-9751-78B0F1340649}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{230A9B80-E1AA-469F-86F2-B7E257F14E66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{230A9B80-E1AA-469F-86F2-B7E257F14E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{230A9B80-E1AA-469F-86F2-B7E257F14E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{230A9B80-E1AA-469F-86F2-B7E257F14E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CC63AEB-0098-4D3B-9606-F07692C03E90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CC63AEB-0098-4D3B-9606-F07692C03E90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CC63AEB-0098-4D3B-9606-F07692C03E90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CC63AEB-0098-4D3B-9606-F07692C03E90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43C696FA-3812-4312-9529-98CECCD32A81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43C696FA-3812-4312-9529-98CECCD32A81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43C696FA-3812-4312-9529-98CECCD32A81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43C696FA-3812-4312-9529-98CECCD32A81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C615906-AA60-4BA7-9B04-6A4E20969D6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C615906-AA60-4BA7-9B04-6A4E20969D6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C615906-AA60-4BA7-9B04-6A4E20969D6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C615906-AA60-4BA7-9B04-6A4E20969D6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0E671B9-78DE-410F-A0AA-612FF1F900F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0E671B9-78DE-410F-A0AA-612FF1F900F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0E671B9-78DE-410F-A0AA-612FF1F900F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0E671B9-78DE-410F-A0AA-612FF1F900F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C599D79-87D0-476B-9CBA-F731E5627622}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C599D79-87D0-476B-9CBA-F731E5627622}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C599D79-87D0-476B-9CBA-F731E5627622}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C599D79-87D0-476B-9CBA-F731E5627622}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D546118-B70A-44D0-B675-39EDB99FCEEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D546118-B70A-44D0-B675-39EDB99FCEEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D546118-B70A-44D0-B675-39EDB99FCEEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D546118-B70A-44D0-B675-39EDB99FCEEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64E32F7A-8989-480E-AFE7-3BD343424F6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64E32F7A-8989-480E-AFE7-3BD343424F6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64E32F7A-8989-480E-AFE7-3BD343424F6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64E32F7A-8989-480E-AFE7-3BD343424F6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|Any CPU.Build.0 = Debug|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|x64.ActiveCfg = Debug|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|x64.Build.0 = Debug|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|x86.ActiveCfg = Debug|x86
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Debug|x86.Build.0 = Debug|x86
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|Any CPU.ActiveCfg = Release|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|Any CPU.Build.0 = Release|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|x64.ActiveCfg = Release|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|x64.Build.0 = Release|x64
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|x86.ActiveCfg = Release|x86
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5DFDF781-F24C-45B1-82EF-9125875A80A4} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{0434F813-5F94-4195-8A2C-E2E755513822} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{188219D1-D123-46C9-B905-A9ED30E6AAA7} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{3BCE5D99-147B-4305-9970-AB0F683A6E8D} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{EFBFC324-B459-4D39-8E19-CE4AD0DBF15F} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{237A1C92-DE9E-4649-961B-BBB7CF0DFE01} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{FDB5C8D0-018D-4FF9-9680-C6A5078F819B} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{4B243CF1-4269-45C6-A238-1A9BFA58B8CC} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{0D546118-B70A-44D0-B675-39EDB99FCEEE} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{086FF8A0-9CEE-470A-9751-78B0F1340649} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{C98950B1-DC4B-43DA-974F-EF2CF325EC2B} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{5B52C0C0-A554-4E53-9D17-B121E78FF919} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{3493346B-44F6-4F50-8FB4-51D0090DF544} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{DD3E8ED8-A0E4-482E-A5ED-115E21D543C0} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{8E1555D1-13D5-4DBF-9631-117D840C3158} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{DC7D131A-AF99-46AB-9AA6-463443E3B992} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{43782238-E7BB-49D0-9541-1121DACA6EB5} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{FA487690-E88C-4A57-9187-B71CB70C1AAE} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{BB3F7D85-7E20-4AEB-A32A-8AF150CC37B2} = {EFE48691-1FBA-41D5-9BFD-676771973F0C}
+		{AB8596C1-CFDA-4A5E-9E9C-74A3DF9AED77} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{1A5E9F40-F3A5-4B59-9898-3DCD65C459C3} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{42FA33DD-AEA3-4FF3-8319-F30244A666A4} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{472DBA92-4FEA-4B9A-BA70-0E97B942E12D} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{EEA89ACD-CFBB-4F60-A150-74F0A84DF028} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{8BDF1DE0-E6DE-48AD-AAA3-CE09CB544E2C} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{EF718502-7760-45B5-A563-5F1B22A6B840} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{8B457E8F-8716-4F29-BBE2-DD6C7BC4AC37} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{303F8E41-691F-4453-AB7D-88A0036C0465} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{D141BD06-DD95-4CAF-85CD-657116E0DAD4} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE} = {EFE48691-1FBA-41D5-9BFD-676771973F0C}
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F} = {EFE48691-1FBA-41D5-9BFD-676771973F0C}
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {EFE48691-1FBA-41D5-9BFD-676771973F0C}
+		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{AAD9038B-8F16-4E09-93AF-B13E9F7ACD66} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{8D949A40-5F4B-4EB0-B8FD-301B472C96AE} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{E02B141F-E7C0-46CF-B9F6-39427218E714} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{C00D8070-A38A-4267-9730-E9985CAE77DF} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{B8D132F6-43E3-44D9-902C-78051DBAD01C} = {E5439139-6F94-44FA-9590-C32FCC1C7A93}
+		{2F3B6271-B9A3-48A3-9DB6-847F3EF41F0A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{9518425A-36A5-4B8F-B0B8-6137DB88441D} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{498A300E-D036-49B7-A43D-821D1CAF11A5} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{EFE48691-1FBA-41D5-9BFD-676771973F0C} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{8683D82A-2BBE-4199-9C36-C59F48804F90} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{91E50134-0E55-4D22-B180-6967174FCE0B} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{CC53E5C5-9D3E-4AD9-A9CA-D2190463EB5B} = {A0C5FBBB-CFB2-4FB9-B8F0-55676E9DCF06}
+		{E5439139-6F94-44FA-9590-C32FCC1C7A93} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{933F1D4B-1216-4BC1-956E-8C30818BAA0F} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{6DF72F24-D842-4F1E-948C-ED89093325D6} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{021EFBA6-C4BA-4DE5-BF3F-C263EE9E20DB} = {933F1D4B-1216-4BC1-956E-8C30818BAA0F}
+		{AA88952E-9393-4A4B-85B5-CC7F03629CE1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{472B69A0-956F-42C0-9CB8-30107821C43B} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{5EE6B6EB-B768-47EC-882B-8DCACA2B1360} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{B5A0C6B0-66C8-46EB-B699-44EB2DD1784A} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{C1210E08-58E5-44D4-BE6F-634C3FC5E410} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{600953C4-BD8F-4A4B-A275-6D6F9EF48342} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{0E036453-2C80-4FC9-A517-771F0071734B} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{061AB58B-8235-4DAE-8D56-5F081DD78F5E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{BD46EFCC-177C-466E-81DF-39314B780ADA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{E3FB283A-B766-4887-95E1-329667671921} = {A0C5FBBB-CFB2-4FB9-B8F0-55676E9DCF06}
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{1B9E6BF4-9D48-4988-9945-248096119E46} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3538EF5E-377E-430A-AFB8-F2DB5FAEDE95} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{4AD438D9-D4E3-4EB5-8851-89DB4D1CFB9C} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{BC998ACD-353B-4A56-8A56-DF6200E141B6} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{8EAABFB9-8A47-4B11-AD7F-AC8B373CDE49} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{662B587F-97B5-4CEF-ABF9-6C76A6DBD29E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{94B50277-FB50-4B42-BA79-770ADB24CB80} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{95613224-C1D7-4D4A-8926-F70DA26371CA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{78004AA7-26DD-44DB-A2C7-C287A5BBE5D6} = {A0C5FBBB-CFB2-4FB9-B8F0-55676E9DCF06}
+		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{5450EA0B-56D3-4E29-932E-094AD037B345} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{6BB875B5-9FA7-4FB4-9224-B0FA2245CE0B} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{B93AD901-B761-486D-80AE-443742DB65E0} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{7203DD2B-739F-4223-AE50-D26A7FEEE1A4} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{83290961-40BF-48CB-B925-FBBE48E629F3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{6E8D73F3-082C-455B-BBD5-03A156DCDD0F} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{65492DD4-CCD9-437A-B383-E7EB7AB872D2} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{04B3C44A-D21B-40A8-A167-CB6C035D613B} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{0972AD57-B16B-494F-AE0A-091DD6F3B42B} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{AF000E79-8F94-4F52-A7EE-52781C958DCB} = {0972AD57-B16B-494F-AE0A-091DD6F3B42B}
+		{7C66569C-1174-49AF-8DA7-8B216685C1D4} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{EE45C020-5EC5-4722-9E35-BC5CC62D2722} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{8A73100E-F2C3-44D3-A5B8-49B5BFDF1B52} = {0972AD57-B16B-494F-AE0A-091DD6F3B42B}
+		{CF364E70-F5B5-4D44-B29E-2165525D3A69} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{463A6FB2-1ABE-4B92-A470-97134D0BBC7E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{7471A7A8-B89C-4C94-8EB1-24180E71CA1F} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{9D5935CB-2DF2-46CB-A5E1-98BE134CAFCC} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{6C599D79-87D0-476B-9CBA-F731E5627622} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{B0E671B9-78DE-410F-A0AA-612FF1F900F2} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{CA3D605F-8DD7-4041-B024-70A24036AFA1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{DA81EF3E-FDB3-417F-AA20-60FC495E3596} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3CB0B2C2-7664-4D71-8F43-3D207EE80DB7} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{B22311CE-EC71-4ADD-ADC6-C466B2D10230} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{C4C1E313-C7C1-4490-AECE-0DD0062380A4} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{536F1D82-D40C-4E33-B7FA-76A0F17BF672} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{5A806F4B-39E7-4F38-B36F-F5CFC4F8760A} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{7DFDD339-30C5-4C1D-AB07-F9106256AF77} = {933F1D4B-1216-4BC1-956E-8C30818BAA0F}
+		{73252693-2563-4B20-A2F5-F8DB37B91DBE} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{6F38B456-1D16-4842-AEE5-E74564FB506A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{65A66859-2735-4DD6-A927-B416B7A62D0F} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{BED94A61-6FD9-4103-BD35-70B4798C301C} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{C49095FE-A186-4DED-8DC1-02CE8A42F56B} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{8D337CD2-9D76-46FE-8AD3-EBDA8F43CD77} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{E961D189-3EF9-4D79-95A1-78D825B73B01} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{24834112-8C25-4A3D-BDD3-0ACEC825FF2C} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{0980BCDD-A231-42D1-B689-41A41BBA161A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{238F67DB-1E48-447C-B1B8-BDC692103791} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{D917DD3B-EF86-4DF9-AC32-D50330A4DEDA} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{C7EC2FF7-C495-4A35-80DF-1F57B61214AC} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{8D4DA889-124E-4164-AD90-F9480E43F685} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{C94E0739-1DA0-4657-8D53-FA4143F6FDA3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{31D192AF-5454-4D91-97E1-889723AAD309} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{887AC8BA-35A6-4646-BF9A-59357155805E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{595BB494-CD26-4A51-8E5B-009219E3F2AE} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{7A0D8A39-C60D-4BA1-93AB-D429080BBFA5} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{230A9B80-E1AA-469F-86F2-B7E257F14E66} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{0DF4363A-0DF4-4882-A39F-3C9F404B8DE5} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{FF2E8DD2-CA25-4D53-A77C-9F88E41F8C98} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2CC63AEB-0098-4D3B-9606-F07692C03E90} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{DEACDE01-95FE-4777-B70A-F20A96AABEA7} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{754F73E1-F7A4-47C7-A3F7-DC59ADA5105A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{F6A03B6C-EBF9-4581-9904-EDC7270CF3BD} = {0972AD57-B16B-494F-AE0A-091DD6F3B42B}
+		{4067EAF6-28C5-4B04-9C8A-80720C0541E6} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{C4CDF6A6-40E5-4CCD-AC4C-143F9F4398CA} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{CD816C0C-D116-49A1-93A7-8095594224EB} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{FCE813DE-7BF2-4F63-8303-E92F90780C81} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{16427BFB-B4C6-46A9-A290-8EA51FF73FEA} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
+		{2BED2D88-0B51-468B-A559-DA7B4BACA00B} = {16427BFB-B4C6-46A9-A290-8EA51FF73FEA}
+		{B1F9F419-87E1-4B59-A954-9895FCD7949E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{BBAD4449-D414-4A20-BCA2-DE9C40E4A866} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{FFF9AF47-7556-4B38-8BAC-1CB51EDF8F7A} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{0884B566-D22E-498C-BAA9-26D50ABCAE3A} = {16427BFB-B4C6-46A9-A290-8EA51FF73FEA}
+		{9235DCFA-9EDD-48EF-B1DB-E15B738C85A6} = {0884B566-D22E-498C-BAA9-26D50ABCAE3A}
+		{7415B0FB-A446-41D6-A0CD-D64B703F15AD} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{8C615906-AA60-4BA7-9B04-6A4E20969D6D} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{43C696FA-3812-4312-9529-98CECCD32A81} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{63B3A841-F3E0-4D60-B85D-156D7251FFDF} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{0F0F7D45-0E13-42B0-A158-8F303BBE8358} = {C4C1E313-C7C1-4490-AECE-0DD0062380A4}
+		{BB2D2ED3-4378-4B44-974E-8BE80F0021EF} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{4F377216-3D76-4169-BE2B-8DA3A653DD5E} = {0884B566-D22E-498C-BAA9-26D50ABCAE3A}
+		{CB56AC5A-D2C1-40DE-99D5-DCF9F44C9482} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{560E1104-9A6E-41E7-AB3D-85BA2740A0F7} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{64E32F7A-8989-480E-AFE7-3BD343424F6A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{3c6dd42e-9214-4747-92ba-78de29aace59}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{6d86109f-b7c9-477d-86d7-45735a3a0818}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{7b0822f6-80de-4b49-8125-93975678d0d5}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{99a62ccf-8e7f-4d57-8383-d38c371c8087}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{b417e258-a21f-4546-b78f-8a7a4879472a}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{b6a98887-4a47-4c19-9c6f-d833e24f4b1c}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{bbb60b0f-bf01-4499-936a-4a299a9acfd4}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{f5582f54-e911-4258-b419-5e894d338c5b}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{fab2b108-e5be-4647-869b-1dc5d362252e}*SharedItemsImports = 4
+	EndGlobalSection
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -907,3 +907,105 @@ services:
     - DD_TRACE_AGENT_URL=http://test-agent:8126
     depends_on:
     - test-agent
+
+  StartDependencies.OSXARM64:
+    image: andrewlock/wait-for-dependencies
+    depends_on:
+      - servicestackredis_osx_arm64
+      - stackexchangeredis_osx_arm64
+      - stackexchangeredis_osx_arm64-replica
+      - stackexchangeredis_osx_arm64-single
+      - elasticsearch7_osx_arm64
+      - sqledge_osx_arm64
+      - mongo_osx_arm64
+      - postgres_osx_arm64
+      - mysql_osx_arm64
+      - rabbitmq_osx_arm64
+      - aws_sqs_osx_arm64
+    environment:
+      - TIMEOUT_LENGTH=120
+    command: servicestackredis_osx_arm64:6379 stackexchangeredis_osx_arm64:6379 stackexchangeredis_osx_arm64-replica:6379 stackexchangeredis_osx_arm64-single:6379 elasticsearch7_osx_arm64:9200 sqledge_osx_arm64:1433 mongo_osx_arm64:27017 postgres_osx_arm64:5432 mysql_osx_arm64:3306 rabbitmq_osx_arm64:5672 aws_sqs_osx_arm64:9324
+
+  # OSX ARM64 dependencies
+
+  aws_sqs_osx_arm64:
+    image: softwaremill/elasticmq
+    ports:
+      - "9324:9324"
+
+  elasticsearch7_osx_arm64:
+    image: elasticsearch:7.10.1
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+
+  mongo_osx_arm64:
+    image: mongo:4.0.9
+    ports:
+      - "27017:27017"
+    command: mongod
+
+  mysql_osx_arm64:
+    image: mysql/mysql-server:8.0
+    environment:
+      - MYSQL_DATABASE=world
+      - MYSQL_ROOT_PASSWORD=mysqldb
+      - MYSQL_USER=mysqldb
+      - MYSQL_PASSWORD=mysqldb
+    ports:
+      - "3306:3306"
+
+  postgres_osx_arm64:
+    image: postgres:10.5-alpine
+    environment:
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+    ports:
+      - "5432:5432"
+
+  rabbitmq_osx_arm64:
+    image: rabbitmq:3-management
+    command: rabbitmq-server
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  servicestackredis_osx_arm64:
+    image: redis:4-alpine
+    command: redis-server --bind 0.0.0.0
+    ports:
+      - "6379:6379"
+
+  stackexchangeredis_osx_arm64:
+    image: redis:4-alpine
+    hostname: stackexchangeredis_osx_arm64
+    command: redis-server --bind 0.0.0.0
+    ports:
+      - "6392:6379"
+
+  stackexchangeredis_osx_arm64-replica:
+    image: redis:4-alpine
+    hostname: stackexchangeredis_osx_arm64-replica
+    command: redis-server --bind 0.0.0.0 --slaveof stackexchangeredis_osx_arm64 6379
+    ports:
+      - "6390:6379"
+
+  stackexchangeredis_osx_arm64-single:
+    image: redis:4-alpine
+    hostname: stackexchangeredis_osx_arm64-single
+    command: redis-server --bind 0.0.0.0
+    ports:
+      - "6391:6379"
+
+  sqledge_osx_arm64:
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    ports:
+      - "1433:1433"
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=Strong!Passw0rd
+

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -33,7 +33,7 @@
     <SHARED-LIB-BINARIES Condition="'$(Configuration)'=='Release'">$(SHARED-LIB-PATH)fmt_$(SHARED-LIB-PLATFORM)-windows-static\lib\fmt.lib</SHARED-LIB-BINARIES>
     <SHARED-LIB-BINARIES Condition="'$(Configuration)'=='Debug'">$(SHARED-LIB-PATH)fmt_$(SHARED-LIB-PLATFORM)-windows-static\debug\lib\fmtd.lib</SHARED-LIB-BINARIES>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" Condition=" '$(OS)' == 'Windows_NT' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -76,7 +76,7 @@
     <TargetName>Datadog.Trace.ClrProfiler.Native</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" Condition=" '$(OS)' == 'Windows_NT' " />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -262,7 +262,8 @@
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="Build" Condition=" '$(OS)' != 'Windows_NT' "></Target>
 </Project>

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -33,7 +33,7 @@
     <SHARED-LIB-BINARIES Condition="'$(Configuration)'=='Release'">$(SHARED-LIB-PATH)fmt_$(SHARED-LIB-PLATFORM)-windows-static\lib\fmt.lib</SHARED-LIB-BINARIES>
     <SHARED-LIB-BINARIES Condition="'$(Configuration)'=='Debug'">$(SHARED-LIB-PATH)fmt_$(SHARED-LIB-PLATFORM)-windows-static\debug\lib\fmtd.lib</SHARED-LIB-BINARIES>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -76,7 +76,7 @@
     <TargetName>Datadog.Trace.ClrProfiler.Native</TargetName>
     <TargetExt>.dll</TargetExt>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -262,8 +262,7 @@
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="Build" Condition=" '$(OS)' != 'Windows_NT' "></Target>
 </Project>

--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -30,4 +30,14 @@
   <PropertyGroup>
     <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildThisFileDirectory)..\</SolutionDir>
   </PropertyGroup>
+  
+  <!-- OS Detection Properties -->
+  <PropertyGroup>
+    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
 </Project>

--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -35,9 +35,19 @@
   <PropertyGroup>
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(MSBuildRuntimeType)' == 'Core'">
+      <PropertyGroup>
+        <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+        <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <IsOSX>false</IsOSX>
+        <IsLinux>false</IsLinux>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  
 </Project>

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -102,10 +102,10 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 ./build.sh PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-./build.sh BuildAndRunLinuxIntegrationTests
+./build.sh BuildAndRunOsxIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
-./build.sh BuildAndRunLinuxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
+./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
 ```
 
 ## Additional Technical Documentation

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -93,19 +93,19 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 
 ```bash
 # Clean and build the main tracer project
-.\build.sh Clean BuildTracerHome
+./build.sh Clean BuildTracerHome
 
 # Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
-.\build.sh BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests
+./build.sh BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests
 
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
-.\build.sh PackageTracerHome
+./build.sh PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
-.\build.sh BuildAndRunLinuxIntegrationTests
+./build.sh BuildAndRunLinuxIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
-.\build.sh BuildAndRunLinuxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
+./build.sh BuildAndRunLinuxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
 ```
 
 ## Additional Technical Documentation

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -101,11 +101,17 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
 ./build.sh PackageTracerHome
 
+# Start IntegrationTests dependencies.
+docker-compose up StartDependencies.OSXARM64
+
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
 ./build.sh BuildAndRunOsxIntegrationTests
 
 # Build and run integration tests filtering on one framework, one set of tests and a sample app.
 ./build.sh BuildAndRunOsxIntegrationTests --framework "net6.0" --filter "rabbit" --SampleName "Samples.Rabbit"
+
+# Stop IntegrationTests dependencies.
+docker-compose down
 ```
 
 ## Additional Technical Documentation

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1362,6 +1362,11 @@ partial class Build
                 "Sandbox.AutomaticInstrumentation", // Doesn't run on Linux
             };
 
+            if (IsOsx)
+            {
+                projectsToSkip = projectsToSkip.Concat("Samples.GrpcDotNet").ToArray();
+            }
+
             // These sample projects are built using RestoreAndBuildSamplesForPackageVersions
             // so no point building them now
             var multiPackageProjects = new List<string>();

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -42,6 +42,7 @@ partial class Build
     AbsolutePath ArtifactsDirectory => Artifacts ?? (OutputDirectory / "artifacts");
     AbsolutePath WindowsTracerHomeZip => ArtifactsDirectory / "windows-tracer-home.zip";
     AbsolutePath WindowsSymbolsZip => ArtifactsDirectory / "windows-native-symbols.zip";
+    AbsolutePath OsxTracerHomeZip => ArtifactsDirectory / "macOS-tracer-home.zip";
     AbsolutePath BuildDataDirectory => TracerDirectory / "build_data";
     AbsolutePath TestLogsDirectory => BuildDataDirectory / "logs";
     AbsolutePath ToolSourceDirectory => ToolSource ?? (OutputDirectory / "runnerTool");
@@ -655,7 +656,8 @@ partial class Build
 
     Target ZipMonitoringHome => _ => _
        .DependsOn(ZipMonitoringHomeWindows)
-       .DependsOn(ZipMonitoringHomeLinux);
+       .DependsOn(ZipMonitoringHomeLinux)
+       .DependsOn(ZipMonitoringHomeOsx);
 
     Target ZipMonitoringHomeWindows => _ => _
         .Unlisted()
@@ -769,6 +771,16 @@ partial class Build
                 workingDirectory / versionedName);
         });
 
+    Target ZipMonitoringHomeOsx => _ => _
+        .Unlisted()
+        .After(BuildTracerHome, BuildNativeLoader)
+        .OnlyWhenStatic(() => IsOsx)
+        .Requires(() => Version)
+        .Executes(() =>
+        {
+            // As a naive approach let's do the same as windows, create a zip folder
+            CompressZip(MonitoringHomeDirectory, OsxTracerHomeZip, fileMode: FileMode.Create);
+        });
 
     Target CompileInstrumentationVerificationLibrary => _ => _
         .Unlisted()

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1362,11 +1362,6 @@ partial class Build
                 "Sandbox.AutomaticInstrumentation", // Doesn't run on Linux
             };
 
-            if (IsOsx)
-            {
-                projectsToSkip = projectsToSkip.Concat("Samples.GrpcDotNet").ToArray();
-            }
-
             // These sample projects are built using RestoreAndBuildSamplesForPackageVersions
             // so no point building them now
             var multiPackageProjects = new List<string>();

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -277,7 +277,7 @@ partial class Build : NukeBuild
         .Requires(() => IsOsx)
         .Description("Builds and runs the osx integration tests. Requires docker-compose dependencies")
         .DependsOn(BuildOsxIntegrationTests)
-        .DependsOn(RunLinuxIntegrationTests);
+        .DependsOn(RunOsxIntegrationTests);
     
     Target BuildAndRunToolArtifactTests => _ => _
        .Description("Builds and runs the tool artifacts tests")

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -249,9 +249,9 @@ partial class Build : NukeBuild
         .DependsOn(CompileDependencyLibs)
         .DependsOn(CompileRegressionDependencyLibs)
         .DependsOn(CompileManagedTestHelpers)
-        .DependsOn(CompileSamplesLinux)
+        .DependsOn(CompileSamplesLinuxOrOsx)
         .DependsOn(CompileMultiApiPackageVersionSamples)
-        .DependsOn(CompileLinuxIntegrationTests)
+        .DependsOn(CompileLinuxOrOsxIntegrationTests)
         .DependsOn(BuildRunnerTool)
         .DependsOn(CopyServerlessArtifacts);
 
@@ -261,6 +261,24 @@ partial class Build : NukeBuild
         .DependsOn(BuildLinuxIntegrationTests)
         .DependsOn(RunLinuxIntegrationTests);
 
+    Target BuildOsxIntegrationTests => _ => _
+        .Requires(() => IsOsx)
+        .Description("Builds the osx integration tests")
+        .DependsOn(CompileDependencyLibs)
+        .DependsOn(CompileRegressionDependencyLibs)
+        .DependsOn(CompileManagedTestHelpers)
+        .DependsOn(CompileSamplesLinuxOrOsx)
+        .DependsOn(CompileMultiApiPackageVersionSamples)
+        .DependsOn(CompileLinuxOrOsxIntegrationTests)
+        .DependsOn(BuildRunnerTool)
+        .DependsOn(CopyServerlessArtifacts);
+
+    Target BuildAndRunOsxIntegrationTests => _ => _
+        .Requires(() => IsOsx)
+        .Description("Builds and runs the osx integration tests. Requires docker-compose dependencies")
+        .DependsOn(BuildOsxIntegrationTests)
+        .DependsOn(RunLinuxIntegrationTests);
+    
     Target BuildAndRunToolArtifactTests => _ => _
        .Description("Builds and runs the tool artifacts tests")
        .DependsOn(CompileManagedTestHelpers)

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -176,6 +176,7 @@ internal static partial class DotNetSettingsExtensions
         {
             "x86" => "X86",
             "x64" => "X64",
+            "arm64" => "ARM64",
             _ => throw new InvalidOperationException("Should only use x64 and x86 for Test target platform"),
         };
 
@@ -240,5 +241,24 @@ internal static partial class DotNetSettingsExtensions
         }
 
         return settings;
+    }
+
+    public static T SetLocalOsxEnvironmentVariables<T>(this T toolSettings)
+        where T : ToolSettings
+    {
+        return toolSettings
+            .SetProcessEnvironmentVariable("MONGO_HOST", "localhost")
+            .SetProcessEnvironmentVariable("SERVICESTACK_REDIS_HOST", "localhost:6379")
+            .SetProcessEnvironmentVariable("STACKEXCHANGE_REDIS_HOST", "localhost:6392,127.0.0.1:6390")
+            .SetProcessEnvironmentVariable("STACKEXCHANGE_REDIS_SINGLE_HOST", "localhost:6391")
+            .SetProcessEnvironmentVariable("ELASTICSEARCH7_HOST", "localhost:9200")
+            .SetProcessEnvironmentVariable("ELASTICSEARCH6_HOST", "localhost:9200")
+            .SetProcessEnvironmentVariable("ELASTICSEARCH5_HOST", "localhost:9200")
+            .SetProcessEnvironmentVariable("SQLSERVER_CONNECTION_STRING", "Server=localhost;User=sa;Password=Strong!Passw0rd")
+            .SetProcessEnvironmentVariable("POSTGRES_HOST", "localhost")
+            .SetProcessEnvironmentVariable("MYSQL_HOST", "localhost")
+            .SetProcessEnvironmentVariable("MYSQL_PORT", "3306")
+            .SetProcessEnvironmentVariable("RABBITMQ_HOST", "localhost")
+            .SetProcessEnvironmentVariable("AWS_SQS_HOST", "localhost:9324");
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj
+++ b/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj
@@ -30,7 +30,7 @@
     <LIB_BINARIES Condition="'$(Configuration)'=='Release'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\lib\fmt.lib</LIB_BINARIES>
     <LIB_BINARIES Condition="'$(Configuration)'=='Debug'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\debug\lib\fmtd.lib</LIB_BINARIES>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" Condition=" '$(OS)' == 'Windows_NT' " />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -57,7 +57,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" Condition=" '$(OS)' == 'Windows_NT' " />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -221,7 +221,8 @@
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="Build" Condition=" '$(OS)' != 'Windows_NT' "></Target>
 </Project>

--- a/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj
+++ b/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.DLL.vcxproj
@@ -30,7 +30,7 @@
     <LIB_BINARIES Condition="'$(Configuration)'=='Release'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\lib\fmt.lib</LIB_BINARIES>
     <LIB_BINARIES Condition="'$(Configuration)'=='Debug'">$(LIB_PATH)fmt_$(LIB_PLATFORM)-windows-static\debug\lib\fmtd.lib</LIB_BINARIES>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
@@ -57,7 +57,7 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
   <ImportGroup Label="Shared">
@@ -221,8 +221,7 @@
   <ItemGroup>
     <ResourceCompile Include="Resource.rc" />
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" Condition=" '$(OS)' == 'Windows_NT' " />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="Build" Condition=" '$(OS)' != 'Windows_NT' "></Target>
 </Project>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -51,11 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #endif
         public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transportType)
         {
-            if (EnvironmentTools.IsOsx())
-            {
-                throw new SkipException("This test is not supported on macOS");
-            }
-
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             if (transportType == TestTransports.WindowsNamedPipe && !EnvironmentTools.IsWindows())
             {
                 throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
@@ -79,8 +75,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
-            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
-                               "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                "ProcessStartTests.SubmitsTracesLinux" :
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                    "ProcessStartTests.SubmitsTracesOsx" :
+                    "ProcessStartTests.SubmitsTraces";
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)
                               .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -51,6 +51,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #endif
         public void SubmitsTraces(AgentBehaviour behaviour, TestTransports transportType)
         {
+            if (EnvironmentTools.IsOsx())
+            {
+                throw new SkipException("This test is not supported on macOS");
+            }
+
             if (transportType == TestTransports.WindowsNamedPipe && !EnvironmentTools.IsWindows())
             {
                 throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
@@ -74,7 +79,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
-            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                               "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)
                               .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -339,13 +339,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockCIVisibilityTest targetTest)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetTest, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -290,13 +290,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockSpan targetSpan)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetSpan, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -391,13 +391,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockCIVisibilityTest targetTest)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetTest, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -340,13 +340,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockSpan targetSpan)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetSpan, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -364,13 +364,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockCIVisibilityTest targetTest)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetTest, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetTest, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetTest, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetTest, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetTest, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -309,13 +309,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         private static void CheckRuntimeValues(MockSpan targetSpan)
         {
-            FrameworkDescription framework = FrameworkDescription.Instance;
-
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeName, framework.Name);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeVersion, framework.ProductVersion);
-            AssertTargetSpanEqual(targetSpan, CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSArchitecture, framework.OSArchitecture);
-            AssertTargetSpanEqual(targetSpan, CommonTags.OSPlatform, framework.OSPlatform);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeName);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeVersion);
+            AssertTargetSpanExists(targetSpan, CommonTags.RuntimeArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSArchitecture);
+            AssertTargetSpanExists(targetSpan, CommonTags.OSPlatform);
             AssertTargetSpanEqual(targetSpan, CommonTags.OSVersion, CIVisibility.GetOperatingSystemVersion());
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -48,7 +48,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
-            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                               "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
 
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -48,8 +48,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(StackRegex, string.Empty);
             settings.AddRegexScrubber(ErrorMsgRegex, string.Empty);
-            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
-                               "ProcessStartTests.SubmitsTracesLinux" : "ProcessStartTests.SubmitsTraces";
+            var filename = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+                "ProcessStartTests.SubmitsTracesLinux" :
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                    "ProcessStartTests.SubmitsTracesOsx" :
+                    "ProcessStartTests.SubmitsTraces";
 
             await VerifyHelper.VerifySpans(spans, settings)
                               .UseFileName(filename)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void MetricsDisabled()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "0");
             using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
 
@@ -42,11 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void UdpSubmitsMetrics()
         {
-            if (EnvironmentTools.IsOsx())
-            {
-                throw new SkipException("Can't use UDS on OSX");
-            }
-
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             EnvironmentHelper.EnableDefaultTransport();
             RunTest();
         }
@@ -57,11 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "False")]
         public void UdsSubmitsMetrics()
         {
-            if (EnvironmentTools.IsOsx())
-            {
-                throw new SkipException("Can't use UDS on OSX");
-            }
-
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             EnvironmentHelper.EnableUnixDomainSockets();
             RunTest();
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -42,6 +42,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void UdpSubmitsMetrics()
         {
+            if (EnvironmentTools.IsOsx())
+            {
+                throw new SkipException("Can't use UDS on OSX");
+            }
+
             EnvironmentHelper.EnableDefaultTransport();
             RunTest();
         }
@@ -52,6 +57,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "False")]
         public void UdsSubmitsMetrics()
         {
+            if (EnvironmentTools.IsOsx())
+            {
+                throw new SkipException("Can't use UDS on OSX");
+            }
+
             EnvironmentHelper.EnableUnixDomainSockets();
             RunTest();
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -74,8 +74,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 settings.UseFileName($"{nameof(StackExchangeRedisTests)}.{calculatedVersion}");
                 settings.DisableRequireUniquePrefix();
                 settings.AddSimpleScrubber($" {TestPrefix}StackExchange.Redis.", " StackExchange.Redis.");
-                settings.AddSimpleScrubber($"out.host: {host}", "out.host: stackexchangeredis");
-                settings.AddSimpleScrubber($"out.port: {port}", "out.port: 6379");
+                if (EnvironmentTools.IsOsx())
+                {
+                    settings.AddSimpleScrubber("out.host: localhost", "out.host: stackexchangeredis");
+                    settings.AddSimpleScrubber("out.host: 127.0.0.1", "out.host: stackexchangeredis-replica");
+                    settings.AddSimpleScrubber("out.port: 6390", "out.port: 6379");
+                    settings.AddSimpleScrubber("out.port: 6391", "out.port: 6379");
+                    settings.AddSimpleScrubber("out.port: 6392", "out.port: 6379");
+                }
+                else
+                {
+                    settings.AddSimpleScrubber($"out.host: {host}", "out.host: stackexchangeredis");
+                    settings.AddSimpleScrubber($"out.port: {port}", "out.port: 6379");
+                }
 
                 await VerifyHelper.VerifySpans(
                     spans,

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -14,6 +15,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         [SkippableFact]
         public void ShouldNotInitialize()
         {
+            SkipOn.PlatformAndArchitecture(SkipOn.Platform.MacOs, SkipOn.Architecture.ARM64);
             var libraryInitializationResult = WafLibraryInvoker.Initialize("1.4.0");
             libraryInitializationResult.Success.Should().BeFalse();
             libraryInitializationResult.ExportErrorHappened.Should().BeTrue();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafCompatibilityTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         [SkippableFact]
         public void ShouldNotInitialize()
         {
-            SkipOn.PlatformAndArchitecture(SkipOn.Platform.MacOs, SkipOn.Architecture.ARM64);
+            SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.MacOs, SkipOn.ArchitectureValue.ARM64);
             var libraryInitializationResult = WafLibraryInvoker.Initialize("1.4.0");
             libraryInitializationResult.Success.Should().BeFalse();
             libraryInitializationResult.ExportErrorHappened.Should().BeTrue();

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
@@ -74,6 +74,11 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux);
         }
 
+        public static bool IsOsx()
+        {
+            return RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX);
+        }
+
         public static string GetPlatform()
         {
             return RuntimeInformation.ProcessArchitecture.ToString();

--- a/tracer/test/Datadog.Trace.TestHelpers/SkipOn.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SkipOn.cs
@@ -1,0 +1,74 @@
+// <copyright file="SkipOn.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace Datadog.Trace.TestHelpers;
+
+/// <summary>
+/// SkipOn helper
+/// </summary>
+public static class SkipOn
+{
+    /// <summary>
+    /// Platform enum
+    /// </summary>
+    public enum Platform
+    {
+        /// <summary>
+        /// Windows platform
+        /// </summary>
+        Windows,
+
+        /// <summary>
+        /// Linux platform
+        /// </summary>
+        Linux,
+
+        /// <summary>
+        /// MacOs platform
+        /// </summary>
+        MacOs
+    }
+
+    /// <summary>
+    /// Architecture enum
+    /// </summary>
+    public enum Architecture
+    {
+        /// <summary>
+        /// X86 arch
+        /// </summary>
+        X86,
+
+        /// <summary>
+        /// X64 arch
+        /// </summary>
+        X64,
+
+        /// <summary>
+        /// ARM64 arch
+        /// </summary>
+        ARM64
+    }
+
+    public static void PlatformAndArchitecture(Platform platform, Architecture architecture)
+    {
+#if NETCOREAPP
+        if ((platform == Platform.Linux && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+            (platform == Platform.Windows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ||
+            (platform == Platform.MacOs && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+        {
+            if ((architecture == Architecture.X64 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X64) ||
+                (architecture == Architecture.X86 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X86) ||
+                (architecture == Architecture.ARM64 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64))
+            {
+                throw new SkipException($"Platform {platform} with Architecture {architecture} is not supported by this test.");
+            }
+        }
+#endif
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/SkipOn.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SkipOn.cs
@@ -16,7 +16,7 @@ public static class SkipOn
     /// <summary>
     /// Platform enum
     /// </summary>
-    public enum Platform
+    public enum PlatformValue
     {
         /// <summary>
         /// Windows platform
@@ -37,7 +37,7 @@ public static class SkipOn
     /// <summary>
     /// Architecture enum
     /// </summary>
-    public enum Architecture
+    public enum ArchitectureValue
     {
         /// <summary>
         /// X86 arch
@@ -55,19 +55,31 @@ public static class SkipOn
         ARM64
     }
 
-    public static void PlatformAndArchitecture(Platform platform, Architecture architecture)
+    public static void PlatformAndArchitecture(PlatformValue platform, ArchitectureValue architecture)
     {
 #if NETCOREAPP
-        if ((platform == Platform.Linux && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
-            (platform == Platform.Windows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ||
-            (platform == Platform.MacOs && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+        if ((platform == PlatformValue.Linux && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+            (platform == PlatformValue.Windows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ||
+            (platform == PlatformValue.MacOs && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
         {
-            if ((architecture == Architecture.X64 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X64) ||
-                (architecture == Architecture.X86 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.X86) ||
-                (architecture == Architecture.ARM64 && RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64))
+            if ((architecture == ArchitectureValue.X64 && RuntimeInformation.OSArchitecture == Architecture.X64) ||
+                (architecture == ArchitectureValue.X86 && RuntimeInformation.OSArchitecture == Architecture.X86) ||
+                (architecture == ArchitectureValue.ARM64 && RuntimeInformation.OSArchitecture == Architecture.Arm64))
             {
-                throw new SkipException($"Platform {platform} with Architecture {architecture} is not supported by this test.");
+                throw new SkipException($"Platform '{platform}' with Architecture '{architecture}' is not supported by this test.");
             }
+        }
+#endif
+    }
+
+    public static void Platform(PlatformValue platform)
+    {
+#if NETCOREAPP
+        if ((platform == PlatformValue.Linux && RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) ||
+            (platform == PlatformValue.Windows && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ||
+            (platform == PlatformValue.MacOs && RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+        {
+            throw new SkipException($"Platform '{platform}' is not supported by this test.");
         }
 #endif
     }

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
@@ -151,7 +151,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
 
             exitCode.Should().Be(1);
             callbackInvoked.Should().BeFalse();
-            console.Output.Should().Contain("Error: Missing command");
+            console.Output.Should().Contain("Missing command");
         }
 
         private static MockTracerAgent.TcpUdpAgent GetMockTracerAgent()

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/AgentConnectivityCheckTests.cs
@@ -40,6 +40,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [MemberData(nameof(TestData))]
         public async Task DetectAgentUrl((string, string)[] environmentVariables)
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(enableProfiler: false, environmentVariables);
 
             using var console = ConsoleHelper.Redirect();
@@ -57,6 +58,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task DetectTransportHttp()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var agent = MockTracerAgent.Create(Output, TcpPortProvider.GetOpenPort());
 
             var url = $"http://127.0.0.1:{agent.Port}/";
@@ -79,6 +81,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task DetectTransportUds()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var tracesUdsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var url = $"unix://{tracesUdsPath}";
             var uri = new System.Uri(url);

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -49,6 +49,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task DetectRuntime()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(enableProfiler: false);
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 
@@ -71,6 +72,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task VersionConflict1X()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var environmentHelper = new EnvironmentHelper("VersionConflict.1x", typeof(TestHelper), Output);
             using var helper = await StartConsole(environmentHelper, enableProfiler: true);
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
@@ -92,6 +94,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task NoEnvironmentVariables()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(enableProfiler: false);
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 
@@ -126,6 +129,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task WrongEnvironmentVariables()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(
                 enableProfiler: false,
                 ("DD_PROFILING_ENABLED", "1"),
@@ -166,6 +170,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public async Task Working()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(enableProfiler: true);
             var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 
@@ -203,6 +208,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task WorkingWithContinuousProfiler()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             string archFolder;
 
             if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)
@@ -254,6 +260,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task WrongLdPreload()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(
                                    enableProfiler: true,
                                    ("DD_PROFILING_ENABLED", "1"),
@@ -279,6 +286,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [SkippableFact]
         public async Task LdPreloadNotFound()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             using var helper = await StartConsole(
                                    enableProfiler: true,
                                    ("DD_PROFILING_ENABLED", "1"),
@@ -307,6 +315,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [InlineData(null)]
         public async Task DetectContinousProfilerState(bool? enabled)
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var environmentVariables = enabled == null ? Array.Empty<(string, string)>()
                 : new[] { ("DD_PROFILING_ENABLED", enabled == true ? "1" : "0") };
 
@@ -340,6 +349,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public void GoodRegistry()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var registryService = MockRegistryService(Array.Empty<string>(), ProfilerPath);
 
             using var console = ConsoleHelper.Redirect();
@@ -359,6 +369,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [InlineData(false)]
         public void BadRegistryKey(bool wow64)
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var registryService = MockRegistryService(new[] { "cor_profiler" }, ProfilerPath, wow64);
 
             using var console = ConsoleHelper.Redirect();
@@ -376,6 +387,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public void ProfilerNotRegistered()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var registryService = MockRegistryService(Array.Empty<string>(), null);
 
             using var console = ConsoleHelper.Redirect();
@@ -391,6 +403,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public void ProfilerNotFoundRegistry()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var registryService = MockRegistryService(Array.Empty<string>(), "dummyPath/" + Path.GetFileName(ProfilerPath));
 
             using var console = ConsoleHelper.Redirect();
@@ -407,6 +420,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
         [Trait("RunOnWindows", "True")]
         public void WrongProfilerRegistry()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             var registryService = MockRegistryService(Array.Empty<string>(), "wrongProfiler.dll");
 
             using var console = ConsoleHelper.Redirect();

--- a/tracer/test/snapshots/ProcessStartTests.SubmitsTracesOsx.verified.txt
+++ b/tracer/test/snapshots/ProcessStartTests.SubmitsTracesOsx.verified.txt
@@ -1,0 +1,78 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: command_execution,
+    Resource: nonexisting1.exe,
+    Service: Samples.ProcessStart-command,
+    Type: system,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: command_execution,
+    Resource: nonexisting2.exe,
+    Service: Samples.ProcessStart-command,
+    Type: system,
+    Error: 1,
+    Tags: {
+      cmd.environment_variables:
+PATH=testPath
+,
+      env: integration_tests,
+      error.type: System.ComponentModel.Win32Exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: command_execution,
+    Resource: nonexisting5.exe,
+    Service: Samples.ProcessStart-command,
+    Type: system,
+    Error: 1,
+    Tags: {
+      cmd.environment_variables:
+PATH=testPath
+,
+      env: integration_tests,
+      error.type: System.ComponentModel.Win32Exception,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: internal,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -27,11 +27,20 @@
   <PropertyGroup>
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(MSBuildRuntimeType)' == 'Core'">
+      <PropertyGroup>
+        <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+        <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <IsOSX>false</IsOSX>
+        <IsLinux>false</IsLinux>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <Import Project=".\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -23,5 +23,15 @@
     <NoWarn>SYSLIB0014</NoWarn>
   </PropertyGroup>
 
+  <!-- OS Detection Properties -->
+  <PropertyGroup>
+    <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+  </PropertyGroup>
+
   <Import Project=".\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.Couchbase3/Samples.Couchbase3.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase3/Samples.Couchbase3.csproj
@@ -5,12 +5,16 @@
     <DefineConstants Condition="'$(ApiVersion)'&lt;'3.1.2'">$(DefineConstants);COUCHBASE_3_0</DefineConstants>
     <OutputType>Exe</OutputType>
     <RequiresDockerDependency>true</RequiresDockerDependency>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CouchbaseNetClient" Version="$(ApiVersion)" />
-    <PackageReference Condition="'$(ApiVersion)' == '3.0.0' OR ('$(ApiVersion)'&gt;='3.1.2' AND '$(ApiVersion)'&lt;='3.1.7')"
-                      Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0.0" />
+    <PackageReference Condition="'$(ApiVersion)' == '3.0.0' OR ('$(ApiVersion)'&gt;='3.1.2' AND '$(ApiVersion)'&lt;='3.1.7')" Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
@@ -17,6 +17,11 @@
     <GeneratedFolder>Generated_Code\$(TargetFramework)</GeneratedFolder>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(IsOSX)">
+    <!-- If OSX we force the x64 version (protoc is only available in x64) -->
+    <Protobuf_ToolsCpu>x64</Protobuf_ToolsCpu>
+  </PropertyGroup>
+  
   <ItemGroup>
     <Protobuf Include="Protos\greet.proto" GrpcServices="Both" OutputDir="$(GeneratedFolder)\$(ApiVersion)" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
@@ -17,7 +17,7 @@
     <GeneratedFolder>Generated_Code\$(TargetFramework)</GeneratedFolder>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(IsOSX)">
+  <PropertyGroup Condition="'$(IsOSX)' == 'true'">
     <!-- If OSX we force the x64 version (protoc is only available in x64) -->
     <Protobuf_ToolsCpu>x64</Protobuf_ToolsCpu>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
+++ b/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <!-- Needed because some of these projects target net20, and the .NET SDK doesn't include them by default   -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
 
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dependency-libs\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj">
@@ -106,4 +107,11 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
+  <Import Project="..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net461.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net461.targets'))" />
+  </Target>
 </Project>

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/packages.config
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.3" targetFramework="net461" developmentDependency="true" />
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net461" version="1.0.3" targetFramework="net461" developmentDependency="true" />
+</packages>


### PR DESCRIPTION
## Summary of changes

This PR improves the overall developer experience in the tracer library when using JetBrains Rider in macOS. 

**Changes:**
- New `Datadog.Trace.OSX` solution file, that has been cleaned removing all projects that cannot be built from OSX, like: ASPNET projects, legacy (.NET Framework) related stuff and VC++ projects.
- Adds the `BuildAndRunOsxIntegrationTests` nuke step.

## Reason for change

Currently is hard to work from the Rider IDE in a mac and use the debugger in certain test projects because it fails to build. Also the `BuildLinuxIntegrationTests` was failing when running from mac.

This PR fixes both issues.

**Now building the solution is just that simple:** 
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/69803/223772109-3122f7b4-fcc1-4be8-9875-3a5c4cd698c7.png">

<img width="573" alt="image" src="https://user-images.githubusercontent.com/69803/224083520-59d9c002-6007-46f3-9a6a-73cec8bcc29e.png">
