### PR TITLE
[Tracer] Make the querystring length in http.url configurable

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -384,6 +384,13 @@ namespace Datadog.Trace.Configuration
         public const string ObfuscationQueryStringRegexTimeout = "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_TIMEOUT";
 
         /// <summary>
+        /// Configuration key for setting the max size of the querystring to report, before obfuscation
+        /// Default value is 200, 0 means that we don't limit the size.
+        /// </summary>
+        /// <seealso cref="TracerSettings.QueryStringReportingSize"/>
+        public const string QueryStringReportingSize = "DD_HTTP_SERVER_TAG_QUERY_STRING_SIZE";
+
+        /// <summary>
         /// Configuration key for enabling/disabling reporting query string
         /// Default value is true
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -385,7 +385,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for setting the max size of the querystring to report, before obfuscation
-        /// Default value is 200, 0 means that we don't limit the size.
+        /// Default value is 5000, 0 means that we don't limit the size.
         /// </summary>
         /// <seealso cref="TracerSettings.QueryStringReportingSize"/>
         public const string QueryStringReportingSize = "DD_HTTP_SERVER_TAG_QUERY_STRING_SIZE";

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -114,6 +114,7 @@ namespace Datadog.Trace.Configuration
             ObfuscationQueryStringRegex = settings.ObfuscationQueryStringRegex;
             QueryStringReportingEnabled = settings.QueryStringReportingEnabled;
             ObfuscationQueryStringRegexTimeout = settings.ObfuscationQueryStringRegexTimeout;
+            QueryStringReportingSize = settings.QueryStringReportingSize;
 
             IsRunningInAzureAppService = settings.IsRunningInAzureAppService;
             AzureAppServiceMetadata = settings.AzureAppServiceMetadata;
@@ -355,6 +356,12 @@ namespace Datadog.Trace.Configuration
         /// Default value is 200ms
         /// </summary>
         internal double ObfuscationQueryStringRegexTimeout { get; }
