### PR TITLE
Limit the concurrency in xunit

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -234,11 +234,11 @@ namespace Datadog.Trace.PlatformHelpers
             var client = new HttpClient();
             var zipFilePath = Path.GetTempFileName();
             Console.WriteLine($"Downloading Procdump to '{zipFilePath}'");
-            using (var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead))
+            using (var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
             {
-                using var bodyStream = await response.Content.ReadAsStreamAsync();
+                using var bodyStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 using Stream streamToWriteTo = File.Open(zipFilePath, FileMode.Create);
-                await bodyStream.CopyToAsync(streamToWriteTo);
+                await bodyStream.CopyToAsync(streamToWriteTo).ConfigureAwait(false);
             }
 
             var unpackedDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
@@ -272,7 +272,6 @@ namespace Datadog.Trace.PlatformHelpers
 
             return true;
         }
-
 
         /// <summary>
         /// Holds state that we want to pass between diagnostic source events

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -170,6 +170,15 @@ namespace Datadog.Trace.PlatformHelpers
                 }
 
                 span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+
+                if (httpContext.Request.Path.ToString().Contains("bad-request"))
+                {
+                    if (!string.IsNullOrEmpty(span.Tags.GetTag("http.response.headers.sample_correlation_identifier")))
+                    {
+                        Environment.FailFast("wrong header");
+                    }
+                }
+
                 if (security.Settings.Enabled)
                 {
                     var transport = new SecurityCoordinator(security, httpContext, span);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -6,11 +6,7 @@
 #if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Coordinator;
 using Datadog.Trace.Configuration;
@@ -175,14 +171,6 @@ namespace Datadog.Trace.PlatformHelpers
 
                 span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
 
-                if (httpContext.Request.Path.ToString().Contains("bad-request"))
-                {
-                    if (!string.IsNullOrEmpty(span.Tags.GetTag("http.response.headers.sample_correlation_identifier")))
-                    {
-                        CaptureDumpAndFail("wrong header");
-                    }
-                }
-
                 if (security.Settings.Enabled)
                 {
                     var transport = new SecurityCoordinator(security, httpContext, span);
@@ -218,61 +206,6 @@ namespace Datadog.Trace.PlatformHelpers
                     security.CheckAndBlock(httpContext, span);
                 }
             }
-        }
-
-        private void CaptureDumpAndFail(string message)
-        {
-            var procDumpExecutable = DownloadProcdumpZipAndExtract().Result;
-            var args = $"-ma {Process.GetCurrentProcess().Id} -accepteula";
-            CaptureMemoryDump(procDumpExecutable, args);
-
-            Environment.FailFast(message);
-        }
-
-        private async Task<string> DownloadProcdumpZipAndExtract()
-        {
-            // We don't know if procdump is available, so download it fresh
-            const string url = @"https://download.sysinternals.com/files/Procdump.zip";
-            var client = new HttpClient();
-            var zipFilePath = Path.GetTempFileName();
-            Console.WriteLine($"Downloading Procdump to '{zipFilePath}'");
-            using (var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
-            {
-                using var bodyStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-                using Stream streamToWriteTo = File.Open(zipFilePath, FileMode.Create);
-                await bodyStream.CopyToAsync(streamToWriteTo).ConfigureAwait(false);
-            }
-
-            var unpackedDirectory = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetTempFileName()));
-            Console.WriteLine($"Procdump downloaded. Unpacking to '{unpackedDirectory}'");
-            System.IO.Compression.ZipFile.ExtractToDirectory(zipFilePath, unpackedDirectory);
-
-            var procDump = Path.Combine(unpackedDirectory, "procdump.exe");
-            return procDump;
-        }
-
-        private bool CaptureMemoryDump(string tool, string args)
-        {
-            Console.WriteLine($"Capturing memory dump using '{tool} {args}'");
-
-            using var dumpToolProcess = Process.Start(new ProcessStartInfo(tool, args)
-            {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            });
-
-            dumpToolProcess.WaitForExit();
-
-            if (dumpToolProcess.ExitCode == 0)
-            {
-                Console.WriteLine($"Memory dump successfully captured using '{tool} {args}'.");
-            }
-            else
-            {
-                Console.WriteLine($"Failed to capture memory dump using '{tool} {args}'. {tool}'s exit code was {dumpToolProcess.ExitCode}.");
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -170,7 +170,6 @@ namespace Datadog.Trace.PlatformHelpers
                 }
 
                 span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-
                 if (security.Settings.Enabled)
                 {
                     var transport = new SecurityCoordinator(security, httpContext, span);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -182,13 +182,6 @@ namespace Datadog.Trace.PlatformHelpers
                         CaptureDumpAndFail("wrong header");
                     }
                 }
