### PR TITLE
Remove unused reference to Datadog.Trace in HttpMessageHandler.StackOverflowException

### DIFF
--- a/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
+++ b/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
@@ -6,8 +6,4 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Properties/launchSettings.json
@@ -5,11 +5,11 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
       },


### PR DESCRIPTION
## Summary of changes

Removes an unused reference to `Datadog.Trace` that was in `HttpMessageHandler.StackOverflowException`.

## Reason for change

Don't want the reference to `Datadog.Trace` and it wasn't actually being used here.

## Implementation details

- Remove the reference to `Datadog.Trace`

## Test coverage

I'm not really sure where the test for this is, but the sample runs fine.

## Other details
<!-- Fixes #{issue} -->
