### PR TITLE
Capture exceptions in Azure Functions

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/DiagnosticObserverListener.cs
+++ b/tracer/src/Datadog.Trace/Activity/DiagnosticObserverListener.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Activity
         {
             if (shouldListen)
             {
-                ((IObservable<KeyValuePair<string, object>>)source.Instance).Subscribe(new DiagnosticSourceEventListener(source.Name));
+                ((IObservable<KeyValuePair<string, object>>?)source.Instance)?.Subscribe(new DiagnosticSourceEventListener(source.Name));
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DefaultActivityHandler.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Activity.Handlers
                     return;
                 }
 
-                ActivityMappingById.GetOrAdd(activity.Id, _ => new(activity.Instance, CreateScopeFromActivity(activity, parent, traceId, spanId, rawTraceId, rawSpanId)));
+                ActivityMappingById.GetOrAdd(activity.Id, _ => new(activity.Instance!, CreateScopeFromActivity(activity, parent, traceId, spanId, rawTraceId, rawSpanId)));
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsExecutorTryExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsExecutorTryExecuteAsyncIntegration.cs
@@ -8,6 +8,7 @@ using System;
 using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 {
@@ -53,7 +54,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            where TReturn : IDelayedException, IDuckType
         {
+            if (exception == null && returnValue.Instance != null)
+            {
+                exception = returnValue.Exception;
+            }
+
             state.Scope?.DisposeWithException(exception);
             return returnValue;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsExecutorTryExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsExecutorTryExecuteAsyncIntegration.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
             where TReturn : IDelayedException, IDuckType
         {
-            if (exception == null && returnValue.Instance != null)
+            if (exception is null && returnValue.Instance is not null)
             {
                 exception = returnValue.Exception;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/IDelayedException.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/IDelayedException.cs
@@ -5,13 +5,15 @@
 
 #if !NETFRAMEWORK
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 {
     internal interface IDelayedException
     {
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
     }
 }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/IDelayedException.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/IDelayedException.cs
@@ -1,0 +1,18 @@
+// <copyright file="IDelayedException.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
+{
+    internal interface IDelayedException
+    {
+        public Exception Exception { get; }
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
         internal static Test? CreateTest(ITest currentTest)
         {
-            if (ExistingTestCreation.TryGetValue(currentTest.Instance, out _))
+            if (ExistingTestCreation.TryGetValue(currentTest.Instance!, out _))
             {
                 return null;
             }
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             }
 
             var test = suite.CreateTest(testMethod.Name);
-            ExistingTestCreation.GetOrCreateValue(currentTest.Instance);
+            ExistingTestCreation.GetOrCreateValue(currentTest.Instance!);
             string? skipReason = null;
 
             // Get test parameters
@@ -203,7 +203,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             }
 
             if (test is not null &&
-                ModulesItems.TryGetValue(test.Instance, out var moduleObject) &&
+                ModulesItems.TryGetValue(test.Instance!, out var moduleObject) &&
                 moduleObject is TestModule module)
             {
                 return module;
@@ -216,11 +216,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         {
             if (test.TestType == TestModuleConst)
             {
-                ModulesItems.Add(test.Instance, module);
+                ModulesItems.Add(test.Instance!, module);
             }
             else if (GetParentWithTestType(test, TestModuleConst) is { } assemblyITest)
             {
-                ModulesItems.Add(assemblyITest.Instance, module);
+                ModulesItems.Add(assemblyITest.Instance!, module);
             }
         }
 
@@ -237,7 +237,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             }
 
             if (test is not null &&
-                SuiteItems.TryGetValue(test.Instance, out var suiteObject) &&
+                SuiteItems.TryGetValue(test.Instance!, out var suiteObject) &&
                 suiteObject is TestSuite suite)
             {
                 return suite;
@@ -250,11 +250,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         {
             if (test.TestType == TestSuiteConst)
             {
-                SuiteItems.Add(test.Instance, suite);
+                SuiteItems.Add(test.Instance!, suite);
             }
             else if (GetParentWithTestType(test, TestSuiteConst) is { } suiteITest)
             {
-                SuiteItems.Add(suiteITest.Instance, suite);
+                SuiteItems.Add(suiteITest.Instance!, suite);
             }
         }
 

--- a/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Gets instance
         /// </summary>
-        object Instance { get; }
+        object? Instance { get; }
 
         /// <summary>
         /// Gets instance Type

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AzureFunctionsTests.cs" company="Datadog">
+// <copyright file="AzureFunctionsTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -130,7 +130,7 @@ public abstract class AzureFunctionsTests : TestHelper
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunAzureFunctionAndWaitForExit(agent, framework: "net6.0"))
             {
-                const int expectedSpanCount = 9;
+                const int expectedSpanCount = 12;
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
                 using var s = new AssertionScope();

--- a/tracer/test/snapshots/AzureFunctionsTests.InProcess.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.InProcess.verified.txt
@@ -152,6 +152,30 @@
   {
     TraceId: Id_1,
     SpanId: Id_8,
+    Name: http.request,
+    Resource: GET localhost:00000/api/error,
+    Service: AzureFunctionsAllTriggers-http-client,
+    Type: http,
+    ParentId: Id_6,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 500,
+      http.url: http://localhost:00000/api/error,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
     Name: azure-functions.invoke,
     Resource: GET /api/simple,
     Service: AzureFunctionsAllTriggers,
@@ -189,12 +213,57 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_9,
+    SpanId: Id_10,
+    Name: azure-functions.invoke,
+    Resource: GET /api/error,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_8,
+    Error: 1,
+    Tags: {
+      aas.environment.extension_version: unknown,
+      aas.environment.instance_id: unknown,
+      aas.environment.instance_name: IntegrationTestHost,
+      aas.environment.os: unknown,
+      aas.environment.runtime: .NET,
+      aas.function.binding: Microsoft.Azure.WebJobs.Host.Executors.BindingSource,
+      aas.function.method: Samples.AzureFunctions.AllTriggers.AllTriggers.Error,
+      aas.function.name: Error,
+      aas.function.trigger: Http,
+      aas.site.kind: functionapp,
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      component: AzureFunctions,
+      env: integration_tests,
+      error.msg: Exception while executing function: Error,
+      error.stack:
+Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Error
+---> System.InvalidOperationException: Task failed successfully.
+at Samples.AzureFunctions.AllTriggers.AllTriggers.Error(HttpRequest req, ILogger log),
+      error.type: Microsoft.Azure.WebJobs.Host.FunctionInvocationException,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.url: http://localhost:00000/api/error,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
     Name: azure-functions.invoke,
     Resource: Http SimpleHttpTrigger,
     Service: AzureFunctionsAllTriggers,
     Type: serverless,
-    ParentId: Id_8,
+    ParentId: Id_9,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,
@@ -204,11 +273,33 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_10,
+    SpanId: Id_12,
+    Name: azure-functions.invoke,
+    Resource: Http Error,
+    Service: AzureFunctionsAllTriggers,
+    Type: serverless,
+    ParentId: Id_10,
+    Error: 1,
+    Tags: {
+      aas.site.name: AzureFunctionsAllTriggers,
+      aas.site.type: function,
+      env: integration_tests,
+      error.msg: Exception while executing function: Error,
+      error.stack:
+Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Error
+---> System.InvalidOperationException: Task failed successfully.
+at Samples.AzureFunctions.AllTriggers.AllTriggers.Error(HttpRequest req, ILogger log),
+      error.type: Microsoft.Azure.WebJobs.Host.FunctionInvocationException,
+      language: dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
     Name: Manual inside Simple,
     Resource: Manual inside Simple,
     Service: AzureFunctionsAllTriggers,
-    ParentId: Id_9,
+    ParentId: Id_11,
     Tags: {
       aas.site.name: AzureFunctionsAllTriggers,
       aas.site.type: function,

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V3InProcess/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V3InProcess/AllTriggers.cs
@@ -48,6 +48,18 @@ namespace Samples.AzureFunctions.AllTriggers
             return new OkObjectResult("This HTTP triggered function executed successfully. ");
         }
 
+        [FunctionName("Error")]
+        public async Task<IActionResult> Error(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "error")] HttpRequest req,
+            ILogger log)
+        {
+            await Task.Yield();
+
+            log.LogInformation("Called error HTTP trigger function.");
+
+            throw new InvalidOperationException("Task failed successfully.");
+        }
+        
         [FunctionName("TriggerCaller")]
         public async Task<IActionResult> Trigger(
                 [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "trigger")] HttpRequest req,
@@ -61,6 +73,7 @@ namespace Samples.AzureFunctions.AllTriggers
             if (doAll || triggers.Contains("http"))
             {
                 await Attempt(() => CallFunctionHttp("simple", log), log);
+                await Attempt(() => CallFunctionHttp("error", log), log);
             }
 
             return new OkObjectResult("Attempting triggers.");
@@ -82,7 +95,7 @@ namespace Samples.AzureFunctions.AllTriggers
             return response;
         }
 
-        private async Task Attempt(Func<Task> action, ILogger log)
+        private async Task Attempt(Func<Task> action, ILogger log, bool expectFailure = false)
         {
             try
             {
@@ -90,7 +103,14 @@ namespace Samples.AzureFunctions.AllTriggers
             }
             catch (Exception ex)
             {
-                log.LogError(ex, "Trigger attempt failure");
+                if (expectFailure)
+                {
+                    log.LogInformation(ex, "Trigger attempt failure as expected");
+                }
+                else
+                {
+                    log.LogError(ex, "Trigger attempt failure");
+                }
             }
         }
     }

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V3InProcess/AllTriggers.cs
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V3InProcess/AllTriggers.cs
@@ -73,7 +73,7 @@ namespace Samples.AzureFunctions.AllTriggers
             if (doAll || triggers.Contains("http"))
             {
                 await Attempt(() => CallFunctionHttp("simple", log), log);
-                await Attempt(() => CallFunctionHttp("error", log), log);
+                await Attempt(() => CallFunctionHttp("error", log), log, expectFailure: true);
             }
 
             return new OkObjectResult("Attempting triggers.");


### PR DESCRIPTION
## Summary of changes

When an exception is thrown in an Azure Functions, it's caught in `FunctionExecutor.TryExecuteAsync`, wrapped in an instance of `IDelayedException`, and returned to the caller. Because of that, our current instrumentation misses it and doesn't mark the span as error.

This PR adds some logic to inspect the instance `IDelayedException` and attach the exception to the span.

## Reason for change

Customers couldn't see if an error occurred in their azure functions.

## Implementation details

Because ducktype proxies can't be null, I had to use the `IDuckType` interface and inspect if `Instance` is null. There are a few unrelated changes in the PR because the property was wrongly marked as not nullable.

## Test coverage

Added an exception to the current Azure Functions test.
