### PR TITLE
[Tracer][Naming] MSMQ tags

### DIFF
--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -310,4 +310,3 @@ using Datadog.Trace;
 ## Get in touch
 
 If you have questions, feedback, or feature requests, reach our [support](https://docs.datadoghq.com/help).
-

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -313,8 +313,8 @@ Name | Required |
 component | `msmq`
 messaging.destination | Yes
 messaging.msmq.message.transactional | No
+messaging.msmq.queue.transactional | No
 messaging.operation | Yes
-msmq.queue.transactional | No
 span.kind | `client`; `producer`; `consumer`
 
 ## MySql

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -312,7 +312,7 @@ Name | Required |
 ---------|----------------|
 component | `msmq`
 messaging.destination | Yes
-msmq.command | Yes
+messaging.operation | Yes
 msmq.message.transactional | No
 msmq.queue.transactional | No
 span.kind | `client`; `producer`; `consumer`

--- a/docs/span_metadata.md
+++ b/docs/span_metadata.md
@@ -312,8 +312,8 @@ Name | Required |
 ---------|----------------|
 component | `msmq`
 messaging.destination | Yes
+messaging.msmq.message.transactional | No
 messaging.operation | Yes
-msmq.message.transactional | No
 msmq.queue.transactional | No
 span.kind | `client`; `producer`; `consumer`
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -18,8 +18,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
         // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
         private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.queue.transactional");
+        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
         public override string? GetTag(string key)
         {
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tagging
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
                 "messaging.msmq.message.transactional" => MessageWithTransaction,
-                "msmq.queue.transactional" => IsTransactionalQueue,
+                "messaging.msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
-                case "msmq.queue.transactional": 
+                case "messaging.msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
                 case "span.kind": 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                processor.Process(new TagItem<string>("msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                sb.Append("msmq.queue.transactional (tag):")
+                sb.Append("messaging.msmq.queue.transactional (tag):")
                   .Append(IsTransactionalQueue)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.Tagging
 {
     partial class MsmqTags
     {
-        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("msmq.command");
-        private static readonly byte[] CommandBytes = new byte[] { 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
+        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("messaging.operation");
+        private static readonly byte[] CommandBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
         // SpanKindBytes = System.Text.Encoding.UTF8.GetBytes("span.kind");
         private static readonly byte[] SpanKindBytes = new byte[] { 115, 112, 97, 110, 46, 107, 105, 110, 100 };
         // InstrumentationNameBytes = System.Text.Encoding.UTF8.GetBytes("component");
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tagging
         {
             return key switch
             {
-                "msmq.command" => Command,
+                "messaging.operation" => Command,
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
-                case "msmq.command": 
+                case "messaging.operation": 
                     Command = value;
                     break;
                 case "messaging.destination": 
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                processor.Process(new TagItem<string>("msmq.command", Command, CommandBytes));
+                processor.Process(new TagItem<string>("messaging.operation", Command, CommandBytes));
             }
 
             if (SpanKind is not null)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                sb.Append("msmq.command (tag):")
+                sb.Append("messaging.operation (tag):")
                   .Append(Command)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] InstrumentationNameBytes = new byte[] { 99, 111, 109, 112, 111, 110, 101, 110, 116 };
         // PathBytes = System.Text.Encoding.UTF8.GetBytes("messaging.destination");
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("msmq.message.transactional");
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
+        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
         // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
         private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tagging
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
-                "msmq.message.transactional" => MessageWithTransaction,
+                "messaging.msmq.message.transactional" => MessageWithTransaction,
                 "msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.destination": 
                     Path = value;
                     break;
-                case "msmq.message.transactional": 
+                case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
                 case "msmq.queue.transactional": 
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                processor.Process(new TagItem<string>("msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
             }
 
             if (IsTransactionalQueue is not null)
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                sb.Append("msmq.message.transactional (tag):")
+                sb.Append("messaging.msmq.message.transactional (tag):")
                   .Append(MessageWithTransaction)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -18,8 +18,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
         // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
         private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.queue.transactional");
+        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
         public override string? GetTag(string key)
         {
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tagging
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
                 "messaging.msmq.message.transactional" => MessageWithTransaction,
-                "msmq.queue.transactional" => IsTransactionalQueue,
+                "messaging.msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
-                case "msmq.queue.transactional": 
+                case "messaging.msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
                 case "span.kind": 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                processor.Process(new TagItem<string>("msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                sb.Append("msmq.queue.transactional (tag):")
+                sb.Append("messaging.msmq.queue.transactional (tag):")
                   .Append(IsTransactionalQueue)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.Tagging
 {
     partial class MsmqTags
     {
-        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("msmq.command");
-        private static readonly byte[] CommandBytes = new byte[] { 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
+        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("messaging.operation");
+        private static readonly byte[] CommandBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
         // SpanKindBytes = System.Text.Encoding.UTF8.GetBytes("span.kind");
         private static readonly byte[] SpanKindBytes = new byte[] { 115, 112, 97, 110, 46, 107, 105, 110, 100 };
         // InstrumentationNameBytes = System.Text.Encoding.UTF8.GetBytes("component");
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tagging
         {
             return key switch
             {
-                "msmq.command" => Command,
+                "messaging.operation" => Command,
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
-                case "msmq.command": 
+                case "messaging.operation": 
                     Command = value;
                     break;
                 case "messaging.destination": 
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                processor.Process(new TagItem<string>("msmq.command", Command, CommandBytes));
+                processor.Process(new TagItem<string>("messaging.operation", Command, CommandBytes));
             }
 
             if (SpanKind is not null)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                sb.Append("msmq.command (tag):")
+                sb.Append("messaging.operation (tag):")
                   .Append(Command)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] InstrumentationNameBytes = new byte[] { 99, 111, 109, 112, 111, 110, 101, 110, 116 };
         // PathBytes = System.Text.Encoding.UTF8.GetBytes("messaging.destination");
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("msmq.message.transactional");
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
+        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
         // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
         private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tagging
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
-                "msmq.message.transactional" => MessageWithTransaction,
+                "messaging.msmq.message.transactional" => MessageWithTransaction,
                 "msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.destination": 
                     Path = value;
                     break;
-                case "msmq.message.transactional": 
+                case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
                 case "msmq.queue.transactional": 
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                processor.Process(new TagItem<string>("msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
             }
 
             if (IsTransactionalQueue is not null)
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                sb.Append("msmq.message.transactional (tag):")
+                sb.Append("messaging.msmq.message.transactional (tag):")
                   .Append(MessageWithTransaction)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -18,8 +18,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
         // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
         private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.queue.transactional");
+        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
         public override string? GetTag(string key)
         {
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tagging
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
                 "messaging.msmq.message.transactional" => MessageWithTransaction,
-                "msmq.queue.transactional" => IsTransactionalQueue,
+                "messaging.msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
-                case "msmq.queue.transactional": 
+                case "messaging.msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
                 case "span.kind": 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                processor.Process(new TagItem<string>("msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                sb.Append("msmq.queue.transactional (tag):")
+                sb.Append("messaging.msmq.queue.transactional (tag):")
                   .Append(IsTransactionalQueue)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.Tagging
 {
     partial class MsmqTags
     {
-        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("msmq.command");
-        private static readonly byte[] CommandBytes = new byte[] { 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
+        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("messaging.operation");
+        private static readonly byte[] CommandBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
         // SpanKindBytes = System.Text.Encoding.UTF8.GetBytes("span.kind");
         private static readonly byte[] SpanKindBytes = new byte[] { 115, 112, 97, 110, 46, 107, 105, 110, 100 };
         // InstrumentationNameBytes = System.Text.Encoding.UTF8.GetBytes("component");
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tagging
         {
             return key switch
             {
-                "msmq.command" => Command,
+                "messaging.operation" => Command,
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
-                case "msmq.command": 
+                case "messaging.operation": 
                     Command = value;
                     break;
                 case "messaging.destination": 
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                processor.Process(new TagItem<string>("msmq.command", Command, CommandBytes));
+                processor.Process(new TagItem<string>("messaging.operation", Command, CommandBytes));
             }
 
             if (SpanKind is not null)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                sb.Append("msmq.command (tag):")
+                sb.Append("messaging.operation (tag):")
                   .Append(Command)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] InstrumentationNameBytes = new byte[] { 99, 111, 109, 112, 111, 110, 101, 110, 116 };
         // PathBytes = System.Text.Encoding.UTF8.GetBytes("messaging.destination");
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("msmq.message.transactional");
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
+        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
         // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
         private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tagging
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
-                "msmq.message.transactional" => MessageWithTransaction,
+                "messaging.msmq.message.transactional" => MessageWithTransaction,
                 "msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.destination": 
                     Path = value;
                     break;
-                case "msmq.message.transactional": 
+                case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
                 case "msmq.queue.transactional": 
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                processor.Process(new TagItem<string>("msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
             }
 
             if (IsTransactionalQueue is not null)
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                sb.Append("msmq.message.transactional (tag):")
+                sb.Append("messaging.msmq.message.transactional (tag):")
                   .Append(MessageWithTransaction)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -18,8 +18,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
         // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
         private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
-        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
-        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.queue.transactional");
+        private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
         public override string? GetTag(string key)
         {
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tagging
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
                 "messaging.msmq.message.transactional" => MessageWithTransaction,
-                "msmq.queue.transactional" => IsTransactionalQueue,
+                "messaging.msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
         }
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
-                case "msmq.queue.transactional": 
+                case "messaging.msmq.queue.transactional": 
                     IsTransactionalQueue = value;
                     break;
                 case "span.kind": 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                processor.Process(new TagItem<string>("msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.queue.transactional", IsTransactionalQueue, IsTransactionalQueueBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Tagging
 
             if (IsTransactionalQueue is not null)
             {
-                sb.Append("msmq.queue.transactional (tag):")
+                sb.Append("messaging.msmq.queue.transactional (tag):")
                   .Append(IsTransactionalQueue)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -8,8 +8,8 @@ namespace Datadog.Trace.Tagging
 {
     partial class MsmqTags
     {
-        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("msmq.command");
-        private static readonly byte[] CommandBytes = new byte[] { 109, 115, 109, 113, 46, 99, 111, 109, 109, 97, 110, 100 };
+        // CommandBytes = System.Text.Encoding.UTF8.GetBytes("messaging.operation");
+        private static readonly byte[] CommandBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 111, 112, 101, 114, 97, 116, 105, 111, 110 };
         // SpanKindBytes = System.Text.Encoding.UTF8.GetBytes("span.kind");
         private static readonly byte[] SpanKindBytes = new byte[] { 115, 112, 97, 110, 46, 107, 105, 110, 100 };
         // InstrumentationNameBytes = System.Text.Encoding.UTF8.GetBytes("component");
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tagging
         {
             return key switch
             {
-                "msmq.command" => Command,
+                "messaging.operation" => Command,
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tagging
         {
             switch(key)
             {
-                case "msmq.command": 
+                case "messaging.operation": 
                     Command = value;
                     break;
                 case "messaging.destination": 
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                processor.Process(new TagItem<string>("msmq.command", Command, CommandBytes));
+                processor.Process(new TagItem<string>("messaging.operation", Command, CommandBytes));
             }
 
             if (SpanKind is not null)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tagging
         {
             if (Command is not null)
             {
-                sb.Append("msmq.command (tag):")
+                sb.Append("messaging.operation (tag):")
                   .Append(Command)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/MsmqTags.g.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.Tagging
         private static readonly byte[] InstrumentationNameBytes = new byte[] { 99, 111, 109, 112, 111, 110, 101, 110, 116 };
         // PathBytes = System.Text.Encoding.UTF8.GetBytes("messaging.destination");
         private static readonly byte[] PathBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 100, 101, 115, 116, 105, 110, 97, 116, 105, 111, 110 };
-        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("msmq.message.transactional");
-        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
+        // MessageWithTransactionBytes = System.Text.Encoding.UTF8.GetBytes("messaging.msmq.message.transactional");
+        private static readonly byte[] MessageWithTransactionBytes = new byte[] { 109, 101, 115, 115, 97, 103, 105, 110, 103, 46, 109, 115, 109, 113, 46, 109, 101, 115, 115, 97, 103, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
         // IsTransactionalQueueBytes = System.Text.Encoding.UTF8.GetBytes("msmq.queue.transactional");
         private static readonly byte[] IsTransactionalQueueBytes = new byte[] { 109, 115, 109, 113, 46, 113, 117, 101, 117, 101, 46, 116, 114, 97, 110, 115, 97, 99, 116, 105, 111, 110, 97, 108 };
 
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tagging
                 "span.kind" => SpanKind,
                 "component" => InstrumentationName,
                 "messaging.destination" => Path,
-                "msmq.message.transactional" => MessageWithTransaction,
+                "messaging.msmq.message.transactional" => MessageWithTransaction,
                 "msmq.queue.transactional" => IsTransactionalQueue,
                 _ => base.GetTag(key),
             };
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tagging
                 case "messaging.destination": 
                     Path = value;
                     break;
-                case "msmq.message.transactional": 
+                case "messaging.msmq.message.transactional": 
                     MessageWithTransaction = value;
                     break;
                 case "msmq.queue.transactional": 
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                processor.Process(new TagItem<string>("msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
+                processor.Process(new TagItem<string>("messaging.msmq.message.transactional", MessageWithTransaction, MessageWithTransactionBytes));
             }
 
             if (IsTransactionalQueue is not null)
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Tagging
 
             if (MessageWithTransaction is not null)
             {
-                sb.Append("msmq.message.transactional (tag):")
+                sb.Append("messaging.msmq.message.transactional (tag):")
                   .Append(MessageWithTransaction)
                   .Append(',');
             }

--- a/tracer/src/Datadog.Trace/Tagging/AwsSqsTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AwsSqsTags.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Tagging
 {
     internal partial class AwsSqsTags : AwsSdkTags
     {
-        [Tag(Trace.Tags.AwsQueueName)]
+        [Tag(Trace.Tags.MessagingDestination)]
         public string QueueName { get; set; }
 
         [Tag(Trace.Tags.AwsQueueUrl)]

--- a/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tagging
         /// <param name="spanKind">kind of span</param>
         public MsmqTags(string spanKind) => SpanKind = spanKind;
 
-        [Tag(Trace.Tags.MsmqCommand)]
+        [Tag(Trace.Tags.MessagingOperation)]
         public string Command { get; set; }
 
         /// <inheritdoc/>

--- a/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.InstrumentationName)]
         public string InstrumentationName => "msmq";
 
-        [Tag(Trace.Tags.MsmqQueuePath)]
+        [Tag(Trace.Tags.MessagingDestination)]
         public string Path { get; set; }
 
         [Tag(Trace.Tags.MsmqMessageWithTransaction)]

--- a/tracer/src/Datadog.Trace/Tagging/RabbitMQTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/RabbitMQTags.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.InstrumentationName)]
         public string InstrumentationName { get; set; }
 
-        [Tag(Trace.Tags.AmqpCommand)]
+        [Tag(Trace.Tags.MessagingOperation)]
         public string Command { get; set; }
 
         [Tag(Trace.Tags.AmqpDeliveryMode)]

--- a/tracer/src/Datadog.Trace/Tagging/RabbitMQTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/RabbitMQTags.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.MessageSize)]
         public string MessageSize { get; set; }
 
-        [Tag(Trace.Tags.AmqpQueue)]
+        [Tag(Trace.Tags.MessagingDestination)]
         public string Queue { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -421,11 +421,6 @@ namespace Datadog.Trace
         internal const string PartialSnapshot = "_dd.partial_version";
 
         /// <summary>
-        /// The name of the Msmq command the message was published to.
-        /// </summary>
-        internal const string MsmqCommand = "msmq.command";
-
-        /// <summary>
         /// Is the msmq queue supporting transactional messages
         /// </summary>
         internal const string MsmqIsTransactionalQueue = "msmq.queue.transactional";
@@ -439,6 +434,7 @@ namespace Datadog.Trace
 
         /// <summary>
         /// The AMQP method.
+        /// The name of the Msmq command the message was published to.
         /// </summary>
         internal const string MessagingOperation = "messaging.operation";
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -267,11 +267,6 @@ namespace Datadog.Trace
         internal const string AmqpRoutingKey = "messaging.rabbitmq.routing_key";
 
         /// <summary>
-        /// The name of the queue for the AMQP message.
-        /// </summary>
-        internal const string AmqpQueue = "messaging.destination";
-
-        /// <summary>
         /// The delivery mode of the AMQP message.
         /// </summary>
         internal const string AmqpDeliveryMode = "messaging.rabbitmq.delivery_mode";
@@ -320,11 +315,6 @@ namespace Datadog.Trace
         /// The service associated with the AWS SDK span.
         /// </summary>
         internal const string AwsServiceName = "aws.service";
-
-        /// <summary>
-        /// The queue name associated with the AWS SDK span.
-        /// </summary>
-        internal const string AwsQueueName = "messaging.destination";
 
         /// <summary>
         /// The queue URL associated with the AWS SDK span.
@@ -446,9 +436,11 @@ namespace Datadog.Trace
         internal const string MsmqIsTransactionalQueue = "msmq.queue.transactional";
 
         /// <summary>
+        /// The name of the queue for the AMQP message.
         /// The name of the Msmq queue the message was published to, containing host name and path.
+        /// The queue name associated with the AWS SDK span.
         /// </summary>
-        internal const string MsmqQueuePath = "messaging.destination";
+        internal const string MessagingDestination = "messaging.destination";
 
         /// <summary>
         /// A boolean indicating if it's part of a transaction.

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -252,11 +252,6 @@ namespace Datadog.Trace
         internal const string GraphQLSource = "graphql.source";
 
         /// <summary>
-        /// The AMQP method.
-        /// </summary>
-        internal const string AmqpCommand = "messaging.operation";
-
-        /// <summary>
         /// The name of the AMQP exchange the message was originally published to.
         /// </summary>
         internal const string AmqpExchange = "messaging.rabbitmq.exchange";
@@ -441,6 +436,11 @@ namespace Datadog.Trace
         /// The queue name associated with the AWS SDK span.
         /// </summary>
         internal const string MessagingDestination = "messaging.destination";
+
+        /// <summary>
+        /// The AMQP method.
+        /// </summary>
+        internal const string MessagingOperation = "messaging.operation";
 
         /// <summary>
         /// A boolean indicating if it's part of a transaction.

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -423,7 +423,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Is the msmq queue supporting transactional messages
         /// </summary>
-        internal const string MsmqIsTransactionalQueue = "msmq.queue.transactional";
+        internal const string MsmqIsTransactionalQueue = "messaging.msmq.queue.transactional";
 
         /// <summary>
         /// The name of the queue for the AMQP message.

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -441,7 +441,7 @@ namespace Datadog.Trace
         /// <summary>
         /// A boolean indicating if it's part of a transaction.
         /// </summary>
-        internal const string MsmqMessageWithTransaction = "msmq.message.transactional";
+        internal const string MsmqMessageWithTransaction = "messaging.msmq.message.transactional";
 
         /// <summary>
         /// A CosmosDb container name.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -59,12 +59,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 if (span.Tags[Tags.MsmqIsTransactionalQueue] == "True")
                 {
-                    span.Tags[Tags.MsmqQueuePath].Should().Be(".\\Private$\\private-transactional-queue");
+                    span.Tags[Tags.MessagingDestination].Should().Be(".\\Private$\\private-transactional-queue");
                     transactionalTraces++;
                 }
                 else
                 {
-                    span.Tags[Tags.MsmqQueuePath].Should().Be(".\\Private$\\private-nontransactional-queue");
+                    span.Tags[Tags.MessagingDestination].Should().Be(".\\Private$\\private-nontransactional-queue");
                     nonTransactionalTraces++;
                 }
 
@@ -74,25 +74,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 {
                     span.Tags[Tags.MsmqMessageWithTransaction].Should().Be(span.Tags[Tags.MsmqIsTransactionalQueue], "The program is supposed to send messages within transactions to transactional queues, and outside of transactions to non transactional queues");
                     span.Tags[Tags.SpanKind].Should().Be(SpanKinds.Producer);
-                    span.Resource.Should().Be($"msmq.send {span.Tags[Tags.MsmqQueuePath]}");
+                    span.Resource.Should().Be($"msmq.send {span.Tags[Tags.MessagingDestination]}");
                     sendCount++;
                 }
                 else if (string.Equals(command, "msmq.receive", StringComparison.OrdinalIgnoreCase))
                 {
                     span.Tags[Tags.SpanKind].Should().Be(SpanKinds.Consumer);
-                    span.Resource.Should().Be($"msmq.receive {span.Tags[Tags.MsmqQueuePath]}");
+                    span.Resource.Should().Be($"msmq.receive {span.Tags[Tags.MessagingDestination]}");
                     receiveCount++;
                 }
                 else if (string.Equals(command, "msmq.peek", StringComparison.OrdinalIgnoreCase))
                 {
                     span.Tags[Tags.SpanKind].Should().Be(SpanKinds.Consumer);
-                    span.Resource.Should().Be($"msmq.peek {span.Tags[Tags.MsmqQueuePath]}");
+                    span.Resource.Should().Be($"msmq.peek {span.Tags[Tags.MessagingDestination]}");
                     peekCount++;
                 }
                 else if (string.Equals(command, "msmq.purge", StringComparison.OrdinalIgnoreCase))
                 {
                     span.Tags[Tags.SpanKind].Should().Be(SpanKinds.Client);
-                    span.Resource.Should().Be($"msmq.purge {span.Tags[Tags.MsmqQueuePath]}");
+                    span.Resource.Should().Be($"msmq.purge {span.Tags[Tags.MessagingDestination]}");
                     purgeCount++;
                 }
                 else

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     nonTransactionalTraces++;
                 }
 
-                var command = span.Tags[Tags.MsmqCommand];
+                var command = span.Tags[Tags.MessagingOperation];
 
                 if (string.Equals(command, "msmq.send", StringComparison.OrdinalIgnoreCase))
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             }
 
                             Assert.Equal(SpanKinds.Consumer, span.Tags[Tags.SpanKind]);
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
+                            Assert.NotNull(span.Tags[Tags.MessagingDestination]);
 
                             // Enforce that the resource name has the following structure: "basic.get [<generated>|{actual queueName}]"
                             string regexPattern = @"basic\.get (?<queueName>\S*)";
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             Assert.True(match.Success);
 
                             var queueName = match.Groups["queueName"].Value;
-                            Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.AmqpQueue]));
+                            Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.MessagingDestination]));
                         }
                         else if (string.Equals(command, "basic.deliver", StringComparison.OrdinalIgnoreCase))
                         {
@@ -146,7 +146,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             }
 
                             Assert.Equal(SpanKinds.Consumer, span.Tags[Tags.SpanKind]);
-                            // Assert.NotNull(span.Tags[Tags.AmqpQueue]); // Java does this but we're having difficulty doing this. Push to v2?
+                            // Assert.NotNull(span.Tags[Tags.MessagingDestination]); // Java does this but we're having difficulty doing this. Push to v2?
                             Assert.NotNull(span.Tags[Tags.AmqpExchange]);
                             Assert.NotNull(span.Tags[Tags.AmqpRoutingKey]);
 
@@ -159,7 +159,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             // Assert.True(match.Success); // Enable once we can get the queue name included
 
                             var queueName = match.Groups["queueName"].Value;
-                            // Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.AmqpQueue])); // Enable once we can get the queue name included
+                            // Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.MessagingDestination])); // Enable once we can get the queue name included
                         }
                         else
                         {
@@ -179,13 +179,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         else if (string.Equals(command, "queue.declare", StringComparison.OrdinalIgnoreCase))
                         {
                             queueDeclareCount++;
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
+                            Assert.NotNull(span.Tags[Tags.MessagingDestination]);
                         }
                         else if (string.Equals(command, "queue.bind", StringComparison.OrdinalIgnoreCase))
                         {
                             queueBindCount++;
                             Assert.NotNull(span.Tags[Tags.AmqpExchange]);
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
+                            Assert.NotNull(span.Tags[Tags.MessagingDestination]);
                             Assert.NotNull(span.Tags[Tags.AmqpRoutingKey]);
                         }
                         else

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in rabbitmqSpans)
                 {
-                    var command = span.Tags[Tags.AmqpCommand];
+                    var command = span.Tags[Tags.MessagingOperation];
 
                     if (command.StartsWith("basic.", StringComparison.OrdinalIgnoreCase))
                     {

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -261,7 +261,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("messaging.operation")
                 .IsOptional("messaging.msmq.message.transactional")
                 .IsPresent("messaging.destination")
-                .IsOptional("msmq.queue.transactional")
+                .IsOptional("messaging.msmq.queue.transactional")
                 .Matches("component", "msmq")
                 .MatchesOneOf("span.kind", "client", "producer", "consumer"));
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -259,7 +259,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "queue"))
             .Tags(s => s
                 .IsPresent("messaging.operation")
-                .IsOptional("msmq.message.transactional")
+                .IsOptional("messaging.msmq.message.transactional")
                 .IsPresent("messaging.destination")
                 .IsOptional("msmq.queue.transactional")
                 .Matches("component", "msmq")

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataRules.cs
@@ -258,7 +258,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Name, "msmq.command")
                 .Matches(Type, "queue"))
             .Tags(s => s
-                .IsPresent("msmq.command")
+                .IsPresent("messaging.operation")
                 .IsOptional("msmq.message.transactional")
                 .IsPresent("messaging.destination")
                 .IsOptional("msmq.queue.transactional")


### PR DESCRIPTION
## Summary of changes

Merged identical tag (destination and operation).
Renamed msmq tags

```java
    new TagMapping("msmq.command", "meta.messaging.operation"),
    new TagMapping("msmq.message.transactional", "meta.messaging.msmq.message.transactional"),
    new TagMapping("msmq.queue.path", "meta.messaging.destination"),
    new TagMapping("msmq.queue.transactional", "meta.messaging.msmq.queue.transactional"),
```

Based on #3875 and reviewable commit by commits

## Reason for change

Now that the backend handles remapping, we can switch the tracer code base to use the target attribute names as documented in the [public documentation](https://docs.datadoghq.com/tracing/trace_collection/tracing_naming_convention/#core).

To be sure, we are not introducing any breaking change, I'm only renaming what is handled by the backend remapper.

## Implementation details

Here's how to proceed (in case Ecosystem team wants to take over):

- Change the tags names
- Change the span assertion
- Impact the snapshot files
- Build to generate the generated `tracer/src/Datadog.Trace/Generated/**/*.g.cs` files
- Run `./build.sh GenerateSpanDocumentation`

## Test coverage

Span Metadata assertions. Metadata are updated in the metadata doc.

## Other details
<!-- Fixes #{issue} -->
