### PR TITLE
[CI Visibility] - Fixes git parser when using a SSH signature

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/GitInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/GitInfo.cs
@@ -402,21 +402,20 @@ namespace Datadog.Trace.Ci
                     {
                         string pgpLine = line.Substring(GpgSigPrefix.Length) + Environment.NewLine;
                         PgpSignature = pgpLine;
-                        while (!pgpLine.Contains("END PGP SIGNATURE"))
+                        while (!pgpLine.Contains("END PGP SIGNATURE") && !pgpLine.Contains("END SSH SIGNATURE") && i + 1 < lines.Length)
                         {
                             i++;
                             pgpLine = lines[i];
                             PgpSignature += pgpLine + Environment.NewLine;
                         }
 
-                        i++;
                         continue;
                     }
 
-                    msgLines.Add(line);
+                    msgLines.Add(line.Trim());
                 }
 
-                Message += string.Join(Environment.NewLine, msgLines);
+                Message = string.Join(Environment.NewLine, msgLines);
             }
 
             public static bool TryGetFromObjectFile(string filePath, out GitCommitObject commitObject)


### PR DESCRIPTION
## Summary of changes

This PR fixes the `System.IndexOutOfRangeException` exception when the committer is using a `SSH signature`.

Previous implementation was failing when the committer uses a ssh signature as a pgp signature with the following error:

```
Error getting commit object from object file System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at DatadogTestLogger.Vendors.Datadog.Trace.Ci.GitInfo.GitCommitObject..ctor(String content) in /Users/tony.redondo/repos/github/tonyredondo/datadog-test-logger/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/GitInfo.cs:line 345
   at DatadogTestLogger.Vendors.Datadog.Trace.Ci.GitInfo.GitCommitObject.TryGetFromObjectFile(String filePath, GitCommitObject& commitObject) in /Users/tony.redondo/repos/github/tonyredondo/datadog-test-logger/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/GitInfo.cs:line 446

{ MachineName: ".", Process: "[3780 dotnet]", AppDomain: "[1 vstest.console]", TracerVersion: "2.25.0.0" }
```

Also the algorithm has been updated to avoid the exception even if the signature is not supported.

## Reason for change

@lucaspimentel found this issue when working with the repo.