### PR TITLE
Fix codeowners file around ASM folders.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@
 /tracer/test/test-applications/security   @DataDog/asm-dotnet
 /tracer/test/Datadog.Trace.Security.IntegrationTests @DataDog/asm-dotnet
 /tracer/test/Datadog.Trace.Security.Unit.Tests       @DataDog/asm-dotnet
+/tracer/test/snapshots/Security*          @DataDog/asm-dotnet
 
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,17 +13,17 @@
 # ASM
 /tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
 /tracer/src/Datadog.Trace/IAST/           @DataDog/asm-dotnet
-/tracer/src/Datadog.Tracer.Native/iast    @DataDog/asm-dotnet
-/tracer/test/test-applications/security   @DataDog/asm-dotnet
-/tracer/test/Datadog.Trace.Security.IntegrationTests @DataDog/asm-dotnet
-/tracer/test/Datadog.Trace.Security.Unit.Tests       @DataDog/asm-dotnet
+/tracer/src/Datadog.Tracer.Native/iast/    @DataDog/asm-dotnet
+/tracer/test/test-applications/security/   @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.IntegrationTests/ @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.Unit.Tests/       @DataDog/asm-dotnet
 /tracer/test/snapshots/Security*          @DataDog/asm-dotnet
 
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet
 .github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
-/tracer/src/Datadog.Trace/ContinuousProfiler @DataDog/profiling-dotnet @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.Tests/ContinuousProfiler @DataDog/profiling-dotnet @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
 
 # Debugger
 /tracer/src/Datadog.Trace/Debugger/        @DataDog/debugger-dotnet


### PR DESCRIPTION
## Summary of changes
Added Security snapshots in ASM ownership and added `/` at the end of folders.

## Reason for change
Each path should finish by a `/` IIUC github examples. As of now, the ASM tests were not reported to ASM. 
