### PR TITLE
Split `ZipMonitoringHomeLinux` task

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -668,7 +668,7 @@ partial class Build
             CompressZip(MonitoringHomeDirectory, WindowsTracerHomeZip, fileMode: FileMode.Create);
         });
 
-    Target ZipMonitoringHomeLinux => _ => _
+    Target PrepareMonitoringHomeLinux => _ => _
         .Unlisted()
         .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
         .OnlyWhenStatic(() => IsLinux)
@@ -725,7 +725,21 @@ partial class Build
             // Copy createLogPath.sh script and set the permissions
             CopyFileToDirectory(BuildDirectory / "artifacts" / FileNames.CreateLogPathScript, assetsDirectory);
             chmod.Invoke($"+x {assetsDirectory / FileNames.CreateLogPathScript}");
+        });
 
+    Target ZipMonitoringHomeLinux => _ => _
+        .Unlisted()
+        .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
+        .DependsOn(PrepareMonitoringHomeLinux)
+        .OnlyWhenStatic(() => IsLinux)
+        .Requires(() => Version)
+        .Executes(() =>
+        {
+            var fpm = Fpm.Value;
+            var gzip = GZip.Value;
+
+            var (arch, ext) = GetUnixArchitectureAndExtension();
+            var assetsDirectory = TemporaryDirectory / arch;
             var workingDirectory = ArtifactsDirectory / $"linux-{UnixArchitectureIdentifier}";
             EnsureCleanDirectory(workingDirectory);
 


### PR DESCRIPTION
## Summary of changes
This pull request splits the `ZipMonitoringHomeLinux` task into two separate tasks.

## Implementation details
This pull request splits the `ZipMonitoringHomeLinux` task into two separate tasks, `PrepareMonitoringHomeLinux` and `ZipMonitoringHomeLinux`. The prepare task creates a temporary folder with all the required files, while the zip task creates the actual package.

## Reason for change
The reason for this change is to improve the ability to run system tests. 
This change eliminates the need to manually copy files and allows for skipping the zipping of artefacts. 
Depends the merge of [PR  ](https://github.com/DataDog/system-tests/pull/1008) to function properly.