### PR TITLE
Downgrade AWS dotnet7 image

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1602,7 +1602,7 @@ stages:
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:6"
         net7:
           publishTargetFramework: "net7.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7.2023.03.21.20"
     pool:
       name: azure-linux-scale-set
 


### PR DESCRIPTION
## Summary of changes

Downgrade the AWS .NET 7 image used for serverless tests.

## Reason for change

For some weird reason, the latest `dotnet:7` image is for ARM64, so it causes our jobs to fail.

## Implementation details

Now using `public.ecr.aws/lambda/dotnet:7.2023.03.21.20` instead of latest.
