### PR TITLE
Fix AAS direct log submission log correlation

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -32,12 +32,13 @@ namespace Datadog.Trace.Logging.DirectSubmission
         public static DirectLogSubmissionManager Create(
             DirectLogSubmissionManager? previous,
             ImmutableDirectLogSubmissionSettings settings,
+            ImmutableAzureAppServiceSettings? azureAppServiceSettings,
             string serviceName,
             string env,
             string serviceVersion,
             IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            var formatter = new LogFormatter(settings, serviceName, env, serviceVersion, gitMetadataTagsProvider);
+            var formatter = new LogFormatter(settings, azureAppServiceSettings, serviceName, env, serviceVersion, gitMetadataTagsProvider);
             if (previous is not null)
             {
                 // Only the formatter uses settings that are configurable in code.

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -18,6 +18,8 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
 {
     internal class LogFormatter
     {
+        private const string KeyValueTagSeparator = ":";
+        private const string TagSeparator = ",";
         private const string SourcePropertyName = "ddsource";
         private const string ServicePropertyName = "service";
         private const string HostPropertyName = "host";
@@ -62,9 +64,9 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                 return string.IsNullOrEmpty(globalTags) ? null : globalTags;
             }
 
-            var aasTags = $"{Tags.AzureAppServicesResourceId}:{aasSettings.ResourceId}";
+            var aasTags = $"{Tags.AzureAppServicesResourceId}{KeyValueTagSeparator}{aasSettings.ResourceId}";
 
-            return string.IsNullOrEmpty(globalTags) ? aasTags : aasTags + "," + globalTags;
+            return string.IsNullOrEmpty(globalTags) ? aasTags : aasTags + TagSeparator + globalTags;
         }
 
         private void EnrichTagsStringWithGitMetadata()
@@ -82,8 +84,8 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
 
             if (gitMetadata != GitMetadata.Empty)
             {
-                var gitMetadataTags = $"{CommonTags.GitCommit}:{gitMetadata.CommitSha},{CommonTags.GitRepository}:{RemoveScheme(gitMetadata.RepositoryUrl)}";
-                _tags = string.IsNullOrEmpty(_tags) ? gitMetadataTags : $"{_tags},{gitMetadataTags}";
+                var gitMetadataTags = $"{CommonTags.GitCommit}{KeyValueTagSeparator}{gitMetadata.CommitSha},{CommonTags.GitRepository}{KeyValueTagSeparator}{RemoveScheme(gitMetadata.RepositoryUrl)}";
+                _tags = string.IsNullOrEmpty(_tags) ? gitMetadataTags : $"{_tags}{TagSeparator}{gitMetadataTags}";
             }
 
             _gitMetadataAdded = true;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -116,6 +116,7 @@ namespace Datadog.Trace
             logSubmissionManager = DirectLogSubmissionManager.Create(
                 logSubmissionManager,
                 settings.LogSubmissionSettings,
+                settings.AzureAppServiceMetadata,
                 defaultServiceName,
                 settings.Environment,
                 settings.ServiceVersion,

--- a/tracer/test/Datadog.Trace.TestHelpers/AzureAppServiceHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AzureAppServiceHelper.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="AzureAppServiceHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.Tests.PlatformHelpers;
+
+public static class AzureAppServiceHelper
+{
+    public static IConfigurationSource GetRequiredAasConfigurationValues(
+        string subscriptionId,
+        string deploymentId,
+        string planResourceGroup,
+        string siteResourceGroup,
+        string ddTraceDebug = null,
+        string functionsVersion = null,
+        string functionsRuntime = null,
+        string enableCustomTracing = null,
+        string enableCustomMetrics = null,
+        bool addContextKey = true)
+    {
+        var vars = Environment.GetEnvironmentVariables();
+
+        if (vars.Contains(ConfigurationKeys.AzureAppService.InstanceNameKey))
+        {
+            // This is the COMPUTERNAME key which we'll remove for consistent testing
+            vars.Remove(ConfigurationKeys.AzureAppService.InstanceNameKey);
+        }
+
+        if (vars.Contains(ConfigurationKeys.DebugEnabled))
+        {
+            vars.Remove(ConfigurationKeys.DebugEnabled);
+        }
+
+        if (!vars.Contains(ConfigurationKeys.ApiKey))
+        {
+            // This is a needed configuration for the AAS extension
+            vars.Add(ConfigurationKeys.ApiKey, "1");
+        }
+
+        if (addContextKey)
+        {
+            vars.Add(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1");
+        }
+
+        vars.Add(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, $"{subscriptionId}+{planResourceGroup}-EastUSwebspace");
+        vars.Add(ConfigurationKeys.AzureAppService.ResourceGroupKey, siteResourceGroup);
+        vars.Add(ConfigurationKeys.AzureAppService.SiteNameKey, deploymentId);
+        vars.Add(ConfigurationKeys.AzureAppService.OperatingSystemKey, "windows");
+        vars.Add(ConfigurationKeys.AzureAppService.InstanceIdKey, "instance_id");
+        vars.Add(ConfigurationKeys.AzureAppService.InstanceNameKey, "instance_name");
+        vars.Add(ConfigurationKeys.DebugEnabled, ddTraceDebug);
+
+        if (functionsVersion != null)
+        {
+            vars.Add(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, functionsVersion);
+        }
+
+        if (functionsRuntime != null)
+        {
+            vars.Add(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, functionsRuntime);
+        }
+
+        vars.Add(ConfigurationKeys.AzureAppService.AasEnableCustomTracing, enableCustomTracing ?? "false");
+        vars.Add(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics, enableCustomMetrics ?? "false");
+
+        var collection = new NameValueCollection();
+
+        foreach (DictionaryEntry kvp in vars)
+        {
+            collection.Add(kvp.Key as string, kvp.Value as string);
+        }
+
+        return new NameValueConfigurationSource(collection);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
@@ -17,10 +17,11 @@ namespace Datadog.Trace.TestHelpers
     {
         public static LogFormatter GetFormatter() => new(
             GetValidSettings(),
+            aasSettings: null,
             serviceName: "MyTestService",
             env: "integration_tests",
             version: "1.0.0",
-            new NullGitMetadataProvider());
+            gitMetadataTagsProvider: new NullGitMetadataProvider());
 
         public static ImmutableDirectLogSubmissionSettings GetValidSettings()
         {

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.PlatformHelpers;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -26,13 +27,13 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
         private const string Service = "TestService";
         private const string Env = "integrationTests";
         private const string Version = "1.0.0";
-        private readonly LogFormatter _formatter;
         private readonly JsonTextWriter _writer;
         private readonly StringBuilder _sb;
+        private readonly ImmutableDirectLogSubmissionSettings _settings;
 
         public LogFormatterTests()
         {
-            var settings = ImmutableDirectLogSubmissionSettings.Create(
+            _settings = ImmutableDirectLogSubmissionSettings.Create(
                 host: Host,
                 source: Source,
                 intakeUrl: "http://localhost",
@@ -41,14 +42,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
                 globalTags: new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
                 enabledLogShippingIntegrations: new List<string> { nameof(IntegrationId.ILogger) },
                 batchingOptions: new BatchingSinkOptions(batchSizeLimit: 100, queueLimit: 1000, TimeSpan.FromSeconds(2)));
-            settings.IsEnabled.Should().BeTrue();
-
-            _formatter = new LogFormatter(
-                settings,
-                serviceName: Service,
-                env: Env,
-                version: Version,
-                new NullGitMetadataProvider());
+            _settings.IsEnabled.Should().BeTrue();
 
             _sb = new StringBuilder();
             _writer = LogFormatter.GetJsonWriter(_sb);
@@ -140,15 +134,25 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
             bool hasRenderedHost,
             bool hasRenderedTags,
             bool hasRenderedEnv,
-            bool hasRenderedVersion)
+            bool hasRenderedVersion,
+            bool isInAas)
         {
             var timestamp = new DateTime(year: 2020, month: 3, day: 7, hour: 11, minute: 23, second: 26, millisecond: 500, DateTimeKind.Utc);
             var sb = new StringBuilder();
             var state = new TestObject();
             var message = "Some message";
             var logLevel = "Info";
+            var aasSettings = isInAas ? GetAasSettings() : null;
 
-            _formatter.FormatLog(sb, state, timestamp, message, eventId: null, logLevel, exception: null, RenderProperties);
+            var formatter = new LogFormatter(
+                _settings,
+                aasSettings: aasSettings,
+                serviceName: Service,
+                env: Env,
+                version: Version,
+                gitMetadataTagsProvider: new NullGitMetadataProvider());
+
+            formatter.FormatLog(sb, state, timestamp, message, eventId: null, logLevel, exception: null, RenderProperties);
 
             var log = sb.ToString();
 
@@ -162,7 +166,14 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
             HasExpectedValue(log, !hasRenderedSource, $"\"ddsource\":\"{Source}\"");
             HasExpectedValue(log, !hasRenderedService, $"\"service\":\"{Service}\"");
             HasExpectedValue(log, !hasRenderedHost, $"\"host\":\"{Host}\"");
-            HasExpectedValue(log, !hasRenderedTags, $"\"ddtags\":\"Key1:Value1,Key2:Value2\"");
+            var (shouldContainLogs, expectedLogValue) = (isInAas, hasRenderedTags) switch
+            {
+                (_, true) => (false, "\"ddtags\""), // if the log itself adds this, we don't add the global tags currently
+                (true, false) => (true, $"\"ddtags\":\"aas.resource.id:{aasSettings!.ResourceId},Key1:Value1,Key2:Value2\""),
+                (false, false) => (true, $"\"ddtags\":\"Key1:Value1,Key2:Value2\""),
+            };
+
+            HasExpectedValue(log, shouldContainLogs, expectedLogValue);
             HasExpectedValue(log, !hasRenderedEnv, $"\"dd_env\":\"{Env}\"");
             HasExpectedValue(log, !hasRenderedVersion, $"\"dd_version\":\"{Version}\"");
 
@@ -187,6 +198,16 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
                     log.Should().NotContain(value);
                 }
             }
+
+            ImmutableAzureAppServiceSettings GetAasSettings()
+            {
+                return new ImmutableAzureAppServiceSettings(
+                    AzureAppServiceHelper.GetRequiredAasConfigurationValues(
+                        subscriptionId: "8c500027-5f00-400e-8f00-60000000000f",
+                        deploymentId: "AzureExampleSiteName",
+                        planResourceGroup: "apm-dotnet",
+                        siteResourceGroup: "apm-dotnet-site-resource-group"));
+            }
         }
 
         private class TestData
@@ -200,7 +221,8 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
                    from tags in Options
                    from env in Options
                    from version in Options
-                   select new object[] { src, service, host, tags, env, version };
+                   from aas in Options
+                   select new object[] { src, service, host, tags, env, version, aas };
         }
 
         private class FormattableObject : IFormattable

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void AzureContext_AzureAppService_Default()
         {
-            var vars = GetMockVariables(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(expected: AzureContext.AzureAppService, actual: metadata.AzureContext);
             Assert.Equal(expected: AppServiceKind, actual: metadata.SiteKind);
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void AzureContext_AzureFunction_WhenFunctionVariablesPresent()
         {
-            var vars = GetMockVariables(
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(
                 SubscriptionId,
                 DeploymentId,
                 PlanResourceGroup,
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void ResourceId_Created_WhenAllRequirementsExist()
         {
-            var vars = GetMockVariables(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             var resourceId = metadata.ResourceId;
             Assert.Equal(expected: ExpectedResourceId, actual: resourceId);
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void IsRelevant_True_WhenVariableSetTrue()
         {
-            var vars = GetMockVariables(null, null, null, null);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
             var settings = new TracerSettings(vars);
             Assert.True(settings.IsRunningInAzureAppService);
         }
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void OperatingSystem_Set()
         {
-            var vars = GetMockVariables(null, null, null, null);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(expected: "windows", actual: metadata.OperatingSystem);
         }
@@ -99,7 +99,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void InstanceId_Set()
         {
-            var vars = GetMockVariables(null, null, null, null);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(expected: "instance_id", actual: metadata.InstanceId);
         }
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void InstanceName_Set()
         {
-            var vars = GetMockVariables(null, null, null, null);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(expected: "instance_name", actual: metadata.InstanceName);
         }
@@ -115,7 +115,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void Runtime_Set()
         {
-            var vars = GetMockVariables(null, null, null, null);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.True(metadata.Runtime?.Length > 0);
         }
@@ -123,7 +123,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         [Fact]
         public void IsRelevant_False_WhenVariableDoesNotExist()
         {
-            var vars = GetMockVariables(null, null, null, null, addContextKey: false);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null, addContextKey: false);
             var metadata = new TracerSettings(vars);
             Assert.False(metadata.IsRunningInAzureAppService);
         }
@@ -139,7 +139,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void ResourceId_IsNull_WhenAnyRequirementsMissing(string subscriptionId, string deploymentId, string siteResourceGroup)
         {
             // plan resource group actually doesn't matter for the resource id we build
-            var vars = GetMockVariables(subscriptionId, deploymentId, "some-resource-group", siteResourceGroup);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(subscriptionId, deploymentId, "some-resource-group", siteResourceGroup);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Null(metadata.ResourceId);
         }
@@ -157,7 +157,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void DebugModeEnabled_Tests(string ddTraceDebug, bool expectation)
         {
             // plan resource group actually doesn't matter for the resource id we build
-            var vars = GetMockVariables("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", ddTraceDebug: ddTraceDebug);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", ddTraceDebug: ddTraceDebug);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(actual: metadata.DebugModeEnabled, expected: expectation);
         }
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void CustomMetricsEnabled_Tests(string customMetrics, bool expectation)
         {
             // plan resource group actually doesn't matter for the resource id we build
-            var vars = GetMockVariables("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomMetrics: customMetrics);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomMetrics: customMetrics);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(actual: metadata.NeedsDogStatsD, expected: expectation);
         }
@@ -193,7 +193,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void CustomTracingEnabled_Tests(string customTracing, bool expectation)
         {
             // plan resource group actually doesn't matter for the resource id we build
-            var vars = GetMockVariables("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomTracing: customTracing);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomTracing: customTracing);
             var metadata = new ImmutableAzureAppServiceSettings(vars);
             Assert.Equal(actual: metadata.CustomTracingEnabled, expected: expectation);
         }
@@ -202,7 +202,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void DoNotTagSpans()
         {
             // AAS Tags are handled at serialization now. So no tags should be set on spans
-            var vars = GetMockVariables(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
+            var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var settings = new TracerSettings(vars);
             var tracer = TracerHelper.Create(settings);
             var spans = new List<ISpan>();
@@ -245,73 +245,6 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             spans.Should().NotContain(s => s.GetTag(Tags.AzureAppServicesOperatingSystem) != null);
             spans.Should().NotContain(s => s.GetTag(Tags.AzureAppServicesRuntime) != null);
             spans.Should().NotContain(s => s.GetTag(Tags.AzureAppServicesExtensionVersion) != null);
-        }
-
-        private IConfigurationSource GetMockVariables(
-            string subscriptionId,
-            string deploymentId,
-            string planResourceGroup,
-            string siteResourceGroup,
-            string ddTraceDebug = null,
-            string functionsVersion = null,
-            string functionsRuntime = null,
-            string enableCustomTracing = null,
-            string enableCustomMetrics = null,
-            bool addContextKey = true)
-        {
-            var vars = Environment.GetEnvironmentVariables();
-
-            if (vars.Contains(ConfigurationKeys.AzureAppService.InstanceNameKey))
-            {
-                // This is the COMPUTERNAME key which we'll remove for consistent testing
-                vars.Remove(ConfigurationKeys.AzureAppService.InstanceNameKey);
-            }
-
-            if (vars.Contains(ConfigurationKeys.DebugEnabled))
-            {
-                vars.Remove(ConfigurationKeys.DebugEnabled);
-            }
-
-            if (!vars.Contains(ConfigurationKeys.ApiKey))
-            {
-                // This is a needed configuration for the AAS extension
-                vars.Add(ConfigurationKeys.ApiKey, "1");
-            }
-
-            if (addContextKey)
-            {
-                vars.Add(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1");
-            }
-
-            vars.Add(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, $"{subscriptionId}+{planResourceGroup}-EastUSwebspace");
-            vars.Add(ConfigurationKeys.AzureAppService.ResourceGroupKey, siteResourceGroup);
-            vars.Add(ConfigurationKeys.AzureAppService.SiteNameKey, deploymentId);
-            vars.Add(ConfigurationKeys.AzureAppService.OperatingSystemKey, "windows");
-            vars.Add(ConfigurationKeys.AzureAppService.InstanceIdKey, "instance_id");
-            vars.Add(ConfigurationKeys.AzureAppService.InstanceNameKey, "instance_name");
-            vars.Add(ConfigurationKeys.DebugEnabled, ddTraceDebug);
-
-            if (functionsVersion != null)
-            {
-                vars.Add(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, functionsVersion);
-            }
-
-            if (functionsRuntime != null)
-            {
-                vars.Add(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, functionsRuntime);
-            }
-
-            vars.Add(ConfigurationKeys.AzureAppService.AasEnableCustomTracing, enableCustomTracing ?? "false");
-            vars.Add(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics, enableCustomMetrics ?? "false");
-
-            var collection = new NameValueCollection();
-
-            foreach (DictionaryEntry kvp in vars)
-            {
-                collection.Add(kvp.Key as string, kvp.Value as string);
-            }
-
-            return new NameValueConfigurationSource(collection);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fixes log correlation for host in AAS

## Reason for change

Currently, if you try to view the logs for a given host/resource in AAS, you won't get any results. This is the first step to fix that. Note that it also requires changes from the serverless team to fix the query they use to find the logs

## Implementation details

If we're running in AAS, add the `aas.resource.id` tag to all logs sent to the backend.

## Test coverage

Added unit tests for the behaviour. Once merged I'll create a dev AAS extension package and manually confirm it works as expected.
