### PR TITLE
Swap DogStatsD.RaceCondition to not use Datadog.Trace

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -19,10 +19,10 @@ namespace Samples
         private static readonly Type CorrelationIdentifierType = Type.GetType("Datadog.Trace.CorrelationIdentifier, Datadog.Trace");
         private static readonly Type SpanCreationSettingsType = Type.GetType("Datadog.Trace.SpanCreationSettings, Datadog.Trace");
         private static readonly Type SpanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace");
-        private static readonly Type TracerSettingsType = Type.GetType("Datadog.Trace.TracerSettings, Datadog.Trace.Configuration");
+        private static readonly Type TracerSettingsType = Type.GetType("Datadog.Trace.Configuration.TracerSettings, Datadog.Trace");
         private static readonly Type TracerConstantsType = Type.GetType("Datadog.Trace.TracerConstants, Datadog.Trace");
         private static readonly MethodInfo GetNativeTracerVersionMethod = InstrumentationType?.GetMethod("GetNativeTracerVersion");
-        private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance")?.GetMethod;
+        private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetMethod;
         private static readonly MethodInfo StartActiveMethod = TracerType?.GetMethod("StartActive", types: new[] { typeof(string) });
         private static readonly MethodInfo StartActiveWithContextMethod;
         private static readonly MethodInfo ExtractMethod = SpanContextExtractorType?.GetMethod("Extract");
@@ -37,7 +37,7 @@ namespace Samples
         private static readonly MethodInfo SetResourceNameProperty = SpanType?.GetProperty("ResourceName", BindingFlags.NonPublic | BindingFlags.Instance)?.SetMethod;
         private static readonly MethodInfo SetTagMethod = SpanType?.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.Public | BindingFlags.Static);
         private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -38,7 +38,7 @@ namespace Samples
         private static readonly MethodInfo SetTagMethod = SpanType?.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.Public | BindingFlags.Static);
-        private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
+        private static readonly MethodInfo SetServiceName = TracerSettingsType?.GetProperty("ServiceName")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
@@ -66,7 +66,7 @@ namespace Samples
                 return;
             }
             var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
-            SetService.Invoke(tracerSettings, new object[] { serviceName });
+            SetServiceName.Invoke(tracerSettings, new object[] { serviceName });
 
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
             ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });

