### PR TITLE
[ASM] Command injection vulnerability detection

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/ProcessStartIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/ProcessStartIntegration.cs
@@ -35,8 +35,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Process
         {
             if (instance is System.Diagnostics.Process process && process.StartInfo is var startInfo)
             {
-                var scope = ProcessStartCommon.CreateScope(startInfo);
-
                 if (Iast.Iast.Instance.Settings.Enabled)
                 {
 #if NETCOREAPP3_1_OR_GREATER
@@ -46,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Process
 #endif
                 }
 
-                return new CallTargetState(scope: scope);
+                return new CallTargetState(scope: ProcessStartCommon.CreateScope(startInfo));
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -45,14 +45,14 @@ internal static class IastModule
         {
             var joinList = StringModuleImpl.OnStringJoin(string.Join(" ", argumentList), argumentList);
             var fileWithSpace = file + " ";
-            _ = StringModuleImpl.PropagateTaint(file, fileWithSpace) as string;
+            _ = PropagationModuleImpl.PropagateTaint(file, fileWithSpace) as string;
             return StringModuleImpl.OnStringConcat(fileWithSpace, joinList, string.Concat(fileWithSpace, joinList));
         }
 
         if (!string.IsNullOrEmpty(argumentLine))
         {
             var fileWithSpace = file + " ";
-            _ = StringModuleImpl.PropagateTaint(file, fileWithSpace) as string;
+            _ = PropagationModuleImpl.PropagateTaint(file, fileWithSpace) as string;
             return StringModuleImpl.OnStringConcat(fileWithSpace, argumentLine, string.Concat(fileWithSpace, argumentLine));
         }
         else

--- a/tracer/src/Datadog.Trace/IAST/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/IAST/StackWalker.cs
@@ -24,13 +24,15 @@ internal static class StackWalker
         "Oracle.DataAccess",
         "Oracle.ManagedDataAccess",
         "System.Data",
+        "System",
         "System.Data.Common",
         "System.Security.Cryptography",
         "System.Security.Cryptography.Algorithms",
         "System.Security.Cryptography.Csp",
         "System.Security.Cryptography.Primitives",
         "System.Data.SqlClient",
-        "System.Data.SQLite"
+        "System.Data.SQLite",
+        "System.Diagnostics.Process"
     };
 
     private const int DefaultSkipFrames = 2;

--- a/tracer/src/Datadog.Trace/IAST/VulnerabilityType.cs
+++ b/tracer/src/Datadog.Trace/IAST/VulnerabilityType.cs
@@ -22,4 +22,7 @@ internal enum VulnerabilityType
 
     /// <summary> SQL_INJECTION vulnerability </summary>
     SqlInjection,
+
+    /// <summary> COMMAND_INJECTION vulnerability </summary>
+    CommandInjection,
 }

--- a/tracer/src/Datadog.Trace/IAST/VulnerabilityTypeName.cs
+++ b/tracer/src/Datadog.Trace/IAST/VulnerabilityTypeName.cs
@@ -23,6 +23,8 @@ internal static class VulnerabilityTypeName
 
     public const string SqlInjection = "SQL_INJECTION";
 
+    public const string CommandInjection = "COMMAND_INJECTION";
+
     public static string GetName(VulnerabilityType vulnerability)
     {
         return vulnerability switch
@@ -31,6 +33,7 @@ internal static class VulnerabilityTypeName
             VulnerabilityType.WeakCipher => WeakCipher,
             VulnerabilityType.WeakHash => WeakHash,
             VulnerabilityType.SqlInjection => SqlInjection,
+            VulnerabilityType.CommandInjection => CommandInjection,
             _ => throw new System.ArgumentException($"VulnerabilityName for VulnerabilityType.{vulnerability} missing.", "vulnerability"),
         };
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -122,6 +122,25 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
                               .UseFileName(filename)
                               .DisableRequireUniquePrefix();
         }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestIastCommandInjectionRequest()
+        {
+            var filename = IastEnabled ? "Iast.CommandInjection.AspNetCore2.IastEnabled" : "Iast.CommandInjection.AspNetCore2.IastDisabled";
+            var url = "/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1";
+            IncludeAllHttpSpans = true;
+            await TryStartApp();
+            var agent = Fixture.Agent;
+            var spans = await SendRequestsAsync(agent, new string[] { url });
+            var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+            settings.AddIastScrubbing();
+            await VerifyHelper.VerifySpans(spansFiltered, settings)
+                              .UseFileName(filename)
+                              .DisableRequireUniquePrefix();
+        }
     }
 
     public class AspNetCore2IastTests50PctSamplingIastEnabled : AspNetCore2IastTests

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -181,6 +181,26 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
                               .UseFileName(filename)
                               .DisableRequireUniquePrefix();
         }
+
+        [SkippableFact]
+        [Trait("Category", "ArmUnsupported")]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestIastCommandInjectionRequest()
+        {
+            var filename = IastEnabled ? "Iast.CommandInjection.AspNetCore5.IastEnabled" : "Iast.CommandInjection.AspNetCore5.IastDisabled";
+            var url = "/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1";
+            IncludeAllHttpSpans = true;
+            await TryStartApp();
+            var agent = Fixture.Agent;
+            var spans = await SendRequestsAsync(agent, new string[] { url });
+            var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+            settings.AddIastScrubbing();
+            await VerifyHelper.VerifySpans(spansFiltered, settings)
+                              .UseFileName(filename)
+                              .DisableRequireUniquePrefix();
+        }
     }
 
     public abstract class AspNetCore5IastTests : AspNetBase, IClassFixture<AspNetCoreTestFixture>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -70,7 +70,6 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             SetEnvironmentVariable("DD_IAST_MAX_CONCURRENT_REQUESTS", "100");
             SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
             SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
-            SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory, "sqli"));
             DisableObfuscationQueryString();
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -64,7 +65,12 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             EnableIast(enableIast);
+            SetEnvironmentVariable("DD_IAST_DEDUPLICATION_ENABLED", "false");
+            SetEnvironmentVariable("DD_IAST_REQUEST_SAMPLING", "100");
+            SetEnvironmentVariable("DD_IAST_MAX_CONCURRENT_REQUESTS", "100");
+            SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
             SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
+            SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory, "sqli"));
             DisableObfuscationQueryString();
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -177,7 +177,7 @@ public class IastInstrumentationUnitTests : TestHelper
 #else
             if (EnvironmentTools.IsLinux())
             {
-                arguments += " --filter (Category!=LinuxUnsupported)";
+                arguments += " --TestCaseFilter:\"Category!=LinuxUnsupported\"";
             }
 #endif
             SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory, "InstrumentedTests"));

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -174,6 +174,11 @@ public class IastInstrumentationUnitTests : TestHelper
             string arguments = string.Empty;
 #if NET462
             arguments = @" /Framework:"".NETFramework,Version=v4.6.2"" ";
