### PR TITLE
[Tracer] Protect against null Activity TraceId

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -83,10 +83,14 @@ namespace Datadog.Trace.Activity.Handlers
 
                 // We convert the activity traceId and spanId to use it in the
                 // Datadog span creation.
-                traceId ??= Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
-                spanId = Convert.ToUInt64(w3cActivity.SpanId, 16);
-                rawTraceId = w3cActivity.TraceId;
-                rawSpanId = w3cActivity.SpanId;
+                if (w3cActivity.TraceId is not null)
+                {
+                    // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
+                    traceId ??= Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
+                    spanId = Convert.ToUInt64(w3cActivity.SpanId, 16);
+                    rawTraceId = w3cActivity.TraceId;
+                    rawSpanId = w3cActivity.SpanId;
+                }
             }
 
             try

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -83,11 +83,11 @@ namespace Datadog.Trace.Activity.Handlers
 
                 // We convert the activity traceId and spanId to use it in the
                 // Datadog span creation.
-                if (w3cActivity.TraceId is { } w3cTraceId)
+                if (w3cActivity.TraceId is { } w3cTraceId && w3cActivity.SpanId is { } w3cSpanId)
                 {
                     // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
                     traceId ??= Convert.ToUInt64(w3cTraceId.Substring(16), 16);
-                    spanId = Convert.ToUInt64(w3cActivity.SpanId, 16);
+                    spanId = Convert.ToUInt64(w3cSpanId, 16);
                     rawTraceId = w3cTraceId;
                     rawSpanId = w3cActivity.SpanId;
                 }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -83,12 +83,12 @@ namespace Datadog.Trace.Activity.Handlers
 
                 // We convert the activity traceId and spanId to use it in the
                 // Datadog span creation.
