### PR TITLE
Update the AspNetCoreTestFixture to let aspnetcore pick a port

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.TestHelpers
 
         private readonly HttpClient _httpClient;
         private ITestOutputHelper _currentOutput;
+        private object _outputLock = new();
 
         public AspNetCoreTestFixture()
         {
@@ -46,7 +47,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void SetOutput(ITestOutputHelper output)
         {
-            lock (this)
+            lock (_outputLock)
             {
                 _currentOutput = output;
             }
@@ -247,7 +248,7 @@ namespace Datadog.Trace.TestHelpers
 
         private void WriteToOutput(string line)
         {
-            lock (this)
+            lock (_outputLock)
             {
                 _currentOutput?.WriteLine(line);
             }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -91,11 +91,13 @@ namespace Datadog.Trace.TestHelpers
                                 var splitIndex = args.Data.LastIndexOf(':');
                                 port = int.Parse(args.Data.Substring(splitIndex + 1));
                             }
-                            else if (args.Data.Contains("Unable to start Kestrel"))
+
+                            if (args.Data.Contains("Unable to start Kestrel"))
                             {
                                 mutex.Set();
                             }
-                            else if (args.Data.Contains("Webserver started") || args.Data.Contains("Application started"))
+
+                            if (args.Data.Contains("Webserver started") || args.Data.Contains("Application started"))
                             {
                                 mutex.Set();
                             }
@@ -115,10 +117,14 @@ namespace Datadog.Trace.TestHelpers
                     Process.BeginOutputReadLine();
                     Process.BeginErrorReadLine();
 
-                    mutex.Wait(TimeSpan.FromSeconds(15));
+                    if (!mutex.Wait(TimeSpan.FromSeconds(15)))
+                    {
+                        WriteToOutput("Timeout while waiting for the proces to start");
+                    }
 
                     if (port == null)
                     {
+                        WriteToOutput("Unable to determine port application is listening on");
                         throw new Exception("Unable to determine port application is listening on");
                     }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -122,6 +122,7 @@ namespace Datadog.Trace.TestHelpers
                         throw new Exception("Unable to determine port application is listening on");
                     }
 
+                    HttpPort = port.Value;
                     WriteToOutput($"Started aspnetcore sample, listening on {HttpPort}");
                 }
             }


### PR DESCRIPTION
## Summary of changes

Instead of giving a port to aspnetcore, let it find one by itself.

## Reason for change

There is a race condition between the moment we find a port with `TcpPortProvider.GetOpenPort` and the moment aspnetcore binds it, which leads to flackiness.

## Implementation details

This is mostly a copy/paste of the logic used in the HotChocolate tests.
