### PR TITLE
Swap DatadogThreadTest to use SampleHelpers

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -40,7 +40,6 @@ namespace Samples
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
-        private static readonly MethodInfo SetLogsInjectionEnabled = TracerSettingsType?.GetProperty("SetLogsInjectionEnabled")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
@@ -69,20 +68,6 @@ namespace Samples
             }
             var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
             SetService.Invoke(tracerSettings, new object[] { serviceName });
-
-            var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
-            ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });
-        }
-
-        public static void ConfigureTracerWithLogsInjection()
-        {
-            if (TracerSettingsType is null || GetTracerInstance is null || ConfigureMethod is null || FromDefaultSourcesMethod is null)
-            {
-                return;
-            }
-
-            var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
-            SetLogsInjectionEnabled.Invoke(tracerSettings, new object[] { true });
 
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
             ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -39,6 +39,7 @@ namespace Samples
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
+        private static readonly MethodInfo SetLogsInjectionEnabled = TracerSettingsType?.GetProperty("SetLogsInjectionEnabled")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
@@ -67,6 +68,20 @@ namespace Samples
             }
             var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
             SetService.Invoke(tracerSettings, new object[] { serviceName });
+
+            var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
+            ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });
+        }
+
+        public static void ConfigureTracerWithLogsInjection()
+        {
+            if (TracerSettingsType is null || GetTracerInstance is null || ConfigureMethod is null || FromDefaultSourcesMethod is null)
+            {
+                return;
+            }
+
+            var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
+            SetLogsInjectionEnabled.Invoke(tracerSettings, new object[] { true });
 
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
             ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -201,6 +201,20 @@ namespace Samples
             spanId = (ulong) SpanIdProperty.Invoke(parentScope, null);
         }
 
+        public static ulong GetTraceId(IDisposable scope)
+        {
+            var span = SpanProperty.Invoke(scope, Array.Empty<object>());
+            var context = SpanContextProperty.Invoke(span, Array.Empty<object>());
+            return (ulong) TraceIdProperty.Invoke(context, Array.Empty<object>());
+        }
+
+        public static ulong GetSpanId(IDisposable scope)
+        {
+            var span = SpanProperty.Invoke(scope, Array.Empty<object>());
+            var context = SpanContextProperty.Invoke(span, Array.Empty<object>());
+            return (ulong) SpanIdProperty.Invoke(context, Array.Empty<object>());
+        }
+
         public static Task ForceTracerFlushAsync()
         {
             if (GetTracerInstance is null || ForceFlushAsyncMethod is null)

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -33,6 +33,7 @@ namespace Samples
         private static readonly MethodInfo TraceIdProperty = SpanContextType?.GetProperty("TraceId")?.GetMethod;
         private static readonly MethodInfo SpanIdProperty = SpanContextType?.GetProperty("SpanId")?.GetMethod;
         private static readonly MethodInfo SpanProperty = ScopeType?.GetProperty("Span", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
+        private static readonly MethodInfo SpanContextProperty = SpanType?.GetProperty("Context", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
         private static readonly MethodInfo CorrelationIdentifierTraceIdProperty = CorrelationIdentifierType?.GetProperty("TraceId", BindingFlags.Public | BindingFlags.Static)?.GetMethod;
         private static readonly MethodInfo SetResourceNameProperty = SpanType?.GetProperty("ResourceName", BindingFlags.NonPublic | BindingFlags.Instance)?.SetMethod;
         private static readonly MethodInfo SetTagMethod = SpanType?.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
@@ -13,8 +13,4 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
@@ -55,16 +55,16 @@ namespace DataDogThreadTest
                                             using (var outerScope = SampleHelpers.CreateScope("thread-test"))
                                             {
                                                 var span = _getSpanProperty.Invoke(outerScope, Array.Empty<object>());
-                                                var outerTraceId = _getTraceIdProperty.Invoke(span, Array.Empty<object>());
-                                                var outerSpanId = _getSpanIdProperty.Invoke(span, Array.Empty<object>());
+                                                var outerTraceId = (ulong)_getTraceIdProperty.Invoke(span, Array.Empty<object>());
+                                                var outerSpanId = (ulong)_getSpanIdProperty.Invoke(span, Array.Empty<object>());
 
                                                 logger.Info($"TraceId: {outerTraceId}, SpanId: {outerSpanId}");
 
                                                 using (var innerScope = SampleHelpers.CreateScope("nest-thread-test"))
                                                 {
                                                     var innerSpan = _getSpanProperty.Invoke(innerScope, Array.Empty<object>());
-                                                    var innerTraceId = _getTraceIdProperty.Invoke(innerSpan, Array.Empty<object>());
-                                                    var innerSpanId = _getSpanIdProperty.Invoke(innerSpan, Array.Empty<object>());
+                                                    var innerTraceId = (ulong)_getTraceIdProperty.Invoke(innerSpan, Array.Empty<object>());
+                                                    var innerSpanId = (ulong)_getSpanIdProperty.Invoke(innerSpan, Array.Empty<object>());
 
                                                     if (outerTraceId != innerTraceId)
                                                     {

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
@@ -11,7 +11,9 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home"
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+
+        "DD_LOGS_INJECTION": "true"
       },
       "nativeDebugging": true
     }

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "DataDogThreadTest": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home"
+      },
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary of changes

Replaces the reference to `Datadog.Trace` to use `SampleHelpers`/Reflection

## Reason for change

Don't want the direct reference to `Datadog.Trace`

## Implementation details

- Removes `Datadog.Trace` reference in favor of `SampleHelpers`/Reflection

## Test coverage

- Issue with this version and the prior version where the `loggingEvent.Properties[TraceIdKey]` and `loggingEvent.Properties[SpanIdKey]` don't actually exist. Not sure what is going on there.

## Other details
<!-- Fixes #{issue} -->
