### PR TITLE
Swap Samples.GrpcLegacy to use .NET Activity

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -201,6 +201,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             _usesAspNetCore = usesAspNetCore;
             SetEnvironmentVariable(ConfigurationKeys.GrpcTags, MetadataHeaders);
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public GrpcLegacyTests(ITestOutputHelper output)
             : base("GrpcLegacy", output, usesAspNetCore: false)
         {
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()
@@ -201,7 +202,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             _usesAspNetCore = usesAspNetCore;
             SetEnvironmentVariable(ConfigurationKeys.GrpcTags, MetadataHeaders);
-            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         /// <summary>

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
@@ -14,7 +14,8 @@
       otel.trace_id: Guid_1,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -81,7 +82,8 @@
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -105,7 +107,8 @@
       otel.trace_id: Guid_3,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -172,7 +175,8 @@
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -196,7 +200,8 @@
       otel.trace_id: Guid_4,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -271,7 +276,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -295,7 +301,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_5,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -370,7 +377,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -394,7 +402,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_6,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -469,7 +478,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -493,7 +503,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_7,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -568,7 +579,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -592,7 +604,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_8,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -667,7 +680,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -691,7 +705,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_9,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -766,7 +781,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -790,7 +806,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_10,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -865,7 +882,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -889,7 +907,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_11,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -964,7 +983,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -988,7 +1008,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_12,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1055,7 +1076,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1079,7 +1101,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_13,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1146,7 +1169,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1170,7 +1194,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_14,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1237,7 +1262,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1261,7 +1287,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_15,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1331,7 +1358,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1355,7 +1383,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       otel.trace_id: Guid_16,
       runtime-id: Guid_2,
       span.kind: internal,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1425,7 +1454,8 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
@@ -2,13 +2,18 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: SendBothStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendBothStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -39,7 +44,7 @@
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -73,7 +78,7 @@
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -88,13 +93,18 @@
   {
     TraceId: Id_5,
     SpanId: Id_6,
-    Name: SendClientStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendClientStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_3,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -125,7 +135,7 @@
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -159,7 +169,7 @@
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -174,13 +184,18 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: SendErrors_Cancelled,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_Cancelled,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -217,7 +232,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -253,7 +268,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -268,13 +283,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_13,
     SpanId: Id_14,
-    Name: SendErrors_DataLoss,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_DataLoss,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -311,7 +331,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -347,7 +367,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -362,13 +382,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_17,
     SpanId: Id_18,
-    Name: SendErrors_NotFound,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_NotFound,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_6,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -405,7 +430,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -441,7 +466,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -456,13 +481,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_21,
     SpanId: Id_22,
-    Name: SendErrors_Throw,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_Throw,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_7,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -499,7 +529,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -535,7 +565,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -550,13 +580,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_25,
     SpanId: Id_26,
-    Name: SendErrorsAsync_Cancelled,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_Cancelled,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_8,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -593,7 +628,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -629,7 +664,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -644,13 +679,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_29,
     SpanId: Id_30,
-    Name: SendErrorsAsync_DataLoss,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_DataLoss,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_9,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -687,7 +727,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -723,7 +763,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -738,13 +778,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_33,
     SpanId: Id_34,
-    Name: SendErrorsAsync_NotFound,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_NotFound,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_10,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -781,7 +826,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -817,7 +862,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -832,13 +877,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_37,
     SpanId: Id_38,
-    Name: SendErrorsAsync_Throw,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_Throw,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_11,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -875,7 +925,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -911,7 +961,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -926,13 +976,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_41,
     SpanId: Id_42,
-    Name: SendServerStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendServerStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_12,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -963,7 +1018,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -997,7 +1052,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -1012,13 +1067,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: SendUnaryRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendUnaryRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_13,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1049,7 +1109,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -1083,7 +1143,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -1098,13 +1158,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_49,
     SpanId: Id_50,
-    Name: SendUnaryRequestAsync,
+    Name: Samples.Grpc.internal,
     Resource: SendUnaryRequestAsync,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_14,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1135,7 +1200,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.request.metadata.client-value1: some-client-value,
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: client,
       _dd.p.dm: -0
@@ -1169,7 +1234,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -1184,13 +1249,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_53,
     SpanId: Id_54,
-    Name: SendVerySlowRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendVerySlowRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_15,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1223,7 +1293,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.method.service: Greeter,
       grpc.request.metadata.client-value1: some-client-value,
       grpc.status.code: 4,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client,
       _dd.p.dm: -0
     },
@@ -1258,7 +1328,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 4,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0
@@ -1273,13 +1343,18 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_57,
     SpanId: Id_58,
-    Name: SendVerySlowRequestAsync,
+    Name: Samples.Grpc.internal,
     Resource: SendVerySlowRequestAsync,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_16,
+      runtime-id: Guid_2,
+      span.kind: internal,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1312,7 +1387,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.method.service: Greeter,
       grpc.request.metadata.client-value1: some-client-value,
       grpc.status.code: 4,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client,
       _dd.p.dm: -0
     },
