### PR TITLE
Attempt to fix the DataStreams test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -39,6 +39,8 @@ public class DataStreamsMonitoringTransportTests
 #if !NETCOREAPP3_1_OR_GREATER
             .Where(x => x != TracesTransportType.UnixDomainSocket)
 #endif
+             // Run named pipes tests only on Windows
+            .Where(x => EnvironmentTools.IsWindows() || x != TracesTransportType.WindowsNamedPipe)
             .Select(x => new object[] { x });
 
     [SkippableTheory]


### PR DESCRIPTION
## Summary of changes

Call `WaitForDataStreams` to make sure the result is available.

## Reason for change

Maybe there's a good reason why we're not doing that, but I can't think of any.

## Implementation details

Also removing the retry because I hope this will fix the flakiness 🤞 