### PR TITLE
[Test] Fix flakiness in Aerospike integration test - Attempt 1

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
@@ -17,7 +17,7 @@ namespace Samples.Aerospike
             {
                 try
                 {
-                    client = new AsyncClient(host.Item1, host.Item2);
+                    client = new AsyncClient(new AsyncClientPolicy { timeout = 10_000 }, host.Item1, host.Item2);
                     break;
                 }
                 catch (AerospikeException) when (retries > 0)

--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
@@ -10,8 +10,23 @@ namespace Samples.Aerospike
         static async Task Main(string[] args)
         {
             var host = Host();
+            AsyncClient client = null;
 
-            var client = new AsyncClient(host.Item1, host.Item2);
+            int retries = 3;
+            while (true)
+            {
+                try
+                {
+                    client = new AsyncClient(host.Item1, host.Item2);
+                    break;
+                }
+                catch (AerospikeException) when (retries > 0)
+                {
+                    retries--;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+            }
 
             var key1 = new Key("test", "myset1", "mykey1");
             var key2 = new Key("test", "myset2", "mykey2");

--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Properties/launchSettings.json
@@ -1,20 +1,20 @@
 {
   "profiles": {
-    "Samples.Elasticsearch": {
+    "Samples.Aerospike": {
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         "DD_VERSION": "1.0.0"
       },
-      "nativeDebugging": true
+      "nativeDebugging": false
     }
   }
 }


### PR DESCRIPTION
## Summary of changes
Add retry loop to initialization of Aerospike client, to hopefully fix sources of timing flakiness. There was an instance where an unhandled `AerospikeException` bubbled up from this constructor call, so this may fix that issue.

## Reason for change

## Implementation details

## Test coverage

## Other details

