### PR TITLE
Swap to SampleHelpers for LogsInjectionHelper

### DIFF
--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -19,10 +19,10 @@ namespace Samples
         private static readonly Type CorrelationIdentifierType = Type.GetType("Datadog.Trace.CorrelationIdentifier, Datadog.Trace");
         private static readonly Type SpanCreationSettingsType = Type.GetType("Datadog.Trace.SpanCreationSettings, Datadog.Trace");
         private static readonly Type SpanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace");
-        private static readonly Type TracerSettingsType = Type.GetType("Datadog.Trace.TracerSettings, Datadog.Trace.Configuration");
+        private static readonly Type TracerSettingsType = Type.GetType("Datadog.Trace.Configuration.TracerSettings, Datadog.Trace");
         private static readonly Type TracerConstantsType = Type.GetType("Datadog.Trace.TracerConstants, Datadog.Trace");
         private static readonly MethodInfo GetNativeTracerVersionMethod = InstrumentationType?.GetMethod("GetNativeTracerVersion");
-        private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance")?.GetMethod;
+        private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetMethod;
         private static readonly MethodInfo StartActiveMethod = TracerType?.GetMethod("StartActive", types: new[] { typeof(string) });
         private static readonly MethodInfo StartActiveWithContextMethod;
         private static readonly MethodInfo ExtractMethod = SpanContextExtractorType?.GetMethod("Extract");
@@ -37,7 +37,7 @@ namespace Samples
         private static readonly MethodInfo SetResourceNameProperty = SpanType?.GetProperty("ResourceName", BindingFlags.NonPublic | BindingFlags.Instance)?.SetMethod;
         private static readonly MethodInfo SetTagMethod = SpanType?.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.Public | BindingFlags.Static);
         private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -38,7 +38,7 @@ namespace Samples
         private static readonly MethodInfo SetTagMethod = SpanType?.GetMethod("SetTag", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo SetExceptionMethod = SpanType?.GetMethod("SetException", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo FromDefaultSourcesMethod = TracerSettingsType?.GetMethod("FromDefaultSources", BindingFlags.Public | BindingFlags.Static);
-        private static readonly MethodInfo SetService = TracerSettingsType?.GetProperty("Service")?.SetMethod;
+        private static readonly MethodInfo SetServiceName = TracerSettingsType?.GetProperty("ServiceName")?.SetMethod;
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
 
 
@@ -66,7 +66,7 @@ namespace Samples
                 return;
             }
             var tracerSettings = FromDefaultSourcesMethod.Invoke(null, Array.Empty<object>());
-            SetService.Invoke(tracerSettings, new object[] { serviceName });
+            SetServiceName.Invoke(tracerSettings, new object[] { serviceName });
 
             var tracer = GetTracerInstance.Invoke(null, Array.Empty<object>());
             ConfigureMethod.Invoke(tracer, new object[] { tracerSettings });

--- a/tracer/test/test-applications/Samples.Shared/WebServer.cs
+++ b/tracer/test/test-applications/Samples.Shared/WebServer.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Samples
 {
-    public class WebServer : IDisposable
+    internal class WebServer : IDisposable
     {
         private readonly HttpListener _listener;
 

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -35,8 +35,8 @@ namespace PluginApplication
 
             // Do not explicitly set LogsInjectionEnabled = true, use DD_LOGS_INJECTION environment variable to enable
 
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_ENV")
-                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_VERSION"))
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_ENV"))
+                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_VERSION")))
             {
                 // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
                 // Ensure that we have a version value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -35,8 +35,13 @@ namespace PluginApplication
 
             // Do not explicitly set LogsInjectionEnabled = true, use DD_LOGS_INJECTION environment variable to enable
 
-            Environment.SetEnvironmentVariable("DD_ENV", "dev"); // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
-            Environment.SetEnvironmentVariable("DD_VERSION", "1.0.0"); // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_ENV")
+                || string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_VERSION"))
+            {
+                // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
+                // Ensure that we have a version value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null
+                throw new Exception("You must set DD_ENV or DD_VERSION");
+            }
 
             try
             {

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
 using System.Reflection;
-using Datadog.Trace;
-using Datadog.Trace.Configuration;
 
 namespace PluginApplication
 {
@@ -35,17 +33,15 @@ namespace PluginApplication
             var applicationAppDomain = AppDomain.CreateDomain("ApplicationAppDomain", null, applicationFilesDirectory, applicationFilesDirectory, false);
 #endif
 
-            // Set up Tracer and start a trace
             // Do not explicitly set LogsInjectionEnabled = true, use DD_LOGS_INJECTION environment variable to enable
-            var settings = TracerSettings.FromDefaultSources();
-            settings.Environment ??= "dev"; // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
-            settings.ServiceVersion ??= "1.0.0"; // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null
-            Tracer.Configure(settings);
+
+            Environment.SetEnvironmentVariable("DD_ENV", "dev"); // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
+            Environment.SetEnvironmentVariable("DD_VERSION", "1.0.0"); // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null
 
             try
             {
                 logAction($"{ExcludeMessagePrefix}Entering Datadog scope.");
-                using (var scope = Tracer.Instance.StartActive("transaction"))
+                using (var scope = Samples.SampleHelpers.CreateScope("transaction"))
                 {
                     // In the middle of the trace, make a call across AppDomains
                     // Unless handled properly, this can cause the following error due

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LogsInjectionHelper.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LogsInjectionHelper.csproj
@@ -5,8 +5,6 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
## Summary of changes

Removes the reference to `Datadog.Trace` in favor of using `Samples.Shared`.

## Reason for change

Want to try and remove usages of `Datadog.Trace` from samples.

## Implementation details

- Removed `Datadog.Trace` reference, adds `Samples.Shared` reference/usage
- Opted to use `Environment.SetEnvironmentVariable` instead of making new reflection calls to the `.Environment` and `.ServiceVersion` properties

## Test coverage

- Tested this out locally with the Serilog sample and it seemed to work still

## Other details
<!-- Fixes #{issue} -->