+#else
+            if (EnvironmentTools.IsLinux())
+            {
+                arguments += " --filter (Category!=LinuxUnsupported)";
+            }
 #endif
             SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory, "InstrumentedTests"));
             ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, arguments: arguments, forceVsTestParam: true);

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastDisabled.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore2,
+    Type: web,
+    Tags: {
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommand,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore2,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommand,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
@@ -45,12 +45,12 @@
   ],
   "sources": [
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "file",
       "value": "nonexisting.exe"
     },
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "argumentLine",
       "value": "arg1"
     }

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
@@ -1,0 +1,87 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore2,
+    Type: web,
+    Tags: {
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommand,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "nonexisting.exe",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "value": "arg1",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter.value",
+      "name": "file",
+      "value": "nonexisting.exe"
+    },
+    {
+      "origin": "http.request.parameter.value",
+      "name": "argumentLine",
+      "value": "arg1"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore2,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommand,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastDisabled.verified.txt
@@ -1,0 +1,51 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.ExecuteCommand (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommand,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommand,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
@@ -1,0 +1,88 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.ExecuteCommand (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommand,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "nonexisting.exe",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "value": "arg1",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter.value",
+      "name": "file",
+      "value": "nonexisting.exe"
+    },
+    {
+      "origin": "http.request.parameter.value",
+      "name": "argumentLine",
+      "value": "arg1"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommand,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommand,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
@@ -46,12 +46,12 @@
   ],
   "sources": [
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "file",
       "value": "nonexisting.exe"
     },
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "argumentLine",
       "value": "arg1"
     }

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastDisabled.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /iast/executecommand,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller}/{action}/{id},
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: sample,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet.action: executecommand,
+      aspnet.controller: iast,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -43,12 +43,12 @@
   ],
   "sources": [
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "file",
       "value": "nonexisting.exe"
     },
     {
-      "origin": "http.request.parameter.value",
+      "origin": "http.request.parameter",
       "name": "argumentLine",
       "value": "arg1"
     }

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -1,0 +1,89 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /iast/executecommand,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller}/{action}/{id},
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "nonexisting.exe",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "value": "arg1",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.parameter.value",
+      "name": "file",
+      "value": "nonexisting.exe"
+    },
+    {
+      "origin": "http.request.parameter.value",
+      "name": "argumentLine",
+      "value": "arg1"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /iast/executecommand,
+    Service: sample,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet.action: executecommand,
+      aspnet.controller: iast,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -17,7 +17,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
     private string untaintedProcessName = "nonexisting2.exe";
     private string taintedArgument = "taintedArgument";
     private string untaintedArgument = "untaintedArgument";
-    private string vulnerabilityType = "COMMAND_INJECTION";
+    private string commandInjectionType = "COMMAND_INJECTION";
 
     public CommandInjectionTests()
     {
@@ -32,7 +32,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable()
     {
         TestProcessCall(() => Process.Start(new ProcessStartInfo(taintedProcessName) { UseShellExecute = true }));
-        AssertVulnerable(vulnerabilityType, taintedProcessName);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+:");
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable2()
     {
         TestProcessCall(() => Process.Start(new ProcessStartInfo(taintedProcessName) { UseShellExecute = false }));
-        AssertVulnerable(vulnerabilityType, taintedProcessName);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+:");
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable3()
     {
         TestProcessCall(() => Process.Start(taintedProcessName, untaintedArgument, "user", new SecureString(), "domain"));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: untaintedArgument");
     }
 
     [Trait("Category", "LinuxUnsupported")]
@@ -73,7 +73,15 @@ public class CommandInjectionTests : InstrumentationTestsBase
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable4()
     {
         TestProcessCall(() => Process.Start(untaintedProcessName, taintedArgument, "user", new SecureString(), "domain"));
-        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+        AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
+    }
+
+        [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable5()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, taintedArgument, "user", new SecureString(), "domain"));
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: :+-taintedArgument-+:");
     }
 
     [Trait("Category", "LinuxUnsupported")]
@@ -90,10 +98,10 @@ public class CommandInjectionTests : InstrumentationTestsBase
 
     [Trait("Category", "LinuxUnsupported")]
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable5()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable6()
     {
         TestProcessCall(() => Process.Start(taintedProcessName, "user", new SecureString(), "domain"));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+:");
     }
 
     [Trait("Category", "LinuxUnsupported")]
@@ -109,22 +117,32 @@ public class CommandInjectionTests : InstrumentationTestsBase
     // Process Start()
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable6()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable7()
     {
         Process process = new Process();
         process.StartInfo = new ProcessStartInfo(taintedProcessName, untaintedArgument);
         TestProcessCall(() => process.Start());
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: untaintedArgument");
     }
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable7()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable8()
     {
         Process process = new Process();
         process.StartInfo = new ProcessStartInfo(untaintedProcessName, taintedArgument);
         TestProcessCall(() => process.Start());
-        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+        AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
     }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable9()
+    {
+        Process process = new Process();
+        process.StartInfo = new ProcessStartInfo(taintedProcessName, taintedArgument);
+        TestProcessCall(() => process.Start());
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: :+-taintedArgument-+:");
+    }
+
     [Fact]
     public void GivenAProcess_WhenStartUntaintedProcess_ThenIsNotVulnerable3()
     {
@@ -135,23 +153,33 @@ public class CommandInjectionTests : InstrumentationTestsBase
     }
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable8()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable10()
     {
         Process process = new Process();
         process.StartInfo.FileName = taintedProcessName;
         process.StartInfo.Arguments = untaintedArgument;
         TestProcessCall(() => process.Start());
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: untaintedArgument");
     }
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable9()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable11()
     {
         Process process = new Process();
         process.StartInfo.FileName = untaintedProcessName;
         process.StartInfo.Arguments = taintedArgument;
         TestProcessCall(() => process.Start());
-        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+        AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable12()
+    {
+        Process process = new Process();
+        process.StartInfo.FileName = taintedProcessName;
+        process.StartInfo.Arguments = taintedArgument;
+        TestProcessCall(() => process.Start());
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: :+-taintedArgument-+:");
     }
 
     [Fact]
@@ -167,10 +195,10 @@ public class CommandInjectionTests : InstrumentationTestsBase
     // Process Start(string fileName)
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable10()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable13()
     {
         TestProcessCall(() => Process.Start(taintedProcessName));
-        AssertVulnerable(vulnerabilityType, taintedProcessName);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+:");
     }
 
     [Fact]
@@ -183,17 +211,24 @@ public class CommandInjectionTests : InstrumentationTestsBase
     // Process Start(string fileName, string arguments)
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable11()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable14()
     {
         TestProcessCall(() => Process.Start(taintedProcessName, untaintedArgument));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: untaintedArgument");
     }
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable12()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable15()
     {
         TestProcessCall(() => Process.Start(untaintedProcessName, taintedArgument));
-        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+        AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable16()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, taintedArgument));
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: :+-taintedArgument-+:");
     }
 
     [Fact]
@@ -207,24 +242,31 @@ public class CommandInjectionTests : InstrumentationTestsBase
     // Process Start(string fileName, string arguments)
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable13()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable17()
     {
         TestProcessCall(() => Process.Start(taintedProcessName, new List<string>() { untaintedArgument }));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: untaintedArgument");
     }
 
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable14()
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable18()
     {
-        TestProcessCall(() => Process.Start(taintedProcessName, new List<string>() { taintedArgument }));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + taintedArgument);
+        TestProcessCall(() => Process.Start(untaintedProcessName, new List<string>() { taintedArgument }));
+        AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable19()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, new List<string>() { taintedArgument, taintedArgument }));
+        AssertVulnerable(commandInjectionType, ":+-nonexisting1.exe-+: :+-taintedArgument-+: :+-taintedArgument-+:");
     }
 
     [Fact]
     public void GivenAProcess_WhenStartNotTaintedProcess_ThenIsNotVulnerable7()
     {
         TestProcessCall(() => Process.Start(untaintedProcessName, new List<string>() { untaintedArgument, untaintedArgument }));
-        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertNotVulnerable();
     }
 #endif
     private void TestProcessCall(Func<object> expression)

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -17,7 +17,6 @@ public class CommandInjectionTests : InstrumentationTestsBase
     private string untaintedProcessName = "nonexisting2.exe";
     private string taintedArgument = "taintedArgument";
     private string untaintedArgument = "untaintedArgument";
