### PR TITLE
[Profiler] Build the root references for live objects

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -66,6 +66,7 @@ Configuration::Configuration()
     _isTimestampsAsLabelEnabled = GetEnvironmentValue(EnvironmentVariables::TimestampsAsLabelEnabled, false);
     _useBacktrace2 = GetEnvironmentValue(EnvironmentVariables::UseBacktrace2, true);
     _isAllocationRecorderEnabled = GetEnvironmentValue(EnvironmentVariables::AllocationRecorderEnabled, false);
+    _isRootReferenceEnabled = GetEnvironmentValue(EnvironmentVariables::RootReferenceEnabled, false);
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -254,6 +255,11 @@ bool Configuration::UseBacktrace2() const
 bool Configuration::IsAllocationRecorderEnabled() const
 {
     return _isAllocationRecorderEnabled;
+}
+
+bool Configuration::IsRootReferenceEnabled() const
+{
+    return _isRootReferenceEnabled;
 }
 
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -57,6 +57,7 @@ public:
     bool IsHeapProfilingEnabled() const override;
     bool UseBacktrace2() const override;
     bool IsAllocationRecorderEnabled() const override;
+    bool IsRootReferenceEnabled() const override;
 
 private:
     static tags ExtractUserTags();
@@ -125,6 +126,7 @@ private:
     int32_t _codeHotspotsThreadsThreshold;
     bool _useBacktrace2;
     bool _isAllocationRecorderEnabled;
+    bool _isRootReferenceEnabled;
 
     double _minimumCores;
     std::string _namedPipeName;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -29,6 +29,7 @@
 #include "MetricsRegistry.h"
 #include "ProxyMetric.h"
 #include "IAllocationsRecorder.h"
+#include "IRootReferenceManager.h"
 
 #include "shared/src/native-src/string.h"
 
@@ -233,6 +234,7 @@ private :
     std::unique_ptr<IRuntimeInfo> _pRuntimeInfo = nullptr;
     std::unique_ptr<IEnabledProfilers> _pEnabledProfilers = nullptr;
     std::unique_ptr<IAllocationsRecorder> _pAllocationsRecorder = nullptr;
+    std::unique_ptr<IRootReferenceManager> _pRootReferenceManager = nullptr;
 
     MetricsRegistry _metricsRegistry;
     std::shared_ptr<ProxyMetric> _managedThreadsMetric;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -246,6 +246,7 @@
     <ClInclude Include="IAllocationsRecorder.h" />
     <ClInclude Include="IBatchedSamplesProvider.h" />
     <ClInclude Include="IGarbageCollectionsListener.h" />
+    <ClInclude Include="IRootReferenceManager.h" />
     <ClInclude Include="ISampledAllocationsListener.h" />
     <ClInclude Include="LiveObjectInfo.h" />
     <ClInclude Include="LiveObjectsProvider.h" />
@@ -254,6 +255,7 @@
     <ClInclude Include="MetricsRegistry.h" />
     <ClInclude Include="ProxyMetric.h" />
     <ClInclude Include="RawGarbageCollectionSample.h" />
+    <ClInclude Include="RootReferenceManager.h" />
     <ClInclude Include="StopTheWorldGCProvider.h" />
     <ClInclude Include="GenericSampler.h" />
     <ClInclude Include="GroupSampler.h" />
@@ -359,6 +361,7 @@
     <ClCompile Include="MetricsRegistry.cpp" />
     <ClCompile Include="ProxyMetric.cpp" />
     <ClCompile Include="RawGarbageCollectionSample.cpp" />
+    <ClCompile Include="RootReferenceManager.cpp" />
     <ClCompile Include="StopTheWorldGCProvider.cpp" />
     <ClCompile Include="GenericSampler.cpp" />
     <ClCompile Include="HResultConverter.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -53,4 +53,5 @@ public:
     inline static const shared::WSTRING CoreMinimumOverride         = WStr("DD_PROFILING_MIN_CORES_THRESHOLD");
     inline static const shared::WSTRING UseBacktrace2               = WStr("DD_INTERNAL_USE_BACKTRACE2");
     inline static const shared::WSTRING AllocationRecorderEnabled   = WStr("DD_INTERNAL_PROFILING_ALLOCATION_RECORDER_ENABLED");
