### PR TITLE
Remove validation on IIS site names

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -26,22 +26,6 @@ namespace Datadog.Trace.Tools.Runner
             return ExecuteAsync(settings, null, null);
         }
 
-        public override ValidationResult Validate(CommandContext context, CheckIisSettings settings)
-        {
-            var result = base.Validate(context, settings);
-
-            if (result.Successful)
-            {
-                // Perform additional validation
-                if (settings.SiteName?.Count(c => c == '/') > 1)
-                {
-                    return ValidationResult.Error($"IIS site names can't have multiple / in their name: {settings.SiteName}");
-                }
-            }
-
-            return result;
-        }
-
         internal static async Task<int> ExecuteAsync(CheckIisSettings settings, string applicationHostConfigurationPath, int? pid, IRegistryService registryService = null)
         {
             static IEnumerable<string> GetAllApplicationNames(ServerManager sm)
@@ -63,7 +47,7 @@ namespace Datadog.Trace.Tools.Runner
                 return 1;
             }
 
-            var values = settings.SiteName.Split('/');
+            var values = settings.SiteName.Split('/', 2);
 
             var siteName = values[0];
             var applicationName = values.Length > 1 ? $"/{values[1]}" : "/";

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/applicationHost.config
@@ -161,6 +161,9 @@
         <application path="/mixed" applicationPool="Clr4IntegratedAppPool">
           <virtualDirectory path="/" physicalPath="[PATH]" />
         </application>
+        <application path="/nested/app" applicationPool="[POOL]">
+          <virtualDirectory path="/" physicalPath="[PATH]" />
+        </application>
         <bindings>
           <binding protocol="http" bindingInformation="*:[PORT]:localhost" />
         </bindings>


### PR DESCRIPTION
## Summary of changes

For some obscure reason, the validation code was rejecting IIS sites with multiple `/` in the name. This PR removes that validation.

## Reason for change

For even obscurer reasons, applications can be nested inside of other application, so that check was getting in the way.

## Test coverage

Added a test with a nested application.
