### PR TITLE
[Tracer] Implement all system-tests W3C tracecontext behaviors

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -278,7 +278,7 @@ namespace Datadog.Trace.Propagators
             }
             else
             {
-                sampled = false;
+                return false;
             }
 #else
             rawTraceId = header.Substring(startIndex: 3, length: 32);
@@ -302,7 +302,7 @@ namespace Datadog.Trace.Propagators
             }
             else
             {
-                sampled = false;
+                return false;
             }
 #endif
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -53,7 +53,8 @@ namespace Datadog.Trace.Propagators
         {
             new(',', '_'),
             new(';', '_'),
-            new('=', '_'),
+            new('~', '_'),
+            new('=', '~'), // note '=' is encoded as '~' when injecting
         };
 
         private static readonly KeyValuePair<char, char>[] InjectPropagatedTagKeyReplacements =

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData(-5, null, null, null, "dd=s:-5")]
         // origin only
         [InlineData(null, "abc", null, null, "dd=o:abc")]
+        [InlineData(null, "synthetics~;,=web", null, null, "dd=o:synthetics___~web")]
         // propagated tags only
         [InlineData(null, null, "_dd.p.a=1", null, "dd=t.a:1")]
         [InlineData(null, null, "_dd.p.a=1,_dd.p.b=2", null, "dd=t.a:1;t.b:2")]

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -183,6 +183,8 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData("xz-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad version value (xz)
         [InlineData("00-000000000000000000000000075bcd1z-000000003ade68b1-00")]      // bad trace id value ("z" in hex)
         [InlineData("00-000000000000000000000000075bcd15-000000003ade68bx-00")]      // bad parent id value ("x" in hex)
+        [InlineData("00-12345678901234567890123456789012-1234567890123456-.0")]      // bad value in the first trace flags character
+        [InlineData("00-12345678901234567890123456789012-1234567890123456-0.")]      // bad value in the second trace flags character
         [InlineData("00-000000000000000000000000075bcd15-000000003ade68b1-00-1234")] // do NOT allow more data after trace-flags if the version is "00"
         public void TryParseTraceParent_Invalid(string header)
         {

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -72,10 +72,10 @@ namespace Datadog.Trace.Tests.Propagators
             var propagatedTags = TagPropagation.ParseHeader(tags, 100);
 
             var traceContext = new TraceContext(tracer: null, propagatedTags)
-                               {
-                                   Origin = origin,
-                                   AdditionalW3CTraceState = additionalState
-                               };
+            {
+                Origin = origin,
+                AdditionalW3CTraceState = additionalState
+            };
 
             traceContext.SetSamplingPriority(samplingPriority, mechanism: null, notifyDistributedTracer: false);
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: 1, spanId: 2);
@@ -93,10 +93,10 @@ namespace Datadog.Trace.Tests.Propagators
             var span = new Span(spanContext, DateTimeOffset.Now);
 
             var user = new UserDetails("12345")
-                       {
-                           PropagateId = true,
-                           Email = "user@example.com"
-                       };
+            {
+                PropagateId = true,
+                Email = "user@example.com"
+            };
 
             // use public APIs to add propagated tags
             span.SetTraceSamplingPriority(SamplingPriority.UserKeep); // adds "_dd.p.dm"
@@ -112,10 +112,10 @@ namespace Datadog.Trace.Tests.Propagators
         public void Inject_IHeadersCollection()
         {
             var traceContext = new TraceContext(tracer: null, tags: null)
-                               {
-                                   Origin = "origin",
-                                   AdditionalW3CTraceState = "key1=value1"
-                               };
+            {
+                Origin = "origin",
+                AdditionalW3CTraceState = "key1=value1"
+            };
 
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, mechanism: null, notifyDistributedTracer: false);
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: 123456789, spanId: 987654321, rawTraceId: null, rawSpanId: null);
@@ -132,10 +132,10 @@ namespace Datadog.Trace.Tests.Propagators
         public void Inject_CarrierAndDelegate()
         {
             var traceContext = new TraceContext(tracer: null, tags: null)
-                               {
-                                   Origin = "origin",
-                                   AdditionalW3CTraceState = "key1=value1"
-                               };
+            {
+                Origin = "origin",
+                AdditionalW3CTraceState = "key1=value1"
+            };
 
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, mechanism: null, notifyDistributedTracer: false);
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: 123456789, spanId: 987654321, rawTraceId: null, rawSpanId: null);
@@ -538,6 +538,222 @@ namespace Datadog.Trace.Tests.Propagators
                                      .ToString() // NETCOREAPP returns ReadOnlySpan<char>
                                      .Should()
                                      .Be(expected);
