### PR TITLE
[Dynamic Instrumentation] Deploy dotnet to debugger backend demo applications

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,10 @@ variables:
   DOWNSTREAM_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
-
+  DEPLOY_TO_DEBUGGER_BACKEND:
+    value: "false"
+    description: "Set to true to deploy to debugger backend demo application"
+    
 build:
   only:
     - master
@@ -161,3 +164,17 @@ deploy_latest_musl_tag_to_docker_registries:
     IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA-musl
     IMG_DESTINATIONS: dd-lib-dotnet-init:latest-musl
     IMG_SIGNING: "false"
+
+deploy_to_debugger_backend:
+  stage: deploy
+  rules:
+    - if: '$DEPLOY_TO_DEBUGGER_BACKEND == "true"'
+  trigger:
+    project: DataDog/debugger-backend
+    branch: main
+  variables:
+    UPSTREAM_PACKAGE_JOB: build
+    UPSTREAM_PROJECT_NAME: $CI_PROJECT_NAME
+    UPSTREAM_BRANCH: $CI_COMMIT_BRANCH
+    UPSTREAM_TAG: $DEPLOY_TAG
+


### PR DESCRIPTION
## Summary of changes
Added a GitLab pipeline stage to deploy the latest dotnet version to the debugger backend demo applications.

## Reason for the change
We need to deploy the latest dotnet tracer version to the debugger backend demo applications.

## Implementation details
This PR introduces a new GitLab pipeline stage to deploy the latest dotnet tracer version to the debugger backend demo applications. The pipeline will be triggered by a daily schedule.