### PR TITLE
[Tracer] Fix test: remove WebSockets tests on GraphQL version 4

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -79,7 +79,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         public async Task SubmitsTracesWebsockets(string packageVersion)
-            => await RunSubmitsTraces("SubmitsTracesWebsockets", packageVersion, true);
+        {
+            try
+            {
+                // Remove the websockets tests on version 4
+                // Because websockets have some issues on that specific version
+                var ver = new Version(packageVersion);
+                if (ver.Major == 4)
+                {
+                    return;
+                }
+            }
+            catch
+            { }
+
+            await RunSubmitsTraces("SubmitsTracesWebsockets", packageVersion, true);
+        }
     }
 #endif
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -80,18 +80,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task SubmitsTracesWebsockets(string packageVersion)
         {
-            try
+            // Remove the websockets tests on version 4
+            // Because websockets have some issues on that specific version
+            // Run tests on GraphQL 5 by default
+            if (!string.IsNullOrEmpty(packageVersion)
+             && new Version(packageVersion).Major == 4)
             {
-                // Remove the websockets tests on version 4
-                // Because websockets have some issues on that specific version
-                var ver = new Version(packageVersion);
-                if (ver.Major == 4)
-                {
-                    return;
-                }
+                return;
             }
-            catch
-            { }
 
             await RunSubmitsTraces("SubmitsTracesWebsockets", packageVersion, true);
         }


### PR DESCRIPTION
## Summary of changes
Remove WebSockets tests for the version 4 of GraphQL.

## Reason for change
Too much flaky tests on that version.
[The bug was fixed on newer versions of that framework.](https://github.com/graphql-dotnet/server/issues/458)