-    private string commandInjectionType = "COMMAND_INJECTION";
 
     public CommandInjectionTests()
     {
@@ -76,7 +75,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         AssertVulnerable(commandInjectionType, "nonexisting2.exe :+-taintedArgument-+:");
     }
 
-        [Trait("Category", "LinuxUnsupported")]
+    [Trait("Category", "LinuxUnsupported")]
     [Fact]
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable5()
     {

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -141,8 +141,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         process.StartInfo.FileName = taintedProcessName;
         process.StartInfo.Arguments = untaintedArgument;
         TestProcessCall(() => process.Start());
-        // AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
-        AssertVulnerable();
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -25,6 +25,13 @@ public class CommandInjectionTests : InstrumentationTestsBase
         Environment.SetEnvironmentVariable("PATH", "testPath");
     }
 
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenLocationIsCorrect()
+    {
+        TestProcessCall(() => Process.Start(new ProcessStartInfo(taintedProcessName) { UseShellExecute = true }));
+        AssertLocation(nameof(CommandInjectionTests));
+    }
+
     // Process? Start(ProcessStartInfo startInfo)
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -1,0 +1,240 @@
+// <copyright file="CommandInjectionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Security;
+using Xunit;
+
+namespace Samples.InstrumentedTests.Iast.Vulnerabilities;
+public class CommandInjectionTests : InstrumentationTestsBase
+{ 
+    private string taintedProcessName = "nonexisting1.exe";
+    private string untaintedProcessName = "nonexisting2.exe";
+    private string taintedArgument = "taintedArgument";
+    private string untaintedArgument = "untaintedArgument";
+    private string vulnerabilityType = "COMMAND_INJECTION";
+
+    public CommandInjectionTests()
+    {
+        AddTainted(taintedProcessName);
+        AddTainted(taintedArgument);
+        Environment.SetEnvironmentVariable("PATH", "testPath");
+    }
+
+    // Process? Start(ProcessStartInfo startInfo)
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable()
+    {
+        TestProcessCall(() => Process.Start(new ProcessStartInfo(taintedProcessName) { UseShellExecute = true }));
+        AssertVulnerable(vulnerabilityType, taintedProcessName);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartUntaintedProcess_ThenIsNotVulnerable()
+    {
+        TestProcessCall(() => Process.Start(new ProcessStartInfo(untaintedProcessName) { UseShellExecute = true }));
+        AssertNotVulnerable();
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable2()
+    {
+        TestProcessCall(() => Process.Start(new ProcessStartInfo(taintedProcessName) { UseShellExecute = false }));
+        AssertVulnerable(vulnerabilityType, taintedProcessName);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartUntaintedProcess_ThenIsNotVulnerable2()
+    {
+        TestProcessCall(() => Process.Start(new ProcessStartInfo(untaintedProcessName) { UseShellExecute = false }));
+        AssertNotVulnerable();
+    }
+
+    // Start(string fileName, string arguments, string userName, SecureString password, string domain)
+
+#pragma warning disable CA1416 // this overload is only supported on Windows
+#if NET5_0_OR_GREATER
+    [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable3()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, untaintedArgument, "user", new SecureString(), "domain"));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+
+    [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable4()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, taintedArgument, "user", new SecureString(), "domain"));
+        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+    }
+
+    [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsNotVulnerable3()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, untaintedArgument, taintedArgument, new SecureString(), "domain"));
+        AssertNotVulnerable();
+    }
+
+#endif
+
+    // Process? Start(string fileName, string userName, SecureString password, string domain)
+
+    [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable5()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, "user", new SecureString(), "domain"));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+
+    [Trait("Category", "LinuxUnsupported")]
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsNotVulnerable2()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, "user", new SecureString(), "domain"));
+        AssertNotVulnerable();
+    }
+
+#pragma warning restore CA1416 // this overload is only supported on Windows
+
+    // Process Start()
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable6()
+    {
+        Process process = new Process();
+        process.StartInfo = new ProcessStartInfo(taintedProcessName, untaintedArgument);
+        TestProcessCall(() => process.Start());
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable7()
+    {
+        Process process = new Process();
+        process.StartInfo = new ProcessStartInfo(untaintedProcessName, taintedArgument);
+        TestProcessCall(() => process.Start());
+        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+    }
+    [Fact]
+    public void GivenAProcess_WhenStartUntaintedProcess_ThenIsNotVulnerable3()
+    {
+        Process process = new Process();
+        process.StartInfo = new ProcessStartInfo(untaintedProcessName, untaintedArgument);
+        TestProcessCall(() => process.Start());
+        AssertNotVulnerable();
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable8()
+    {
+        Process process = new Process();
+        process.StartInfo.FileName = taintedProcessName;
+        process.StartInfo.Arguments = untaintedArgument;
+        TestProcessCall(() => process.Start());
+        // AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+        AssertVulnerable();
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable9()
+    {
+        Process process = new Process();
+        process.StartInfo.FileName = untaintedProcessName;
+        process.StartInfo.Arguments = taintedArgument;
+        TestProcessCall(() => process.Start());
+        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartUnTaintedProcess_ThenIsNotVulnerable4()
+    {
+        Process process = new Process();
+        process.StartInfo.FileName = untaintedProcessName;
+        process.StartInfo.Arguments = untaintedArgument;
+        TestProcessCall(() => process.Start());
+        AssertNotVulnerable();
+    }
+
+    // Process Start(string fileName)
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable10()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName));
+        AssertVulnerable(vulnerabilityType, taintedProcessName);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartNotTaintedProcess_ThenIsNotVulnerable5()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName));
+        AssertNotVulnerable();
+    }
+
+    // Process Start(string fileName, string arguments)
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable11()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, untaintedArgument));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable12()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, taintedArgument));
+        AssertVulnerable(vulnerabilityType, untaintedProcessName + " " + taintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartNotTaintedProcess_ThenIsNotVulnerable6()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, untaintedArgument));
+        AssertNotVulnerable();
+    }
+
+#if NET5_0_OR_GREATER
+    // Process Start(string fileName, string arguments)
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable13()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, new List<string>() { untaintedArgument }));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable14()
+    {
+        TestProcessCall(() => Process.Start(taintedProcessName, new List<string>() { taintedArgument }));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + taintedArgument);
+    }
+
+    [Fact]
+    public void GivenAProcess_WhenStartNotTaintedProcess_ThenIsNotVulnerable7()
+    {
+        TestProcessCall(() => Process.Start(untaintedProcessName, new List<string>() { untaintedArgument, untaintedArgument }));
+        AssertVulnerable(vulnerabilityType, taintedProcessName + " " + untaintedArgument);
+    }
+#endif
+    private void TestProcessCall(Func<object> expression)
+    {
+        try
+        {
+            expression.Invoke();
+        }
+        catch (Win32Exception) { }
+        catch (PlatformNotSupportedException) { }
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -105,7 +105,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
 
     [Trait("Category", "LinuxUnsupported")]
     [Fact]
-    public void GivenAProcess_WhenStartTaintedProcess_ThenIsNotVulnerable2()
+    public void GivenAProcess_WhenStartUntaintedProcess_ThenIsNotVulnerable4()
     {
         TestProcessCall(() => Process.Start(untaintedProcessName, "user", new SecureString(), "domain"));
         AssertNotVulnerable();

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/CommandInjection/CommandInjectionTests.cs
@@ -33,7 +33,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         AssertLocation(nameof(CommandInjectionTests));
     }
 
-    // Process? Start(ProcessStartInfo startInfo)
+    // Tests for method Process? Start(ProcessStartInfo startInfo)
 
     [Fact]
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable()
@@ -69,7 +69,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         Assert.Throws<InvalidOperationException>(() => Process.Start(new ProcessStartInfo(null) { UseShellExecute = false }));
     }
 