-                if (w3cActivity.TraceId is not null)
+                if (w3cActivity.TraceId is { } w3cTraceId)
                 {
                     // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
-                    traceId ??= Convert.ToUInt64(w3cActivity.TraceId.Substring(16), 16);
+                    traceId ??= Convert.ToUInt64(w3cTraceId.Substring(16), 16);
                     spanId = Convert.ToUInt64(w3cActivity.SpanId, 16);
-                    rawTraceId = w3cActivity.TraceId;
+                    rawTraceId = w3cTraceId;
                     rawSpanId = w3cActivity.SpanId;
                 }
             }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -386,9 +386,13 @@ namespace Datadog.Trace
                     var activity = Activity.ActivityListener.GetCurrentActivity();
                     if (activity is Activity.DuckTypes.IW3CActivity w3CActivity)
                     {
-                        // If there's an existing activity we use the same traceId (converted).
-                        rawTraceId = w3CActivity.TraceId;
-                        traceId = Convert.ToUInt64(w3CActivity.TraceId.Substring(16), 16);
+                        // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
+                        if (w3CActivity.TraceId is not null)
+                        {
+                            // If there's an existing activity we use the same traceId (converted).
+                            rawTraceId = w3CActivity.TraceId;
+                            traceId = Convert.ToUInt64(w3CActivity.TraceId.Substring(16), 16);
+                        }
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -387,11 +387,11 @@ namespace Datadog.Trace
                     if (activity is Activity.DuckTypes.IW3CActivity w3CActivity)
                     {
                         // If the Activity has an ActivityIdFormat.Hierarchical instead of W3C it's TraceId & SpanId will be null
-                        if (w3CActivity.TraceId is not null)
+                        if (w3CActivity.TraceId is { } w3cTraceId)
                         {
                             // If there's an existing activity we use the same traceId (converted).
-                            rawTraceId = w3CActivity.TraceId;
-                            traceId = Convert.ToUInt64(w3CActivity.TraceId.Substring(16), 16);
+                            rawTraceId = w3cTraceId;
+                            traceId = Convert.ToUInt64(w3cTraceId.Substring(16), 16);
                         }
                     }
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent))
             {
-                const int expectedSpanCount = 23;
+                const int expectedSpanCount = 25;
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
                 using var s = new AssertionScope();

--- a/tracer/test/snapshots/NetActivitySdkTests.verified.txt
+++ b/tracer/test/snapshots/NetActivitySdkTests.verified.txt
@@ -259,6 +259,46 @@
   {
     TraceId: Id_16,
     SpanId: Id_17,
+    Name: opentelemetry.internal,
+    Resource: Parent-NonW3CId,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_16,
+    SpanId: Id_18,
+    Name: opentelemetry.internal,
+    Resource: Child-NonW3CId,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_17,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.status_code: STATUS_CODE_UNSET,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_20,
     Name: Samples.NetActivitySdk.internal,
     Resource: RootSpan,
     Service: Samples.NetActivitySdk,
@@ -283,13 +323,13 @@
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_18,
+    TraceId: Id_19,
+    SpanId: Id_21,
     Name: Saying hello!,
     Resource: AddTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_17,
+    ParentId: Id_20,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -315,13 +355,13 @@
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_19,
+    TraceId: Id_19,
+    SpanId: Id_22,
     Name: Samples.NetActivitySdk.internal,
     Resource: SetTagsActivity,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_17,
+    ParentId: Id_20,
     Tags: {
       attribute-bool: true,
       attribute-boolArray: [false,true,false],
@@ -348,46 +388,10 @@
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_20,
+    TraceId: Id_19,
+    SpanId: Id_23,
     Name: Samples.NetActivitySdk.internal,
     Resource: NameEvent,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_17,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_16,
-    SpanId: Id_21,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: AddBaggage,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_17,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_16,
-    SpanId: Id_22,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: NameDateEvent,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_20,
@@ -402,31 +406,13 @@
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_23,
-    Name: Samples.NetActivitySdk.internal,
-    Resource: SetBaggage,
-    Service: Samples.NetActivitySdk,
-    Type: custom,
-    ParentId: Id_21,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.NetActivitySdk,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_4,
-      span.kind: internal,
-      version: 1.0.0
-    }
-  },
-  {
-    TraceId: Id_16,
+    TraceId: Id_19,
     SpanId: Id_24,
     Name: Samples.NetActivitySdk.internal,
-    Resource: EmptyTagsEvent,
+    Resource: AddBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_22,
+    ParentId: Id_20,
     Tags: {
       env: integration_tests,
       language: dotnet,
@@ -438,10 +424,28 @@
     }
   },
   {
-    TraceId: Id_16,
+    TraceId: Id_19,
     SpanId: Id_25,
     Name: Samples.NetActivitySdk.internal,
-    Resource: TagsEvent,
+    Resource: NameDateEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_23,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_26,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: SetBaggage,
     Service: Samples.NetActivitySdk,
     Type: custom,
     ParentId: Id_24,
@@ -456,13 +460,49 @@
     }
   },
   {
-    TraceId: Id_16,
-    SpanId: Id_26,
+    TraceId: Id_19,
+    SpanId: Id_27,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: EmptyTagsEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_25,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_28,
+    Name: Samples.NetActivitySdk.internal,
+    Resource: TagsEvent,
+    Service: Samples.NetActivitySdk,
+    Type: custom,
+    ParentId: Id_27,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      otel.library.name: Samples.NetActivitySdk,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      span.kind: internal,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_29,
     Name: Samples.NetActivitySdk.internal,
     Resource: MultipleEvents,
     Service: Samples.NetActivitySdk,
     Type: custom,
-    ParentId: Id_25,
+    ParentId: Id_28,
     Tags: {
       env: integration_tests,
       language: dotnet,

--- a/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Program.cs
@@ -34,6 +34,7 @@ public static class Program
         // needs to be outside of the above root span as we don't want a parent here
         RunActivityConstructors(); // 4 spans (total 14)
         RunActivityUpdate(); //  9 spans (total 23)
+        RunNonW3CId(); // 2 spans (total 25)
         await Task.Delay(1000);
     }
 
@@ -140,6 +141,20 @@ public static class Program
         setBaggageSpan?.AddBaggage("string-value", "string-1");
         setBaggageSpan?.SetBaggage("string-value", "string-2"); // change existing
         setBaggageSpan?.SetBaggage("new-string", "new-string"); // create new
+    }
+
+    private static void RunNonW3CId()
+    {
+        using (var parent = new Activity("Parent-NonW3CId"))
+        {
+            parent.SetIdFormat(ActivityIdFormat.Hierarchical);
+            parent.Start();
+            using (var child = new Activity("Child-NonW3CId"))
+            {
+                child.SetIdFormat(ActivityIdFormat.Hierarchical);
+                child.Start();
+            }
+        }
     }
 
     private static void RunActivityUpdate()


### PR DESCRIPTION
## Summary of changes

Adds protections against the `Activity.TraceId` being `null` when it isn't in a W3C ID format.

## Reason for change

Since we ducktype the `Activity` object we might get a null value for its `TraceId`/`SpanId` when it is not in the W3C format (e.g. in its Hierarchical format). We weren't handling this and throwing a NRE in `Tracer.CreateSpanContext` and `DefaultActivityHandler.ActivityStarted`.

## Implementation details

Added null check to make sure that the `Activity.TraceId` isn't null before we use it.
Checked for other usages of `Activity.TraceId` and `Activity.SpanId` and didn't see any more.

## Test coverage

 - Added a new test to the `NetActivitySdkTests` that uses the Hierarchical format and it threw.
 - Added the fixes to make it not throw and updated the snapshots.

## Other details

Fixes #3857

