### PR TITLE
Test Azure Functions out of process on .NET 7

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -160,6 +160,7 @@ partial class Build : NukeBuild
                 {
                     // new {framework = TargetFramework.NETCOREAPP3_1, runtimeInstall = v3Install, runtimeUninstall = v3Uninstall },
                     new {framework = TargetFramework.NET6_0, runtimeInstall = v4Install, runtimeUninstall = v4Uninstall },
+                    new {framework = TargetFramework.NET7_0, runtimeInstall = v4Install, runtimeUninstall = v4Uninstall },
                 };
 
                 var matrix = new Dictionary<string, object>();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -163,7 +163,9 @@ public abstract class AzureFunctionsTests : TestHelper
             }
         }
     }
+#endif
 
+#if NET6_0_OR_GREATER
     [UsesVerify]
     [Collection(nameof(AzureFunctionsTestsCollection))]
     public class IsolatedRuntimeV4 : AzureFunctionsTests
@@ -181,7 +183,7 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunAzureFunctionAndWaitForExit(agent, framework: "net6.0", expectedExitCode: -1))
+            using (RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
+++ b/tracer/test/test-applications/azure-functions/Samples.AzureFunctions.V4Isolated/Samples.AzureFunctions.V4Isolated.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -9,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Summary of changes

Add .NET 7 tests to isolated Azure Functions tests

## Reason for change

V4 isolated functions are supported in .NET 7

## Implementation details

Fix some `#ifdef` and enable in CI. Had to bump some package versions to support .NET 7

## Test coverage

Added in this PR

## Other details
Follow up from #3900
