### PR TITLE
Increase log level in AspNetCore2 security sample app

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/appsettings.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/appsettings.json
@@ -1,7 +1,9 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
## Summary of changes

Set log level to info instead of warning in Samples.Security.AspNetCore2

## Reason for change

The occasional failures in Iast sampling tests could be caused by an unexpected number of requests (health check?)
