### PR TITLE
Fix duplicate logging issue with DirectLogSubmission and Serilog

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ConditionalSinkProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ConditionalSinkProxy.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="ConditionalSinkProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+
+[DuckCopy]
+internal struct ConditionalSinkProxy
+{
+    [DuckField(Name = "_wrapped")]
+    public object Sink;
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
@@ -62,51 +62,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
                     break;
                 }
 
-                // they may have created a sub logger that we've already added the sink to
-                // Unfortunately there's no way to "detect" the logger being created will
-                // be a sub-logger, so we have to retrospectively disable it instead.
-                // We don't look for instances of the public datadog serilog sink, just our internal
-                // direct submission one - if they're using the public sink we already
-                // essentially disable direct submission to avoid duplicate logs.
-                // Also, early versions of Serilog use a different pattern, so we add an additional
-                // check on .NET FX
-                if (logEventSink is not null)
-                {
-                    LoggerProxy? secondaryLogger = null;
-
-                    if (logEventSink.TryDuckCast<SecondaryLoggerSinkProxy>(out var proxy1))
-                    {
-                        secondaryLogger = proxy1.Logger;
-                    }
-#if NETFRAMEWORK
-                    else if (logEventSink.TryDuckCast<CopyingSinkProxy>(out var proxy2))
-                    {
-                        secondaryLogger = proxy2.Logger;
-                    }
-#endif
-
-                    if (secondaryLogger is { Sink: { } secondarySink })
-                    {
-                        if (secondarySink is DirectSubmissionSerilogSink subSink1)
-                        {
-                            subSink1.Disable();
-                        }
-                        else
-                        {
-                            if (secondarySink.TryDuckCast<AggregateSinkProxy>(out var aggregateSink))
-                            {
-                                foreach (var subSink in aggregateSink.LogEventSinks)
-                                {
-                                    if (subSink is IDuckType { Instance: DirectSubmissionSerilogSink subSink2 })
-                                    {
-                                        subSink2.Disable();
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                TryDisablingSubLoggerSinks(logEventSink);
             }
 
             if (!sinkAlreadyAdded)
@@ -125,6 +81,56 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
                 var proxy = sink.DuckImplement(targetType);
                 instance.LogEventSinks.Add(proxy);
                 Log.Information("Direct log submission via Serilog enabled");
+            }
+        }
+
+        private static void TryDisablingSubLoggerSinks(object? logEventSink)
+        {
+            // they may have created a sub logger that we've already added the sink to
+            // Unfortunately there's no way to "detect" the logger being created will
+            // be a sub-logger, so we have to retrospectively disable it instead.
+            // We don't look for instances of the public datadog serilog sink, just our internal
+            // direct submission one - if they're using the public sink we already
+            // essentially disable direct submission to avoid duplicate logs.
+            // Also, early versions of Serilog use a different pattern, so we add an additional
+            // check on .NET FX. There could be multiple layers of sinks here, so we recursively check them all
+            if (logEventSink is null)
+            {
+                return;
+            }
+            else if (logEventSink is DirectSubmissionSerilogSink directLogSink1)
+            {
+                directLogSink1.Disable();
+            }
+            else if (logEventSink is IDuckType { Instance: DirectSubmissionSerilogSink directLogSink2 })
+            {
+                directLogSink2.Disable();
+            }
+            else if (logEventSink.TryDuckCast<SecondaryLoggerSinkProxy>(out var secondaryLoggerSink))
+            {
+                TryDisablingSubLoggerSinks(secondaryLoggerSink.Logger.Sink);
+            }
+#if NETFRAMEWORK
+            else if (logEventSink.TryDuckCast<CopyingSinkProxy>(out var copyingSink))
+            {
+                TryDisablingSubLoggerSinks(copyingSink.Logger.Sink);
+            }
+#endif
+            else if (logEventSink.TryDuckCast<AggregateSinkProxy>(out var aggregateSink))
+            {
+                foreach (var subSink in aggregateSink.LogEventSinks)
+                {
+                    TryDisablingSubLoggerSinks(subSink);
+                }
+            }
+            else if (logEventSink.TryDuckCast<LoggerProxy>(out var nestedLogger))
+            {
+                // Various other sink wrappers have a similar shape to the Logger proxy
+                TryDisablingSubLoggerSinks(nestedLogger.Sink);
+            }
+            else if (logEventSink.TryDuckCast<ConditionalSinkProxy>(out var conditionalSink))
+            {
+                TryDisablingSubLoggerSinks(conditionalSink.Sink);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -34,23 +34,24 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
+        // exclude loadFromConfig from v1.x as it's not available
         public static IEnumerable<object[]> GetTestData()
-        {
-            foreach (var item in PackageVersions.Serilog)
-            {
-                yield return item.Concat(false);
-                yield return item.Concat(true);
-            }
-        }
+            => from packageVersion in PackageVersions.Serilog.SelectMany(x => x).Select(x => (string)x)
+               from enableLogShipping in new[] { true, false }
+               from loadFromConfig in new[] { true, false }
+               where !loadFromConfig // only include loadFromConfig when >= 2.12.0 (early versions of the config package are buggy)
+                  || (!string.IsNullOrEmpty(packageVersion) && new Version(packageVersion) >= new Version("2.12.0"))
+               select new object[] { packageVersion, enableLogShipping, loadFromConfig };
 
         [SkippableTheory]
         [MemberData(nameof(GetTestData))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping)
+        public void InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetSerilogConfiguration(loadFromConfig);
             SetInstrumentationVerification();
             using var logsIntake = new MockLogsIntake();
             if (enableLogShipping)
@@ -78,9 +79,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping)
+        public void DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
+            SetSerilogConfiguration(loadFromConfig);
             SetInstrumentationVerification();
             using var logsIntake = new MockLogsIntake();
             if (enableLogShipping)
@@ -104,16 +106,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableTheory]
-        [MemberData(nameof(PackageVersions.Serilog), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(GetTestData))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DirectlyShipsLogs(string packageVersion)
+        public void DirectlyShipsLogs(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
+            if (!enableLogShipping)
+            {
+                // invalid config, just easier than creating another test data configuration
+                return;
+            }
+
             var hostName = "integration_serilog_tests";
             using var logsIntake = new MockLogsIntake();
 
             SetInstrumentationVerification();
+            SetSerilogConfiguration(loadFromConfig);
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), hostName);
 
@@ -145,6 +154,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             VerifyInstrumentation(processResult.Process);
         }
+
+        private void SetSerilogConfiguration(bool loadFromConfig)
+            => SetEnvironmentVariable("SERILOG_CONFIGURE_FROM_APPSETTINGS", loadFromConfig ? "1" : "0");
 
         private LogFileTest[] GetLogFiles(string packageVersion, bool logsInjectionEnabled)
         {

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
@@ -4,12 +4,14 @@
     <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">1.4.16</ApiVersion>
     <ApiVersion Condition="'$(ApiVersion)' == '' AND !$(TargetFramework.StartsWith('net4')) ">2.0.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='2.0.0'">$(DefineConstants);SERILOG_2_0</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.12.0'">$(DefineConstants);SERILOG_2_12</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='1.4.152' and '$(ApiVersion)'&lt;'2.0.0'">$(DefineConstants);SERILOG_LOG_OPTIN_CROSS_APPDOMAIN</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'&lt;'1.4.152'">$(DefineConstants);SERILOG_CROSS_APPDOMAIN_FAILURE</DefineConstants>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
 
   </PropertyGroup>
 
@@ -22,21 +24,28 @@
     <!-- Use somewhat older versions of Serilog packages for easiest compatibility -->
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="2.2.0" />
-    
+
     <!-- Directly reference dependencies of Serilog.Sinks.File to avoid package downgrade errors -->
     <PackageReference Include="System.IO" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(ApiVersion)' &gt;= '2.0.0'">
-    <!-- Directly reference dependencies of Serilog.Sinks.File to avoid package downgrade errors -->
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <!-- Load from config tests -->
+  <ItemGroup Condition="'$(ApiVersion)' &gt;= '2.12.0'">
+    <PackageReference Include="Serilog.Sinks.Console" Version="2.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\dependency-libs\LogsInjectionHelper\LogsInjectionHelper.csproj" />
     <ProjectReference Include="..\dependency-libs\PluginApplication\PluginApplication.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="AfterBuildMovePluginApplication" AfterTargets="AfterBuild">

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
@@ -36,6 +36,7 @@
   <ItemGroup Condition="'$(ApiVersion)' &gt;= '2.12.0'">
     <PackageReference Include="Serilog.Sinks.Console" Version="2.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/Program.cs
@@ -1,6 +1,10 @@
 
 using System;
 using System.IO;
+#if SERILOG_2_12
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+#endif
 using PluginApplication;
 using Serilog;
 using Serilog.Configuration;
@@ -28,22 +32,49 @@ namespace LogsInjection.Serilog
             var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
             var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
             var jsonFilePath = Path.Combine(appDirectory, "log-jsonFile.log");
+            var useConfiguration = Environment.GetEnvironmentVariable("SERILOG_CONFIGURE_FROM_APPSETTINGS") == "1";
 
-            var log = new LoggerConfiguration()
-                                        .Enrich.FromLogContext()
-                                        .MinimumLevel.Is(LogEventLevel.Information)
-                                        .WriteTo.Logger(lc => lc.WriteTo.File(
-                                            textFilePath,
-                                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {{ dd_service: \"{dd_service}\", dd_version: \"{dd_version}\", dd_env: \"{dd_env}\", dd_trace_id: \"{dd_trace_id}\", dd_span_id: \"{dd_span_id}\" }} {Message:lj} {NewLine}{Exception}")
-                                        .WriteTo.Logger(lc2 => lc2.WriteTo.Console()))
-#if SERILOG_2_0
-                                        .WriteTo.File(
-                                            new JsonFormatter(),
-                                            jsonFilePath)
+            LoggerConfiguration configuration;
+            if (useConfiguration)
+            {
+#if SERILOG_2_12
+                System.Console.WriteLine("Reading configuration...");
+                var appSettingsConfig = new ConfigurationBuilder()
+                                       .SetBasePath(appDirectory)
+                                       .AddJsonFile("appsettings.json")
+                                       .AddInMemoryCollection(new Dictionary<string, string>
+                                        {
+                                            { "Serilog:WriteTo:0:Args:configureLogger:WriteTo:0:Args:path", textFilePath },
+                                            { "Serilog:WriteTo:1:Args:path", jsonFilePath },
+                                        })
+                                       .Build();
+
+                configuration = new LoggerConfiguration()
+                               .ReadFrom.Configuration(appSettingsConfig);
+                System.Console.WriteLine("Building logger...");
+#else
+                throw new Exception("Unable to load from configuration in Serilog <2.12.0");
 #endif
-                                        .WriteTo.Logger(lc => lc.WriteTo.Console())
-                                        .CreateLogger();
-            
+            }
+            else
+            {
+                configuration = new LoggerConfiguration()
+                               .Enrich.FromLogContext()
+                               .MinimumLevel.Is(LogEventLevel.Information)
+                               .WriteTo.Logger(
+                                    lc => lc.WriteTo.File(
+                                                 textFilePath,
+                                                 outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {{ dd_service: \"{dd_service}\", dd_version: \"{dd_version}\", dd_env: \"{dd_env}\", dd_trace_id: \"{dd_trace_id}\", dd_span_id: \"{dd_span_id}\" }} {Message:lj} {NewLine}{Exception}")
+                                            .WriteTo.Logger(lc2 => lc2.WriteTo.Console()))
+#if SERILOG_2_0
+                               .WriteTo.File(
+                                    new JsonFormatter(),
+                                    jsonFilePath)
+#endif
+                               .WriteTo.Logger(lc => lc.WriteTo.Console());
+            }
+
+            var log = configuration.CreateLogger();
 
             return LoggingMethods.RunLoggingProcedure(LogWrapper(log));
         }

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/appsettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/appsettings.json
@@ -12,11 +12,27 @@
     "Enrich": [
       "FromLogContext"
     ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/health%'"
+        }
+      }
+    ],
     "WriteTo": [
       {
         "Name": "Logger",
         "Args": {
           "configureLogger": {
+            "Filter": [
+              {
+                "Name": "ByExcluding",
+                "Args": {
+                  "expression": "RequestPath like '/health%'"
+                }
+              }
+            ],
             "WriteTo": [
               {
                 "Name": "File",

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/appsettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/appsettings.json
@@ -1,0 +1,44 @@
+﻿{
+  "AllowedHosts": "*",
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.File",
+      "Serilog.Settings.Configuration"
+    ],
+    "MinimumLevel": {
+      "Default": "Information"
+    },
+    "Enrich": [
+      "FromLogContext"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Logger",
+        "Args": {
+          "configureLogger": {
+            "WriteTo": [
+              {
+                "Name": "File",
+                "Args": {
+                  "path": "log-textFile.log",
+                  "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {{ dd_service: \"{dd_service}\", dd_version: \"{dd_version}\", dd_env: \"{dd_env}\", dd_trace_id: \"{dd_trace_id}\", dd_span_id: \"{dd_span_id}\" }} {Message:lj} {NewLine}{Exception}"
+                }
+              },
+              {
+                "Name": "Console"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "Name": "File",
+        "Args": {
+          "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog",
+          "path": "log-textFile.log"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary of changes

- Add testing of `Serilog.Settings.Configuration`
- Add testing of `Filter` expressions
- Fix bug that caused duplicate logs to be submitted with certain configurations

## Reason for change

In some cases, if you are using Filters with subloggers, we fail to disable the DirectLogSubmission logger. A similar bug was fixed in 2.22.0, but the solution wasn't sufficiently generalized, so we essentially have the same issue.

## Implementation details

Make the "check for existing logger" more generalised, so that we recursively search through the full logger/sink graph. Otherwise it's all updates to testing

## Test coverage

Added tests that use the `Microsoft.Extensions.Configuration`-based configuration (as I thought this might be culprit initially) and that use the `Filter` expressions. Restricted it to recent versions of Serilog for testing, because ran into a lot of dependency issues otherwise, and I don't think it's worth the hassle to do otherwise.
