### PR TITLE
Docker Base Images. Fix snapshot generation and fix draft releases

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -80,3 +80,17 @@ jobs:
         working-directory: ${{steps.assets.outputs.artifacts_path}}
         run: |
           dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      
+      - name: "Trigger Docker Base Images Github Pipeline"
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token $GITHUB_TOKEN"\
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
+          -d '{"event_type": "Trigger Workflow","inputs":{"targetBranch":"$targetBranch","commitSha":"$commitSha"}}'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          targetBranch: ${{ github.event.ref }}
+          commitSha: "${{ github.event.inputs.forced_commit_id }}"

--- a/.github/workflows/docker-base-images.yml
+++ b/.github/workflows/docker-base-images.yml
@@ -6,10 +6,16 @@ on:
     inputs:
       azdo_build_id:
         description: 'The specific AzDo build from which the release artifacts will be downloaded.'
-        required: true
+        required: false
       is_snapshot:
         description: 'True when we are building main branch, false when we are building a release'
-        required: true
+        required: false
+      targetBranch:
+        description: Parameter comming from only draft release. The branch that generates the trigger. 
+        required: false
+      commitSha:
+        description: Parameter comming from only draft release. Commit that trigger the build.
+        required: false
 jobs:
   build-and-publish-base-image:
     runs-on: ubuntu-latest
@@ -31,9 +37,13 @@ jobs:
 
     - name: "Download build assets from Azure Pipelines"
       id: assets
-      run: ./tracer/build.sh DownloadAzurePipelineFromBuild 
+      run: |
+        # If AzureDevopsBuildId is empty we download release artifact, else we download the artifacts from azure build id
+        [ -z "$AzureDevopsBuildId" ] && ./tracer/build.sh DownloadReleaseArtifacts || ./tracer/build.sh DownloadAzurePipelineFromBuild     
       env:
         AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
+        TargetBranch: "${{ github.event.inputs.targetBranch }}"
+        CommitSha: "${{ github.event.inputs.commitSha }}"
 
     - name: Copy tooling files to artifacts path
       shell: bash
@@ -52,7 +62,7 @@ jobs:
       id: docker-base-image-tags
       shell: bash
       run: |
-        if [ "$is_snapshot" = "true" ]; then
+        if [ "$is_snapshot" = "True" ]; then
           echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot" >> $GITHUB_OUTPUT
         else
           echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
There was a bug in the pipeline, and we aren't generating the snapshot base images. Fixed. 
When we create a release from "draft release pipeline" we weren't invoking to the docker base image pipeline. Fixed

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
