### PR TITLE
Add a "block list" to profiled processes in native profilers

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -11,4 +11,6 @@ public:
     inline static const shared::WSTRING LogPath = WStr("DD_TRACE_LOG_PATH");
     inline static const shared::WSTRING LogDirectory = WStr("DD_TRACE_LOG_DIRECTORY");
     inline static const shared::WSTRING DebugLogEnabled = WStr("DD_TRACE_DEBUG");
+    inline static const shared::WSTRING IncludeProcessNames = WStr("DD_PROFILER_PROCESSES");
+    inline static const shared::WSTRING ExcludeProcessNames = WStr("DD_PROFILER_EXCLUDE_PROCESSES");
 };

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -124,11 +124,11 @@ namespace datadog::shared::nativeloader
 
         const auto& include_process_names = GetEnvironmentValues(EnvironmentVariables::IncludeProcessNames);
 
-        // if there is a process inclusion list, attach profiler only if this
+        // if there is a process inclusion list, attach clrprofiler only if this
         // process's name is on the list
         if (!include_process_names.empty() && !Contains(include_process_names, process_name))
         {
-            Log::Info("CorProfiler::Initialize Profiler disabled: ", process_name, " not found in ",
+            Log::Info("CorProfiler::Initialize ClrProfiler disabled: ", process_name, " not found in ",
                          EnvironmentVariables::IncludeProcessNames, ".");
             return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
         }
@@ -139,22 +139,22 @@ namespace datadog::shared::nativeloader
             const auto& exclude_process_names = GetEnvironmentValues(EnvironmentVariables::ExcludeProcessNames);
             if (!exclude_process_names.empty())
             {
-                // attach profiler only if this process's name is NOT on the provided list
+                // attach clrprofiler only if this process's name is NOT on the provided list
                 if (Contains(exclude_process_names, process_name))
                 {
-                    Log::Info("CorProfiler::Initialize Profiler disabled: ", process_name, " found in ",
+                    Log::Info("CorProfiler::Initialize ClrProfiler disabled: ", process_name, " found in ",
                                  EnvironmentVariables::ExcludeProcessNames, ".");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
             }
             else
             {
-                // attach profiler only if this process's name is NOT on the default block list
+                // attach clrprofiler only if this process's name is NOT on the default block list
                 for (auto&& exclude_assembly : default_exclude_assemblies)
                 {
                     if (process_name == exclude_assembly)
                     {
-                        Log::Info("CorProfiler::Initialize Profiler disabled: ", process_name," found in default exclude list");
+                        Log::Info("CorProfiler::Initialize ClrProfiler disabled: ", process_name," found in default exclude list");
                         return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                     }
                 }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -20,6 +20,14 @@ const ::shared::WSTRING cfg_filepath_env = WStr("DD_NATIVELOADER_CONFIGFILE");
 const ::shared::WSTRING cfg_instrumentation_verification_env = WStr("DD_WRITE_INSTRUMENTATION_TO_DISK");
 const ::shared::WSTRING cfg_copying_originals_modules_env = WStr("DD_COPY_ORIGINALS_MODULES_TO_DISK");
 const ::shared::WSTRING cfg_log_directory_env = WStr("DD_TRACE_LOG_DIRECTORY");
+
+// Note that this list should be kept in sync with the values in tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+const shared::WSTRING default_exclude_assemblies[]{
+    WStr("dd-trace"),
+    WStr("dd-trace.exe"),
+    WStr("aspnet_state.exe"),
+};
+
 inline static const ::shared::WSTRING datadog_logs_folder_path = WStr(R"(Datadog .NET Tracer\logs)");
 
 static fs::path GetCurrentModuleFolderPath()

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -26,6 +26,7 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace"),
     WStr("dd-trace.exe"),
     WStr("aspnet_state.exe"),
+    WStr("sqlservr.exe"),
 };
 
 inline static const ::shared::WSTRING datadog_logs_folder_path = WStr(R"(Datadog .NET Tracer\logs)");

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -119,11 +119,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     const auto& include_process_names = shared::GetEnvironmentValues(environment::include_process_names);
 
-    // if there is a process inclusion list, attach profiler only if this
+    // if there is a process inclusion list, attach clrprofiler only if this
     // process's name is on the list
     if (!include_process_names.empty() && !shared::Contains(include_process_names, process_name))
     {
-        Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " not found in ",
+        Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name, " not found in ",
                      environment::include_process_names, ".");
         return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
@@ -134,22 +134,22 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         const auto& exclude_process_names = shared::GetEnvironmentValues(environment::exclude_process_names);
         if (!exclude_process_names.empty())
         {
-            // attach profiler only if this process's name is NOT on the provided list
+            // attach clrprofiler only if this process's name is NOT on the provided list
             if (shared::Contains(exclude_process_names, process_name))
             {
-                Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " found in ",
+                Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name, " found in ",
                              environment::exclude_process_names, ".");
                 return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
             }
         }
         else
         {
-            // attach profiler only if this process's name is NOT on the default block list
+            // attach clrprofiler only if this process's name is NOT on the default block list
             for (auto&& exclude_assembly : default_exclude_assemblies)
             {
                 if (process_name == exclude_assembly)
                 {
-                    Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name," found in default exclude list");
+                    Logger::Info("DATADOG TRACER DIAGNOSTICS - ClrProfiler disabled: ", process_name," found in default exclude list");
                     return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
                 }
             }

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -64,6 +64,7 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace"),
     WStr("dd-trace.exe"),
     WStr("aspnet_state.exe"),
+    WStr("sqlservr.exe"),
 };
 
 const shared::WSTRING skip_traceattribute_assembly_prefixes[]{

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -59,6 +59,13 @@ const shared::WSTRING include_assemblies[]{
     WStr("System.Diagnostics.Process"),
 };
 
+// Note that this list should be kept in sync with the values in shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+const shared::WSTRING default_exclude_assemblies[]{
+    WStr("dd-trace"),
+    WStr("dd-trace.exe"),
+    WStr("aspnet_state.exe"),
+};
+
 const shared::WSTRING skip_traceattribute_assembly_prefixes[]{
     WStr("System."), WStr("Microsoft."), WStr("Datadog.")};
 


### PR DESCRIPTION
## Summary of changes

- Automatically bail-out loader and tracer profilers if process is in the default block list
- Unify existing check for dd-trace/dd-trace.exe
- If the library is explicitly on the "include list", then skip the exclude check

## Reason for change

We already had code to bail-out if we were profiling `dd-trace.exe`. We recently discovered we were potentially profiling aspnet_state.exe too, which doesn't make sense, so wanted to add to exclude that. This PR generalises the behaviour.

## Implementation details

Added the same checks to the native loader + tracer profilers. Because I'm not v. good at C++, it was easiest to copy-paste code. When I tried referencing things directly I didn't get compile errors, stuff just broke at runtime, so I gave up and resorted to old school "see this file" comments 😅 

## Test coverage

Tested each combination manually by renaming a target process to `aspnet_state.exe` and it all worked ok

## Other details

It's C++, so...

![scaler-create-impact](https://user-images.githubusercontent.com/18755388/228231574-d37881c5-fff1-4102-ac5c-ca570149d19a.gif)



