### PR TITLE
Convert RabbitMQ tests to snapshot tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -6,19 +6,26 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions.Execution;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [UsesVerify]
     [Trait("RequiresDockerDependency", "true")]
     public class RabbitMQTests : TracingIntegrationTest
     {
         private const string ExpectedServiceName = "Samples.RabbitMQ-rabbitmq";
+        private static readonly Regex GeneratedQueueRegex = new(@"(amqp\.queue\:) amq\.gen\-.*,");
+        private static readonly Regex GeneratedRoutingKeyRegex = new(@"(amqp\.routing_key\:) amq\.gen\-.*,");
 
         public RabbitMQTests(ITestOutputHelper output)
             : base("RabbitMQ", output)
@@ -31,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(PackageVersions.RabbitMQ), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion)
+        public async Task SubmitsTraces(string packageVersion)
         {
 #if NET6_0_OR_GREATER
             if (packageVersion?.StartsWith("3.") == true)
@@ -44,181 +51,75 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var expectedSpanCount = 52;
 
-            int basicPublishCount = 0;
-            int basicGetCount = 0;
-            int basicDeliverCount = 0;
-            int exchangeDeclareCount = 0;
-            int queueDeclareCount = 0;
-            int queueBindCount = 0;
-            var distributedParentSpans = new Dictionary<ulong, int>();
-
-            int emptyBasicGetCount = 0;
-
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
+                using var assertionScope = new AssertionScope();
                 var spans = agent.WaitForSpans(expectedSpanCount); // Do not filter on operation name because they will vary depending on instrumented method
-                Assert.True(spans.Count >= expectedSpanCount, $"Expecting at least {expectedSpanCount} spans, only received {spans.Count}");
 
                 var rabbitmqSpans = spans.Where(span => string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
-                var manualSpans = spans.Where(span => !string.Equals(span.Service, ExpectedServiceName, StringComparison.OrdinalIgnoreCase));
 
                 ValidateIntegrationSpans(rabbitmqSpans, expectedServiceName: "Samples.RabbitMQ-rabbitmq");
+                var settings = VerifyHelper.GetSpanVerifierSettings();
 
-                foreach (var span in rabbitmqSpans)
-                {
-                    var command = span.Tags[Tags.AmqpCommand];
+                // We generate a new queue name for the "default" queue with each run
+                settings.AddScrubber(QueueScrubber.ReplaceRabbitMqQueues);
 
-                    if (command.StartsWith("basic.", StringComparison.OrdinalIgnoreCase))
-                    {
-                        if (string.Equals(command, "basic.publish", StringComparison.OrdinalIgnoreCase))
-                        {
-                            basicPublishCount++;
-                            Assert.Equal(SpanKinds.Producer, span.Tags[Tags.SpanKind]);
-                            Assert.NotNull(span.Tags[Tags.AmqpExchange]);
-                            Assert.NotNull(span.Tags[Tags.AmqpRoutingKey]);
-
-                            Assert.NotNull(span.Tags["message.size"]);
-                            Assert.True(int.TryParse(span.Tags["message.size"], out _));
-
-                            // Enforce that the resource name has the following structure: "basic.publish [<default>|{actual exchangeName}] -> [<all>|<generated>|{actual routingKey}]"
-                            string regexPattern = @"basic\.publish (?<exchangeName>\S*) -> (?<routingKey>\S*)";
-                            var match = Regex.Match(span.Resource, regexPattern);
-                            Assert.True(match.Success);
-
-                            var exchangeName = match.Groups["exchangeName"].Value;
-                            Assert.True(string.Equals(exchangeName, "<default>") || string.Equals(exchangeName, span.Tags[Tags.AmqpExchange]));
-
-                            var routingKey = match.Groups["routingKey"].Value;
-                            Assert.True(string.Equals(routingKey, "<all>") || string.Equals(routingKey, "<generated>") || string.Equals(routingKey, span.Tags[Tags.AmqpRoutingKey]));
-                        }
-                        else if (string.Equals(command, "basic.get", StringComparison.OrdinalIgnoreCase))
-                        {
-                            basicGetCount++;
-
-                            // Successful responses will have the "message.size" tag
-                            // Empty responses will not
-                            if (span.Tags.TryGetValue("message.size", out string messageSize))
-                            {
-                                Assert.NotNull(span.ParentId);
-                                Assert.True(int.TryParse(messageSize, out _));
-
-                                // Add the parent span ID to a dictionary so we can later assert 1:1 mappings
-                                if (distributedParentSpans.TryGetValue(span.ParentId.Value, out int count))
-                                {
-                                    distributedParentSpans[span.ParentId.Value] = count + 1;
-                                }
-                                else
-                                {
-                                    distributedParentSpans[span.ParentId.Value] = 1;
-                                }
-                            }
-                            else
-                            {
-                                emptyBasicGetCount++;
-                            }
-
-                            Assert.Equal(SpanKinds.Consumer, span.Tags[Tags.SpanKind]);
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
-
-                            // Enforce that the resource name has the following structure: "basic.get [<generated>|{actual queueName}]"
-                            string regexPattern = @"basic\.get (?<queueName>\S*)";
-                            var match = Regex.Match(span.Resource, regexPattern);
-                            Assert.True(match.Success);
-
-                            var queueName = match.Groups["queueName"].Value;
-                            Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.AmqpQueue]));
-                        }
-                        else if (string.Equals(command, "basic.deliver", StringComparison.OrdinalIgnoreCase))
-                        {
-                            basicDeliverCount++;
-                            Assert.NotNull(span.ParentId);
-
-                            // Add the parent span ID to a dictionary so we can later assert 1:1 mappings
-                            if (distributedParentSpans.TryGetValue(span.ParentId.Value, out int count))
-                            {
-                                distributedParentSpans[span.ParentId.Value] = count + 1;
-                            }
-                            else
-                            {
-                                distributedParentSpans[span.ParentId.Value] = 1;
-                            }
-
-                            Assert.Equal(SpanKinds.Consumer, span.Tags[Tags.SpanKind]);
-                            // Assert.NotNull(span.Tags[Tags.AmqpQueue]); // Java does this but we're having difficulty doing this. Push to v2?
-                            Assert.NotNull(span.Tags[Tags.AmqpExchange]);
-                            Assert.NotNull(span.Tags[Tags.AmqpRoutingKey]);
-
-                            Assert.NotNull(span.Tags["message.size"]);
-                            Assert.True(int.TryParse(span.Tags["message.size"], out _));
-
-                            // Enforce that the resource name has the following structure: "basic.deliver [<generated>|{actual queueName}]"
-                            string regexPattern = @"basic\.deliver (?<queueName>\S*)";
-                            var match = Regex.Match(span.Resource, regexPattern);
-                            // Assert.True(match.Success); // Enable once we can get the queue name included
-
-                            var queueName = match.Groups["queueName"].Value;
-                            // Assert.True(string.Equals(queueName, "<generated>") || string.Equals(queueName, span.Tags[Tags.AmqpQueue])); // Enable once we can get the queue name included
-                        }
-                        else
-                        {
-                            throw new Xunit.Sdk.XunitException($"amqp.command {command} not recognized.");
-                        }
-                    }
-                    else
-                    {
-                        Assert.Equal(SpanKinds.Client, span.Tags[Tags.SpanKind]);
-                        Assert.Equal(command, span.Resource);
-
-                        if (string.Equals(command, "exchange.declare", StringComparison.OrdinalIgnoreCase))
-                        {
-                            exchangeDeclareCount++;
-                            Assert.NotNull(span.Tags[Tags.AmqpExchange]);
-                        }
-                        else if (string.Equals(command, "queue.declare", StringComparison.OrdinalIgnoreCase))
-                        {
-                            queueDeclareCount++;
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
-                        }
-                        else if (string.Equals(command, "queue.bind", StringComparison.OrdinalIgnoreCase))
-                        {
-                            queueBindCount++;
-                            Assert.NotNull(span.Tags[Tags.AmqpExchange]);
-                            Assert.NotNull(span.Tags[Tags.AmqpQueue]);
-                            Assert.NotNull(span.Tags[Tags.AmqpRoutingKey]);
-                        }
-                        else
-                        {
-                            throw new Xunit.Sdk.XunitException($"amqp.command {command} not recognized.");
-                        }
-                    }
-                }
-
-                foreach (var span in manualSpans)
-                {
-                    Assert.Equal("Samples.RabbitMQ", span.Service);
-                    Assert.Equal("1.0.0", span.Tags[Tags.Version]);
-                    Assert.True(rabbitmqSpans.Count(s => s.TraceId == span.TraceId) > 0);
-                }
+                var filename = $"{nameof(RabbitMQTests)}.{GetPackageVersionSuffix(packageVersion)}";
+                await VerifyHelper.VerifySpans(spans, settings)
+                                  .UseFileName(filename);
             }
 