-    // Start(string fileName, string arguments, string userName, SecureString password, string domain)
+    // Tests for method Start(string fileName, string arguments, string userName, SecureString password, string domain)
 
 #pragma warning disable CA1416 // this overload is only supported on Windows
 #if NET5_0_OR_GREATER
@@ -156,7 +156,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
 
 #pragma warning restore CA1416 // this overload is only supported on Windows
 
-    // Process Start()
+    // Tests for method Process Start()
 
     [Fact]
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable7()
@@ -234,7 +234,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         AssertNotVulnerable();
     }
 
-    // Process Start(string fileName)
+    // Tests for method Process Start(string fileName)
 
     [Fact]
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable13()
@@ -256,7 +256,7 @@ public class CommandInjectionTests : InstrumentationTestsBase
         Assert.Throws<InvalidOperationException>(() => Process.Start((string)null));
     }
 
-    // Process Start(string fileName, string arguments)
+    // Tests for method Process Start(string fileName, string arguments)
 
     [Fact]
     public void GivenAProcess_WhenStartTaintedProcess_ThenIsVulnerable14()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -59,6 +59,7 @@ public class InstrumentationTestsBase
     
     protected static string WeakHashVulnerabilityType = "WEAK_HASH";
 
+    protected string commandInjectionType = "COMMAND_INJECTION";
     public InstrumentationTestsBase()
     {
         AssertInstrumented();

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -153,7 +153,10 @@ public class InstrumentationTestsBase
         vulnerabilityType.Should().Be(expectedType);
         var evidence = _evidenceProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
         var evidenceValue = _evidenceValueField.GetValue(evidence);
-        evidenceValue.Should().Be(expectedEvidence);        
+        if (!string.IsNullOrEmpty(expectedEvidence))
+        {
+            FormatTainted(evidenceValue).Should().Be(expectedEvidence);
+        }
     }
 
     protected void AssertNotVulnerable()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -61,8 +61,8 @@ public class InstrumentationTestsBase
     private static FieldInfo _evidenceValueField = _evidenceType.GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance);
     
     protected static string WeakHashVulnerabilityType = "WEAK_HASH";
+    protected static string commandInjectionType = "COMMAND_INJECTION";
 
