### PR TITLE
Enable CI Visibility static analysis.

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,4 +1,0 @@
-name: 'CodeQL Config'
-
-paths-ignore:
-  - '**/test/**'

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: 'CodeQL Config'
+
+paths-ignore:
+  - '**/test/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [ master, hotfix/**/* ]
   pull_request:
-    branches: [ master, hotfix/**/* ]
 
 env:
   DD_ENV: ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,6 +51,8 @@ jobs:
 
     - name: Upload sarif file
       run: |
+        ls
+        ls ./results
         datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
       env:
@@ -97,6 +99,8 @@ jobs:
 
     - name: Upload sarif file
       run: |
+        ls
+        ls ./results
         datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,6 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -80,7 +79,6 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,17 +48,17 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      with:
-        cleanup-level: 'none'
+#      with:
+#        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
         pwd
-        ls /home/runner/work/dd-trace-dotnet/results/
-        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/csharp.sarif --service dd-trace-dotnet
+        ls ../results/
+        datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
       env:
-        DD_API_KEY: '${{ secrets.DD_API_KEY }}'
+        DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'
 
   tracer:
     name: Analyze Tracer
@@ -98,14 +98,13 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      with:
-        cleanup-level: 'none'
+#      with:
+#        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        pwd
-        ls /home/runner/work/dd-trace-dotnet/results/
-        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/csharp.sarif --service dd-trace-dotnet
+        ls ../results/
+        datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
       env:
-        DD_API_KEY: '${{ secrets.DD_API_KEY }}'
+        DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -60,6 +61,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
+        config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,5 @@
 name: "CodeQL"
 
