### PR TITLE
Temporarily remove python install from system tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3794,11 +3794,6 @@ stages:
     steps:
       - checkout: none
 
-      - task: UsePythonVersion@0
-        inputs:
-            versionSpec: '3.9'
-        displayName: Install python 3.9
-
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 


### PR DESCRIPTION
## Summary of changes

Remove the python install we added in https://github.com/DataDog/dd-trace-dotnet/pull/3948

## Reason for change

We seem to have seen a lot of inexplicable flakiness since it was merged. Reverting to see if it improves things

## Implementation details

Delete the python install

## Test coverage

If it works... :shipit: 