-    protected string commandInjectionType = "COMMAND_INJECTION";
     public InstrumentationTestsBase()
     {
         AssertInstrumented();

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -23,6 +23,7 @@ public class InstrumentationTestsBase
     private static readonly Type _taintedObjectType = Type.GetType("Datadog.Trace.Iast.TaintedObject, Datadog.Trace");
     private static readonly Type _iastRequestContextType = Type.GetType("Datadog.Trace.Iast.IastRequestContext, Datadog.Trace");
     private static readonly Type _scopeType = Type.GetType("Datadog.Trace.Scope, Datadog.Trace");
+    private static readonly Type _locationType = Type.GetType("Datadog.Trace.Iast.Location, Datadog.Trace");
     private static readonly Type _spanType = Type.GetType("Datadog.Trace.Span, Datadog.Trace");
     private static readonly Type _arrayBuilderType = Type.GetType("Datadog.Trace.Util.ArrayBuilder`1, Datadog.Trace");
     private static readonly Type _arrayBuilderOfSpanType = _arrayBuilderType.MakeGenericType(new Type[] { _spanType });
@@ -46,6 +47,8 @@ public class InstrumentationTestsBase
     private static MethodInfo _vulnerabilitiesProperty = _vulnerabilityBatchType.GetProperty("Vulnerabilities", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _vulnerabilityTypeProperty = _vulnerabilityType.GetProperty("Type", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _evidenceProperty = _vulnerabilityType.GetProperty("Evidence", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
+    private static MethodInfo _locationProperty = _vulnerabilityType.GetProperty("Location", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
+    private static MethodInfo _pathProperty = _locationType.GetProperty("Path", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _getTaintedObjectsMethod = _taintedObjectsType.GetMethod("Get", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _taintInputStringMethod = _taintedObjectsType.GetMethod("TaintInputString", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _taintMethod = _taintedObjectsType.GetMethod("Taint", BindingFlags.Instance | BindingFlags.Public);
@@ -163,6 +166,14 @@ public class InstrumentationTestsBase
     protected void AssertNotVulnerable()
     {
         AssertVulnerable(0);
+    }
+
+    protected void AssertLocation(string location)
+    {
+        var vulnerability = GetGeneratedVulnerabilities()[0];
+        var locationProperty = _locationProperty.Invoke(vulnerability, Array.Empty<object>());
+        var path = _pathProperty.Invoke(locationProperty, Array.Empty<object>());
+        path.ToString().Should().Contain(location);
     }
 
     private List<object> GetGeneratedVulnerabilities()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -145,6 +145,22 @@ public class InstrumentationTestsBase
         }
     }
 
+    protected void AssertVulnerable(string type, string evidence = "")
+    {
+        var spans = GetGeneratedSpans(_traceContext);
+        var vulnerabilitySpan = spans.First(x => GetTag(x, "_dd.iast.enabled") != null);
+        var json = GetTag(vulnerabilitySpan, "_dd.iast.json");
+        var vulnerabilyList = JsonConvert.DeserializeObject<VulnerabilityList>(json.ToString());
+        vulnerabilyList.Vulnerabilities.Count.Should().Be(1);
+
+        if (evidence != string.Empty)
+        {
+            vulnerabilyList.Vulnerabilities[0].Evidence.Value.Should().Be(evidence);
+        }
+
+        vulnerabilyList.Vulnerabilities[0].type.Should().Be(type);
+    }
+
     protected void AssertNotVulnerable()
     {
         AssertVulnerable(0);

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -157,7 +157,8 @@ public class InstrumentationTestsBase
         vulnerabilityType.Should().Be(expectedType);
         var evidence = _evidenceProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
         var evidenceValue = _evidenceValueField.GetValue(evidence);
-        if (!string.IsNullOrEmpty(expectedEvidence))
+
+        if (!string.IsNullOrEmpty(expectedEvidence) && GetTainted(evidenceValue) != null)
         {
             FormatTainted(evidenceValue).Should().Be(expectedEvidence);
         }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -54,7 +54,6 @@ public class InstrumentationTestsBase
     private static MethodInfo _taintMethod = _taintedObjectsType.GetMethod("Taint", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _enableIastInRequestMethod = _traceContextType.GetMethod("EnableIastInRequest", BindingFlags.Instance | BindingFlags.NonPublic);
     private static MethodInfo _getArrayMethod = _arrayBuilderOfSpanType.GetMethod("GetArray");
-    private static MethodInfo _spanGetTagMethod = _spanType.GetMethod("GetTag", BindingFlags.NonPublic | BindingFlags.Instance);
     private static FieldInfo _taintedObjectsField = _iastRequestContextType.GetField("_taintedObjects", BindingFlags.NonPublic | BindingFlags.Instance);
     private static FieldInfo _spansField = _traceContextType.GetField("_spans", BindingFlags.NonPublic | BindingFlags.Instance);
     private static FieldInfo _vulnerabilityBatchField = _iastRequestContextType.GetField("_vulnerabilityBatch", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -128,7 +127,7 @@ public class InstrumentationTestsBase
         vulnerabilityList.Count.Should().Be(vulnerabilities);
     }
 
-    protected void AssertVulnerable(string expectedType, string expectedEvidence = "", bool evidenceTainted = false)
+    protected void AssertVulnerable(string expectedType, string expectedEvidence = "", bool evidenceTainted = true)
     {
         var vulnerabilityList = GetGeneratedVulnerabilities();
         vulnerabilityList.Count.Should().Be(1);
@@ -146,21 +145,6 @@ public class InstrumentationTestsBase
             {
                 evidenceValue.Should().Be(expectedEvidence);
             }
-        }
-    }
-
-    protected void AssertVulnerable(string expectedType, string expectedEvidence = "")
-    {
-        var vulnerabilityList = GetGeneratedVulnerabilities();
-        vulnerabilityList.Count.Should().Be(1);
-        var vulnerabilityType = _vulnerabilityTypeProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
-        vulnerabilityType.Should().Be(expectedType);
-        var evidence = _evidenceProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
-        var evidenceValue = _evidenceValueField.GetValue(evidence);
-
-        if (!string.IsNullOrEmpty(expectedEvidence) && GetTainted(evidenceValue) != null)
-        {
-            FormatTainted(evidenceValue).Should().Be(expectedEvidence);
         }
     }
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -145,20 +145,15 @@ public class InstrumentationTestsBase
         }
     }
 
-    protected void AssertVulnerable(string type, string evidence = "")
+    protected void AssertVulnerable(string expectedType, string expectedEvidence = "")
     {
-        var spans = GetGeneratedSpans(_traceContext);
-        var vulnerabilitySpan = spans.First(x => GetTag(x, "_dd.iast.enabled") != null);
-        var json = GetTag(vulnerabilitySpan, "_dd.iast.json");
-        var vulnerabilyList = JsonConvert.DeserializeObject<VulnerabilityList>(json.ToString());
-        vulnerabilyList.Vulnerabilities.Count.Should().Be(1);
-
-        if (evidence != string.Empty)
-        {
-            vulnerabilyList.Vulnerabilities[0].Evidence.Value.Should().Be(evidence);
-        }
-
-        vulnerabilyList.Vulnerabilities[0].type.Should().Be(type);
+        var vulnerabilityList = GetGeneratedVulnerabilities();
+        vulnerabilityList.Count.Should().Be(1);
+        var vulnerabilityType = _vulnerabilityTypeProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
+        vulnerabilityType.Should().Be(expectedType);
+        var evidence = _evidenceProperty.Invoke(vulnerabilityList[0], Array.Empty<object>());
+        var evidenceValue = _evidenceValueField.GetValue(evidence);
+        evidenceValue.Should().Be(expectedEvidence);        
     }
 
     protected void AssertNotVulnerable()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
@@ -24,4 +24,3 @@ class ClassForStringTest
         return str;
     }
 }
-

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
@@ -25,19 +25,3 @@ class ClassForStringTest
     }
 }
 
-public class VulnerabilityList
-{
-    public List<TestVulnerability> Vulnerabilities { get; set; }
-}
-
-public class TestVulnerability
-{
-    public string type { get; set; }
-
-    public EvidenceForTest Evidence { get; set; }
-}
-
-public class EvidenceForTest
-{
-    public string Value { get; set; }
-}

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/ObjectsForTests.cs
@@ -24,3 +24,20 @@ class ClassForStringTest
         return str;
     }
 }