-#on: [push]
 on:
   push:
     branches: [ master, hotfix/**/* ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,6 +54,7 @@ jobs:
     - name: Upload sarif file
       run: |
         ls 
+        ls /home/runner/work/dd-trace-dotnet/results/
         datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:
@@ -103,6 +104,7 @@ jobs:
     - name: Upload sarif file
       run: |
         ls 
+        ls /home/runner/work/dd-trace-dotnet/results/
         datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,6 +48,28 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
 
+    - name: filter-sarif cpp
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**/src/Demos/**
+          -**/test/test-applications/**
+          -**/test/samples/**
+          -**/Web.config
+        input: ../results/cpp.sarif
+        output: ../results/cpp.sarif
+
+    - name: filter-sarif csharp
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**/src/Demos/**
+          -**/test/test-applications/**
+          -**/test/samples/**
+          -**/Web.config
+        input: ../results/csharp.sarif
+        output: ../results/csharp.sarif
+
     - name: Upload sarif file
       run: |
         datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
@@ -92,6 +114,28 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
+
+    - name: filter-sarif cpp
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**/src/Demos/**
+          -**/test/test-applications/**
+          -**/test/samples/**
+          -**/Web.config
+        input: ../results/cpp.sarif
+        output: ../results/cpp.sarif
+
+    - name: filter-sarif csharp
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -**/src/Demos/**
+          -**/test/test-applications/**
+          -**/test/samples/**
+          -**/Web.config
+        input: ../results/csharp.sarif
+        output: ../results/csharp.sarif
 
     - name: Upload sarif file
       run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -51,8 +51,10 @@ jobs:
 
     - name: Upload sarif file
       run: |
-        datadog-ci sarif ./results/cpp.sarif --service dd-trace-dotnet --dry-run
-        datadog-ci sarif ./results/csharp.sarif --service dd-trace-dotnet --dry-run
+        datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
+      env:
+        DD_API_KEY: '${{ secrets.DD_API_KEY }}'
 
   tracer:
     name: Analyze Tracer
@@ -95,5 +97,7 @@ jobs:
 
     - name: Upload sarif file
       run: |
-        datadog-ci sarif ./results/cpp.sarif --service dd-trace-dotnet --dry-run
-        datadog-ci sarif ./results/csharp.sarif --service dd-trace-dotnet --dry-run
+        datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
+      env:
+        DD_API_KEY: '${{ secrets.DD_API_KEY }}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,13 +49,14 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
       with:
-        output: $(System.DefaultWorkingDirectory)
+        output: ${{ github.workspace }}
+        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        ls  $(System.DefaultWorkingDirectory)/
-        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/csharp.sarif --service dd-trace-dotnet
+        ls  ${{ github.workspace }}/
+        datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'
 
@@ -98,12 +99,13 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
       with:
-        output: $(System.DefaultWorkingDirectory)
+        output: ${{ github.workspace }}
+        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        ls  $(System.DefaultWorkingDirectory)/
-        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/csharp.sarif --service dd-trace-dotnet
+        ls  ${{ github.workspace }}/
+        datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
@@ -47,7 +47,7 @@ jobs:
         ./tracer/build.sh BuildProfilerHome BuildNativeLoader
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
       with:
         output: ${{ github.workspace }}
         cleanup-level: 'none'
@@ -82,7 +82,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         config-file: ./.github/codeql/codeql-config.yml
         languages: csharp, cpp
@@ -97,7 +97,7 @@ jobs:
         ./tracer/build.sh BuildTracerHome
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
       with:
         output: ${{ github.workspace }}
         cleanup-level: 'none'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,10 +53,10 @@ jobs:
 
     - name: Upload sarif file
       run: |
-        ls 
+        pwd
         ls /home/runner/work/dd-trace-dotnet/results/
-        datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'
 
@@ -103,9 +103,9 @@ jobs:
 
     - name: Upload sarif file
       run: |
-        ls 
+        pwd
         ls /home/runner/work/dd-trace-dotnet/results/
-        datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload /home/runner/work/dd-trace-dotnet/results/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,9 +1,11 @@
 name: "CodeQL"
 
-on: [push]
-#on:
-#  push:
-#    branches: [ master, hotfix/**/* ]
+#on: [push]
+on:
+  push:
+    branches: [ master, hotfix/**/* ]
+  pull_request:
+    branches: [ master, hotfix/**/* ]
 
 env:
   DD_ENV: ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [ master, hotfix/**/* ]
   pull_request:
+    branches: [ master, hotfix/**/* ]
 
 env:
   DD_ENV: ci

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,13 @@
 name: "CodeQL"
 
-on:
-  push:
-    branches: [ master, hotfix/**/* ]
+on: [push]
+#on:
+#  push:
+#    branches: [ master, hotfix/**/* ]
+
+env:
+  DD_ENV: ci
+  DD_SERVICE: dd-trace-dotnet
 
 jobs:
   profiler:
@@ -20,6 +25,10 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '7.0.101'
+
+    - name: Download datadog-ci
+      run: |
+        npm install -g @datadog/datadog-ci
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -39,7 +48,11 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-      
+
+    - name: Upload sarif file
+      run: |
+        datadog-ci sarif ./results/cpp.sarif --service dd-trace-dotnet --dry-run
+        datadog-ci sarif ./results/csharp.sarif --service dd-trace-dotnet --dry-run
 
   tracer:
     name: Analyze Tracer
@@ -56,6 +69,10 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '7.0.101'
+
+    - name: Download datadog-ci
+      run: |
+        npm install -g @datadog/datadog-ci
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -75,3 +92,8 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+
+    - name: Upload sarif file
+      run: |
+        datadog-ci sarif ./results/cpp.sarif --service dd-trace-dotnet --dry-run
+        datadog-ci sarif ./results/csharp.sarif --service dd-trace-dotnet --dry-run

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,13 +48,9 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-#      with:
-#        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        pwd
-        ls ../results/
         datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
       env:
@@ -98,12 +94,9 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-#      with:
-#        cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        ls ../results/
         datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,12 +49,11 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        output: ${{ github.workspace }}
         cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        ls  ${{ github.workspace }}/
+        ls 
         datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:
@@ -99,12 +98,11 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:
-        output: ${{ github.workspace }}
         cleanup-level: 'none'
 
     - name: Upload sarif file
       run: |
-        ls  ${{ github.workspace }}/
+        ls 
         datadog-ci sarif upload  ${{ github.workspace }}/cpp.sarif --service dd-trace-dotnet
         datadog-ci sarif upload  ${{ github.workspace }}/csharp.sarif --service dd-trace-dotnet
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,13 +48,14 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      with:
+        output: $(System.DefaultWorkingDirectory)
 
     - name: Upload sarif file
       run: |
-        ls
-        ls ./results
-        datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
+        ls  $(System.DefaultWorkingDirectory)/
+        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'
 
@@ -96,12 +97,13 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      with:
+        output: $(System.DefaultWorkingDirectory)
 
     - name: Upload sarif file
       run: |
-        ls
-        ls ./results
-        datadog-ci sarif upload ./results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload ./results/csharp.sarif --service dd-trace-dotnet
+        ls  $(System.DefaultWorkingDirectory)/
+        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/cpp.sarif --service dd-trace-dotnet
+        datadog-ci sarif upload  $(System.DefaultWorkingDirectory)/csharp.sarif --service dd-trace-dotnet
       env:
         DD_API_KEY: '${{ secrets.DD_API_KEY }}'


### PR DESCRIPTION
## Summary of changes

This PR uploads the github codeql sarif file for both `C#` and `C++` code to CI Visibility using the `datadog-ci` CLI

## Reason for change

We are testing a new feature for CI Visibility that process `sarif` files, with static analysis information.

## Results on CI Visibility UI

<img width="773" alt="image" src="https://user-images.githubusercontent.com/69803/230889105-ee7d831f-63aa-4a80-b7ba-907a438166d2.png">


<img width="615" alt="image" src="https://user-images.githubusercontent.com/69803/230889654-b0b9a92e-c4a8-4754-abcc-43a3704b47f4.png">