### PR TITLE
Remove Datadog.Trace from Samples.Security.AspNet

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -292,7 +292,7 @@ namespace Samples
 
             var span = SpanProperty.Invoke(scope, Array.Empty<object>());
             var userDetails = UserDetailsStringCtor.Invoke(new object[] { userId });
-            SetUserMethod.Invoke(span, new object[] { span, userDetails });
+            SetUserMethod.Invoke(null, new object[] { span, userDetails });
         }
 
         public static IEnumerable<KeyValuePair<string,string>> GetDatadogEnvironmentVariables()

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
@@ -18,7 +18,4 @@
     <Compile Include="..\Samples.Security.AspNetCore5\Models\**\*.*" Link="Models\%(RecursiveDir)%(Filename)%(Extension)" />
     <Content Include="..\Samples.Security.AspNetCore5\Views\**\*.*" Link="Views\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
@@ -4,7 +4,7 @@ using Samples.Security.AspNetCore5.Models;
 using System;
 using System.Diagnostics;
 using System.Linq;
-using Datadog.Trace;
+using System.Reflection;
 
 namespace Samples.Security.AspNetCore5.Controllers
 {
@@ -19,11 +19,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         public IActionResult Index()
         {
-            var userDetails = new UserDetails()
-            {
-                Id = "user3",
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            SampleHelpers.TrySetUserOnActiveScope("user3");
 
             return View();
         }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -18,7 +18,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCoreBare/Properties/launchSettings.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCoreBare/Properties/launchSettings.json
@@ -34,7 +34,7 @@
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home\\",
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
         "DD_VERSION": "1.0.0",
         "DD_TRACE_HEADER_TAGS": "sample.correlation.identifier, Server",
         "DD_APPSEC_RULES": "C:\\Repositories\\dd-trace-dotnet\\tracer\\test\\Datadog.Trace.Security.IntegrationTests\\ruleset.3.0.json",

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/UserController.cs
@@ -1,22 +1,38 @@
+using System;
 using System.Linq;
+using System.Reflection;
 using System.Web.Mvc;
-using Datadog.Trace;
 using Samples.AspNetMvc5.Models;
 
 namespace Samples.AspNetMvc5.Controllers
 {
     public class UserController : Controller
     {
+        private static readonly Type _scopeType = Type.GetType("Datadog.Trace.Scope, Datadog.Trace");
+        private static readonly Type _spanType = Type.GetType("Datadog.Trace.Span, Datadog.Trace");
+        private static readonly Type _userDetailsType = Type.GetType("Datadog.Trace.UserDetails, Datadog.Trace");
+        private static readonly Type _spanExtensionsType = Type.GetType("Datadog.Trace.SpanExtensions, Datadog.Trace");
+        private static MethodInfo _spanProperty = _scopeType.GetProperty("Span", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
+
+        private static MethodInfo _setUserMethod = _spanExtensionsType.GetMethod("SetUser", BindingFlags.Public | BindingFlags.Static);
+        private static ConstructorInfo _userDetailsCtor = _userDetailsType.GetConstructor(new[] { typeof(string) });
+
         [ValidateInput(false)]
         public ActionResult Index()
         {
             var userId = "user3";
 
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            var userDetails = _userDetailsCtor.Invoke(new object[] {userId});
+
+            //var userDetails = new UserDetails()
+            //{
+            //    Id = userId,
+            //};
+            //Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            var scope = SampleHelpers.GetActiveScope();
+            var span = _spanProperty.Invoke(scope, Array.Empty<object>());
+            _setUserMethod.Invoke(span, new object[] {userDetails});
+
 
             return View();
         }

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -161,7 +161,7 @@
     <Compile Include="Controllers\PostsController.cs" />
     <Compile Include="Controllers\RenderController.cs" />
     <Compile Include="Data\DatabaseHelper.cs" />
-	<Compile Include="..\..\Samples.Security.AspNetCore5\Data\IastControllerHelper.cs" Link="Data\IastControllerHelper.cs" />
+    <Compile Include="..\..\Samples.Security.AspNetCore5\Data\IastControllerHelper.cs" Link="Data\IastControllerHelper.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
@@ -194,12 +194,6 @@
     <None Include="packages.config" />
     <Content Include="Views\Home\Upload.cshtml" />
     <Content Include="Views\User\Index.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
   </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(SecurityLibraryFiles)" DestinationFolder="$(TargetDir)\%(RecursiveDir)" SkipUnchangedFiles="true" />

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Controllers/UserController.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Web.Http;
 using System.Web.Mvc;
-using Datadog.Trace;
 
 namespace Samples.Security.WebApi.Controllers
 {
@@ -20,11 +19,7 @@ namespace Samples.Security.WebApi.Controllers
         {
             var userId = id ?? "user3";
 
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            SampleHelpers.TrySetUserOnActiveScope(userId);
 
             return userId;
         }

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
@@ -188,12 +188,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -234,4 +228,5 @@
   </Target>
   <Target Name="AfterBuild">
   </Target> -->
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
@@ -193,12 +193,6 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -239,4 +233,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 </Project>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/User.aspx.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/User.aspx.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using Datadog.Trace;
 
 namespace Samples.Security.WebForms
 {
@@ -14,11 +13,7 @@ namespace Samples.Security.WebForms
         {
             var userId = "user3";
 
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            SampleHelpers.TrySetUserOnActiveScope(userId);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Adds a call to `SpanExtensions.SetUser` within the `SampleHelpers` (`TrySetUserOnActiveScope`)
- Removes `Datadog.Trace` from all of the security ASP NET samples in favor of `SampleHelpers`
  - It's mostly the same change for all projects

## Reason for change

- Want to avoid using `Datadog.Trace` in samples

## Implementation details

- Adds a Reflection call to `SetUser` to `SampleHelpers` and replaced the actual `SetUser` call with that one in the samples.

## Test coverage

- I only tested out the `Samples.Security.AspNetCore5` and it was setting the user ID correctly within the tags - haven't tried all the tests yet.

## Other details
<!-- Fixes #{issue} -->
