### PR TITLE
[Profiler] Fix possible missing CPU sampling - DO NOT MERGE

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -155,15 +155,17 @@ uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
     return cpuTime;
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
+bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
     bool isRunning = false;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))
     {
         cpuTime = 0;
+        failed = true;
         return false;
     }
 
+    failed = false;
     return isRunning;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -162,7 +162,7 @@ bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 
             if (msgBuffer != NULL)
             {
-                Log::Error("IsRunning() error calling NtQueryInformationThread (", errorCode, "): ", (LPTSTR)msgBuffer);
+                Log::Error("IsRunning() error 0x", std::hex, lResult, " calling NtQueryInformationThread (last error =  0x", std::hex, errorCode, std::dec, "): ", (LPTSTR)msgBuffer);
                 LocalFree(msgBuffer);
             }
         }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -19,6 +19,6 @@ namespace OsSpecificApi
 {
    std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
    uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
-   bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
+   bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
    int32_t GetProcessorCount();
 } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -244,16 +244,22 @@ void StackSamplerLoop::CpuProfilingIteration()
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)
         {
+            // detect Windows API call failure
+            bool failure = false;
+
             // sample only if the thread is currently running on a core
             uint64_t currentConsumption = 0;
             uint64_t lastConsumption = _targetThread->GetCpuConsumptionMilliseconds();
-            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption);
-            // Note: it is not possible to get this information on Windows 32-bit
-            //       so true is returned if this thread consumed some CPU since
-            //       the last iteration
+            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption, failure);
+            // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
+            //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
-    #if BIT64  // nothing to do for Windows 64-bit
-    #else  // Windows 32-bit
+    #if BIT64   // Windows 64-bit
+            if (failure)
+            {
+                isRunning == (lastConsumption < currentConsumption);
+            }
+    #else       // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);
     #endif
 #else  // nothing to do for Linux

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -257,7 +257,7 @@ void StackSamplerLoop::CpuProfilingIteration()
     #if BIT64   // Windows 64-bit
             if (failure)
             {
-                isRunning == (lastConsumption < currentConsumption);
+                isRunning = (lastConsumption < currentConsumption);
             }
     #else       // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);


### PR DESCRIPTION
## Summary of changes
Avoid missing CPU samples

## Reason for change
If an internal Windows API fails, no thread could be considered as running. 

## Implementation details
Take into account possible failure and use the CPU consumption difference to sample a thread like in 32-bit

## Test coverage

## Other details
<!-- Fixes #{issue} -->