+    inline static const shared::WSTRING RootReferenceEnabled        = WStr("DD_INTERNAL_PROFILING_ROOT_REFERENCE_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -126,14 +126,14 @@ std::pair<std::string_view, std::string_view> FrameStore::GetManagedFrame(Functi
     // look into the cache first
     TypeDesc* pTypeDesc = nullptr;  // if already in the cache
     TypeDesc typeDesc; // if needed to be built from a given classId
-    bool typeInCache = GetCachedTypeDesc(classId, pTypeDesc);
+    bool isEncoded = true;
+    bool typeInCache = GetCachedTypeDesc(classId, pTypeDesc, isEncoded);
     // TODO: would it be interesting to have a (moduleId + mdTokenDef) -> TypeDesc cache for the non cached generic types?
 
     if (!typeInCache)
     {
         // try to get the type description
-        bool isEncoded = true;
-        if (!BuildTypeDesc(pMetadataImport.Get(), classId, moduleId, mdTokenType, typeDesc, isEncoded))
+        if (!BuildTypeDesc(pMetadataImport.Get(), classId, moduleId, mdTokenType, typeDesc, false, isEncoded))
         {
             // This should never happen but in case it happens, we cache the module/frame value.
             // It's safe to cache, because there is no reason that the next calls to
@@ -145,9 +145,9 @@ std::pair<std::string_view, std::string_view> FrameStore::GetManagedFrame(Functi
 
         if (classId != 0)
         {
-            std::lock_guard<std::mutex> lock(_typesLock);
+            std::lock_guard<std::mutex> lock(_encodedTypesLock);
             pTypeDesc = &typeDesc;
-            _types[classId] = typeDesc;
+            _encodedTypes[classId] = typeDesc;
         }
         else
         {
@@ -217,7 +217,7 @@ bool FrameStore::GetTypeName(ClassID classId, std::string_view& name)
         return false;
     }
 
-    if (!GetCachedTypeDesc(classId, pTypeDesc))
+    if (!GetCachedTypeDesc(classId, pTypeDesc, isEncoded))
     {
         return false;
     }
@@ -229,17 +229,31 @@ bool FrameStore::GetTypeName(ClassID classId, std::string_view& name)
 }
 
 
-bool FrameStore::GetCachedTypeDesc(ClassID classId, TypeDesc*& typeDesc)
+bool FrameStore::GetCachedTypeDesc(ClassID classId, TypeDesc*& typeDesc, bool isEncoded)
 {
     if (classId != 0)
     {
-        std::lock_guard<std::mutex> lock(_typesLock);
-
-        auto typeEntry = _types.find(classId);
-        if (typeEntry != _types.end())
+        if (isEncoded)
         {
-            typeDesc = &(_types.at(classId));
-            return true;
+            std::lock_guard<std::mutex> lock(_encodedTypesLock);
+
+            auto typeEntry = _encodedTypes.find(classId);
+            if (typeEntry != _encodedTypes.end())
+            {
+                typeDesc = &(_encodedTypes.at(classId));
+                return true;
+            }
+        }
+        else
+        {
+            std::lock_guard<std::mutex> lock(_typesLock);
+
+            auto typeEntry = _types.find(classId);
+            if (typeEntry != _types.end())
+            {
+                typeDesc = &(_types.at(classId));
+                return true;
+            }
         }
     }
 
@@ -250,16 +264,45 @@ bool FrameStore::GetTypeDesc(ClassID classId, TypeDesc*& pTypeDesc, bool isEncod
 {
     // get type related description (assembly, namespace and type name)
     // look into the cache first
-    bool typeInCache = GetCachedTypeDesc(classId, pTypeDesc);
+    bool typeInCache = GetCachedTypeDesc(classId, pTypeDesc, isEncoded);
     // TODO: would it be interesting to have a (moduleId + mdTokenDef) -> TypeDesc cache for the non cached generic types?
 
     if (!typeInCache)
     {
+        ClassID originalClassId = classId;
+
+        // deal with class[]
+        // read https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/icorprofilerinfo-isarrayclass-method for more details
+        bool isArray = false;
+        CorElementType baseElementType;
+        ClassID itemClassId;
+        ULONG rank = 0;
+        if (_pCorProfilerInfo->IsArrayClass(classId, &baseElementType, &itemClassId, &rank) == S_OK)
+        {
+            classId = itemClassId;
+            isArray = true;
+
+            // in case of matrices, it is needed to look for the last "good" item class ID
+            // because all others might be array of array of ...
+            for (size_t i = 0; i < rank; i++)
+            {
+                HRESULT hr = _pCorProfilerInfo->IsArrayClass(classId, &baseElementType, &itemClassId, &rank);
+                if ((hr == S_FALSE) || FAILED(hr))
+                {
+                    itemClassId = classId;
+
+                    break;
+                }
+
+                classId = itemClassId;
+            }
+        }
+
         ModuleID moduleId;
         mdTypeDef typeDefToken;
         INVOKE(_pCorProfilerInfo->GetClassIDInfo(classId, &moduleId, &typeDefToken));
 
-        // for some types, it is not possible to find the moduleId ???
+        // for some types, it is not possible to find the moduleId ???  --> could be arrays...
         if (moduleId == 0)
         {
             INVOKE(_pCorProfilerInfo->GetClassIDInfo2(classId, &moduleId, &typeDefToken, nullptr, 0, nullptr, nullptr));
@@ -270,17 +313,27 @@ bool FrameStore::GetTypeDesc(ClassID classId, TypeDesc*& pTypeDesc, bool isEncod
 
         // try to get the type description
         TypeDesc typeDesc;
-        if (!BuildTypeDesc(metadataImport.Get(), classId, moduleId, typeDefToken, typeDesc, isEncoded))
+        if (!BuildTypeDesc(metadataImport.Get(), classId, moduleId, typeDefToken, typeDesc, isArray, isEncoded))
         {
             return false;
         }
 
-        if (classId != 0)
+        if (originalClassId != 0)
         {
-            std::lock_guard<std::mutex> lock(_typesLock);
+            if (isEncoded)
+            {
+                std::lock_guard<std::mutex> lock(_encodedTypesLock);
 
-            _types[classId] = typeDesc;
-            pTypeDesc = &(_types.at(classId));
+                _encodedTypes[originalClassId] = typeDesc;
+                pTypeDesc = &(_encodedTypes.at(originalClassId));
+            }
+            else
+            {
+                std::lock_guard<std::mutex> lock(_typesLock);
+
+                _types[originalClassId] = typeDesc;
+                pTypeDesc = &(_types.at(originalClassId));
+            }
         }
         else
         {
@@ -300,6 +353,7 @@ bool FrameStore::BuildTypeDesc(
     ModuleID moduleId,
     mdTypeDef mdTokenType,
     TypeDesc& typeDesc,
+    bool isArray,
     bool isEncoded)
 {
     // 1. Get the assembly from the module
@@ -309,7 +363,7 @@ bool FrameStore::BuildTypeDesc(
     }
 
     // 2. Look for the type name including namespace (need to take into account nested types and generic types)
-    auto [ns, ct] = GetManagedTypeName(_pCorProfilerInfo, pMetadataImport, moduleId, classId, mdTokenType, isEncoded);
+    auto [ns, ct] = GetManagedTypeName(_pCorProfilerInfo, pMetadataImport, moduleId, classId, mdTokenType, isArray, isEncoded);
     typeDesc.Namespace = ns;
     typeDesc.Type = ct;
 
@@ -523,7 +577,7 @@ std::string FrameStore::GetTypeNameFromMetadata(IMetaDataImport2* pMetadata, mdT
     return shared::ToString(shared::WSTRING(pBuffer));
 }
 
-std::pair<std::string, std::string> FrameStore::GetTypeWithNamespace(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType)
+std::pair<std::string, std::string> FrameStore::GetTypeWithNamespace(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType, bool isArray)
 {
     mdTypeDef mdEnclosingType = 0;
     HRESULT hr = pMetadata->GetNestedClassProps(mdTokenType, &mdEnclosingType);
@@ -533,7 +587,7 @@ std::pair<std::string, std::string> FrameStore::GetTypeWithNamespace(IMetaDataIm
     std::string ns;
     if (isNested)
     {
-        std::tie(ns, enclosingType) = GetTypeWithNamespace(pMetadata, mdEnclosingType);
+        std::tie(ns, enclosingType) = GetTypeWithNamespace(pMetadata, mdEnclosingType, false);
     }
 
     // Get type name
@@ -543,6 +597,11 @@ std::pair<std::string, std::string> FrameStore::GetTypeWithNamespace(IMetaDataIm
     {
         // TODO: check if this is what we really want
         typeName = "?";
+    }
+
+    if (isArray)
+    {
+        typeName += "[]";
     }
 
     if (isNested)
@@ -671,7 +730,7 @@ std::string FrameStore::FormatGenericParameters(
                 }
                 else
                 {
-                    auto [ns, ct] = GetManagedTypeName(pInfo, pMetadata.Get(), argModuleId, argClassId, mdType, isEncoded);
+                    auto [ns, ct] = GetManagedTypeName(pInfo, pMetadata.Get(), argModuleId, argClassId, mdType, false, isEncoded);
                     if (isEncoded)
                     {
                         builder << "|ns:" << ns << " |ct:" << ct;
@@ -712,9 +771,10 @@ std::pair<std::string, std::string> FrameStore::GetManagedTypeName(
     ModuleID moduleId,
     ClassID classId,
     mdTypeDef mdTokenType,
+    bool isArray,
     bool isEncoded)
 {
-    auto [ns, typeName] = GetTypeWithNamespace(pMetadata, mdTokenType);
+    auto [ns, typeName] = GetTypeWithNamespace(pMetadata, mdTokenType, isArray);
     // we have everything we need if not a generic type
 
     // if classId == 0 (i.e. one generic parameter is a reference type), no way to get the exact generic parameters

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -59,6 +59,7 @@ private:
         mdTypeDef mdTokenType,
         TypeDesc& typeDesc,
         bool isArray,
+        const char* arraySuffix,
         bool isEncoded
         );
     bool GetTypeDesc(ClassID classId, TypeDesc*& typeDesc, bool isEncoded);
@@ -72,7 +73,12 @@ public:   // global helpers
 private:  // global helpers
     static void FixTrailingGeneric(WCHAR* name);
     static std::string GetTypeNameFromMetadata(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType);
-    static std::pair<std::string, std::string> GetTypeWithNamespace(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType, bool isArray);
+    static std::pair<std::string, std::string> GetTypeWithNamespace(
+        IMetaDataImport2* pMetadata,
+        mdTypeDef mdTokenType,
+        bool isArray,
+        const char* arraySuffix
+        );
     static std::string FormatGenericTypeParameters(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType, bool isEncoded);
     static std::string FormatGenericParameters(
         ICorProfilerInfo4* pInfo,
@@ -86,6 +92,7 @@ private:  // global helpers
         ClassID classId,
         mdTypeDef mdTokenType,
         bool isArray,
+        const char* arraySuffix,
         bool isEncoded
         );
     static std::pair<std::string, mdTypeDef> GetMethodNameFromMetadata(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -58,10 +58,11 @@ private:
         ModuleID moduleId,
         mdTypeDef mdTokenType,
         TypeDesc& typeDesc,
+        bool isArray,
         bool isEncoded
         );
     bool GetTypeDesc(ClassID classId, TypeDesc*& typeDesc, bool isEncoded);
-    bool GetCachedTypeDesc(ClassID classId, TypeDesc*& typeDesc);
+    bool GetCachedTypeDesc(ClassID classId, TypeDesc*& typeDesc, bool isEncoded);
     std::pair <std::string_view, std::string_view> GetManagedFrame(FunctionID functionId);
     std::pair <std::string_view, std::string_view> GetNativeFrame(uintptr_t instructionPointer);
 
@@ -71,7 +72,7 @@ public:   // global helpers
 private:  // global helpers
     static void FixTrailingGeneric(WCHAR* name);
     static std::string GetTypeNameFromMetadata(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType);
-    static std::pair<std::string, std::string> GetTypeWithNamespace(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType);
+    static std::pair<std::string, std::string> GetTypeWithNamespace(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType, bool isArray);
     static std::string FormatGenericTypeParameters(IMetaDataImport2* pMetadata, mdTypeDef mdTokenType, bool isEncoded);
     static std::string FormatGenericParameters(
         ICorProfilerInfo4* pInfo,
@@ -84,6 +85,7 @@ private:  // global helpers
         ModuleID moduleId,
         ClassID classId,
         mdTypeDef mdTokenType,
+        bool isArray,
         bool isEncoded
         );
     static std::pair<std::string, mdTypeDef> GetMethodNameFromMetadata(
@@ -97,11 +99,14 @@ private:
     ICorProfilerInfo4* _pCorProfilerInfo;
 
     std::mutex _methodsLock;
-    std::mutex _typesLock;
     std::mutex _nativeLock;
+
     // caches functions                      V-- module    V-- full frame
     std::unordered_map<FunctionID, std::pair<std::string, std::string>> _methods;
-    std::unordered_map<ClassID, TypeDesc> _types;
+    std::mutex _typesLock;
+    std::unordered_map<ClassID, TypeDesc> _types;  // for allocations/exceptions
+    std::mutex _encodedTypesLock;
+    std::unordered_map<ClassID, TypeDesc> _encodedTypes;  // for frames
     std::unordered_map<std::string, std::string> _framePerNativeModule;
 
     bool _resolveNativeFrames;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -54,4 +54,5 @@ public:
     virtual bool IsHeapProfilingEnabled() const = 0;
     virtual bool UseBacktrace2() const = 0;
     virtual bool IsAllocationRecorderEnabled() const = 0;
+    virtual bool IsRootReferenceEnabled() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IRootReferenceManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IRootReferenceManager.h
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+#pragma once
+
+// from dotnet coreclr includes
+#include "cor.h"
+#include "corprof.h"
+// end
+
+class IRootReferenceManager
+{
+public:
+    virtual HRESULT OnRootReferences2(
+        ULONG cRootRefs,
+        ObjectID rootRefIds[],
+        COR_PRF_GC_ROOT_KIND rootKinds[],
+        COR_PRF_GC_ROOT_FLAGS rootFlags[],
+        UINT_PTR rootIds[]) = 0;
+
+    virtual HRESULT OnObjectReferences(
+        ObjectID objectId,
+        ClassID classId,
+        ULONG cObjectRefs,
+        ObjectID objectRefIds[]) = 0;
+
+    virtual void OnGarbageCollectionFinished() = 0;
+
+public:
+    virtual void DumpReferences(ObjectID objectId) = 0;
+
+public:
+    virtual ~IRootReferenceManager() = default;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -11,6 +11,7 @@
 #include "AllocationsProvider.h"
 #include "IBatchedSamplesProvider.h"
 #include "IGarbageCollectionsListener.h"
+#include "IRootReferenceManager.h"
 #include "ISampledAllocationsListener.h"
 #include "IService.h"
 #include "LiveObjectInfo.h"
@@ -22,7 +23,6 @@ class IThreadsCpuManager;
 class IAppDomainStore;
 class IRuntimeIdStore;
 class IConfiguration;
-class ISampledAllocationsListener;
 
 class LiveObjectsProvider : public IService,
                             public IBatchedSamplesProvider,
@@ -42,7 +42,8 @@ public:
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
         IConfiguration* pConfiguration,
-        MetricsRegistry& metricsRegistry);
+        MetricsRegistry& metricsRegistry,
+        IRootReferenceManager* pRootReferenceManager);
 
 public:
     // Inherited via IService
@@ -76,6 +77,7 @@ private:
     ObjectHandleID CreateWeakHandle(uintptr_t address) const;
     void CloseWeakHandle(ObjectHandleID handle) const;
     bool IsAlive(ObjectHandleID handle) const;
+    ObjectID GetObjectId(ObjectHandleID handle) const;
 
 private:
     uint32_t _valueOffset = 0;
@@ -84,8 +86,9 @@ private:
     IAppDomainStore* _pAppDomainStore = nullptr;
     IRuntimeIdStore* _pRuntimeIdStore = nullptr;
     IThreadsCpuManager* _pThreadsCpuManager = nullptr;
-    std::unique_ptr<AllocationsProvider> _pAllocationsProvider;
+    IRootReferenceManager* _pRootReferenceManager = nullptr;
 
+    std::unique_ptr<AllocationsProvider> _pAllocationsProvider;
     bool _isTimestampsAsLabelEnabled = false;
 
     std::mutex _liveObjectsLock;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RootReferenceManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RootReferenceManager.cpp
@@ -1,0 +1,361 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include <iostream>
+#include <string_view>
+
+#include "RootReferenceManager.h"
+
+
+ObjectNode::ObjectNode(ObjectID objectId)
+{
+    instance = objectId;
+}
+
+
+RootReferenceManager::RootReferenceManager(ICorProfilerInfo5* pCorProfilerInfo, IFrameStore* frameStore)
+    :
+    _objectsCount {0},
+    _pCorProfilerInfo {pCorProfilerInfo},
+    _pFrameStore {frameStore}
+{
+}
+
+
+// get the list of roots with their kind/flags
+HRESULT RootReferenceManager::OnRootReferences2(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[])
+{
+    uint16_t stackRoots = 0;
+    uint16_t finalizerRoots = 0;
+    uint16_t handleRoots = 0;
+    uint16_t otherRoots = 0;
+
+    std::lock_guard<std::mutex> lock(_lock);
+
+    for (ULONG current = 0; current < cRootRefs; current++)
+    {
+        ObjectID objectId = rootRefIds[current];
+        if (objectId == 0)
+        {
+            continue;
+        }
+
+        ObjectRoot root;
+        root.instance = objectId;
+        root.flags = rootFlags[current];
+        root.kind = rootKinds[current];
+        _roots.push_back(root);
+
+
+        if (rootKinds[current] == COR_PRF_GC_ROOT_STACK)
+        {
+            stackRoots++;
+        }
+        else
+        if (rootKinds[current] == COR_PRF_GC_ROOT_FINALIZER)
+        {
+            finalizerRoots++;
+        }
+        else
+        if (rootKinds[current] == COR_PRF_GC_ROOT_HANDLE)
+        {
+            handleRoots++;
+        }
+        else
+        {
+            otherRoots++;
+        }
+    }
+
+    std::cout << "OnRootReferences2: " << stackRoots + finalizerRoots + handleRoots + otherRoots << "/" << cRootRefs << " roots." << std::endl;
+    std::cout << "            stack:" << stackRoots << std::endl;
+    std::cout << "        finalizer:" << finalizerRoots << std::endl;
+    std::cout << "           handle:" << handleRoots << std::endl;
+    std::cout << "            other:" << otherRoots << std::endl;
+    std::cout << "------------------" << std::endl;
+
+    return S_OK;
+}
+
+bool Contains(const std::vector<ObjectNode*>& nodes, ObjectID instance)
+{
+    for (auto& node : nodes)
+    {
+        if (node->instance == instance)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool FindRoot(const std::vector<ObjectRoot>& roots, ObjectID instance, COR_PRF_GC_ROOT_KIND& kind, COR_PRF_GC_ROOT_FLAGS& flags)
+{
+    for (auto& root : roots)
+    {
+        if (root.instance == instance)
+        {
+            kind = root.kind;
+            flags = root.flags;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+HRESULT RootReferenceManager::OnObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[])
+{
+    std::lock_guard<std::mutex> lock(_lock);
+
+    _objectsCount++;
+
+    // check if the given object was already in the heap
+    std::shared_ptr<ObjectNode> pParentNode = nullptr;
+    auto parentSlot = _heap.find(objectId);
+    if (parentSlot != _heap.end())
+    {
+        pParentNode = parentSlot->second;
+    }
+    else
+    {
+        pParentNode = std::make_shared<ObjectNode>(objectId);
+        _heap.insert_or_assign(objectId, pParentNode);
+    }
+
+    // add objectId as parent of all objectRefIds objects
+    for (size_t i = 0; i < cObjectRefs; i++)
+    {
+        std::shared_ptr<ObjectNode> pChildNode = nullptr;
+        auto childObjectId = objectRefIds[i];
+        auto childSlot = _heap.find(childObjectId);
+        if (childSlot != _heap.end())
+        {
+            pChildNode = childSlot->second;
+        }
+        else
+        {
+            pChildNode = std::make_shared<ObjectNode>(childObjectId);
+            _heap.insert_or_assign(childObjectId, pChildNode);
+        }
+
+        if (!Contains(pChildNode->rootRefs, objectId))
+        {
+            pChildNode->rootRefs.push_back(pParentNode.get());
+        }
+    }
+
+    return S_OK;
+}
+
+void DumpFlags(COR_PRF_GC_ROOT_FLAGS flags)
+{
+    if (flags == 0)
+    {
+        std::cout << "0";
+        return;
+    }
+
+    if ((flags & COR_PRF_GC_ROOT_PINNING) == COR_PRF_GC_ROOT_PINNING)
+    {
+        std::cout << "P";
+    }
+    if ((flags & COR_PRF_GC_ROOT_WEAKREF) == COR_PRF_GC_ROOT_WEAKREF)
+    {
+        std::cout << "W";
+    }
+    if ((flags & COR_PRF_GC_ROOT_INTERIOR) == COR_PRF_GC_ROOT_INTERIOR)
+    {
+        std::cout << "I";
+    }
+    if ((flags & COR_PRF_GC_ROOT_REFCOUNTED) == COR_PRF_GC_ROOT_REFCOUNTED)
+    {
+        std::cout << "R";
+    }
+}
+
+void DumpKind(COR_PRF_GC_ROOT_KIND kind)
+{
+    if (kind == COR_PRF_GC_ROOT_STACK)
+    {
+        std::cout << "S";
+    }
+    else if (kind == COR_PRF_GC_ROOT_FINALIZER)
+    {
+        std::cout << "F";
+    }
+    else if (kind == COR_PRF_GC_ROOT_HANDLE)
+    {
+        std::cout << "H";
+    }
+    else
+    {
+        std::cout << kind;
+    }
+}
+
+void RootReferenceManager::DumpRoot(ObjectID objectId, COR_PRF_GC_ROOT_KIND kind, COR_PRF_GC_ROOT_FLAGS flags)
+{
+    std::cout << "   ";
+    DumpKind(kind);
+    std::cout << "-";
+    DumpFlags(flags);
+
+    ClassID classId;
+    if (FAILED(_pCorProfilerInfo->GetClassFromObject(objectId, &classId)))
+    {
+        std::cout << " " << std::hex << objectId << std::dec << std::endl;
+        return;
+    }
+
+    std::string_view name;
+    if (_pFrameStore->GetTypeName(classId, name))
+    {
+        std::cout << " " << name << std::endl;
+    }
+    else
+    {
+        std::cout << " No type name " << std::hex << objectId << std::dec << std::endl;
+    }
+}
+
+void DumpObjectType(ObjectID objectId, ICorProfilerInfo5* pCorProfilerInfo, IFrameStore* pFrameStore)
+{
+    ClassID classId;
+    if (FAILED(pCorProfilerInfo->GetClassFromObject(objectId, &classId)))
+    {
+        std::cout << "??" << std::dec;
+        return;
+    }
+
+    std::string_view name;
+    if (pFrameStore->GetTypeName(classId, name))
+    {
+        std::cout << name;
+    }
+    else
+    {
+        std::cout << "???" << std::dec;
+    }
+}
+
+void RootReferenceManager::OnGarbageCollectionFinished()
+{
+    std::lock_guard<std::mutex> lock(_lock);
+
+    std::cout << "OnGarbageCollectionFinished: " << _objectsCount << " objects in the heap." << std::endl
+              << std::endl;
+
+    //for (auto& root: _roots)
+    //{
+    //    DumpRoot(root.instance, root.kind, root.flags);
+    //}
+
+    _objectsCount = 0;
+    _heap.clear();
+    _roots.clear();
+}
+
+void RootReferenceManager::DumpReferences(ObjectID objectId)
+{
+    std::lock_guard<std::mutex> lock(_lock);
+
+    auto slot = _heap.find(objectId);
+    if (slot == _heap.end())
+    {
+        std::cout << std::hex << objectId << std::dec;
+        DumpObjectType(objectId, _pCorProfilerInfo, _pFrameStore);
+        std::cout << std::endl;
+        return;
+    }
+
+    auto node = slot->second.get();
+
+    std::vector<ObjectID> referenceStack;
+    referenceStack.reserve(64);
+    DumpNode(node, referenceStack);
+    std::cout << "=====================================" << std::endl << std::endl;
+}
+
+void ShiftCout(uint16_t depth)
+{
+    for (size_t i = 0; i < depth; i++)
+    {
+        std::cout << "   ";
+    }
+}
+
+bool Find(std::vector<ObjectID>& referenceStack, ObjectID reference)
+{
+    for (auto objectId : referenceStack)
+    {
+        if (objectId == reference)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool RootReferenceManager::DumpNode(ObjectNode* node, std::vector<ObjectID>& referenceStack)
+{
+    // end of recursion: the node is a root
+    if (node->rootRefs.size() == 0)
+    {
+        //  dump the root
+        std::cout << std::endl;
+        std::cout << std::hex << node->instance << std::dec;
+        COR_PRF_GC_ROOT_KIND kind;
+        COR_PRF_GC_ROOT_FLAGS flags;
+        if (FindRoot(_roots, node->instance, kind, flags))
+        {
+            std::cout << " | ";
+            DumpKind(kind);
+            std::cout << " - ";
+            DumpFlags(flags);
+        }
+        else
+        {
+            std::cout << " | ?";
+        }
+        std::cout << " = ";
+
+        DumpObjectType(node->instance, _pCorProfilerInfo, _pFrameStore);
+        std::cout << std::endl;
+
+        // dump the references from the root
+        for (int16_t i = referenceStack.size()-1; i >= 0; i--)
+        {
+            ObjectID reference = referenceStack[i];
+            std::cout << " --> ";
+            std::cout << std::hex << reference << std::dec;
+            std::cout << " = ";
+            DumpObjectType(reference, _pCorProfilerInfo, _pFrameStore);
+            std::cout << std::endl;
+        }
+
+        return true;
+    }
+
+    // detect cycles
+    if (Find(referenceStack, node->instance))
+    {
+        return false;
+    }
+
+    // go up into the reference chain
+    referenceStack.push_back(node->instance);
+    for (auto& parentNode : node->rootRefs)
+    {
+        if (DumpNode(parentNode, referenceStack))
+        {
+            return true;
+        }
+    }
+    referenceStack.pop_back();
+
+    return false;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RootReferenceManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RootReferenceManager.h
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+// from dotnet coreclr includes
+#include "cor.h"
+#include "corprof.h"
+// end
+
+#include "FrameStore.h"
+#include "IRootReferenceManager.h"
+
+
+// each ObjectNode represents an object in the heap
+struct ObjectNode
+{
+public:
+    ObjectNode(ObjectID objectId);
+
+public:
+    ObjectID instance;
+    std::vector<ObjectNode*> rootRefs;
+
+    // not sure it is needed to keep track of the object type
+    // --> too expensive compared to call ICorProfilerInfo::GetClassID
+    // ClassID type;
+};
+
+// need to keep track of roots and wait for the end of the GC
+// to get their type (especially arrays)
+struct ObjectRoot
+{
+public:
+    ObjectID instance;
+    COR_PRF_GC_ROOT_KIND kind;
+    COR_PRF_GC_ROOT_FLAGS flags;
+};
+
+class RootReferenceManager : public IRootReferenceManager
+{
+public:
+    RootReferenceManager(ICorProfilerInfo5* pCorProfilerInfo, IFrameStore* frameStore);
+
+    // Inherited via IRootReferenceManager
+    virtual HRESULT OnRootReferences2(ULONG cRootRefs, ObjectID rootRefIds[], COR_PRF_GC_ROOT_KIND rootKinds[], COR_PRF_GC_ROOT_FLAGS rootFlags[], UINT_PTR rootIds[]) override;
+    virtual HRESULT OnObjectReferences(ObjectID objectId, ClassID classId, ULONG cObjectRefs, ObjectID objectRefIds[]) override;
+    virtual void OnGarbageCollectionFinished() override;
+    virtual void DumpReferences(ObjectID objectId) override;
+
+private:
+    void DumpRoot(ObjectID objectId, COR_PRF_GC_ROOT_KIND kind, COR_PRF_GC_ROOT_FLAGS flag);
+    bool DumpNode(ObjectNode* node, std::vector<ObjectID>& referenceStack);
+
+private:
+    ICorProfilerInfo5* _pCorProfilerInfo;
+    IFrameStore* _pFrameStore;
+    std::unordered_map<ObjectID, std::shared_ptr<ObjectNode>> _heap;
+    std::vector<ObjectRoot> _roots;
+    uint64_t _objectsCount;
+    std::mutex _lock;
+};

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -59,6 +59,7 @@ public:
     MOCK_METHOD(bool, IsHeapProfilingEnabled, (), (const override));
     MOCK_METHOD(bool, UseBacktrace2, (), (const override));
     MOCK_METHOD(bool, IsAllocationRecorderEnabled, (), (const override));
+    MOCK_METHOD(bool, IsRootReferenceEnabled, (), (const override));
 };
 
 class MockExporter : public IExporter


### PR DESCRIPTION
## Summary of changes
Build the root references for live objects after each GC

## Reason for change
Help figure out the cause of memory leak

## Implementation details
Rely on ICorProfilerCallback ObjectReferences and RootReferences2 to rebuild the live objects dependencies graph
Note that concurrent GCs are disabled if this feature is enabled

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->
