### PR TITLE
Add Windows Arm64 building in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -215,7 +215,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -242,7 +242,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -303,7 +303,7 @@ stages:
 
   - job: build
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -656,7 +656,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-windows-scale-set
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -704,7 +704,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set-3
+    name: azure-windows-scale-set
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -952,7 +952,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -1028,7 +1028,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_debugger_matrix'] ]
@@ -1088,7 +1088,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1146,7 +1146,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1203,7 +1203,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -1278,7 +1278,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     timeoutInMinutes: 60 #default value
 
     steps:
@@ -1354,7 +1354,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_msi_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1910,7 +1910,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -2088,7 +2088,7 @@ stages:
   - job: Windows
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -2455,7 +2455,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     # Enable the Datadog Agent service for this job
     services:
@@ -2721,7 +2721,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -2864,7 +2864,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      name: azure-windows-scale-set-3
+      name: azure-windows-scale-set
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -215,7 +215,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: []
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -242,7 +242,7 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -303,7 +303,7 @@ stages:
 
   - job: build
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -656,7 +656,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set
+    name: azure-windows-scale-set-3
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -704,7 +704,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
   pool:
-    name: azure-windows-scale-set
+    name: azure-windows-scale-set-3
 
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -952,7 +952,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
@@ -1028,7 +1028,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     timeoutInMinutes: 60 #default value
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_debugger_matrix'] ]
@@ -1088,7 +1088,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1146,7 +1146,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_iis_matrix'] ]
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1203,7 +1203,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_azure_functions_matrix'] ]
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -1278,7 +1278,7 @@ stages:
 
   - job: Win
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     timeoutInMinutes: 60 #default value
 
     steps:
@@ -1354,7 +1354,7 @@ stages:
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_msi_matrix'] ]
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
     variables:
       relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
@@ -1910,7 +1910,7 @@ stages:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
 
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -2088,7 +2088,7 @@ stages:
   - job: Windows
     timeoutInMinutes: 60 #default value
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -2455,7 +2455,7 @@ stages:
     strategy:
       matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.exploration_tests_windows_matrix'] ]
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     # Enable the Datadog Agent service for this job
     services:
@@ -2721,7 +2721,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml
@@ -2864,7 +2864,7 @@ stages:
           targetPlatform: "x64"
 
     pool:
-      name: azure-windows-scale-set
+      name: azure-windows-scale-set-3
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -262,6 +262,35 @@ stages:
       displayName: Upload working directory after the managed build
       artifact: build-windows-working-directory
 
+- stage: build_windows_tracer_arm64x
+  dependsOn: [merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [build]
+
+  - job: build
+    timeoutInMinutes: 60 #default value
+    pool:
+      name: azure-windows-scale-set # This VMSS has the Arm64 tools installed
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        targetShaId: $(targetShaId)
+        targetBranch: $(targetBranch)
+    - template: steps/install-latest-dotnet-sdk.yml
+
+    - script: tracer\build.cmd BuildTracerHome BuildNativeLoader -targetPlatform "arm64ec" -PlatformRequirement Single
+      displayName: Build arm64ec tracer home
+      retryCountOnTaskFailure: 1
+
+    - publish: $(monitoringHome)
+      displayName: Upload Windows tracer home directory
+      artifact: windows-tracer-home-arm64ec
+
 - stage: build_windows_profiler
   dependsOn: [merge_commit_id]
   variables:
@@ -4737,6 +4766,7 @@ stages:
     )
   dependsOn:
     - merge_commit_id
+    - build_windows_tracer_arm64x
     - unit_tests_linux
     - unit_tests_macos
     - unit_tests_windows

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -44,11 +44,8 @@ partial class Build
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {
-            // If we're building for x64, build for x86 too
-            var platforms =
-                Equals(TargetPlatform, MSBuildTargetPlatform.x64)
-                    ? new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86 }
-                    : new[] { MSBuildTargetPlatform.x86 };
+            var platforms = ArchitecturesForPlatformForTracer
+               .Where(x => x != TargetPlatform.arm64ec); // Doesn't support arm64 yet
 
             // Can't use dotnet msbuild, as needs to use the VS version of MSBuild
             // Build native profiler assets

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -48,9 +48,6 @@ partial class Build
     [Parameter("Additional environment variables, in the format KEY1=Value1 Key2=Value2 to use when running the IIS Sample")]
     readonly string[] ExtraEnvVars;
 
