### PR TITLE
Start the PipeServer synchronously

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1128,7 +1128,6 @@ namespace Datadog.Trace.TestHelpers
             private readonly PipeServer _statsPipeServer;
             private readonly PipeServer _tracesPipeServer;
             private readonly Task _statsdTask;
-            private readonly Task _tracesListenerTask;
 
             public NamedPipeAgent(WindowsPipesConfig config)
                 : base(config.UseTelemetry, TestTransports.WindowsNamedPipe)
@@ -1171,7 +1170,7 @@ namespace Datadog.Trace.TestHelpers
                     ex => Exceptions.Add(ex),
                     x => Output?.WriteLine(x));
 
-                _tracesListenerTask = Task.Run(_tracesPipeServer.Start);
+                _tracesPipeServer.Start();
             }
 
             public string TracesWindowsPipeName { get; }
@@ -1244,7 +1243,7 @@ namespace Datadog.Trace.TestHelpers
                     _log = log;
                 }
 
-                public Task Start()
+                public void Start()
                 {
                     for (var i = 0; i < ConcurrentInstanceCount; i++)
                     {
@@ -1254,8 +1253,6 @@ namespace Datadog.Trace.TestHelpers
                         _tasks.Add(startPipe);
                         mutex.Wait(5_000);
                     }
-
-                    return Task.CompletedTask;
                 }
 
                 public void Dispose()


### PR DESCRIPTION
## Summary of changes

We were starting the namedpipe server in a background task, do it synchronously instead.

## Reason for change

Some tests were sending data before the server had a chance to start, causing flakiness.

## Other details

Unit tests shouldn't have retries and I'm willing to die on that hill.
