### PR TITLE
Add usr.id when propagating

### DIFF
--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace
 
             var setTag = TaggingUtils.GetSpanSetter(span, out var spanClass);
 
-            // usr.id should always be set, even when PropagetId is true
+            // usr.id should always be set, even when PropagateId is true
             setTag(Tags.User.Id, userDetails.Id);
 
             if (userDetails.PropagateId)

--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -38,15 +38,14 @@ namespace Datadog.Trace
 
             var setTag = TaggingUtils.GetSpanSetter(span, out var spanClass);
 
+            // usr.id should always be set, even when PropagetId is true
+            setTag(Tags.User.Id, userDetails.Id);
+
             if (userDetails.PropagateId)
             {
                 var base64UserId = Convert.ToBase64String(Encoding.UTF8.GetBytes(userDetails.Id));
                 const string propagatedUserIdTag = TagPropagation.PropagatedTagPrefix + Tags.User.Id;
                 setTag(propagatedUserIdTag, base64UserId);
-            }
-            else
-            {
-                setTag(Tags.User.Id, userDetails.Id);
             }
 
             if (userDetails.Email is not null)


### PR DESCRIPTION
## Summary of changes

Always set the `usr.id` even when `PropagateId == true`. 


Fixes #3629 
