### PR TITLE
[Profiler] Patch to compensate error while checking for CPU consumption

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -99,15 +99,17 @@ uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
     return cpuTime;
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
+bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
     bool isRunning = false;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))
     {
         cpuTime = 0;
+        failed = true;
         return false;
     }
 
+    failed = false;
     return isRunning;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -33,15 +33,38 @@ uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
     FILETIME creationTime, exitTime = {}; // not used here
     FILETIME kernelTime = {};
     FILETIME userTime = {};
-
+    static bool isFirstError = true;
     if (::GetThreadTimes(pThreadInfo->GetOsThreadHandle(), &creationTime, &exitTime, &kernelTime, &userTime))
     {
         uint64_t milliseconds = GetTotalMilliseconds(userTime) + GetTotalMilliseconds(kernelTime);
         return milliseconds;
     }
+    else if (isFirstError)
+    {
+        isFirstError = false;
+        LPVOID msgBuffer;
+        DWORD errorCode = GetLastError();
+
+        if (errorCode == 0)
+        {
+            Log::Error("GetThreadCpuTime() error calling GetThreadTimes (last error = 0)");
+        }
+        else
+        {
+            FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                          NULL, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&msgBuffer, 0, NULL);
+
+            if (msgBuffer != NULL)
+            {
+                Log::Error("GetThreadCpuTime() error calling GetThreadTimes (last error = 0x", std::hex, errorCode, std::dec, "): ", (LPTSTR)msgBuffer);
+                LocalFree(msgBuffer);
+            }
+        }
+    }
 
     return 0;
 }
+
 
 
 typedef LONG KPRIORITY;
@@ -126,11 +149,14 @@ bool IsRunning(ULONG threadState)
     // If some callstacks show non cpu-bound frames at the top, return true only for Running state
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
+bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
+    failed = true;
+    cpuTime = 0;
+
     if (NtQueryInformationThread == nullptr)
     {
-        if (!InitializeCallback())
+        if (!InitializeNtQueryInformationThreadCallback())
         {
             return false;
         }
@@ -139,14 +165,42 @@ bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
     SYSTEM_THREAD_INFORMATION sti = {0};
     auto size = sizeof(SYSTEM_THREAD_INFORMATION);
     ULONG buflen = 0;
+    static bool isFirstError = true;
     NTSTATUS lResult = NtQueryInformationThread(pThreadInfo->GetOsThreadHandle(), SYSTEMTHREADINFORMATION, &sti, static_cast<ULONG>(size), &buflen);
+
+    // deal with an invalid thread handle case (thread might have died)
     if (lResult != 0)
     {
+#if BIT64 // Windows 64-bit
+        if (isFirstError && (lResult != STATUS_INVALID_HANDLE))
+        {
+            isFirstError = false;
+            LPVOID msgBuffer;
+            DWORD errorCode = GetLastError();
+
+            if (errorCode == 0)
+            {
+                Log::Error("IsRunning() error 0x", std::hex, lResult, " calling NtQueryInformationThread");
+            }
+            else
+            {
+                FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                              NULL, errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)&msgBuffer, 0, NULL);
+
+                if (msgBuffer != NULL)
+                {
+                    Log::Error("IsRunning() error 0x", std::hex, lResult, " calling NtQueryInformationThread (last error =  0x", std::hex, errorCode, std::dec, "): ", (LPTSTR)msgBuffer);
+                    LocalFree(msgBuffer);
+                }
+            }
+        }
+#endif
         // This always happens in 32 bit so uses another API to at least get the CPU consumption
         cpuTime = GetThreadCpuTime(pThreadInfo);
         return false;
     }
 
+    failed = false;
     cpuTime = GetTotalMilliseconds(sti.UserTime) + GetTotalMilliseconds(sti.KernelTime);
 
     return IsRunning(sti.ThreadState);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -16,7 +16,7 @@ class IConfiguration;
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi {
-std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration);
+std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
 uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
 bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -18,5 +18,5 @@ class IConfiguration;
 namespace OsSpecificApi {
 std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* const pConfiguration);
 uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
+bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -241,20 +241,27 @@ void StackSamplerLoop::CpuProfilingIteration()
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)
         {
+            // detect Windows API call failure
+            bool failure = false;
+
             // sample only if the thread is currently running on a core
             uint64_t currentConsumption = 0;
             uint64_t lastConsumption = _targetThread->GetCpuConsumptionMilliseconds();
-            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption);
-            // Note: it is not possible to get this information on Windows 32-bit
-            //       so true is returned if this thread consumed some CPU since
-            //       the last iteration
+            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption, failure);
+            // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
+            //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
-    #if BIT64  // nothing to do for Windows 64-bit
-    #else  // Windows 32-bit
+#if BIT64 // Windows 64-bit
+            if (failure)
+            {
+                isRunning = (lastConsumption < currentConsumption);
+            }
+#else // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);
-    #endif
-#else  // nothing to do for Linux
 #endif
+#else // nothing to do for Linux
+#endif
+
 
             if (isRunning)
             {


### PR DESCRIPTION
## Summary of changes
Check Windows API errors that could lead to skip sampling threads and add error log

## Reason for change
A customer gets profiles without any CPU sample.

## Implementation details
If IsRunning is returning false, no thread could have CPU sample. The only reasonable reason seems to come from an error returned by undocumented NtQueryInformationThread method. This patch is logging this kind of situation and tried, like in 32 bit, to sample based on CPU consumption difference instead of running on/waiting for a core.
It is still possible that GetThreadTimes could also fails...

## Test coverage

## Other details
<!-- Fixes #{issue} -->
