### PR TITLE
Try fix SetDotnetPath

### DIFF
--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -154,7 +154,7 @@ internal static partial class DotNetSettingsExtensions
     /// </summary>
     public static string GetDotNetPath(MSBuildTargetPlatform platform)
     {
-        if (platform == MSBuildTargetPlatform.x64 || platform == null)
+        if (!MSBuildTargetPlatform.x86.Equals(platform))
             return DotNetTasks.DotNetPath;
 
         var dotnetPath = EnvironmentInfo.GetVariable<string>("DOTNET_EXE_32")


### PR DESCRIPTION
## Summary of changes

Try fixing `RunDotnetSample` Nuke helper

## Reason for change

It was broken in #3964 

## Implementation details

Make sure we only looks for a custom path when running x86

## Test coverage

Manual testing