-                else if (httpContext.Request.Path.ToString().Contains("not-found"))
-                {
-                    if (string.IsNullOrEmpty(span.Tags.GetTag("http.status_code")))
-                    {
-                        CaptureDumpAndFail("missing status code");
-                    }
-                }
 
                 if (security.Settings.Enabled)
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
+using static System.Net.WebRequestMethods;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -31,6 +32,7 @@ namespace Datadog.Trace.TestHelpers
             _httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.UserAgent, "testhelper");
             _httpClient.DefaultRequestHeaders.Add(TracingHeaderName1WithMapping, TracingHeaderValue1);
             _httpClient.DefaultRequestHeaders.Add(TracingHeaderName2, TracingHeaderValue2);
+            _httpClient.DefaultRequestHeaders.ConnectionClose = true;
         }
 
         public Process Process { get; private set; }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -32,7 +32,10 @@ namespace Datadog.Trace.TestHelpers
             _httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.UserAgent, "testhelper");
             _httpClient.DefaultRequestHeaders.Add(TracingHeaderName1WithMapping, TracingHeaderValue1);
             _httpClient.DefaultRequestHeaders.Add(TracingHeaderName2, TracingHeaderValue2);
+
+#if NETCOREAPP2_1
             _httpClient.DefaultRequestHeaders.ConnectionClose = true;
+#endif
         }
 
         public Process Process { get; private set; }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -11,7 +11,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
-using static System.Net.WebRequestMethods;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -34,6 +33,7 @@ namespace Datadog.Trace.TestHelpers
             _httpClient.DefaultRequestHeaders.Add(TracingHeaderName2, TracingHeaderValue2);
 
 #if NETCOREAPP2_1
+            // Keep-alive is causing some weird failures on aspnetcore 2.1
             _httpClient.DefaultRequestHeaders.ConnectionClose = true;
 #endif
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -6,13 +6,11 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.SymbolStore;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Bogus;
 using Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
 using Xunit;
 using Xunit.Abstractions;

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -4,13 +4,17 @@
 // </copyright>
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.SymbolStore;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Bogus;
 using Datadog.Trace.TestHelpers.FluentAssertionsExtensions;
+using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -90,9 +94,54 @@ namespace Datadog.Trace.TestHelpers
             {
             }
 
+            protected override async Task<RunSummary> RunTestCollectionsAsync(IMessageBus messageBus, CancellationTokenSource cancellationTokenSource)
+            {
+                var collections = OrderTestCollections().Select(
+                    pair =>
+                    new
+                    {
+                        Collection = pair.Item1,
+                        TestCases = pair.Item2,
+                        DisableParallelization = IsParallelizationDisabled(pair.Item1)
+                    })
+                    .ToList();
+
+                var summary = new RunSummary();
+
+                // Start with single threaded collections
+                foreach (var test in collections.Where(t => t.DisableParallelization))
+                {
+                    summary.Aggregate(await RunTestCollectionAsync(messageBus, test.Collection, test.TestCases, cancellationTokenSource));
+                }
+
+                using var runner = new ConcurrentRunner();
+
+                var tasks = new List<Task<RunSummary>>();
+
+                foreach (var test in collections.Where(t => !t.DisableParallelization))
+                {
+                    tasks.Add(runner.RunAsync(async () => await RunTestCollectionAsync(messageBus, test.Collection, test.TestCases, cancellationTokenSource)));
+                }
+
+                await Task.WhenAll(tasks);
+
+                foreach (var task in tasks)
+                {
+                    summary.Aggregate(task.Result);
+                }
+
+                return summary;
+            }
+
             protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
             {
                 return new CustomTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+            }
