### PR TITLE
Don't specify patch version for Python install

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3796,7 +3796,7 @@ stages:
 
       - task: UsePythonVersion@0
         inputs:
-            versionSpec: '3.9.x'
+            versionSpec: '3.9'
         displayName: Install python 3.9
 
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git


### PR DESCRIPTION
## Summary of changes

- Use `3.9` instead of `3.9.x`

## Reason for change

CI complains
![image](https://user-images.githubusercontent.com/18755388/228511234-3737f670-62b3-414d-90ad-ab3831d06a8a.png)

## Implementation details

2 presses of <kbd>delete</kbd>

## Test coverage

:stare:
