### PR TITLE
Swap Samples.DatabaseHelper to use Samples.Shared

### DIFF
--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/DapperTestHarness.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/DapperTestHarness.cs
@@ -4,7 +4,6 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
-using Datadog.Trace;
 
 namespace Samples.DatabaseHelper
 {
@@ -26,13 +25,13 @@ namespace Samples.DatabaseHelper
 
             string connectionTypeName = connection.GetType().FullName;
 
-            using (var scopeAll = Tracer.Instance.StartActive("run.all"))
+            using (var scopeAll = SampleHelpers.CreateScope("run.all"))
             {
-                scopeAll.Span.SetTag("connection-type", connectionTypeName);
+                SampleHelpers.TrySetTag(scopeAll, "connection-type", connectionTypeName);
 
-                using (var scopeSync = Tracer.Instance.StartActive("run.sync"))
+                using (var scopeSync = SampleHelpers.CreateScope("run.sync"))
                 {
-                    scopeSync.Span.SetTag("connection-type", connectionTypeName);
+                    SampleHelpers.TrySetTag(scopeSync, "connection-type", connectionTypeName);
 
                     connection.Open();
                     CreateNewTable(connection);
@@ -48,9 +47,9 @@ namespace Samples.DatabaseHelper
                 // leave a small space between spans, for better visibility in the UI
                 await Task.Delay(TimeSpan.FromSeconds(0.1));
 
-                using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
+                using (var scopeAsync = SampleHelpers.CreateScope("run.async"))
                 {
-                    scopeAsync.Span.SetTag("connection-type", connectionTypeName);
+                    SampleHelpers.TrySetTag(scopeAsync, "connection-type", connectionTypeName);
 
                     await connection.OpenAsync();
                     await CreateNewTableAsync(connection);

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace;
 
 // ReSharper disable MethodHasAsyncOverloadWithCancellation
 // ReSharper disable MethodSupportsCancellation
@@ -53,7 +52,7 @@ namespace Samples.DatabaseHelper
                                 new DbCommandNetStandardInterfaceGenericExecutor<TCommand>(),
                             };
 
-            using (var root = Tracer.Instance.StartActive("RunAllAsync<TCommand>"))
+            using (var root = SampleHelpers.CreateScope("RunAllAsync<TCommand>"))
             {
                 foreach (var executor in executors)
                 {
@@ -89,7 +88,7 @@ namespace Samples.DatabaseHelper
                                 new DbCommandNetStandardInterfaceExecutor(),
                             };
 
-            using (var root = Tracer.Instance.StartActive("RunBaseClassesAsync"))
+            using (var root = SampleHelpers.CreateScope("RunBaseClassesAsync"))
             {
                 foreach (var executor in executors)
                 {
@@ -109,7 +108,7 @@ namespace Samples.DatabaseHelper
                                 providerSpecificCommandExecutor
                             };
 
-            using (var root = Tracer.Instance.StartActive("RunSingleAsync"))
+            using (var root = SampleHelpers.CreateScope("RunSingleAsync"))
             {
                 foreach (var executor in executors)
                 {
@@ -133,7 +132,7 @@ namespace Samples.DatabaseHelper
             CancellationToken cancellationToken,
             params IDbCommandExecutor[] providerSpecificCommandExecutors)
         {
-            using (var root = Tracer.Instance.StartActive("RunAllAsync"))
+            using (var root = SampleHelpers.CreateScope("RunAllAsync"))
             {
                 foreach (var executor in providerSpecificCommandExecutors)
                 {
@@ -159,14 +158,14 @@ namespace Samples.DatabaseHelper
             string commandName = commandExecutor.CommandTypeName;
             Console.WriteLine(commandName);
 
-            using (var parentScope = Tracer.Instance.StartActive("command"))
+            using (var parentScope = SampleHelpers.CreateScope("command"))
             {
-                parentScope.Span.ResourceName = commandName;
+                SampleHelpers.TrySetResourceName(parentScope, commandName);
                 IDbCommand command;
 
-                using (var scope = Tracer.Instance.StartActive("sync"))
+                using (var scope = SampleHelpers.CreateScope("sync"))
                 {
-                    scope.Span.ResourceName = commandName;
+                    SampleHelpers.TrySetResourceName(scope, commandName);
 
                     Console.WriteLine("  Synchronous");
                     Console.WriteLine();
@@ -198,9 +197,9 @@ namespace Samples.DatabaseHelper
                 {
                     await Task.Delay(100, cancellationToken);
 
-                    using (var scope = Tracer.Instance.StartActive("async"))
+                    using (var scope = SampleHelpers.CreateScope("async"))
                     {
-                        scope.Span.ResourceName = commandName;
+                        SampleHelpers.TrySetResourceName(scope, commandName);
 
                         Console.WriteLine("  Asynchronous");
                         Console.WriteLine();
@@ -230,9 +229,9 @@ namespace Samples.DatabaseHelper
 
                     await Task.Delay(100, cancellationToken);
 
-                    using (var scope = Tracer.Instance.StartActive("async-with-cancellation"))
+                    using (var scope = SampleHelpers.CreateScope("async-with-cancellation"))
                     {
-                        scope.Span.ResourceName = commandName;
+                        SampleHelpers.TrySetResourceName(scope, commandName);
 
                         Console.WriteLine("  Asynchronous with cancellation");
                         Console.WriteLine();

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
@@ -7,13 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
 
     <!-- this referenced project only targets netstandard2.0 -->
     <ProjectReference Include="..\..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
   </ItemGroup>
+
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
## Summary of changes

- Removes the `Datadog.Trace` references from `Samples.DatabaseHelper`

## Reason for change

- Removing the reference to `Datadog.Trace`.

## Implementation details

- Remove `Datadog.Trace` reference to `Samples.Shared` equivalents

## Test coverage

Tested out a few of the database samples and they all passed without any snapshot changes.

## Other details
<!-- Fixes #{issue} -->