+        }
+
+        [Theory]
+        [InlineData(SamplingPriorityValues.AutoKeep)]
+        [InlineData(SamplingPriorityValues.UserKeep)]
+        [InlineData(3)]
+        public void Extract_MatchingSampled1_UsesTracestateSamplingPriority(int samplingPriority)
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-01" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { $"dd=s:{samplingPriority}" });
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = samplingPriority,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
+        }
+
+        [Theory]
+        [InlineData(SamplingPriorityValues.AutoReject)]
+        [InlineData(SamplingPriorityValues.UserReject)]
+        [InlineData(-2)]
+        public void Extract_MatchingSampled0_UsesTracestateSamplingPriority(int samplingPriority)
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-00" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { $"dd=s:{samplingPriority}" });
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = samplingPriority,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
+        }
+
+        [Fact]
+        public void Extract_MismatchingSampled1_UsesSamplingPriorityOf1()
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-01" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { "dd=s:-1" });
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = 1,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
+        }
+
+        [Fact]
+        public void Extract_MismatchingSampled0_UsesSamplingPriorityOf0()
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-00" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(new[] { "dd=s:1" });
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = 0,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
+        }
+
+        [Fact]
+        public void Extract_Sampled1_MissingSamplingPriority_UsesSamplingPriorityOf1()
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-01" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(Array.Empty<string>());
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = 1,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
+        }
+
+        [Fact]
+        public void Extract_Sampled0_MissingSamplingPriority_UsesSamplingPriorityOf0()
+        {
+            var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
+
+            headers.Setup(h => h.GetValues("traceparent"))
+                   .Returns(new[] { "00-000000000000000000000000075bcd15-000000003ade68b1-00" });
+
+            headers.Setup(h => h.GetValues("tracestate"))
+                   .Returns(Array.Empty<string>());
+
+            var result = W3CPropagator.Extract(headers.Object);
+
+            headers.Verify(h => h.GetValues("traceparent"), Times.Once());
+            headers.Verify(h => h.GetValues("tracestate"), Times.Once());
+            headers.VerifyNoOtherCalls();
+
+            result.Should()
+                  .NotBeNull()
+                  .And
+                  .BeEquivalentTo(
+                       new SpanContextMock
+                       {
+                           TraceId = 123456789,
+                           SpanId = 987654321,
+                           RawTraceId = "000000000000000000000000075bcd15",
+                           RawSpanId = "000000003ade68b1",
+                           SamplingPriority = 0,
+                           Origin = null,
+                           PropagatedTags = null,
+                           Parent = null,
+                           ParentId = null,
+                       });
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Adds missing behaviors that the system-tests were expecting for handling the W3C tracecontext headers.

## Reason for change
This makes the processing of W3C tracecontext headers in the .NET Tracer consistent with the rest of the Datadog libraries.

## Implementation details
Makes the following behavior changes:
- To determine the Datadog sampling priority, the incoming Datadog sampling priority and the `traceparent` sampling flag are considered together. If they agree, the incoming Datadog sampling priority is used. If not, a default value of AutoKeep or AutoReject is used
- The encoding of the origin in the `tracestate` header is updated with the latest rules
- If any invalid characters are present in the trace_flags field of the `traceparent` header, the traceparent is discarded

## Test coverage
Small unit tests have been added to test the W3CTraceContextPropagator. The system-tests have been tested with a developer build, and once this change is merged and published, we will run and pass all the tests from https://github.com/DataDog/system-tests/pull/955.

## Other details
N/A