-            // Assert that all empty get results are expected
-            const int routineCount = 4;
-            Assert.Equal(routineCount * 2, emptyBasicGetCount);
-
-            // Assert that each span that started a distributed trace (basic.publish)
-            // has only one child span (basic.deliver or basic.get)
-            Assert.All(distributedParentSpans, kvp => Assert.Equal(1, kvp.Value));
-
-            Assert.Equal(routineCount * 5, basicPublishCount);
-            Assert.Equal(routineCount * 4, basicGetCount);
-            Assert.Equal(routineCount * 3, basicDeliverCount);
-
-            Assert.Equal(routineCount, exchangeDeclareCount);
-            Assert.Equal(routineCount, queueBindCount);
-            Assert.Equal(routineCount * 4, queueDeclareCount);
             telemetry.AssertIntegrationEnabled(IntegrationId.RabbitMQ);
+        }
+
+        private string GetPackageVersionSuffix(string packageVersion)
+            => packageVersion switch
+            {
+                null or "" => "6_x", // the default version in the csproj
+                _ when new Version(packageVersion) >= new Version("6.0.0") => "6_x",
+                _ when new Version(packageVersion) >= new Version("5.0.0") => "5_x",
+                _ => "3_x",
+            };
+
+        private class QueueScrubber
+        {
+            private static readonly Regex Regex = new(@"amq\.gen\-.*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+            public static void ReplaceRabbitMqQueues(StringBuilder builder)
+            {
+                if (!TryReplaceRabbitMqQueue(builder.ToString(), out var result))
+                {
+                    return;
+                }
+
+                builder.Clear();
+                builder.Append(result);
+            }
+
+            private static bool TryReplaceRabbitMqQueue(string value, out string result)
+            {
+                var queues = Regex.Matches(value);
+                var index = 0;
+                if (queues.Count > 0)
+                {
+                    result = value;
+                    foreach (Match queueMatch in queues)
+                    {
+                        var queue = queueMatch!.Value;
+                        index++;
+                        var convertedQueue = $"AmqQueue_{index}";
+
+                        result = result.Replace(queue, convertedQueue);
+                    }
+
+                    return true;
+                }
+
+                result = null;
+                return false;
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -24,8 +24,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class RabbitMQTests : TracingIntegrationTest
     {
         private const string ExpectedServiceName = "Samples.RabbitMQ-rabbitmq";
-        private static readonly Regex GeneratedQueueRegex = new(@"(amqp\.queue\:) amq\.gen\-.*,");
-        private static readonly Regex GeneratedRoutingKeyRegex = new(@"(amqp\.routing_key\:) amq\.gen\-.*,");
 
         public RabbitMQTests(ITestOutputHelper output)
             : base("RabbitMQ", output)

--- a/tracer/test/snapshots/RabbitMQTests.3_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.3_x.verified.txt
@@ -87,72 +87,73 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_2,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_3,
     SpanId: Id_10,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_4,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_5,
     SpanId: Id_11,
     Name: amqp.command,
-    Resource: queue.bind,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_6,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_7,
     SpanId: Id_12,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_8,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -192,10 +193,76 @@
     TraceId: Id_3,
     SpanId: Id_14,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
     Tags: {
       amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
@@ -210,84 +277,19 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_15,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_16,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_17,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
     SpanId: Id_18,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -314,93 +316,8 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_20,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_22,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
     TraceId: Id_7,
-    SpanId: Id_24,
+    SpanId: Id_20,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -419,16 +336,62 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_25,
+    TraceId: Id_1,
+    SpanId: Id_21,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       runtime-id: Guid_1,
@@ -440,7 +403,7 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_26,
+    SpanId: Id_24,
     Name: amqp.command,
     Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -461,21 +424,60 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_27,
+    TraceId: Id_1,
+    SpanId: Id_25,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: basic.get,
+      amqp.command: queue.declare,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: consumer
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -485,19 +487,17 @@
     TraceId: Id_7,
     SpanId: Id_28,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_8,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -536,7 +536,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_18,
+    ParentId: Id_14,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -562,7 +562,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_23,
+    ParentId: Id_15,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -588,7 +588,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_28,
+    ParentId: Id_16,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -695,26 +695,6 @@
     TraceId: Id_33,
     SpanId: Id_41,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_33,
-    SpanId: Id_42,
-    Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -733,8 +713,71 @@
     }
   },
   {
-    TraceId: Id_33,
+    TraceId: Id_35,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_45,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -756,53 +799,34 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_44,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
-    SpanId: Id_45,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
     SpanId: Id_46,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -818,113 +842,9 @@
     }
   },
   {
-    TraceId: Id_37,
-    SpanId: Id_47,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
+    TraceId: Id_39,
     SpanId: Id_48,
     Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_52,
-    Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -932,7 +852,7 @@
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.routing_key: AmqQueue_7
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       message.size: 61,
@@ -945,12 +865,92 @@
   },
   {
     TraceId: Id_33,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
     SpanId: Id_53,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_43,
+    ParentId: Id_45,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: AmqQueue_1
@@ -979,7 +979,7 @@
     ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_2
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1002,10 +1002,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_49,
+    ParentId: Id_47,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
+      amqp.queue: AmqQueue_3
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1028,10 +1028,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_52,
+    ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1591,17 +1591,23 @@
     }
   },
   {
-    TraceId: Id_57,
+    TraceId: Id_59,
     SpanId: Id_94,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_81,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1612,13 +1618,13 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_61,
     SpanId: Id_95,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_82,
+    ParentId: Id_83,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1639,17 +1645,23 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_63,
     SpanId: Id_96,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_82,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1660,13 +1672,13 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_65,
     SpanId: Id_97,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_83,
+    ParentId: Id_85,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1687,17 +1699,23 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_67,
     SpanId: Id_98,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_83,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1708,13 +1726,13 @@
     }
   },
   {
-    TraceId: Id_63,
+    TraceId: Id_69,
     SpanId: Id_99,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_87,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1735,13 +1753,13 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_71,
     SpanId: Id_100,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_85,
+    ParentId: Id_88,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1762,177 +1780,12 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_73,
     SpanId: Id_101,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_86,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_63,
-    SpanId: Id_102,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_84,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_103,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_85,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_104,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_86,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_87,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_106,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_87,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_107,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_88,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_108,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
     ParentId: Id_89,
     Tags: {
       amqp.command: basic.deliver,
@@ -1944,48 +1797,6 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_109,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_88,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_110,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_89,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1997,7 +1808,7 @@
   },
   {
     TraceId: Id_75,
-    SpanId: Id_111,
+    SpanId: Id_102,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2024,7 +1835,7 @@
   },
   {
     TraceId: Id_77,
-    SpanId: Id_112,
+    SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2051,7 +1862,7 @@
   },
   {
     TraceId: Id_79,
-    SpanId: Id_113,
+    SpanId: Id_104,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2067,6 +1878,195 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_105,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_107,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_108,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_111,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_112,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_113,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {

--- a/tracer/test/snapshots/RabbitMQTests.3_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.3_x.verified.txt
@@ -1,0 +1,2334 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_18,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_19,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_20,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_21,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_24,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_25,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_13,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_18,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_31,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_23,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_32,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_28,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_34,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_36,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_40,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_45,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_46,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_53,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_43,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_54,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_55,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_56,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_52,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_58,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_62,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_64,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_66,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_68,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_70,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_72,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_74,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_76,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_78,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_80,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_81,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_58,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_82,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_83,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_62,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_84,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_64,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_85,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_66,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_86,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_68,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_87,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_70,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_72,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_89,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_74,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_90,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_76,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_91,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_78,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_92,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_80,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_93,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_81,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_95,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_96,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_83,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_98,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_100,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_85,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_101,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_102,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_103,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_104,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_105,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_107,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_88,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_108,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_89,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_111,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_90,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_112,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_91,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_114,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_90,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_115,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_91,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_116,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_117,
+    SpanId: Id_118,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_119,
+    SpanId: Id_120,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_121,
+    SpanId: Id_122,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_123,
+    SpanId: Id_124,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_125,
+    SpanId: Id_126,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_127,
+    SpanId: Id_128,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_129,
+    SpanId: Id_130,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_131,
+    SpanId: Id_132,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/RabbitMQTests.5_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.5_x.verified.txt
@@ -1,0 +1,2334 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_18,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_19,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_20,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_21,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_24,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_25,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_13,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_18,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_31,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_23,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_32,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_28,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_34,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_36,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_40,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_45,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_46,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_53,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_43,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_54,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_55,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_56,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_52,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_58,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_62,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_64,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_66,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_68,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_70,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_72,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_74,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_76,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_78,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_80,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_81,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_58,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_82,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_83,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_62,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_84,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_64,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_85,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_66,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_86,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_68,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_87,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_70,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_72,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_89,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_74,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_90,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_76,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_91,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_78,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_92,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_80,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_93,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_81,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_95,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_96,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_83,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_98,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_100,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_85,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_101,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_102,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_103,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_104,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_105,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_107,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_88,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_108,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_89,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_111,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_90,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_112,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_90,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_91,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_114,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_115,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_91,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_116,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_117,
+    SpanId: Id_118,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_119,
+    SpanId: Id_120,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_121,
+    SpanId: Id_122,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_123,
+    SpanId: Id_124,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_125,
+    SpanId: Id_126,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_127,
+    SpanId: Id_128,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_129,
+    SpanId: Id_130,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_131,
+    SpanId: Id_132,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/RabbitMQTests.5_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.5_x.verified.txt
@@ -87,72 +87,73 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_2,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_3,
     SpanId: Id_10,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_4,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_5,
     SpanId: Id_11,
     Name: amqp.command,
-    Resource: queue.bind,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_6,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_7,
     SpanId: Id_12,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_8,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -192,10 +193,76 @@
     TraceId: Id_3,
     SpanId: Id_14,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
     Tags: {
       amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
@@ -210,84 +277,19 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_15,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_16,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_17,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
     SpanId: Id_18,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -314,93 +316,8 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_20,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_22,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
     TraceId: Id_7,
-    SpanId: Id_24,
+    SpanId: Id_20,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -419,16 +336,62 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_25,
+    TraceId: Id_1,
+    SpanId: Id_21,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       runtime-id: Guid_1,
@@ -440,7 +403,7 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_26,
+    SpanId: Id_24,
     Name: amqp.command,
     Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -461,21 +424,60 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_27,
+    TraceId: Id_1,
+    SpanId: Id_25,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: basic.get,
+      amqp.command: queue.declare,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: consumer
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -485,19 +487,17 @@
     TraceId: Id_7,
     SpanId: Id_28,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_8,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -536,7 +536,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_18,
+    ParentId: Id_14,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -562,7 +562,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_23,
+    ParentId: Id_15,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -588,7 +588,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_28,
+    ParentId: Id_16,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -695,26 +695,6 @@
     TraceId: Id_33,
     SpanId: Id_41,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_33,
-    SpanId: Id_42,
-    Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -733,8 +713,71 @@
     }
   },
   {
-    TraceId: Id_33,
+    TraceId: Id_35,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_45,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -756,53 +799,34 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_44,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
-    SpanId: Id_45,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
     SpanId: Id_46,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -818,113 +842,9 @@
     }
   },
   {
-    TraceId: Id_37,
-    SpanId: Id_47,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
+    TraceId: Id_39,
     SpanId: Id_48,
     Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_52,
-    Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -932,7 +852,7 @@
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.routing_key: AmqQueue_7
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       message.size: 61,
@@ -945,12 +865,92 @@
   },
   {
     TraceId: Id_33,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
     SpanId: Id_53,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_43,
+    ParentId: Id_45,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: AmqQueue_1
@@ -979,7 +979,7 @@
     ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_2
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1002,10 +1002,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_49,
+    ParentId: Id_47,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
+      amqp.queue: AmqQueue_3
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1028,10 +1028,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_52,
+    ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1591,17 +1591,23 @@
     }
   },
   {
-    TraceId: Id_57,
+    TraceId: Id_59,
     SpanId: Id_94,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_81,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1612,13 +1618,13 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_61,
     SpanId: Id_95,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_82,
+    ParentId: Id_83,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1639,17 +1645,23 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_63,
     SpanId: Id_96,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_82,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1660,13 +1672,13 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_65,
     SpanId: Id_97,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_83,
+    ParentId: Id_85,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1687,17 +1699,23 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_67,
     SpanId: Id_98,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_83,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1708,13 +1726,13 @@
     }
   },
   {
-    TraceId: Id_63,
+    TraceId: Id_69,
     SpanId: Id_99,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_87,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1735,13 +1753,13 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_71,
     SpanId: Id_100,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_85,
+    ParentId: Id_88,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1762,13 +1780,13 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_73,
     SpanId: Id_101,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_86,
+    ParentId: Id_89,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1789,215 +1807,8 @@
     }
   },
   {
-    TraceId: Id_63,
+    TraceId: Id_75,
     SpanId: Id_102,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_84,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_103,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_85,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_104,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_86,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_87,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_106,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_87,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_107,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_88,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_108,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_89,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_109,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_88,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_110,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_89,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_111,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2013,27 +1824,6 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_112,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_90,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -2045,7 +1835,7 @@
   },
   {
     TraceId: Id_77,
-    SpanId: Id_113,
+    SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2072,7 +1862,7 @@
   },
   {
     TraceId: Id_79,
-    SpanId: Id_114,
+    SpanId: Id_104,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2088,6 +1878,216 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_105,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_107,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_108,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_111,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_112,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_113,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_114,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_90,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {

--- a/tracer/test/snapshots/RabbitMQTests.6_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.6_x.verified.txt
@@ -1,0 +1,2334 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: False),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_14,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_18,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_19,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_20,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_21,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_24,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: exchange.declare,
+      amqp.exchange: test-exchange-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_25,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_28,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_13,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_30,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_18,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_31,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_23,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_32,
+    Name: amqp.command,
+    Resource: basic.get test-queue-name,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_28,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_34,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_36,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_40,
+    Name: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Resource: Program.PublishAndGetDefault(useDefaultQueue: True),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_41,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_45,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_46,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_48,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_53,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_43,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_1
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_54,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_46,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_55,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_49,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_5
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_56,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_52,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_7
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_58,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_60,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_62,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_64,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_66,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_68,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_70,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_72,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_74,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_76,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_78,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_80,
+    Name: PublishToConsumer(),
+    Resource: PublishToConsumer(),
+    Service: Samples.RabbitMQ,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_81,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_58,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_82,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_60,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_83,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_62,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_84,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_64,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_85,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_66,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_86,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_68,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_87,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_70,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_88,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_72,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_89,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_74,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_90,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_76,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_91,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_78,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_92,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> hello,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_80,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_93,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_81,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_94,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_95,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_96,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_97,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_83,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_98,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_99,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_100,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_101,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_85,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_102,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_103,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_104,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_105,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_87,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_107,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_88,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_108,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_89,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_111,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_90,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_112,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_90,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_113,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_91,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_114,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_92,
+    Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      message.size: 17,
+      runtime-id: Guid_1,
+      span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_77,
+    SpanId: Id_115,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_91,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_79,
+    SpanId: Id_116,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_92,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_117,
+    SpanId: Id_118,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_119,
+    SpanId: Id_120,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_121,
+    SpanId: Id_122,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_123,
+    SpanId: Id_124,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_125,
+    SpanId: Id_126,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_127,
+    SpanId: Id_128,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_129,
+    SpanId: Id_130,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_131,
+    SpanId: Id_132,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: hello,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/RabbitMQTests.6_x.verified.txt
+++ b/tracer/test/snapshots/RabbitMQTests.6_x.verified.txt
@@ -87,72 +87,73 @@
     TraceId: Id_1,
     SpanId: Id_9,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_2,
     Tags: {
-      amqp.command: exchange.declare,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_3,
     SpanId: Id_10,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_4,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_5,
     SpanId: Id_11,
     Name: amqp.command,
-    Resource: queue.bind,
+    Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_6,
     Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
+      amqp.command: basic.get,
       amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
+      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: consumer
     },
     Metrics: {
       _dd.top_level: 1.0
     }
   },
   {
-    TraceId: Id_1,
+    TraceId: Id_7,
     SpanId: Id_12,
     Name: amqp.command,
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_2,
+    ParentId: Id_8,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -192,10 +193,76 @@
     TraceId: Id_3,
     SpanId: Id_14,
     Name: amqp.command,
-    Resource: exchange.declare,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_15,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_16,
+    Name: amqp.command,
+    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_8,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: test-exchange-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 62,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: amqp.command,
+    Resource: exchange.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_2,
     Tags: {
       amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
@@ -210,84 +277,19 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_15,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_16,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
-    SpanId: Id_17,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_4,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_3,
     SpanId: Id_18,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_4,
     Tags: {
-      amqp.command: basic.publish,
+      amqp.command: exchange.declare,
       amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -314,93 +316,8 @@
     }
   },
   {
-    TraceId: Id_5,
-    SpanId: Id_20,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_21,
-    Name: amqp.command,
-    Resource: queue.bind,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: queue.bind,
-      amqp.exchange: test-exchange-name,
-      amqp.queue: test-queue-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_22,
-    Name: amqp.command,
-    Resource: basic.get test-queue-name,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: test-queue-name,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_5,
-    SpanId: Id_23,
-    Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_6,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 62,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
     TraceId: Id_7,
-    SpanId: Id_24,
+    SpanId: Id_20,
     Name: amqp.command,
     Resource: exchange.declare,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -419,16 +336,62 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_25,
+    TraceId: Id_1,
+    SpanId: Id_21,
     Name: amqp.command,
-    Resource: queue.declare,
+    Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: queue.declare,
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
       amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_22,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_23,
+    Name: amqp.command,
+    Resource: queue.bind,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.bind,
+      amqp.exchange: test-exchange-name,
+      amqp.queue: test-queue-name,
+      amqp.routing_key: test-routing-key,
       component: RabbitMQ,
       env: integration_tests,
       runtime-id: Guid_1,
@@ -440,7 +403,7 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_26,
+    SpanId: Id_24,
     Name: amqp.command,
     Resource: queue.bind,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -461,21 +424,60 @@
     }
   },
   {
-    TraceId: Id_7,
-    SpanId: Id_27,
+    TraceId: Id_1,
+    SpanId: Id_25,
     Name: amqp.command,
-    Resource: basic.get test-queue-name,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_8,
+    ParentId: Id_2,
     Tags: {
-      amqp.command: basic.get,
+      amqp.command: queue.declare,
       amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      language: dotnet,
       runtime-id: Guid_1,
-      span.kind: consumer
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_26,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_4,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_27,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_6,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -485,19 +487,17 @@
     TraceId: Id_7,
     SpanId: Id_28,
     Name: amqp.command,
-    Resource: basic.publish test-exchange-name -> test-routing-key,
+    Resource: queue.declare,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_8,
     Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: test-exchange-name,
-      amqp.routing_key: test-routing-key,
+      amqp.command: queue.declare,
+      amqp.queue: test-queue-name,
       component: RabbitMQ,
       env: integration_tests,
-      message.size: 62,
       runtime-id: Guid_1,
-      span.kind: producer
+      span.kind: client
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -536,7 +536,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_18,
+    ParentId: Id_14,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -562,7 +562,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_23,
+    ParentId: Id_15,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -588,7 +588,7 @@
     Resource: basic.get test-queue-name,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_28,
+    ParentId: Id_16,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: test-queue-name,
@@ -695,26 +695,6 @@
     TraceId: Id_33,
     SpanId: Id_41,
     Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_34,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_33,
-    SpanId: Id_42,
-    Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -733,8 +713,71 @@
     }
   },
   {
-    TraceId: Id_33,
+    TraceId: Id_35,
+    SpanId: Id_42,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
     SpanId: Id_43,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_3
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_44,
+    Name: amqp.command,
+    Resource: basic.get <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: basic.get,
+      amqp.queue: AmqQueue_4
+      component: RabbitMQ,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: consumer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_45,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -756,53 +799,34 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_44,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
-    SpanId: Id_45,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_36,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_35,
     SpanId: Id_46,
     Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
     ParentId: Id_36,
+    Tags: {
+      amqp.command: basic.publish,
+      amqp.exchange: ,
+      amqp.routing_key: AmqQueue_2
+      component: RabbitMQ,
+      env: integration_tests,
+      message.size: 61,
+      runtime-id: Guid_1,
+      span.kind: producer
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_47,
+    Name: amqp.command,
+    Resource: basic.publish <default> -> <generated>,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
@@ -818,113 +842,9 @@
     }
   },
   {
-    TraceId: Id_37,
-    SpanId: Id_47,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
+    TraceId: Id_39,
     SpanId: Id_48,
     Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_37,
-    SpanId: Id_49,
-    Name: amqp.command,
-    Resource: basic.publish <default> -> <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_38,
-    Tags: {
-      amqp.command: basic.publish,
-      amqp.exchange: ,
-      amqp.routing_key: AmqQueue_5
-      component: RabbitMQ,
-      env: integration_tests,
-      message.size: 61,
-      runtime-id: Guid_1,
-      span.kind: producer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_50,
-    Name: amqp.command,
-    Resource: queue.declare,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: queue.declare,
-      amqp.queue: ,
-      component: RabbitMQ,
-      env: integration_tests,
-      runtime-id: Guid_1,
-      span.kind: client
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_51,
-    Name: amqp.command,
-    Resource: basic.get <generated>,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_40,
-    Tags: {
-      amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: consumer
-    },
-    Metrics: {
-      _dd.top_level: 1.0
-    }
-  },
-  {
-    TraceId: Id_39,
-    SpanId: Id_52,
-    Name: amqp.command,
     Resource: basic.publish <default> -> <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
@@ -932,7 +852,7 @@
     Tags: {
       amqp.command: basic.publish,
       amqp.exchange: ,
-      amqp.routing_key: AmqQueue_7
+      amqp.routing_key: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       message.size: 61,
@@ -945,12 +865,92 @@
   },
   {
     TraceId: Id_33,
+    SpanId: Id_49,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_34,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_35,
+    SpanId: Id_50,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_36,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_51,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_38,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_52,
+    Name: amqp.command,
+    Resource: queue.declare,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_40,
+    Tags: {
+      amqp.command: queue.declare,
+      amqp.queue: ,
+      component: RabbitMQ,
+      env: integration_tests,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
     SpanId: Id_53,
     Name: amqp.command,
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_43,
+    ParentId: Id_45,
     Tags: {
       amqp.command: basic.get,
       amqp.queue: AmqQueue_1
@@ -979,7 +979,7 @@
     ParentId: Id_46,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_3
+      amqp.queue: AmqQueue_2
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1002,10 +1002,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_49,
+    ParentId: Id_47,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_5
+      amqp.queue: AmqQueue_3
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1028,10 +1028,10 @@
     Resource: basic.get <generated>,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_52,
+    ParentId: Id_48,
     Tags: {
       amqp.command: basic.get,
-      amqp.queue: AmqQueue_7
+      amqp.queue: AmqQueue_4
       component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
@@ -1591,17 +1591,23 @@
     }
   },
   {
-    TraceId: Id_57,
+    TraceId: Id_59,
     SpanId: Id_94,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_81,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_82,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1612,13 +1618,13 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_61,
     SpanId: Id_95,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_82,
+    ParentId: Id_83,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1639,17 +1645,23 @@
     }
   },
   {
-    TraceId: Id_59,
+    TraceId: Id_63,
     SpanId: Id_96,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_82,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_84,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1660,13 +1672,13 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_65,
     SpanId: Id_97,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_83,
+    ParentId: Id_85,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1687,17 +1699,23 @@
     }
   },
   {
-    TraceId: Id_61,
+    TraceId: Id_67,
     SpanId: Id_98,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_83,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_86,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1708,13 +1726,13 @@
     }
   },
   {
-    TraceId: Id_63,
+    TraceId: Id_69,
     SpanId: Id_99,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_84,
+    ParentId: Id_87,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1735,17 +1753,23 @@
     }
   },
   {
-    TraceId: Id_63,
+    TraceId: Id_71,
     SpanId: Id_100,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_84,
+    Name: amqp.command,
+    Resource: basic.deliver,
+    Service: Samples.RabbitMQ-rabbitmq,
+    Type: queue,
+    ParentId: Id_88,
     Tags: {
+      amqp.command: basic.deliver,
+      amqp.exchange: ,
+      amqp.routing_key: hello,
+      component: RabbitMQ,
       env: integration_tests,
       language: dotnet,
+      message.size: 17,
       runtime-id: Guid_1,
-      version: 1.0.0,
+      span.kind: consumer,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -1756,13 +1780,13 @@
     }
   },
   {
-    TraceId: Id_65,
+    TraceId: Id_73,
     SpanId: Id_101,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_85,
+    ParentId: Id_89,
     Tags: {
       amqp.command: basic.deliver,
       amqp.exchange: ,
@@ -1783,225 +1807,12 @@
     }
   },
   {
-    TraceId: Id_67,
+    TraceId: Id_75,
     SpanId: Id_102,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
     Type: queue,
-    ParentId: Id_86,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_65,
-    SpanId: Id_103,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_85,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_67,
-    SpanId: Id_104,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_86,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_105,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_87,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_69,
-    SpanId: Id_106,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_87,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_107,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_88,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_108,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
-    ParentId: Id_89,
-    Tags: {
-      amqp.command: basic.deliver,
-      amqp.exchange: ,
-      amqp.routing_key: hello,
-      component: RabbitMQ,
-      env: integration_tests,
-      language: dotnet,
-      message.size: 17,
-      runtime-id: Guid_1,
-      span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_71,
-    SpanId: Id_109,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_88,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_73,
-    SpanId: Id_110,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_89,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_111,
-    Name: amqp.command,
-    Resource: basic.deliver,
-    Service: Samples.RabbitMQ-rabbitmq,
-    Type: queue,
     ParentId: Id_90,
     Tags: {
       amqp.command: basic.deliver,
@@ -2013,27 +1824,6 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
-      _dd.p.dm: -0
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_75,
-    SpanId: Id_112,
-    Name: consumer.Received event,
-    Resource: consumer.Received event,
-    Service: Samples.RabbitMQ,
-    ParentId: Id_90,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      runtime-id: Guid_1,
-      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {
@@ -2045,7 +1835,7 @@
   },
   {
     TraceId: Id_77,
-    SpanId: Id_113,
+    SpanId: Id_103,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2072,7 +1862,7 @@
   },
   {
     TraceId: Id_79,
-    SpanId: Id_114,
+    SpanId: Id_104,
     Name: amqp.command,
     Resource: basic.deliver,
     Service: Samples.RabbitMQ-rabbitmq,
@@ -2088,6 +1878,216 @@
       message.size: 17,
       runtime-id: Guid_1,
       span.kind: consumer,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_57,
+    SpanId: Id_105,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_81,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_59,
+    SpanId: Id_106,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_82,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_61,
+    SpanId: Id_107,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_83,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_63,
+    SpanId: Id_108,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_84,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_65,
+    SpanId: Id_109,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_85,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_67,
+    SpanId: Id_110,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_86,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_69,
+    SpanId: Id_111,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_87,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_71,
+    SpanId: Id_112,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_88,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_73,
+    SpanId: Id_113,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_89,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_114,
+    Name: consumer.Received event,
+    Resource: consumer.Received event,
+    Service: Samples.RabbitMQ,
+    ParentId: Id_90,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0,
       _dd.p.dm: -0
     },
     Metrics: {


### PR DESCRIPTION
## Summary of changes

Converts the extensive explicit assertion logic to use snapshots instead

## Reason for change

I had an escalation around rabbitMQ and wanted to see what the actual snapshots should look like

## Implementation details

Just dumped snapshots of the existing behaviour. Had to make a couple of changes to make them stable:

- The usual snapshot splitting by package version. They're only minor differences, but we call different methods in the sample depending on the package version, so not entirely surprising
- The ordering that we receive the spans in isn't entirely deterministic, so to ensure a stable sort order, sorting by span depth and then Operation and Resource name.
- In some of the spans we generate the queue dynamically, so we added a `QueueScrubber` (based on the built-in `GuidScrubber` that scrubs _and indexes_ each of the generated queues. This is nicer than the simple scrubbers we tend to use, as it ensures we retain the references between spans correctly.

## Test coverage

Yeah, that's what this is..

## Other details
This sample generates a _lot_ of spans, so as it turns out it's probably too confusing for me to use in my escalation testing. Oh well 😅 
