### PR TITLE
[ASM] Fix native compilation warning

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
@@ -137,7 +137,7 @@ namespace iast
             {
                 if (pMatchLen != nullptr)
                 {
-                    *pMatchLen = valueTrim.length();
+                    *pMatchLen = static_cast<unsigned int>(valueTrim.length());
                 }
                 finalMatch = match;
                 if (match == MatchResult::Exact)


### PR DESCRIPTION
## Summary of changes

In order to remove one compilation warning, a static_cast has been added

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