@@ -1347,7 +1422,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 4,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
       _dd.p.dm: -0

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
@@ -2,14 +2,20 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: SendBothStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendBothStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -71,10 +77,11 @@
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -86,14 +93,20 @@
   {
     TraceId: Id_5,
     SpanId: Id_6,
-    Name: SendClientStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendClientStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_3,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -155,10 +168,11 @@
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -170,14 +184,20 @@
   {
     TraceId: Id_9,
     SpanId: Id_10,
-    Name: SendErrors_Cancelled,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_Cancelled,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_4,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -247,10 +267,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -262,14 +283,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_13,
     SpanId: Id_14,
-    Name: SendErrors_DataLoss,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_DataLoss,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_5,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -339,10 +366,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -354,14 +382,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_17,
     SpanId: Id_18,
-    Name: SendErrors_NotFound,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_NotFound,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_6,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -431,10 +465,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -446,14 +481,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_21,
     SpanId: Id_22,
-    Name: SendErrors_Throw,
+    Name: Samples.Grpc.internal,
     Resource: SendErrors_Throw,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_7,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -523,10 +564,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -538,14 +580,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_25,
     SpanId: Id_26,
-    Name: SendErrorsAsync_Cancelled,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_Cancelled,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_8,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -615,10 +663,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 1,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -630,14 +679,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_29,
     SpanId: Id_30,
-    Name: SendErrorsAsync_DataLoss,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_DataLoss,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_9,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -707,10 +762,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 15,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -722,14 +778,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_33,
     SpanId: Id_34,
-    Name: SendErrorsAsync_NotFound,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_NotFound,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_10,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -799,10 +861,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 5,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -814,14 +877,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_37,
     SpanId: Id_38,
-    Name: SendErrorsAsync_Throw,
+    Name: Samples.Grpc.internal,
     Resource: SendErrorsAsync_Throw,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_11,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -891,10 +960,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 2,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -906,14 +976,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_41,
     SpanId: Id_42,
-    Name: SendServerStreamingRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendServerStreamingRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_12,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -975,10 +1051,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -990,14 +1067,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_45,
     SpanId: Id_46,
-    Name: SendUnaryRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendUnaryRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_13,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1059,10 +1142,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1074,14 +1158,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_49,
     SpanId: Id_50,
-    Name: SendUnaryRequestAsync,
+    Name: Samples.Grpc.internal,
     Resource: SendUnaryRequestAsync,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_14,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1143,10 +1233,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 0,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1158,14 +1249,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_53,
     SpanId: Id_54,
-    Name: SendVerySlowRequest,
+    Name: Samples.Grpc.internal,
     Resource: SendVerySlowRequest,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_15,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1230,10 +1327,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 4,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1245,14 +1343,20 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_57,
     SpanId: Id_58,
-    Name: SendVerySlowRequestAsync,
+    Name: Samples.Grpc.internal,
     Resource: SendVerySlowRequestAsync,
     Service: Samples.GrpcLegacy,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      _dd.p.dm: -0
+      otel.library.name: Samples.Grpc,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_16,
+      runtime-id: Guid_2,
+      span.kind: internal,
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -1317,10 +1421,11 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
       grpc.response.metadata.server-value1: some-server-value,
       grpc.status.code: 4,
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       servermeta: other-server-value,
       span.kind: server,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/test-applications/integrations/Samples.GrpcLegacy/ClientWorker.cs
+++ b/tracer/test/test-applications/integrations/Samples.GrpcLegacy/ClientWorker.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,10 +14,20 @@ public class ClientWorker
 {
     private readonly Logger<ClientWorker> _logger;
     private static readonly ErrorType[] ErrorTypes = (ErrorType[])Enum.GetValues(typeof(ErrorType));
+    private static readonly ActivitySource _source = new("Samples.Grpc");
 
     public ClientWorker(Logger<ClientWorker> logger)
     {
         _logger = logger;
+        var activityListener = new ActivityListener
+        {
+            ActivityStarted = activity => Console.WriteLine($"{activity.DisplayName}:{activity.Id} - Started"),
+            ActivityStopped = activity => Console.WriteLine($"{activity.DisplayName}:{activity.Id} - Stopped"),
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
+        };
+
+        ActivitySource.AddActivityListener(activityListener);
     }
 
     public async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -73,12 +84,13 @@ public class ClientWorker
         // This is kinda horrible, but the "slow requests" don't close until the
         // service has completed, so won't close the span until then
         await delay;
+
         _logger.LogInformation("Stopping application");
     }
 
     private async Task SendUnaryRequestAsync(Greeter.GreeterClient client)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         _logger.LogInformation("Sending unary async request to self");
         var reply = await client.UnaryAsync(
                         new HelloRequest { Name = "GreeterClient" });
@@ -88,7 +100,7 @@ public class ClientWorker
 
     private void SendUnaryRequest(Greeter.GreeterClient client)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         _logger.LogInformation("Sending unary request to self");
         var reply = client.Unary(new HelloRequest { Name = "GreeterClient" });
 
@@ -97,7 +109,7 @@ public class ClientWorker
 
     private async Task SendServerStreamingRequest(Greeter.GreeterClient client, CancellationToken ct)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         _logger.LogInformation("Sending streaming server request to self");
 
         using var messages = client.StreamingFromServer(
@@ -113,7 +125,7 @@ public class ClientWorker
 
     private async Task SendClientStreamingRequest(Greeter.GreeterClient client, CancellationToken ct)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         _logger.LogInformation("Sending streaming client requests to self");
 
         using var call = client.StreamingFromClient();
@@ -133,7 +145,7 @@ public class ClientWorker
 
     private async Task SendBothStreamingRequest(Greeter.GreeterClient client, CancellationToken ct)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         _logger.LogInformation("Sending streaming server request to self");
 
         using var call = client.StreamingBothWays();
@@ -163,7 +175,7 @@ public class ClientWorker
     {
         foreach (var errorType in ErrorTypes)
         {
-            using var scope = SampleHelpers.CreateScope($"SendErrors_{errorType}");
+            using var activity = _source.StartActivity($"SendErrors_{errorType}");
             try
             {
                 _logger.LogInformation("Sending err request to self with " + errorType);
@@ -184,7 +196,7 @@ public class ClientWorker
     {
         foreach (var errorType in ErrorTypes)
         {
-            using var scope = SampleHelpers.CreateScope($"SendErrorsAsync_{errorType}");
+            using var activity = _source.StartActivity($"SendErrorsAsync_{errorType}");
             try
             {
                 _logger.LogInformation("Sending err request to self with " + errorType);
@@ -203,7 +215,7 @@ public class ClientWorker
 
     private async Task SendVerySlowRequestAsync(Greeter.GreeterClient client)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         try
         {
             _logger.LogInformation("Sending very slow request to self");
@@ -211,7 +223,7 @@ public class ClientWorker
 
             throw new Exception("Received reply, when should have exceeded deadline");
         }
-        catch(RpcException ex) when (ex.StatusCode == StatusCode.DeadlineExceeded)
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.DeadlineExceeded)
         {
             _logger.LogInformation("Received deadline exceeded response " + ex.Message);
         }
@@ -219,7 +231,7 @@ public class ClientWorker
 
     private void SendVerySlowRequest(Greeter.GreeterClient client)
     {
-        using var scope = CreateScope();
+        using var activity = StartActivity();
         try
         {
             _logger.LogInformation("Sending very slow request to self");
@@ -233,6 +245,13 @@ public class ClientWorker
         }
     }
 
-    private IDisposable CreateScope([CallerMemberName] string? name = null)
-        => SampleHelpers.CreateScope(name);
+    private IDisposable StartActivity([CallerMemberName] string name = "")
+    {
+        var activity = _source.StartActivity(name);
+
+        return activity is null
+            ? throw new Exception($"Attempted to start a new activity for {name} method, but activity returned was null.")
+            : activity;
+    }
+
 }

--- a/tracer/test/test-applications/integrations/Samples.GrpcLegacy/Samples.GrpcLegacy.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcLegacy/Samples.GrpcLegacy.csproj
@@ -42,4 +42,16 @@
   <ItemGroup Condition="$(TargetFramework) == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <!-- .NET Core 2.0/3.0/3.1 and .NET Framework don't have the Activity* APIs -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' OR '$(TargetFramework)'=='netcoreapp2.1' OR '$(TargetFramework)'=='netcoreapp3.0' OR '$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary of changes

Swaps the `Samples.GrpcLegacy` project to use the .NET Activity API instead of using the `SampleHelpers` for manual instrumentation.

## Reason for change

We want to move toward using .NET Activity/OTel in the samples 

## Implementation details

- Installed `System.Diagnostics.DiagnosticsSource`
- Swapped to use `ActivitySource.StartActivity`
- Enabled Otel for the test
- Updated snapshot

## Test coverage

- Snapshots are updated

## Other details

