### PR TITLE
Revert "Downgrade AWS dotnet7 image"

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1602,7 +1602,7 @@ stages:
           lambdaBaseImage: "public.ecr.aws/lambda/dotnet:6"
         net7:
           publishTargetFramework: "net7.0"
-          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7.2023.03.21.20"
+          lambdaBaseImage: "public.ecr.aws/lambda/dotnet:7"
     pool:
       name: azure-linux-scale-set
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#3969

The AWS images have been fixed: https://github.com/aws/aws-lambda-dotnet/issues/1471