### PR TITLE
Change Samples.TracingWithoutLimits to use Samples.Shared

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -43,6 +43,7 @@ namespace Samples
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.Public | BindingFlags.Static);
         private static readonly MethodInfo SetServiceName = TracerSettingsType?.GetProperty("ServiceName")?.SetMethod;
+        private static readonly MethodInfo GetMetricMethod = SpanType?.GetMethod("GetMetric", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
@@ -289,6 +290,27 @@ namespace Samples
                 }
             }
             return null;
+        }
+
+        public static bool TryGetMetric(object scope, string key, out double metric)
+        {
+            metric = 0.0;
+
+            if (SpanProperty is null || GetMetricMethod is null)
+            {
+                return false;
+            }
+
+            var span = SpanProperty.Invoke(scope, Array.Empty<object>());
+            var metricValue = GetMetricMethod.Invoke(span, new[] { key });
+
+            if (metricValue is null)
+            {
+                return false;
+            }
+
+            metric = (double)metricValue;
+            return true;
         }
 
         public static void TrySetExceptionOnActiveScope(Exception exception)

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Program.cs
@@ -129,24 +129,23 @@ namespace Samples.TracingWithoutLimits
                 Thread.Sleep(3);
             }
 
-            var metrics = SampleHelpers.GetMetrics(root);
             var rulePsrKey = "_dd.rule_psr";
             var limitPsrKey = "_dd.limit_psr";
             var priorityKey = "_sampling_priority_v1";
 
-            if (!metrics.ContainsKey(rulePsrKey))
+            if (!SampleHelpers.TryGetMetric(root, rulePsrKey, out _))
             {
                 throw new Exception($"{rulePsrKey} must be set in a user defined rule.");
             }
 
-            var priority = metrics[priorityKey];
+            SampleHelpers.TryGetMetric(root, priorityKey, out double priorityValue);
 
-            if (priority > 0f && !metrics.ContainsKey(limitPsrKey))
+            if (priorityValue > 0f && !SampleHelpers.TryGetMetric(root, limitPsrKey, out _))
             {
                 throw new Exception($"{limitPsrKey} must be set if a user defined rule is configured and the trace is sampled.");
             }
 
-            Counts[Key(serviceName, operationName, priority)]++;
+            Counts[Key(serviceName, operationName, priorityValue)]++;
         }
 
         private static void PrepKeys(string service, string operation, decimal? expectedKeeps)

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Properties/launchSettings.json
@@ -5,11 +5,11 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         "DD_VERSION": "1.0.0",

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
@@ -1,5 +1,2 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

- Removes the direct reference to `Datadog.Trace` in favor of `Samples.Shared`
- Added a `TryGetMetric` to `SampleHelpers` as the `SampleHelpers.GetMetrics` doesn't work - looks like it is only used in `Samples.RateLimiter` which I think is skipped from testing just like this project.

## Reason for change

- Want to remove direct references to `Datadog.Trace` in the samples

## Implementation details

- Swapped calls over to `SampleHelpers`

## Test coverage

- It looks like this sample didn't have any tests and is skipped - it also takes a long time 5+ minutes or so as it runs so many iterations

## Other details
<!-- Fixes #{issue} -->
