### PR TITLE
Setup python 3.9 for system tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3811,6 +3811,10 @@ stages:
 
     steps:
       - checkout: none
+
+      - script: sudo apt-get update && apt-get install python3.9-venv
+        displayName: Install python 3.9
+
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 
@@ -3826,6 +3830,7 @@ stages:
           echo Moving $PACKAGE_NAME to system-tests/binaries
           mv $(Build.ArtifactStagingDirectory)/$PACKAGE_NAME system-tests/binaries/
         displayName: Move dotnet binary to system test folder
+
       - script: ./build.sh dotnet
         workingDirectory: system-tests
         displayName: Build images

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3812,7 +3812,9 @@ stages:
     steps:
       - checkout: none
 
-      - script: sudo apt-get update && apt-get install python3.9-venv
+      - task: UsePythonVersion@0
+        inputs:
+            versionSpec: '3.9.x'
         displayName: Install python 3.9
 
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git


### PR DESCRIPTION
## Summary of changes

This PR installs python 3.9 for system tests jobs.

## Reason for change

System test executor will run on the host rather than inside a container (see https://github.com/DataDog/system-tests/pull/958). It will allow users to do step-by-step debugging, and will allow to unify architecture with parametric tests.

