### PR TITLE
Use a wrapper for synchronized access to collections

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj
+++ b/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj
@@ -235,6 +235,7 @@
     <ClInclude Include="rejit_preprocessor.h" />
     <ClInclude Include="rejit_work_offloader.h" />
     <ClInclude Include="stats.h" />
+    <ClInclude Include="Synchronized.hpp" />
     <ClInclude Include="tracer_tokens.h" />
     <ClInclude Include="version.h" />
   </ItemGroup>

--- a/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj.filters
+++ b/tracer/src/Datadog.Tracer.Native/Datadog.Tracer.Native.vcxproj.filters
@@ -146,6 +146,7 @@
     <ClInclude Include="iast\string_optimization_aspect_filter.h" />
     <ClInclude Include="iast\dataflow_il_rewriter.h" />
     <ClInclude Include="iast\dataflow_il_analysis.h" />
+    <ClInclude Include="Synchronized.hpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/tracer/src/Datadog.Tracer.Native/Synchronized.hpp
+++ b/tracer/src/Datadog.Tracer.Native/Synchronized.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <mutex>
+
+template <class T>
+class Synchronized
+{
+public:
+    class Scope
+    {
+    public:
+        Scope(Synchronized& synchronized)
+            : _lockGuard(synchronized._mutex), _obj(synchronized._obj)
+        {
+        }
+
+        T* operator->()
+        {
+            return &_obj;
+        }
+
+        T& Ref()
+        {
+            return _obj;
+        }
+
+    private:
+        std::lock_guard<std::mutex> _lockGuard;
+        T& _obj;
+    };
+
+    Synchronized() : _obj{}
+    {
+    }
+
+    Scope Get()
+    {
+        return {*this};
+    }
+
+private:
+    T _obj;
+    std::mutex _mutex;
+};

--- a/tracer/src/Datadog.Tracer.Native/Synchronized.hpp
+++ b/tracer/src/Datadog.Tracer.Native/Synchronized.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <mutex>
+#include <optional>
 
 template <class T>
 class Synchronized
@@ -35,6 +36,18 @@ public:
     Scope Get()
     {
         return {*this};
+    }
+
+    std::optional<Scope> TryGet()
+    {
+        try
+        {
+            return {*this};
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
     }
 
 private:

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -577,15 +577,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
 
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
-
+    auto modules = module_ids.Get();
+    
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
     if (!is_attached_ || rejit_handler == nullptr)
     {
         return S_OK;
     }
 
-    auto hr = TryRejitModule(module_id);
+    auto hr = TryRejitModule(module_id, modules.Ref());
 
     // Push integration definitions from past modules that were unable to be added
     auto rejit_size = rejit_module_method_pairs.size();
@@ -684,7 +684,7 @@ std::string GetNativeLoaderFilePath()
     return native_loader_file_path.string();
 }
 
-HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
+HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& modules)
 {
     const auto& module_info = GetModuleInfo(this->info_, module_id);
     if (!module_info.IsValid())
@@ -912,7 +912,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id)
     }
     else
     {
-        module_ids_.push_back(module_id);
+        modules.push_back(module_id);
 
         bool searchForTraceAttribute = trace_annotations_enabled;
         if (searchForTraceAttribute)
@@ -1180,7 +1180,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
 
     // take this lock so we block until the
     // module metadata is not longer being used
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
+    auto modules = module_ids.Get();
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
     if (!is_attached_)
@@ -1236,9 +1236,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
 
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
+    auto modules = module_ids.Get();
 
-    DEL(_dataflow);
+    DEL(_dataflow)
 
     if (rejit_handler != nullptr)
     {
@@ -1246,10 +1246,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
         rejit_handler = nullptr;
     }
 
+    auto definitions = definitions_ids.Get();
+
     Logger::Info("Exiting...");
-    Logger::Debug("   ModuleIds: ", module_ids_.size());
+    Logger::Debug("   ModuleIds: ", modules->size());
     Logger::Debug("   IntegrationDefinitions: ", integration_definitions_.size());
-    Logger::Debug("   DefinitionsIds: ", definitions_ids_.size());
+    Logger::Debug("   DefinitionsIds: ", definitions->size());
     Logger::Debug("   ManagedProfilerLoadedAppDomains: ", managed_profiler_loaded_app_domains.size());
     Logger::Debug("   FirstJitCompilationAppDomains: ", first_jit_compilation_app_domains.size());
     Logger::Info("Stats: ", Stats::Instance()->ToString());
@@ -1290,7 +1292,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded()
 
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
+    auto modules = module_ids.Get();
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
     if (!is_attached_)
@@ -1320,7 +1322,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
+    auto modules = module_ids.Get();
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
     if (!is_attached_)
@@ -1340,7 +1342,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
     // we have to check if the Id is in the module_ids_ vector.
     // In case is True we create a local ModuleMetadata to inject the loader.
-    if (!shared::Contains(module_ids_, module_id))
+    if (!shared::Contains(modules.Ref(), module_id))
     {
         if (debugger_instrumentation_requester != nullptr)
         {
@@ -1478,7 +1480,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AppDomainShutdownFinished(AppDomainID app
 {
     // take this lock so we block until the
     // module metadata is not longer being used
-    std::lock_guard<std::mutex> guard(module_ids_lock_);
+    auto modules = module_ids.Get();
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
     if (!is_attached_)
@@ -1620,9 +1622,9 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
                                              bool isInterface, bool enable)
 {
     shared::WSTRING definitionsId = shared::WSTRING(id);
-    std::scoped_lock<std::mutex> definitionsLock(definitions_ids_lock_);
+    auto definitions = definitions_ids.Get();
 
-    auto defsIdFound = definitions_ids_.find(definitionsId) != definitions_ids_.end();
+    auto defsIdFound = definitions->find(definitionsId) != definitions->end();
     if (enable && defsIdFound)
     {
         Logger::Info("InitializeProfiler: Id already processed.");
@@ -1681,15 +1683,15 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
             integrationDefinitions.push_back(integration);
         }
 
-        std::scoped_lock<std::mutex> moduleLock(module_ids_lock_);
+        auto modules = module_ids.Get();
 
         if (enable)
         {
-            definitions_ids_.emplace(definitionsId);
+            definitions->emplace(definitionsId);
         }
         else
         {
-            definitions_ids_.erase(definitionsId);
+            definitions->erase(definitionsId);
         }
 
         if (enable)
@@ -1700,12 +1702,12 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
                 integration_definitions_.push_back(integration);
             }
 
-            Logger::Info("Total number of modules to analyze: ", module_ids_.size());
+            Logger::Info("Total number of modules to analyze: ", modules->size());
             if (rejit_handler != nullptr)
             {
                 auto promise = std::make_shared<std::promise<ULONG>>();
                 std::future<ULONG> future = promise->get_future();
-                tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(module_ids_,
+                tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(modules.Ref(),
                     integrationDefinitions, promise);
 
                 // wait and get the value from the future<int>
@@ -1727,12 +1729,12 @@ void CorProfiler::InternalAddInstrumentation(WCHAR* id, CallTargetDefinition* it
                 }
             }
 
-            Logger::Info("Total number of modules to analyze: ", module_ids_.size());
+            Logger::Info("Total number of modules to analyze: ", modules->size());
             if (rejit_handler != nullptr)
             {
                 auto promise = std::make_shared<std::promise<ULONG>>();
                 std::future<ULONG> future = promise->get_future();
-                tracer_integration_preprocessor->EnqueueRequestRevertForLoadedModules(module_ids_,
+                tracer_integration_preprocessor->EnqueueRequestRevertForLoadedModules(modules.Ref(),
                     integrationDefinitions, promise);
 
                 // wait and get the value from the future<int>
@@ -1749,15 +1751,15 @@ void CorProfiler::AddTraceAttributeInstrumentation(WCHAR* id, WCHAR* integration
                                                    WCHAR* integration_type_name_ptr)
 {
     shared::WSTRING definitionsId = shared::WSTRING(id);
-    std::scoped_lock<std::mutex> definitionsLock(definitions_ids_lock_);
+    auto definitions = definitions_ids.Get();
 
-    if (definitions_ids_.find(definitionsId) != definitions_ids_.end())
+    if (definitions->find(definitionsId) != definitions->end())
     {
         Logger::Info("AddTraceAttributeInstrumentation: Id already processed.");
         return;
     }
 
-    definitions_ids_.emplace(definitionsId);
+    definitions->emplace(definitionsId);
     shared::WSTRING integration_assembly_name = shared::WSTRING(integration_assembly_name_ptr);
     shared::WSTRING integration_type_name = shared::WSTRING(integration_type_name_ptr);
     trace_annotation_integration_type =
@@ -1772,9 +1774,9 @@ void CorProfiler::InitializeTraceMethods(WCHAR* id, WCHAR* integration_assembly_
                                          WCHAR* configuration_string_ptr)
 {
     shared::WSTRING definitionsId = shared::WSTRING(id);
-    std::scoped_lock<std::mutex> definitionsLock(definitions_ids_lock_);
+    auto definitions = definitions_ids.Get();
 
-    if (definitions_ids_.find(definitionsId) != definitions_ids_.end())
+    if (definitions->find(definitionsId) != definitions->end())
     {
         Logger::Info("InitializeTraceMethods: Id already processed.");
         return;
@@ -1803,7 +1805,7 @@ void CorProfiler::InitializeTraceMethods(WCHAR* id, WCHAR* integration_assembly_
 
     // TODO we do a handful of string splits here. We could probably do this with indexOf operations instead, but I'm gonna
     // first make sure this works
-    definitions_ids_.emplace(definitionsId);
+    definitions->emplace(definitionsId);
     if (rejit_handler != nullptr)
     {
         if (trace_annotation_integration_type == nullptr)
@@ -1824,15 +1826,15 @@ void CorProfiler::InitializeTraceMethods(WCHAR* id, WCHAR* integration_assembly_
         {
             std::vector<IntegrationDefinition> integrationDefinitions = GetIntegrationsFromTraceMethodsConfiguration(
                 *trace_annotation_integration_type.get(), configuration_string);
-            std::scoped_lock<std::mutex> moduleLock(module_ids_lock_);
+            auto modules = module_ids.Get();
 
-            Logger::Debug("InitializeTraceMethods: Total number of modules to analyze: ", module_ids_.size());
+            Logger::Debug("InitializeTraceMethods: Total number of modules to analyze: ", modules->size());
             if (rejit_handler != nullptr)
             {
                 auto promise = std::make_shared<std::promise<ULONG>>();
                 std::future<ULONG> future = promise->get_future();
                 tracer_integration_preprocessor->EnqueueRequestRejitForLoadedModules(
-                    module_ids_, integrationDefinitions,
+                    modules.Ref(), integrationDefinitions,
                     promise);
 
                 // wait and get the value from the future<int>
@@ -3653,10 +3655,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
     {
         return S_OK;
     }
-    
+
     // keep this lock until we are done using the module,
     // to prevent it from unloading while in use
-    std::lock_guard<std::mutex> guard(module_ids_lock_);    
+    auto modules = module_ids.Get();
 
     // Extract Module metadata
     ModuleID module_id;
@@ -3687,7 +3689,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCachedFunctionSearchStarted(FunctionID
     }
 
     // Verify that we have the metadata for this module
-    if (!shared::Contains(module_ids_, module_id))
+    if (!shared::Contains(modules.Ref(), module_id))
     {
         // we haven't stored a ModuleMetadata for this module,
         // so there's nothing to do here, we accept the NGEN image.

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include "clr_helpers.h"
 #include "debugger_probes_instrumentation_requester.h"
+#include "Synchronized.hpp"
 
 #include "../../../shared/src/native-src/pal.h"
 
@@ -44,8 +45,7 @@ private:
     std::vector<IntegrationDefinition> integration_definitions_;
     std::deque<std::pair<ModuleID, std::vector<MethodReference>>> rejit_module_method_pairs;
 
-    std::unordered_set<shared::WSTRING> definitions_ids_;
-    std::mutex definitions_ids_lock_;
+    Synchronized<std::unordered_set<shared::WSTRING>> definitions_ids;
 
     // Startup helper variables
     bool first_jit_compilation_completed = false;
@@ -84,8 +84,8 @@ private:
     //
     // Module helper variables
     //
-    std::mutex module_ids_lock_;
-    std::vector<ModuleID> module_ids_;
+    Synchronized<std::vector<ModuleID>> module_ids;
+
     ModuleID managedProfilerModuleId_;
 
     //
@@ -105,7 +105,7 @@ private:
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT RewriteForTelemetry(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id);
-    HRESULT TryRejitModule(ModuleID module_id);
+    HRESULT TryRejitModule(ModuleID module_id, std::vector<ModuleID>& modules);
     static bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);
     static bool EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata);
     //

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -320,11 +320,11 @@ void DebuggerProbesInstrumentationRequester::AddMethodProbes(
             return;
         }
 
-        std::scoped_lock<std::mutex> moduleLock(m_corProfiler->module_ids_lock_);
+        auto modules = m_corProfiler->module_ids.Get();
 
         auto promise = std::make_shared<std::promise<std::vector<MethodIdentifier>>>();
         std::future<std::vector<MethodIdentifier>> future = promise->get_future();
-        m_debugger_rejit_preprocessor->EnqueuePreprocessRejitRequests(m_corProfiler->module_ids_, methodProbeDefinitions, promise);
+        m_debugger_rejit_preprocessor->EnqueuePreprocessRejitRequests(modules.Ref(), methodProbeDefinitions, promise);
 
         const auto& methodProbeRequests = future.get();
 
@@ -384,11 +384,11 @@ void DebuggerProbesInstrumentationRequester::AddLineProbes(
             return;
         }
 
-        std::scoped_lock<std::mutex> moduleLock(m_corProfiler->module_ids_lock_);
+        auto modules = m_corProfiler->module_ids.Get();
 
         std::promise<std::vector<MethodIdentifier>> promise;
         std::future<std::vector<MethodIdentifier>> future = promise.get_future();
-        m_debugger_rejit_preprocessor->EnqueuePreprocessLineProbes(m_corProfiler->module_ids_, lineProbeDefinitions, &promise);
+        m_debugger_rejit_preprocessor->EnqueuePreprocessLineProbes(modules.Ref(), lineProbeDefinitions, &promise);
 
         const auto& lineProbeRequests = future.get();
 


### PR DESCRIPTION
## Summary of changes

Introduce a `Synchronized<T>` type to synchronize access to collections.

## Reason for change

While not foolproof, it helps ensuring that we never access those collections outside of a lock.

## Implementation details

:thinkcpp: :tableflip: :oldman:

A lot of trying random stuff and complaining to @gleocadie until it compiles.