### PR TITLE
Exclude `App_LocalResources.` deps from telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -42,6 +42,7 @@ namespace Datadog.Trace.Telemetry
               && (assemblyName.StartsWith("App_Web_", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_Theme_", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_GlobalResources.", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_LocalResources.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)))


### PR DESCRIPTION
## Summary of changes

Exclude dependencies that are prefixed with `App_LocalResources`

## Reason for change

These are dynamic dependencies that don't tell us anything useful.

## Implementation details

Add exclusion.

## Test coverage

Meh