+
+            private static bool IsParallelizationDisabled(ITestCollection collection)
+            {
+                var attr = collection.CollectionDefinition?.GetCustomAttributes(typeof(CollectionDefinitionAttribute)).SingleOrDefault();
+                return attr?.GetNamedArgument<bool>(nameof(CollectionDefinitionAttribute.DisableParallelization)) is true;
             }
         }
 
@@ -170,6 +219,53 @@ namespace Datadog.Trace.TestHelpers
                 {
                     _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"ERROR: {test} ({ex.Message})"));
                     throw;
+                }
+            }
+        }
+
+        private class ConcurrentRunner : IDisposable
+        {
+            private readonly BlockingCollection<Func<Task>> _queue;
+
+            public ConcurrentRunner()
+            {
+                _queue = new();
+
+                for (int i = 0; i < Environment.ProcessorCount; i++)
+                {
+                    Task.Run(DoWork);
+                }
+            }
+
+            public void Dispose()
+            {
+                _queue.CompleteAdding();
+            }
+
+            public Task<T> RunAsync<T>(Func<Task<T>> action)
+            {
+                var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                _queue.Add(async () =>
+                {
+                    try
+                    {
+                        tcs.TrySetResult(await action());
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.TrySetException(ex);
+                    }
+                });
+
+                return tcs.Task;
+            }
+
+            private async Task DoWork()
+            {
+                foreach (var item in _queue)
+                {
+                    await item();
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -108,12 +108,6 @@ namespace Datadog.Trace.TestHelpers
 
                 var summary = new RunSummary();
 
-                // Start with single threaded collections
-                foreach (var test in collections.Where(t => t.DisableParallelization))
-                {
-                    summary.Aggregate(await RunTestCollectionAsync(messageBus, test.Collection, test.TestCases, cancellationTokenSource));
-                }
-
                 using var runner = new ConcurrentRunner();
 
                 var tasks = new List<Task<RunSummary>>();
@@ -128,6 +122,12 @@ namespace Datadog.Trace.TestHelpers
                 foreach (var task in tasks)
                 {
                     summary.Aggregate(task.Result);
+                }
+
+                // Single threaded collections
+                foreach (var test in collections.Where(t => t.DisableParallelization))
+                {
+                    summary.Aggregate(await RunTestCollectionAsync(messageBus, test.Collection, test.TestCases, cancellationTokenSource));
                 }
 
                 return summary;

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -263,7 +263,7 @@ namespace Datadog.Trace.TestHelpers
 
             private async Task DoWork()
             {
-                foreach (var item in _queue)
+                foreach (var item in _queue.GetConsumingEnumerable())
                 {
                     await item();
                 }


### PR DESCRIPTION
## Summary of changes

**sunk-cost fallacy:** _noun_
The phenomenon whereby a person is reluctant to abandon a strategy or course of action because they have invested heavily in it, even when it is clear that abandonment would be more beneficial.
See also: "why are we still using xunit instead of switching to nunit?"


## Reason for change

The concurrent limit in xunit is not working the way we expect: https://github.com/xunit/xunit/issues/2003
Basically, instead of limiting the number of concurrent tests, it just limits the number of concurrent tasks scheduled (what the OS does for us at no cost).

The reason we want to limit the concurrency is because when running tests that spawn external process, the server is completely swamped and it causes various timeouts in tests.

## Implementation details

Picked what we needed from https://gist.github.com/Brokolis/8ca83b4516bb572760bd604b98991117. I have no clue if this is the right way, but it seems to work.