--- a/tracer/test/test-applications/Samples.Shared/WebServer.cs
+++ b/tracer/test/test-applications/Samples.Shared/WebServer.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Samples
 {
-    public class WebServer : IDisposable
+    internal class WebServer : IDisposable
     {
         private readonly HttpListener _listener;
 

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
@@ -9,8 +9,4 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
@@ -1,31 +1,31 @@
 using log4net;
+using Samples;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
-using Datadog.Trace.Configuration;
-using Tracer = Datadog.Trace.Tracer;
 
 namespace DogStatsD.RaceCondition
 {
     class Program
     {
         internal static readonly string ThreadFinishedMessage = "The current thread has finished";
-
+        private static readonly Type GlobalSettingsType = Type.GetType("Datadog.Trace.Configuration.GlobalSettings, Datadog.Trace");
+        private static readonly MethodInfo SetDebugEnabledMethod = GlobalSettingsType?.GetMethod("SetDebugEnabled");
         static int Main(string[] args)
         {
             try
             {
                 InMemoryLog4NetLogger.Setup();
                 var logger = LogManager.GetLogger(typeof(Program));
-                var ddTraceSettings = TracerSettings.FromDefaultSources();
-                ddTraceSettings.LogsInjectionEnabled = true;
-                ddTraceSettings.TraceEnabled = true;
-                ddTraceSettings.TracerMetricsEnabled = true;
-                GlobalSettings.SetDebugEnabled(true);
 
-                Tracer.Configure(ddTraceSettings);
-                var tracer = Tracer.Instance;
+                
+
+                Environment.SetEnvironmentVariable("DD_TRACE_METRICS_ENABLED", "true");
+                Environment.SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+                SetDebugEnabledMethod.Invoke(null, new object[] { true });
+                SampleHelpers.ConfigureTracer("DogStatsD.RaceCondition");
                 var totalIterations = 100;
                 var threadRepresentation = Enumerable.Range(0, 25).ToArray();
                 var threadCount = threadRepresentation.Length;
@@ -48,7 +48,7 @@ namespace DogStatsD.RaceCondition
 
                                         while (i++ < totalIterations)
                                         {
-                                            using (var outerScope = tracer.StartActive("outer-span"))
+                                            using (var outerScope = SampleHelpers.CreateScope("outer-span"))
                                             {
                                             }
                                         }

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
@@ -11,8 +11,7 @@ namespace DogStatsD.RaceCondition
     class Program
     {
         internal static readonly string ThreadFinishedMessage = "The current thread has finished";
-        private static readonly Type GlobalSettingsType = Type.GetType("Datadog.Trace.Configuration.GlobalSettings, Datadog.Trace");
-        private static readonly MethodInfo SetDebugEnabledMethod = GlobalSettingsType?.GetMethod("SetDebugEnabled");
+
         static int Main(string[] args)
         {
             try
@@ -20,11 +19,9 @@ namespace DogStatsD.RaceCondition
                 InMemoryLog4NetLogger.Setup();
                 var logger = LogManager.GetLogger(typeof(Program));
 
-                
-
                 Environment.SetEnvironmentVariable("DD_TRACE_METRICS_ENABLED", "true");
                 Environment.SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
-                SetDebugEnabledMethod.Invoke(null, new object[] { true });
+                Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
                 SampleHelpers.ConfigureTracer("DogStatsD.RaceCondition");
                 var totalIterations = 100;
                 var threadRepresentation = Enumerable.Range(0, 25).ToArray();

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
@@ -3,7 +3,6 @@ using Samples;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 
 namespace DogStatsD.RaceCondition
@@ -11,6 +10,9 @@ namespace DogStatsD.RaceCondition
     class Program
     {
         internal static readonly string ThreadFinishedMessage = "The current thread has finished";
+        private static readonly string TraceMetrics = "DD_TRACE_METRICS_ENABLED";
+        private static readonly string LogsInjection = "DD_LOGS_INJECTION";
+        private static readonly string DebugEnabled = "DD_TRACE_DEBUG";
 
         static int Main(string[] args)
         {
@@ -19,9 +21,14 @@ namespace DogStatsD.RaceCondition
                 InMemoryLog4NetLogger.Setup();
                 var logger = LogManager.GetLogger(typeof(Program));
 
-                Environment.SetEnvironmentVariable("DD_TRACE_METRICS_ENABLED", "true");
-                Environment.SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
-                Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
+                // validate that our Environment Variables are set
+                // the tracer is already initialized at this point, so we can't set them here via .SetEnvironmentVariable
+                var envVars = Environment.GetEnvironmentVariables();
+                if (!envVars.Contains(TraceMetrics) || !envVars.Contains(LogsInjection) || !envVars.Contains(DebugEnabled))
+                {
+                    throw new Exception($"Make sure the following environment variables are set to \"true\": {TraceMetrics}, {LogsInjection}, {DebugEnabled}");
+                }
+
                 SampleHelpers.ConfigureTracer("DogStatsD.RaceCondition");
                 var totalIterations = 100;
                 var threadRepresentation = Enumerable.Range(0, 25).ToArray();

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "DuplicateTypeProxy": {
+    "DogStatsD.RaceCondition": {
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
@@ -11,7 +11,11 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home"
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+
+        "DD_TRACE_METRICS_ENABLED": "true",
+        "DD_LOGS_INJECTION": "true",
+        "DD_TRACE_DEBUG": "true"
       },
       "nativeDebugging": false
     }

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "DuplicateTypeProxy": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home"
+      },
+      "nativeDebugging": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary of changes

- Removes `Datadog.Trace` reference from `DogStatsD.RaceCondition` in favor of `SampleHelpers`/Reflection
- Fixed a couple of reflection calls in `SampleHelpers` related to the `TracerSettings` as they weren't working

## Reason for change

We don't want the direct references to `Datadog.Trace`

## Implementation details

- Removed `Datadog.Trace` and added equivalent reflection calls or calls from `SampleHelpers`.
- Opted to not add the `GlobalSettings` reflection to the `SampleHelpers` as I figure it might be a one-off for this.

## Test coverage

Seems to be the same locally when run before and after the change.

Unsure though what all will be affected by the other `SampleHelpers` fix with type names.

## Other details
<!-- Fixes #{issue} -->