+
+        /// <summary>
+        /// Gets a value limiting the size of the querystring to report and obfuscate
+        /// Default value is 200, 0 means that we don't limit the size.
+        /// </summary>
+        internal int QueryStringReportingSize { get; }
 
         internal ImmutableDirectLogSubmissionSettings LogSubmissionSettings { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -359,7 +359,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets a value limiting the size of the querystring to report and obfuscate
-        /// Default value is 200, 0 means that we don't limit the size.
+        /// Default value is 5000, 0 means that we don't limit the size.
         /// </summary>
         internal int QueryStringReportingSize { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -179,7 +179,7 @@ namespace Datadog.Trace.Configuration
 
             QueryStringReportingEnabled = source?.GetBool(ConfigurationKeys.QueryStringReportingEnabled) ?? true;
 
-            QueryStringReportingSize = source?.GetInt32(ConfigurationKeys.QueryStringReportingSize) ?? 200;
+            QueryStringReportingSize = source?.GetInt32(ConfigurationKeys.QueryStringReportingSize) ?? 5000; // 5000 being the tag value length limit
 
             ObfuscationQueryStringRegexTimeout = source?.GetDouble(ConfigurationKeys.ObfuscationQueryStringRegexTimeout) is { } x and > 0 ? x : 200;
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -179,6 +179,8 @@ namespace Datadog.Trace.Configuration
 
             QueryStringReportingEnabled = source?.GetBool(ConfigurationKeys.QueryStringReportingEnabled) ?? true;
 
+            QueryStringReportingSize = source?.GetInt32(ConfigurationKeys.QueryStringReportingSize) ?? 200;
+
             ObfuscationQueryStringRegexTimeout = source?.GetDouble(ConfigurationKeys.ObfuscationQueryStringRegexTimeout) is { } x and > 0 ? x : 200;
 
             IsActivityListenerEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled) ??
@@ -472,6 +474,12 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether or not http.url should contain the query string, enabled by default
         /// </summary>
         internal bool QueryStringReportingEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value limiting the size of the querystring to report and obfuscate
+        /// Default value is 200, 0 means that we don't limit the size.
+        /// </summary>
+        internal int QueryStringReportingSize { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating a timeout in milliseconds to the execution of the query string obfuscation regex

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -477,7 +477,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets or sets a value limiting the size of the querystring to report and obfuscate
-        /// Default value is 200, 0 means that we don't limit the size.
+        /// Default value is 5000, 0 means that we don't limit the size.
         /// </summary>
         internal int QueryStringReportingSize { get; set; }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace
             Telemetry = telemetry;
             DiscoveryService = discoveryService;
             TraceProcessors = traceProcessors ?? Array.Empty<ITraceProcessor>();
-            QueryStringManager = new(settings?.QueryStringReportingEnabled ?? true, settings?.ObfuscationQueryStringRegexTimeout ?? 100, settings?.ObfuscationQueryStringRegex ?? TracerSettings.DefaultObfuscationQueryStringRegex);
+            QueryStringManager = new(settings?.QueryStringReportingEnabled, settings?.ObfuscationQueryStringRegexTimeout, settings?.QueryStringReportingSize, settings?.ObfuscationQueryStringRegex);
             var lstTagProcessors = new List<ITagProcessor>(TraceProcessors.Length);
             foreach (var traceProcessor in TraceProcessors)
             {
@@ -403,6 +403,9 @@ namespace Datadog.Trace
 
                     writer.WritePropertyName("obfuscation_querystring_regex_timout");
                     writer.WriteValue(instanceSettings.ObfuscationQueryStringRegexTimeout);
+
+                    writer.WritePropertyName("obfuscation_querystring_size");
+                    writer.WriteValue(instanceSettings.QueryStringReportingSize);
 
                     if (string.Compare(instanceSettings.ObfuscationQueryStringRegex, TracerSettings.DefaultObfuscationQueryStringRegex, StringComparison.Ordinal) != 0)
                     {

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace
             Telemetry = telemetry;
             DiscoveryService = discoveryService;
             TraceProcessors = traceProcessors ?? Array.Empty<ITraceProcessor>();
-            QueryStringManager = new(settings?.QueryStringReportingEnabled, settings?.ObfuscationQueryStringRegexTimeout, settings?.QueryStringReportingSize, settings?.ObfuscationQueryStringRegex);
+            QueryStringManager = new(settings.QueryStringReportingEnabled, settings.ObfuscationQueryStringRegexTimeout, settings.QueryStringReportingSize, settings.ObfuscationQueryStringRegex);
             var lstTagProcessors = new List<ITagProcessor>(TraceProcessors.Length);
             foreach (var traceProcessor in TraceProcessors)
             {

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestUtils.cs
@@ -27,8 +27,7 @@ namespace Datadog.Trace.Util.Http
         {
             if (queryStringManager != null)
             {
-                queryString = queryString.Substring(0, Math.Min(queryString.Length, 200));
-                queryString = queryStringManager.Obfuscate(queryString);
+                queryString = queryStringManager.TruncateAndObfuscate(queryString);
                 return $"{scheme}://{(string.IsNullOrEmpty(host) ? NoHostSpecified : host)}{(port.HasValue ? $":{port}" : string.Empty)}{pathBase}{path}{queryString}";
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringManager.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringManager.cs
@@ -16,12 +16,11 @@ namespace Datadog.Trace.Util.Http
         private readonly int _maxSizeBeforeObfuscation;
         private readonly Lazy<ObfuscatorBase> _obfuscatorLazy;
 
-        internal QueryStringManager(bool? reportQueryString, double? timeout, int? maxSizeBeforeObfuscation, string pattern = null, IDatadogLogger logger = null)
+        internal QueryStringManager(bool reportQueryString, double timeout, int maxSizeBeforeObfuscation, string pattern, IDatadogLogger logger = null)
         {
-            _reportQueryString = reportQueryString ?? true;
-            _maxSizeBeforeObfuscation = maxSizeBeforeObfuscation ?? 200;
-            pattern ??= TracerSettings.DefaultObfuscationQueryStringRegex;
-            _obfuscatorLazy = new(() => ObfuscatorFactory.GetObfuscator(timeout ?? 100, pattern, logger, _reportQueryString));
+            _reportQueryString = reportQueryString;
+            _maxSizeBeforeObfuscation = maxSizeBeforeObfuscation;
+            _obfuscatorLazy = new(() => ObfuscatorFactory.GetObfuscator(timeout, pattern, logger, _reportQueryString));
         }
 
         internal string TruncateAndObfuscate(string queryString)

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringManager.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringManager.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Util.Http
 
         internal string TruncateAndObfuscate(string queryString)
         {
-            if (!_reportQueryString)
+            if (!_reportQueryString || string.IsNullOrEmpty(queryString))
             {
                 return string.Empty;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -40,6 +40,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public static IEnumerable<object[]> IntegrationConfig() =>
             from instrumentationOptions in InstrumentationOptionsValues
             from socketHandlerEnabled in new[] { true, false }
+            select new object[] { instrumentationOptions, socketHandlerEnabled };
+
+        public static IEnumerable<object[]> IntegrationConfigWithObfuscation() =>
+            from instrumentationOptions in InstrumentationOptionsValues
+            from socketHandlerEnabled in new[] { true, false }
             from queryStringEnabled in new[] { true, false }
             from queryStringSize in new[] { 200, 2 }
             select new object[] { instrumentationOptions, socketHandlerEnabled, queryStringEnabled, queryStringSize };
@@ -50,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        [MemberData(nameof(IntegrationConfig))]
+        [MemberData(nameof(IntegrationConfigWithObfuscation))]
         public void HttpClient_SubmitsTraces(InstrumentationOptions instrumentation, bool enableSocketsHandler, bool queryStringCaptureEnabled, int queryStringSize)
         {
             SetInstrumentationVerification();
@@ -126,11 +131,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [MemberData(nameof(IntegrationConfig))]
-        public void TracingDisabled_DoesNotSubmitsTraces(InstrumentationOptions instrumentation, bool enableSocketsHandler, bool queryStringCaptureEnabled)
+        public void TracingDisabled_DoesNotSubmitsTraces(InstrumentationOptions instrumentation, bool enableSocketsHandler)
         {
             SetInstrumentationVerification();
             ConfigureInstrumentation(instrumentation, enableSocketsHandler);
-            SetEnvironmentVariable("DD_HTTP_SERVER_TAG_QUERY_STRING", queryStringCaptureEnabled ? "true" : "false");
 
             const string expectedOperationName = "http.request";
 

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(null, null, null, null, null, null, null, null, null, null, null, null)
+                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="QueryStringManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Logging;
+using Datadog.Trace.Util.Http;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util.Http
+{
+    public class QueryStringManagerTests
+    {
+        [Theory]
+        [InlineData(false, null, null, "")]
+        [InlineData(true, 2, null, "ab")]
+        [InlineData(true, 0, null, "abcde")]
+        [InlineData(true, 0, ".*", "<redacted><redacted>")]
+        public void Test(bool? reportQueryString, int? maxSizeBeforeObfuscation, string pattern, string expectedResult)
+        {
+            const int timeout = 1000;
+            const string inputString = "abcde";
+            var logger = new Mock<IDatadogLogger>();
+
+            var queryStringManager = new QueryStringManager(reportQueryString, timeout, maxSizeBeforeObfuscation, pattern, logger.Object);
+
+            var result = queryStringManager.TruncateAndObfuscate(inputString);
+            result.Should().Be(expectedResult);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
@@ -14,19 +14,20 @@ namespace Datadog.Trace.Tests.Util.Http
     public class QueryStringManagerTests
     {
         [Theory]
-        [InlineData(false, 5000, null, "")]
-        [InlineData(true, 2, null, "ab")]
-        [InlineData(true, 0, null, "abcde")]
-        [InlineData(true, 0, ".*", "<redacted><redacted>")]
-        public void Test(bool reportQueryString, int maxSizeBeforeObfuscation, string pattern, string expectedResult)
+        [InlineData("?abcde", false, 5000, null, "")]
+        [InlineData(null, true, 5000, null, "")]
+        [InlineData("", true, 5000, null, "")]
+        [InlineData("?abcde", true, 2, null, "?a")]
+        [InlineData("?abcde", true, 0, null, "?abcde")]
+        [InlineData("?abcde", true, 0, ".*", "<redacted><redacted>")]
+        public void Test(string queryString, bool reportQueryString, int maxSizeBeforeObfuscation, string pattern, string expectedResult)
         {
             const int timeout = 1000;
-            const string inputString = "abcde";
             var logger = new Mock<IDatadogLogger>();
 
             var queryStringManager = new QueryStringManager(reportQueryString, timeout, maxSizeBeforeObfuscation, pattern, logger.Object);
 
-            var result = queryStringManager.TruncateAndObfuscate(inputString);
+            var result = queryStringManager.TruncateAndObfuscate(queryString);
             result.Should().Be(expectedResult);
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringManagerTests.cs
@@ -14,11 +14,11 @@ namespace Datadog.Trace.Tests.Util.Http
     public class QueryStringManagerTests
     {
         [Theory]
-        [InlineData(false, null, null, "")]
+        [InlineData(false, 5000, null, "")]
         [InlineData(true, 2, null, "ab")]
         [InlineData(true, 0, null, "abcde")]
         [InlineData(true, 0, ".*", "<redacted><redacted>")]
-        public void Test(bool? reportQueryString, int? maxSizeBeforeObfuscation, string pattern, string expectedResult)
+        public void Test(bool reportQueryString, int maxSizeBeforeObfuscation, string pattern, string expectedResult)
         {
             const int timeout = 1000;
             const string inputString = "abcde";


### PR DESCRIPTION
## Summary of changes

Adds `DD_HTTP_SERVER_TAG_QUERY_STRING_SIZE` that allows to specify the size of the querystring before obfuscation. Also change the query string size from 2OO to 5000 before obfuscation. 

## Reason for change

Customers asked for their query strings not to be truncated.
Also, @robertpi has improved obfuscation performances with #3009. So besides for .NET Framework, raising this value now shouldn't be too bad. That said, we leave the config knob in case it could impact some apps performances.

## Implementation details

Just added a knob and moved the truncation logic in `QueryStringManager`.

## Test coverage
Added UTests and modified the existing ITest.

## Other details
<!-- Fixes #{issue} -->