-    [Parameter("Force ARM64 build in Windows")]
-    readonly bool ForceARM64BuildInWindows;
-
     [LazyLocalExecutable(@"C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\gacutil.exe")]
     readonly Lazy<Tool> GacUtil;
     [LazyLocalExecutable(@"C:\Program Files\IIS Express\iisexpress.exe")]
@@ -353,22 +350,4 @@ partial class Build
             MoveFile(source, dest, FileExistsPolicy.Overwrite, createDirectories: true);
         }
     }
-
-    private static MSBuildTargetPlatform GetDefaultTargetPlatform()
-    {
-        if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-        {
-            return ARM64TargetPlatform;
-        }
-
-        if (RuntimeInformation.OSArchitecture == Architecture.X86)
-        {
-            return MSBuildTargetPlatform.x86;
-        }
-
-        return MSBuildTargetPlatform.x64;
-    }
-
-    private static MSBuildTargetPlatform ARM64TargetPlatform = (MSBuildTargetPlatform)"ARM64";
-    private static MSBuildTargetPlatform ARM64ECTargetPlatform = (MSBuildTargetPlatform)"ARM64EC";
 }

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -13,40 +13,33 @@ using Nuke.Common.Tools.NuGet;
 internal static partial class DotNetSettingsExtensions
 {
     public static DotNetBuildSettings SetTargetPlatformAnyCPU(this DotNetBuildSettings settings)
-        => settings.SetTargetPlatform(MSBuildTargetPlatform.MSIL);
+        => settings.SetTargetPlatform(TargetPlatform.MSIL);
 
     public static DotNetTestSettings SetTargetPlatformAnyCPU(this DotNetTestSettings settings)
-        => settings.SetTargetPlatform(MSBuildTargetPlatform.MSIL);
+        => settings.SetTargetPlatform(TargetPlatform.MSIL);
 
     public static DotNetPublishSettings SetTargetPlatformAnyCPU(this DotNetPublishSettings settings)
-        => settings.SetTargetPlatform(MSBuildTargetPlatform.MSIL);
+        => settings.SetTargetPlatform(TargetPlatform.MSIL);
 
     public static T SetTargetPlatformAnyCPU<T>(this T settings)
         where T: MSBuildSettings
-        => settings.SetTargetPlatform(MSBuildTargetPlatform.MSIL);
+        => settings.SetTargetPlatform(TargetPlatform.MSIL);
 
-    public static DotNetBuildSettings SetTargetPlatform(this DotNetBuildSettings settings, MSBuildTargetPlatform platform)
-    {
-        return platform is null
-            ? settings
-            : settings.SetProperty("Platform", GetTargetPlatform(platform));
-    }
-    public static DotNetTestSettings SetTargetPlatform(this DotNetTestSettings settings, MSBuildTargetPlatform platform)
-    {
-        return platform is null
-            ? settings
-            : settings.SetProperty("Platform", GetTargetPlatform(platform));
-    }
+    public static DotNetBuildSettings SetTargetPlatform(this DotNetBuildSettings settings, TargetPlatform platform) 
+        => settings.SetProperty("Platform", GetTargetPlatform(platform));
 
-    public static DotNetPublishSettings SetTargetPlatform(this DotNetPublishSettings settings, MSBuildTargetPlatform platform)
-    {
-        return platform is null
-            ? settings
-            : settings.SetProperty("Platform", GetTargetPlatform(platform));
-    }
+    public static DotNetTestSettings SetTargetPlatform(this DotNetTestSettings settings, TargetPlatform platform)
+        => settings.SetProperty("Platform", GetTargetPlatform(platform));
 
-    private static string GetTargetPlatform(MSBuildTargetPlatform platform) =>
-        platform == MSBuildTargetPlatform.MSIL ? "AnyCPU" : platform.ToString();
+    public static DotNetPublishSettings SetTargetPlatform(this DotNetPublishSettings settings, TargetPlatform platform)
+        => settings.SetProperty("Platform", GetTargetPlatform(platform));
+
+    public static T SetTargetPlatform<T>(this T toolSettings, TargetPlatform targetPlatform)
+        where T : MSBuildSettings
+        => toolSettings.SetTargetPlatform((MSBuildTargetPlatform)targetPlatform.ToString());
+
+    private static string GetTargetPlatform(TargetPlatform platform) =>
+        platform == TargetPlatform.MSIL ? "AnyCPU" : platform.ToString();
 
     public static T SetNoWarnDotNetCore3<T>(this T settings)
         where T: ToolSettings
@@ -142,7 +135,7 @@ internal static partial class DotNetSettingsExtensions
     /// <summary>
     /// Conditionally set the dotnet.exe location, using the 32-bit dll when targeting x86
     /// </summary>
-    public static T SetDotnetPath<T>(this T settings, MSBuildTargetPlatform platform)
+    public static T SetDotnetPath<T>(this T settings, TargetPlatform platform)
         where T : ToolSettings
     {
         var dotnetPath = GetDotNetPath(platform);
@@ -152,7 +145,7 @@ internal static partial class DotNetSettingsExtensions
     /// <summary>
     /// Get the path to `dotnet` depending on the platform
     /// </summary>
-    public static string GetDotNetPath(MSBuildTargetPlatform platform)
+    public static string GetDotNetPath(TargetPlatform platform)
     {
         if (!MSBuildTargetPlatform.x86.Equals(platform))
             return DotNetTasks.DotNetPath;
@@ -167,7 +160,7 @@ internal static partial class DotNetSettingsExtensions
         return dotnetPath;
     }
 
-    public static T SetTestTargetPlatform<T>(this T settings, MSBuildTargetPlatform platform)
+    public static T SetTestTargetPlatform<T>(this T settings, TargetPlatform platform)
         where T : ToolSettings
     {
         // To avoid annoying differences in the test code, convert the MSBuildTargetPlatform string values to

--- a/tracer/build/_build/NukeExtensions/PlatformRequirement.cs
+++ b/tracer/build/_build/NukeExtensions/PlatformRequirement.cs
@@ -1,0 +1,17 @@
+﻿public enum PlatformRequirement
+{
+    /// <summary>
+    /// Build default supported platforms
+    /// </summary>
+    Default = 0,
+    
+    /// <summary>
+    /// Build all available platforms. On Windows x64, this includes arm64 builds
+    /// </summary>
+    ForceWindowsArm64 = 1,
+
+    /// <summary>
+    /// Build only the single platform specified in <see cref="Build.TargetPlatform"/>
+    /// </summary>
+    Single = 2,
+}

--- a/tracer/build/_build/NukeExtensions/TargetPlatform.cs
+++ b/tracer/build/_build/NukeExtensions/TargetPlatform.cs
@@ -1,0 +1,16 @@
+﻿/// <summary>
+/// Essentially the same as <see cref="Nuke.Common.Tools.MSBuild.MSBuildTargetPlatform"/>
+/// but with the extra values we need, as a real enum.
+/// These names should match the MSBuildTargetPlatform equivalents for easier interoperability
+/// </summary>
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+public enum TargetPlatform
+{
+    MSIL, 
+    x86,
+    x64,
+    arm64,
+    arm64ec,
+}
+


### PR DESCRIPTION
## Summary of changes

- Introduce new `TargetPlatform` enum to replace `MSBuildTargetPlatform`
- Replace `ForceWindowsArm64` boolean with a `PlatformRequirement` enum
- Add a new arm64 build stage that uses a different azure scale set which includes the arm64 tooling

## Reason for change

**Introduce new `TargetPlatform` enum to replace `MSBuildTargetPlatform`**

The existing MSBuildTargetPlatform is annoyingly limiting
- Not an enum, so can't use in pattern matching 😛 
- Doesn't have all the values (`arm64`, `arm64ec`)
- Can't set values outside of the standard ones (i.e. can't do `BuildTracerHome -TargetPlatform "arm64"`)

Switching to the enum solves these, but we stick to the same naming to make it easier to revert back if support is added, and to interoperate with other built-in Nuke bits

**Replace `ForceWindowsArm64` boolean with a `PlatformRequirement` enum**

So I can add `Single` so we can only build the platform we're interested in if we want

**Add a new arm64 build stage.**

We _could_ add this to the existing windows build stage, but that significantly slows down the build, and isn't worth it while this isn't a supported platform

**Add a new azure VMSS that includes the arm64 tooling**

~~I updated the other VMSS scale set so as to not break the main pipeline in case of issues~~

I _tried_ to update all the stages to use the new VMSS, but for some reason it made the tests really flaky, so currently We're _only_ using the new VMSS for the arm64 build stage...

## Test coverage

None - we're not testing any of this yet

## Other details
Known existing limitations:

- We can't build the Windows MSI for arm. Wix 3.x doesn't support arm, and Wix 4.x isn't stable yet
- We can't run native unit tests on ARM64EC (test FX doesn't support it)
- Integration tests need updating to support targeting arm
- Profiler doesn't work (no support in libdatadog)
- ASM doesn't work (no support in libdwaf)
- Docker smoke tests almost certainly don't work (haven't tried, but seems very unlikely)
- We're only using the new VMSS for the arm64 build, as it seems to make the integration tests more flaky otherwise

