### PR TITLE
Fix modules locking

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3653,20 +3653,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
     {
         return S_OK;
     }
-
-    try
-    {
-        // keep this lock until we are done using the module,
-        // to prevent it from unloading while in use
-        std::lock_guard<std::mutex> guard(module_ids_lock_);
-    }
-    catch (...)
-    {
-        Logger::Error(
-            "JITCachedFunctionSearchStarted: Failed on exception while tried to grab the mutex of `module_ids_lock_` for functionId ",
-            functionId);
-        return S_OK;
-    }
+    
+    // keep this lock until we are done using the module,
+    // to prevent it from unloading while in use
+    std::lock_guard<std::mutex> guard(module_ids_lock_);    
 
     // Extract Module metadata
     ModuleID module_id;


### PR DESCRIPTION
## Summary of changes

The lock in `JITCachedFunctionSearchStarted` was acquired inside of the try/catch block, which means that it was released when leaving the scope.

## Reason for change

Already two reports of assertions caused by unsynchronized access to the modules collection.
