### PR TITLE
FailFast in case of timeout to (hopefully) trigger a dump

### DIFF
--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -91,7 +91,7 @@ internal static partial class DotNetSettingsExtensions
         return settings.SetProperty("BuildProjectReferences", false);
     }
 
-    public static DotNetTestSettings EnableCrashDumps(this DotNetTestSettings settings, MiniDumpType dumpType = MiniDumpType.MiniDumpWithPrivateReadWriteMemory)
+    public static DotNetTestSettings EnableCrashDumps(this DotNetTestSettings settings, MiniDumpType dumpType = MiniDumpType.MiniDumpWithFullMemory)
     {
         if (bool.Parse(Environment.GetEnvironmentVariable("enable_crash_dumps") ?? "false"))
         {

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -187,6 +187,7 @@ namespace Datadog.Trace.Agent
 
             if (!success)
             {
+                Environment.FailFast("(╯°□°)╯︵ ┻━┻ ");
                 Log.Warning("Could not flush all traces before process exit");
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -37,6 +37,15 @@ namespace Datadog.Trace.TestHelpers
 
         private AgentBehaviour behaviour = AgentBehaviour.Normal;
 
+        static MockTracerAgent()
+        {
+            // Eagerly initialize the serializers, to reduce the probability of timeout
+            var resolver = MessagePack.Resolvers.StandardResolver.Instance;
+            _ = resolver.GetFormatter<IList<IList<MockSpan>>>();
+            _ = resolver.GetFormatter<MockClientStatsPayload>();
+            _ = resolver.GetFormatter<MockDataStreamsPayload>();
+        }
+
         protected MockTracerAgent(bool telemetryEnabled, TestTransports transport)
         {
             TelemetryEnabled = telemetryEnabled;


### PR DESCRIPTION
## Summary of changes

Ungracefully failfast in case of timeout when flushing the traces, hoping that this will trigger a memory dump.

## Reason for change

(╯°□°)╯︵ ┻━┻ 

## Implementation details

(╯°□°)╯︵ ┻━┻ 

## Test coverage

(╯°□°)╯︵ ┻━┻ 

## Other details

┬━┬ ノ( ゜-゜ノ)
