### PR TITLE
[Profiler] Don't read ExitTime if the process hasn't exited

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -157,8 +157,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
 
             var ranToCompletion = process.WaitForExit((int)_maxTestRunDuration.TotalMilliseconds) && processHelper.Drain((int)_maxTestRunDuration.TotalMilliseconds / 2);
 
-            var endTime = process.ExitTime;
-            TotalTestDurationInMilliseconds = (endTime - startTime).TotalMilliseconds;
             var standardOutput = processHelper.StandardOutput;
             var errorOutput = processHelper.ErrorOutput;
             ProcessOutput = standardOutput;
@@ -186,6 +184,9 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                     throw new TimeoutException($"The test {_appName} is running for too long or was lost");
                 }
             }
+
+            var endTime = process.ExitTime;
+            TotalTestDurationInMilliseconds = (endTime - startTime).TotalMilliseconds;
 
             if (standardOutput.Contains("[Error]"))
             {


### PR DESCRIPTION
## Summary of changes

Only read `ExitTime` when we know the process has exited.

## Reason for change

Spotted this error in the CI:

```
   System.InvalidOperationException : Process must exit before requested information can be determined.
  Stack Trace:
     at System.Diagnostics.Process.EnsureState(State state)
   at System.Diagnostics.Process.get_ExitTime()
   at Datadog.Profiler.IntegrationTests.Helpers.TestApplicationRunner.RunTest(MockDatadogAgent agent) in /project/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs:line 205
   at Datadog.Profiler.IntegrationTests.Helpers.TestApplicationRunner.Run(MockDatadogAgent agent) in /project/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs:line 70
   at Datadog.Profiler.IntegrationTests.CodeHotspot.CodeHotspotTest.NoTraceContextAttachedIfFeatureDeactivated(String appName, String framework, String appAssembly) in /project/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs:line 186
```