+
+public class VulnerabilityList
+{
+    public List<TestVulnerability> Vulnerabilities { get; set; }
+}
+
+public class TestVulnerability
+{
+    public string type { get; set; }
+
+    public EvidenceForTest Evidence { get; set; }
+}
+
+public class EvidenceForTest
+{
+    public string Value { get; set; }
+}

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakCipher/WeakCipherTests.cs
@@ -8,13 +8,19 @@ using Xunit;
 
 namespace Samples.InstrumentedTests.Iast.Vulnerabilities.WeakCipher;
 
-#if !NETFRAMEWORK
-
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
 #pragma warning disable SYSLIB0022 // Type or member is obsolete
 #pragma warning disable SYSLIB0045 // Type or member is obsolete
 public class WeakCipherTests : InstrumentationTestsBase
 {
+
+    [Fact]
+    public void GivenADes_WhenCreating_ThenLocationIsCorrect()
+    {
+        DES.Create();
+        AssertLocation(nameof(WeakCipherTests));
+    }
+
     [Fact]
     public void GivenADes_WhenCreating_VulnerabilityIsLogged()
     {
@@ -85,4 +91,3 @@ public class WeakCipherTests : InstrumentationTestsBase
         AssertNotVulnerable();
     }
 }
-#endif

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HMACMD5Tests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HMACMD5Tests.cs
@@ -16,14 +16,14 @@ public class HMACMD5Tests : InstrumentationTestsBase
     public void GivenAHMACMD5_WhenComputeHash_VulnerabilityIsLogged()
     {
         new HMACMD5().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 
     [Fact]
     public void GivenAHMACMD5_WhenComputeHash_VulnerabilityIsLogged2()
     {
         new HMACMD5().ComputeHash(new byte[] { });
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public class HMACMD5Tests : InstrumentationTestsBase
     public void GivenAHMACMD5_WhenComputeHash_VulnerabilityIsLogged3()
     {
         new HMACMD5().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 
     [Fact]
@@ -56,21 +56,21 @@ public class HMACMD5Tests : InstrumentationTestsBase
     public void GivenAHMACMD5_WhenComputeHashByte3Args_VulnerabilityIsLogged3()
     {
         HMAC.Create("HMACMD5").ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 
     [Fact]
     public void GivenAHMACMD5_WhenComputeHashStream_VulnerabilityIsLogged()
     {
         HMAC.Create("HMACMD5").ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 
     [Fact]
     public void GivenAHMACMD5_WhenComputeHashByte_VulnerabilityIsLogged()
     {
         HMAC.Create("HMACMD5").ComputeHash(new byte[] { });
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACMD5", false);
     }
 #pragma warning restore SYSLIB0045
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HMACSHA1Tests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HMACSHA1Tests.cs
@@ -38,14 +38,14 @@ public class HMACSHA1Tests : InstrumentationTestsBase
     public void GivenAHMACSHA1_WhenComputeHash_VulnerabilityIsLogged()
     {
         new HMACSHA1().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1", false);
     }
 
     [Fact]
     public void GivenAHMACSHA1_WhenComputeHash_VulnerabilityIsLogged2()
     {
         new HMACSHA1().ComputeHash(new byte[] { });
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1", false);
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class HMACSHA1Tests : InstrumentationTestsBase
     {
 #if NETFRAMEWORK
         HMAC.Create().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1", false);
 #else
         Assert.Throws<PlatformNotSupportedException>(() => HMAC.Create().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2));
 #endif

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HashAlgorithmTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/HashAlgorithmTests.cs
@@ -15,6 +15,13 @@ public class HashAlgorithmTests : InstrumentationTestsBase
     private readonly Mock<HashAlgorithm> hashMock = new Mock<HashAlgorithm>();
 
     [Fact]
+    public void GivenAHashAlgorithm_WhenComputeHash_ThenLocationIsCorrect()
+    {
+        MD5.Create().ComputeHash(new byte[] { });
+        AssertLocation(nameof(HashAlgorithmTests));
+    }
+
+    [Fact]
     public void GivenAHashAlgorithm_WhenComputeHash_NotVulnerable()
     {
         hashMock.Object.ComputeHash(new byte[] { 3, 5 });

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/MD5CryptoServiceProviderTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/MD5CryptoServiceProviderTests.cs
@@ -25,20 +25,20 @@ public class MD5CryptoServiceProviderTests : InstrumentationTestsBase
     public void GivenAMD5CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged()
     {
         new MD5CryptoServiceProvider().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 
     [Fact]
     public void GivenAMD5CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged2()
     {
         new MD5CryptoServiceProvider().ComputeHash(new byte[] { 5, 5, 5 });
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 
     [Fact]
     public void GivenAMD5CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged3()
     {
         new MD5CryptoServiceProvider().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/MD5Tests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/MD5Tests.cs
@@ -41,14 +41,14 @@ public class MD5Tests : InstrumentationTestsBase
     public void GivenAMD5_WhenComputeHash_VulnerabilityIsLogged()
     {
         MD5.Create().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 
     [Fact]
     public void GivenAMD5_WhenComputeHash_VulnerabilityIsLogged2()
     {
         MD5.Create().ComputeHash(new byte[] { });
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 
     [Fact]
@@ -67,6 +67,6 @@ public class MD5Tests : InstrumentationTestsBase
     public void GivenAMD5_WhenComputeHash_VulnerabilityIsLogged3()
     {
         MD5.Create().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "MD5");
+        AssertVulnerable(WeakHashVulnerabilityType, "MD5", false);
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/SHA1CryptoServiceProviderTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/SHA1CryptoServiceProviderTests.cs
@@ -24,21 +24,21 @@ public class SHA1CryptoServiceProviderTests : InstrumentationTestsBase
     public void GivenASHA1CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged()
     {
         _ = new SHA1CryptoServiceProvider().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
     public void GivenASHA1CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged2()
     {
         _ = new SHA1CryptoServiceProvider().ComputeHash(new byte[] { 5, 5, 5 });
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
     public void GivenASHA1CryptoServiceProvider_WhenCreating_VulnerabilityIsLogged3()
     {
         _ = new SHA1CryptoServiceProvider().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
@@ -47,6 +47,6 @@ public class SHA1CryptoServiceProviderTests : InstrumentationTestsBase
         var crypto = new SHA1CryptoServiceProvider();
         Assert.NotNull(crypto);
         crypto.ComputeHash(new byte[] { 0xFF });
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/SHA1Tests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/WeakHashing/SHA1Tests.cs
@@ -41,14 +41,14 @@ public class SHA1Tests : InstrumentationTestsBase
     public void GivenASHA1_WhenComputeHash_VulnerabilityIsLogged()
     {
         SHA1.Create().ComputeHash(new Mock<Stream>().Object);
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
     public void GivenASHA1_WhenComputeHash_VulnerabilityIsLogged2()
     {
         SHA1.Create().ComputeHash(new byte[] { });
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
@@ -67,7 +67,7 @@ public class SHA1Tests : InstrumentationTestsBase
     public void GivenASHA1_WhenComputeHash_VulnerabilityIsLogged3()
     {
         SHA1.Create().ComputeHash(new byte[] { 5, 5, 5 }, 0, 2);
-        AssertVulnerable(WeakHashVulnerabilityType, "SHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "SHA1", false);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class SHA1Tests : InstrumentationTestsBase
     {
         // This is vulnerable because internally, it is using HMACSHA1
         MACTripleDES.Create().ComputeHash(new byte[] { 5, 5, 5 });
-        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1");
+        AssertVulnerable(WeakHashVulnerabilityType, "HMACSHA1", false);
     }
 #endif
 }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -1,66 +1,92 @@
 using System;
+using System.ComponentModel;
 using System.Data.SQLite;
+using System.Diagnostics;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Samples.Security.Data;
 
-namespace Samples.Security.AspNetCore5.Controllers
+namespace Samples.Security.AspNetCore5.Controllers;
+
+[Route("[controller]")]
+[ApiController]
+public class IastController : ControllerBase
 {
-    [Route("[controller]")]
-    [ApiController]
-    public class IastController : ControllerBase
+    static SQLiteConnection dbConnection = null;
+
+    public IActionResult Index()
     {
-        static SQLiteConnection dbConnection = null;
+        return Content("Ok\n");
+    }
 
-        public IActionResult Index()
-        {
-            return Content("Ok\n");
-        }
-
-        [HttpGet("WeakHashing")]
-        [Route("WeakHashing/{delay1}")]
-        public IActionResult WeakHashing(int delay1 = 0, int delay2 = 0)
-        {
-            System.Threading.Thread.Sleep(delay1 + delay2);
+    [HttpGet("WeakHashing")]
+    [Route("WeakHashing/{delay1}")]
+    public IActionResult WeakHashing(int delay1 = 0, int delay2 = 0)
+    {
+        System.Threading.Thread.Sleep(delay1 + delay2);
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
-            var byteArg = new byte[] { 3, 5, 6 };
-            MD5.Create().ComputeHash(byteArg);
-            SHA1.Create().ComputeHash(byteArg);
-            return Content($"Weak hashes launched with delays {delay1} and {delay2}.\n");
+        var byteArg = new byte[] { 3, 5, 6 };
+        MD5.Create().ComputeHash(byteArg);
+        SHA1.Create().ComputeHash(byteArg);
+        return Content($"Weak hashes launched with delays {delay1} and {delay2}.\n");
 #pragma warning restore SYSLIB0021 // Type or member is obsolete
+    }
+
+    [HttpGet("SqlQuery")]
+    [Route("SqlQuery")]
+    public IActionResult SqlQuery(string username, string query)
+    {
+        try
+        {
+            if (dbConnection is null)
+            {
+                dbConnection = IastControllerHelper.CreateDatabase();
+            }
+
+            if (!string.IsNullOrEmpty(username))
+            {
+                var taintedQuery = "SELECT Surname from Persons where name = '" + username + "'";
+                var rname = new SQLiteCommand(taintedQuery, dbConnection).ExecuteScalar();
+                return Content($"Result: " + rname);
+            }
+
+            if (!string.IsNullOrEmpty(query))
+            {
+                var rname = new SQLiteCommand(query, dbConnection).ExecuteScalar();
+                return Content($"Result: " + rname);
+            }
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
         }
 
-        [HttpGet("SqlQuery")]
-        [Route("SqlQuery")]
-        public IActionResult SqlQuery(string username, string query)
+        return BadRequest($"No query or username was provided");
+    }
+
+    [HttpGet("ExecuteCommand")]
+    [Route("ExecuteCommand")]
+    public IActionResult ExecuteCommand(string file, string argumentLine)
+    {
+        try
         {
-            try
+            if (!string.IsNullOrEmpty(file))
             {
-                if (dbConnection is null)
-                {
-                    dbConnection = IastControllerHelper.CreateDatabase();
-                }
-
-                if (!string.IsNullOrEmpty(username))
-                {
-                    var taintedQuery = "SELECT Surname from Persons where name = '" + username + "'";
-                    var rname = new SQLiteCommand(taintedQuery, dbConnection).ExecuteScalar();
-                    return Content($"Result: " + rname);
-                }
-
-                if (!string.IsNullOrEmpty(query))
-                {
-                    var rname = new SQLiteCommand(query, dbConnection).ExecuteScalar();
-                    return Content($"Result: " + rname);
-                }
+                var result = Process.Start(file, argumentLine);
+                return Content($"Process launched: " + result.ProcessName);
             }
-            catch (Exception ex)
+            else
             {
-                return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
+                return BadRequest($"No file was provided");
             }
-
-            return BadRequest($"No query or username was provided");
+        }
+        catch (Win32Exception ex)
+        {
+            return Content(IastControllerHelper.ToFormattedString(ex));
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
         }
     }
 }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -3,90 +3,92 @@ using System.ComponentModel;
 using System.Data.SQLite;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Samples.Security.Data;
 
-namespace Samples.Security.AspNetCore5.Controllers;
-
-[Route("[controller]")]
-[ApiController]
-public class IastController : ControllerBase
+namespace Samples.Security.AspNetCore5.Controllers
 {
-    static SQLiteConnection dbConnection = null;
-
-    public IActionResult Index()
+    [Route("[controller]")]
+    [ApiController]
+    public class IastController : ControllerBase
     {
-        return Content("Ok\n");
-    }
+        static SQLiteConnection dbConnection = null;
 
-    [HttpGet("WeakHashing")]
-    [Route("WeakHashing/{delay1}")]
-    public IActionResult WeakHashing(int delay1 = 0, int delay2 = 0)
-    {
-        System.Threading.Thread.Sleep(delay1 + delay2);
+        public IActionResult Index()
+        {
+            return Content("Ok\n");
+        }
+
+        [HttpGet("WeakHashing")]
+        [Route("WeakHashing/{delay1}")]
+        public IActionResult WeakHashing(int delay1 = 0, int delay2 = 0)
+        {
+            System.Threading.Thread.Sleep(delay1 + delay2);
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
-        var byteArg = new byte[] { 3, 5, 6 };
-        MD5.Create().ComputeHash(byteArg);
-        SHA1.Create().ComputeHash(byteArg);
-        return Content($"Weak hashes launched with delays {delay1} and {delay2}.\n");
+            var byteArg = new byte[] { 3, 5, 6 };
+            MD5.Create().ComputeHash(byteArg);
+            SHA1.Create().ComputeHash(byteArg);
+            return Content($"Weak hashes launched with delays {delay1} and {delay2}.\n");
 #pragma warning restore SYSLIB0021 // Type or member is obsolete
-    }
-
-    [HttpGet("SqlQuery")]
-    [Route("SqlQuery")]
-    public IActionResult SqlQuery(string username, string query)
-    {
-        try
-        {
-            if (dbConnection is null)
-            {
-                dbConnection = IastControllerHelper.CreateDatabase();
-            }
-
-            if (!string.IsNullOrEmpty(username))
-            {
-                var taintedQuery = "SELECT Surname from Persons where name = '" + username + "'";
-                var rname = new SQLiteCommand(taintedQuery, dbConnection).ExecuteScalar();
-                return Content($"Result: " + rname);
-            }
-
-            if (!string.IsNullOrEmpty(query))
-            {
-                var rname = new SQLiteCommand(query, dbConnection).ExecuteScalar();
-                return Content($"Result: " + rname);
-            }
-        }
-        catch (Exception ex)
-        {
-            return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
         }
 
-        return BadRequest($"No query or username was provided");
-    }
+        [HttpGet("SqlQuery")]
+        [Route("SqlQuery")]
+        public IActionResult SqlQuery(string username, string query)
+        {
+            try
+            {
+                if (dbConnection is null)
+                {
+                    dbConnection = IastControllerHelper.CreateDatabase();
+                }
 
-    [HttpGet("ExecuteCommand")]
-    [Route("ExecuteCommand")]
-    public IActionResult ExecuteCommand(string file, string argumentLine)
-    {
-        try
-        {
-            if (!string.IsNullOrEmpty(file))
-            {
-                var result = Process.Start(file, argumentLine);
-                return Content($"Process launched: " + result.ProcessName);
+                if (!string.IsNullOrEmpty(username))
+                {
+                    var taintedQuery = "SELECT Surname from Persons where name = '" + username + "'";
+                    var rname = new SQLiteCommand(taintedQuery, dbConnection).ExecuteScalar();
+                    return Content($"Result: " + rname);
+                }
+
+                if (!string.IsNullOrEmpty(query))
+                {
+                    var rname = new SQLiteCommand(query, dbConnection).ExecuteScalar();
+                    return Content($"Result: " + rname);
+                }
             }
-            else
+            catch (Exception ex)
             {
-                return BadRequest($"No file was provided");
+                return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
             }
+
+            return BadRequest($"No query or username was provided");
         }
-        catch (Win32Exception ex)
+
+        [HttpGet("ExecuteCommand")]
+        [Route("ExecuteCommand")]
+        public IActionResult ExecuteCommand(string file, string argumentLine)
         {
-            return Content(IastControllerHelper.ToFormattedString(ex));
-        }
-        catch (Exception ex)
-        {
-            return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
+            try
+            {
+                if (!string.IsNullOrEmpty(file))
+                {
+                    var result = Process.Start(file, argumentLine);
+                    return Content($"Process launched: " + result.ProcessName);
+                }
+                else
+                {
+                    return BadRequest($"No file was provided");
+                }
+            }
+            catch (Win32Exception ex)
+            {
+                return Content(IastControllerHelper.ToFormattedString(ex));
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, IastControllerHelper.ToFormattedString(ex));
+            }
         }
     }
 }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Views/Home/Index.cshtml
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Views/Home/Index.cshtml
@@ -47,6 +47,8 @@
 
     <div><a href="/Iast/SqlQuery?query=SELECT%20Surname%20from%20Persons%20where%20name%20=%20%27Vicent%27">GET Iast/SqlQuery?query=SELECT%20Surname%20from%20Persons%20where%20name%20=%20%27Vicent%27</a></div>
 
+    <div><a href="/Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1">GET /Iast/ExecuteCommand?file=nonexisting.exe&argumentLine=arg1</a></div>
+
     <div>
         @Html.Raw(Context.Request.Query["q"])
     </div>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
@@ -4,8 +4,8 @@ using System.Data.SQLite;
 using System;
 using System.Text;
 using Samples.Security.Data;
-using System.Diagnostics;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Net;
 
 namespace Samples.Security.AspNetCore5.Controllers
@@ -36,7 +36,7 @@ namespace Samples.Security.AspNetCore5.Controllers
         public ActionResult SqlQuery(string username, string query)
         {
             try
-            { 
+            {
                 if (dbConnection is null)
                 {
                     dbConnection = IastControllerHelper.CreateDatabase();

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
@@ -4,6 +4,9 @@ using System.Data.SQLite;
 using System;
 using System.Text;
 using Samples.Security.Data;
+using System.Diagnostics;
+using System.ComponentModel;
+using System.Net;
 
 namespace Samples.Security.AspNetCore5.Controllers
 {
@@ -58,6 +61,31 @@ namespace Samples.Security.AspNetCore5.Controllers
             }
 
             return Content($"No query or username was provided");
+        }
+
+        [Route("ExecuteCommand")]
+        public ActionResult ExecuteCommand(string file, string argumentLine)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(file))
+                {
+                    var result = Process.Start(file, argumentLine);
+                    return Content($"Process launched: " + result.ProcessName);
+                }
+                else
+                {
+                    return new HttpStatusCodeResult(HttpStatusCode.BadRequest, $"No file was provided");
+                }
+            }
+            catch (Win32Exception ex)
+            {
+                return Content(IastControllerHelper.ToFormattedString(ex));
+            }
+            catch (Exception ex)
+            {
+                return new HttpStatusCodeResult(HttpStatusCode.InternalServerError, IastControllerHelper.ToFormattedString(ex));
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

The command injection vulnerability happens when an attacker can inject malicious data that is used to launch an external process. 

## Reason for change

It is required as an important IAST goal.

## Implementation details

We are already instrumentating the method Process.Start(), so we will use that instrumentation. 

## Test coverage

## Other details
<!-- Fixes #{issue} -->
