### PR TITLE
[Profiler] Compare fixed and Poisson threshold allocation sampling/upscaling

### DIFF
--- a/profiler/src/Tools/AllocSimulator/BinaryFileAllocProvider.cs
+++ b/profiler/src/Tools/AllocSimulator/BinaryFileAllocProvider.cs
@@ -139,7 +139,6 @@ namespace AllocSimulator
                     pos += 8;  // skip the read 2 x 4 bytes
                 }
             }
-
         }
     }
 }

--- a/profiler/src/Tools/AllocSimulator/FixedSampler.cs
+++ b/profiler/src/Tools/AllocSimulator/FixedSampler.cs
@@ -1,0 +1,28 @@
+// <copyright file="FixedSampler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace AllocSimulator
+{
+    public class FixedSampler : ISampler
+    {
+        // the current .NET fixed threshold for AllocationTick is 100 KB
+        private const long Threshold = 100 * 1024;
+
+        private long _totalAllocatedAmount;
+
+        public bool ShouldSample(long size)
+        {
+            _totalAllocatedAmount += size;
+            var shouldSample = _totalAllocatedAmount > Threshold;
+
+            if (shouldSample)
+            {
+                _totalAllocatedAmount = 0;
+            }
+
+            return shouldSample;
+        }
+    }
+}

--- a/profiler/src/Tools/AllocSimulator/FixedUpscaler.cs
+++ b/profiler/src/Tools/AllocSimulator/FixedUpscaler.cs
@@ -1,0 +1,16 @@
+// <copyright file="FixedUpscaler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace AllocSimulator
+{
+    public class FixedUpscaler : UpscalerBase
+    {
+        protected override void OnUpscale(AllocInfo sampled, ref AllocInfo upscaled)
+        {
+            upscaled.Size = (long)((sampled.Size * _totalAllocatedAmount) / _totalSampledSize);
+            upscaled.Count = (int)((sampled.Count * _totalAllocatedAmount) / _totalSampledSize);
+        }
+    }
+}

--- a/profiler/src/Tools/AllocSimulator/IUpscaler.cs
+++ b/profiler/src/Tools/AllocSimulator/IUpscaler.cs
@@ -1,12 +1,14 @@
-// <copyright file="ISampler.cs" company="Datadog">
+// <copyright file="IUpscaler.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
 namespace AllocSimulator
 {
-    public interface ISampler
+    public interface IUpscaler
     {
-        public bool ShouldSample(long size);
+        public void OnAllocationTick(string type, int key, long size, long allocationsAmount);
+
+        public IEnumerable<AllocInfo> GetAllocs();
     }
 }

--- a/profiler/src/Tools/AllocSimulator/JavaPoissonSampler.cs
+++ b/profiler/src/Tools/AllocSimulator/JavaPoissonSampler.cs
@@ -1,0 +1,99 @@
+// <copyright file="JavaPoissonSampler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace AllocSimulator
+{
+    // from https://github.com/openjdk/jdk/blob/master/src/hotspot/share/runtime/threadHeapSampler.cpp
+    public class JavaPoissonSampler : ISampler
+    {
+        private const ulong MeanSamplingSize = 512 * 1024;      // 512 KB is the mean of the distribution
+        private const double MinusLog2 = -0.6931471805599453;   // = - ln(2)
+
+        // for fast randomizer
+        private const ulong PrngMult = 0x5DEECE66D;
+        private const ulong PrngAdd = 0xB;
+        private const ulong PrngModMask = (1 << 48) - 1;
+
+        private ulong _totalAllocatedAmount;
+        private ulong _threshold;  // number of bytes until the next sample
+        private ulong _random;
+
+        public JavaPoissonSampler()
+        {
+            _random = (ulong)Random.Shared.NextInt64(1, 281474976710656); // from 1 to 2^48
+            _threshold = GetNextThreshold();
+        }
+
+        public bool ShouldSample(long size)
+        {
+            _totalAllocatedAmount += (ulong)size;
+            var shouldSample = _totalAllocatedAmount > _threshold;
+
+            if (shouldSample)
+            {
+                _totalAllocatedAmount = 0;
+                _threshold = GetNextThreshold();
+            }
+
+            return shouldSample;
+        }
+
+        // Generates a geometric variable with the specified mean (512K by default).
+        // This is done by generating a random number between 0 and 1 and applying
+        // the inverse cumulative distribution function for an exponential.
+        // Specifically: Let m be the inverse of the sample interval, then
+        // the probability distribution function is m*exp(-mx) so the CDF is
+        // p = 1 - exp(-mx), so
+        // q = 1 - p = exp(-mx)
+        // log_e(q) = -mx
+        // -log_e(q)/m = x
+        // log_2(q) * (-log_e(2) * 1/m) = x
+        // In the code, q is actually in the range 1 to 2**26, hence the -26 below
+        private ulong GetNextThreshold()
+        {
+            _random = GetNextRandom(_random);
+
+            // Take the top 26 bits as the random number
+            // (This plus a 1<<58 sampling bound gives a max possible step of
+            // 5194297183973780480 bytes.  In this case,
+            // for sample_parameter = 1<<19, max possible step is
+            // 9448372 bytes (24 bits).
+
+            // 48 is the number of bits in prng
+            // The uint32_t cast is to prevent a (hard-to-reproduce) NAN
+            // under piii debug for some binaries.
+            double q = (uint)(_random >> (48 - 26)) + 1.0;
+            // Put the computed p-value through the CDF of a geometric.
+            // For faster performance (save ~1/20th exec time), replace
+            // min(0.0, FastLog2(q) - 26)  by  (Fastlog2(q) - 26.000705)
+            // The value 26.000705 is used rather than 26 to compensate
+            // for inaccuracies in FastLog2 which otherwise result in a
+            // negative answer.
+            double log_val = (Log2(q) - 26);
+            if (log_val > 0.0)
+            {
+                log_val = 0.0;
+            }
+
+            double result = (log_val * (MinusLog2 * (MeanSamplingSize))) + 1;
+            ulong interval = (ulong)result;
+            _threshold = interval;
+            return _threshold;
+        }
+
+        // Returns the next prng value.
+        // pRNG is: aX+b mod c with a = 0x5DEECE66D, b =  0xB, c = 1<<48
+        // This is the lrand64 generator.
+        private ulong GetNextRandom(ulong random)
+        {
+            return ((PrngMult * random) + PrngAdd) & PrngModMask;
+        }
+
+        private double Log2(double d)
+        {
+            return Math.Log2(d);
+        }
+    }
+}

--- a/profiler/src/Tools/AllocSimulator/PoissonSampler.cs
+++ b/profiler/src/Tools/AllocSimulator/PoissonSampler.cs
@@ -1,0 +1,43 @@
+// <copyright file="PoissonSampler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace AllocSimulator
+{
+    public class PoissonSampler : ISampler
+    {
+        private const ulong MeanSamplingSize = 512 * 1024;      // 512 KB is the mean of the distribution for Java
+
+        private Random _randomizer = new Random(DateTime.Now.Millisecond);
+        private ulong _totalAllocatedAmount;
+        private ulong _threshold;  // number of bytes until the next sample
+
+        public PoissonSampler()
+        {
+            _threshold = GetNextThreshold();
+        }
+
+        public bool ShouldSample(long size)
+        {
+            _totalAllocatedAmount += (ulong)size;
+            var shouldSample = _totalAllocatedAmount > _threshold;
+
+            if (shouldSample)
+            {
+                _totalAllocatedAmount = 0;
+                _threshold = GetNextThreshold();
+            }
+
+            return shouldSample;
+        }
+
+        public ulong GetNextThreshold()
+        {
+            var q = _randomizer.NextDouble();
+
+            ulong next = (ulong)((-Math.Log(1 - q)) * MeanSamplingSize) + 1;
+            return next;
+        }
+    }
+}

--- a/profiler/src/Tools/AllocSimulator/PoissonSampler.cs
+++ b/profiler/src/Tools/AllocSimulator/PoissonSampler.cs
@@ -7,14 +7,14 @@ namespace AllocSimulator
 {
     public class PoissonSampler : ISampler
     {
-        private const ulong MeanSamplingSize = 512 * 1024;      // 512 KB is the mean of the distribution for Java
-
         private Random _randomizer = new Random(DateTime.Now.Millisecond);
         private ulong _totalAllocatedAmount;
         private ulong _threshold;  // number of bytes until the next sample
+        private float _meanPoisson;
 
-        public PoissonSampler()
+        public PoissonSampler(int meanPoisson)
         {
+            _meanPoisson = meanPoisson * 1024;
             _threshold = GetNextThreshold();
         }
 
@@ -36,7 +36,7 @@ namespace AllocSimulator
         {
             var q = _randomizer.NextDouble();
 
-            ulong next = (ulong)((-Math.Log(1 - q)) * MeanSamplingSize) + 1;
+            ulong next = (ulong)((-Math.Log(1 - q)) * _meanPoisson) + 1;
             return next;
         }
     }

--- a/profiler/src/Tools/AllocSimulator/PoissonUpscaler.cs
+++ b/profiler/src/Tools/AllocSimulator/PoissonUpscaler.cs
@@ -1,0 +1,21 @@
+// <copyright file="PoissonUpscaler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace AllocSimulator
+{
+    public class PoissonUpscaler : UpscalerBase
+    {
+        private const float MeanSamplingSize = 512 * 1024;      // 512 KB is the mean of the distribution for Java
+
+        protected override void OnUpscale(AllocInfo sampled, ref AllocInfo upscaled)
+        {
+            var averageSize = (double)sampled.Size / (double)sampled.Count;
+            var scale = 1 / (1 - Math.Exp(-averageSize / MeanSamplingSize));
+
+            upscaled.Size = (long)((float)sampled.Size * scale);
+            upscaled.Count = (int)((float)sampled.Count * scale);
+        }
+    }
+}

--- a/profiler/src/Tools/AllocSimulator/PoissonUpscaler.cs
+++ b/profiler/src/Tools/AllocSimulator/PoissonUpscaler.cs
@@ -7,12 +7,17 @@ namespace AllocSimulator
 {
     public class PoissonUpscaler : UpscalerBase
     {
-        private const float MeanSamplingSize = 512 * 1024;      // 512 KB is the mean of the distribution for Java
+        private float _meanPoisson;
+
+        public PoissonUpscaler(int meanPoisson)
+        {
+            _meanPoisson = meanPoisson * 1024;
+        }
 
         protected override void OnUpscale(AllocInfo sampled, ref AllocInfo upscaled)
         {
             var averageSize = (double)sampled.Size / (double)sampled.Count;
-            var scale = 1 / (1 - Math.Exp(-averageSize / MeanSamplingSize));
+            var scale = 1 / (1 - Math.Exp(-averageSize / _meanPoisson));
 
             upscaled.Size = (long)((float)sampled.Size * scale);
             upscaled.Count = (int)((float)sampled.Count * scale);

--- a/profiler/src/Tools/AllocSimulator/Program.cs
+++ b/profiler/src/Tools/AllocSimulator/Program.cs
@@ -9,21 +9,21 @@ namespace AllocSimulator
     {
         public static void Main(string[] args)
         {
-            ParseCommandLine(args, out string allocFile, out string allocDirectory);
+            ParseCommandLine(args, out string allocFile, out string allocDirectory, out int meanPoisson);
 
             if (string.IsNullOrEmpty(allocDirectory))
             {
-                SimulateAllocations(allocFile);
+                SimulateAllocations(allocFile, meanPoisson);
                 return;
             }
 
             foreach (var filename in Directory.GetFiles(allocDirectory, "*.alloc"))
             {
-                SimulateAllocations(filename);
+                SimulateAllocations(filename, meanPoisson);
             }
         }
 
-        private static void SimulateAllocations(string allocFile)
+        private static void SimulateAllocations(string allocFile, int meanPoisson)
         {
             try
             {
@@ -43,35 +43,80 @@ namespace AllocSimulator
                     throw new InvalidOperationException($"{extension} file extension is not supported");
                 }
 
-                //var sampler = new FixedSampler();
-                //var upscaler = new FixedUpscaler();
-                var sampler = new PoissonSampler();
-                var upscaler = new PoissonUpscaler();
+                var filename = Path.GetFileNameWithoutExtension(allocFile);
+                Console.WriteLine($"Simulate allocations - {filename}");
+                Console.WriteLine("   Fixed 100 KB sampling");
+                var sampler = new FixedSampler();
+                var upscaler = new FixedUpscaler();
                 Engine engine = new Engine(provider, sampler, upscaler);
                 engine.Run();
                 var realAllocations = engine.GetAllocations();
-                var sampledAllocations = upscaler.GetAllocs().ToList();
+                var fixedSampledAllocations = upscaler.GetAllocs().ToList();
 
-                var filename = Path.GetFileNameWithoutExtension(allocFile);
-                Console.WriteLine($"Simulate allocations - {filename}");
+                Console.WriteLine($"   Poisson {meanPoisson} KB sampling");
+                var poissonSampler = new PoissonSampler(meanPoisson);
+                var poissonUpscaler = new PoissonUpscaler(meanPoisson);
+                Engine poissonEngine = new Engine(provider, poissonSampler, poissonUpscaler);
+                poissonEngine.Run();
+                var poissonSampledAllocations = poissonUpscaler.GetAllocs().ToList();
+
                 Console.WriteLine("---------------------------------------------");
                 foreach (var realAllocation in realAllocations.OrderBy(alloc => { return alloc.Size; }))
                 {
                     var realKey = $"{realAllocation.Type}+{realAllocation.Key}";              // V--- use realKey when key is used
                     Console.WriteLine($"{realAllocation.Count,9} | {realAllocation.Size,13} - {realAllocation.Type}");
-                    var sampled = sampledAllocations.FirstOrDefault(a => (realKey == $"{a.Type}+{a.Key}"));
+
+                    float poissonCountRatio = 0;
+                    float poissonSizeRatio = 0;
+                    float countRatio = 0;
+                    float sizeRatio = 0;
+
+                    var poissonSampled = poissonSampledAllocations.FirstOrDefault(a => (realKey == $"{a.Type}+{a.Key}"));
+                    if (poissonSampled != null)
+                    {
+                        poissonCountRatio = -(float)(realAllocation.Count - poissonSampled.Count) / (float)realAllocation.Count;
+                        poissonSizeRatio = -(float)(realAllocation.Size - poissonSampled.Size) / (float)realAllocation.Size;
+                    }
+
+                    var sampled = fixedSampledAllocations.FirstOrDefault(a => (realKey == $"{a.Type}+{a.Key}"));
                     if (sampled != null)
                     {
-                        Console.WriteLine($"{sampled.Count,9} | {sampled.Size,13}");
+                        countRatio = -(float)(realAllocation.Count - sampled.Count) / (float)realAllocation.Count;
+                        sizeRatio = -(float)(realAllocation.Size - sampled.Size) / (float)realAllocation.Size;
+                    }
 
-                        float countRatio = -(float)(realAllocation.Count - sampled.Count) / (float)realAllocation.Count;
-                        float sizeRatio = -(float)(realAllocation.Size - sampled.Size) / (float)realAllocation.Size;
+                    // show Poisson sampling
+                    if (poissonSampled != null)
+                    {
+                        if ((sampled == null) | (Math.Abs(poissonSizeRatio) < Math.Abs(sizeRatio)))
+                        {
+                            Console.ForegroundColor = ConsoleColor.Green;
+                        }
 
-                        Console.WriteLine($"{countRatio,9:P1} | {sizeRatio,13:P1}");
+                        Console.WriteLine($"{poissonSampled.Count,9} | {poissonSampled.Size,13}  Poisson");
+                        Console.WriteLine($"{poissonCountRatio,9:P1} | {poissonSizeRatio,13:P1}");
+                        Console.ForegroundColor = ConsoleColor.Gray;
                     }
                     else
                     {
-                        Console.WriteLine($"        ~ |-----------------^");
+                        Console.WriteLine($"        ~ |-----Poisson-----^");
+                    }
+
+                    // show fixed sampling
+                    if (sampled != null)
+                    {
+                        if ((poissonSampled == null) | (Math.Abs(sizeRatio) < Math.Abs(poissonSizeRatio)))
+                        {
+                            Console.ForegroundColor = ConsoleColor.Blue;
+                        }
+
+                        Console.WriteLine($"{sampled.Count,9} | {sampled.Size,13}  Fixed");
+                        Console.WriteLine($"{countRatio,9:P1} | {sizeRatio,13:P1}");
+                        Console.ForegroundColor = ConsoleColor.Gray;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"        ~ |------Fixed------^");
                     }
 
                     Console.WriteLine();
@@ -85,14 +130,28 @@ namespace AllocSimulator
             }
         }
 
-        private static void ParseCommandLine(string[] args, out string allocFile, out string allocDirectory)
+        private static void ParseCommandLine(string[] args, out string allocFile, out string allocDirectory, out int meanPoisson)
         {
             allocFile = string.Empty;
             allocDirectory = string.Empty;
+            meanPoisson = 512;  // 512 KB is the mean of the distribution for Java
 
             for (int i = 0; i < args.Length; i++)
             {
                 string arg = args[i];
+                if ("-m".Equals(arg, StringComparison.OrdinalIgnoreCase))
+                {
+                    i++;
+                    if (i < args.Length)
+                    {
+                        if (!int.TryParse(args[i], out meanPoisson))
+                        {
+                            Console.WriteLine($"Invalid mean Poisson = {args[i]}");
+                            meanPoisson = 512;
+                        }
+                    }
+                }
+                else
                 if ("-d".Equals(arg, StringComparison.OrdinalIgnoreCase))
                 {
                     i++;

--- a/profiler/src/Tools/AllocSimulator/Program.cs
+++ b/profiler/src/Tools/AllocSimulator/Program.cs
@@ -43,16 +43,19 @@ namespace AllocSimulator
                     throw new InvalidOperationException($"{extension} file extension is not supported");
                 }
 
-                var sampler = new AllocSampler();
-                Engine engine = new Engine(provider, sampler);
+                //var sampler = new FixedSampler();
+                //var upscaler = new FixedUpscaler();
+                var sampler = new PoissonSampler();
+                var upscaler = new PoissonUpscaler();
+                Engine engine = new Engine(provider, sampler, upscaler);
                 engine.Run();
                 var realAllocations = engine.GetAllocations();
-                var sampledAllocations = sampler.GetAllocs().ToList();
+                var sampledAllocations = upscaler.GetAllocs().ToList();
 
                 var filename = Path.GetFileNameWithoutExtension(allocFile);
                 Console.WriteLine($"Simulate allocations - {filename}");
                 Console.WriteLine("---------------------------------------------");
-                foreach (var realAllocation in realAllocations)
+                foreach (var realAllocation in realAllocations.OrderBy(alloc => { return alloc.Size; }))
                 {
                     var realKey = $"{realAllocation.Type}+{realAllocation.Key}";              // V--- use realKey when key is used
                     Console.WriteLine($"{realAllocation.Count,9} | {realAllocation.Size,13} - {realAllocation.Type}");

--- a/profiler/src/Tools/AllocSimulator/UpscalerBase.cs
+++ b/profiler/src/Tools/AllocSimulator/UpscalerBase.cs
@@ -1,18 +1,21 @@
-// <copyright file="AllocSampler.cs" company="Datadog">
+// <copyright file="UpscalerBase.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
 namespace AllocSimulator
 {
-    public class AllocSampler : ISampler
+    public abstract class UpscalerBase : IUpscaler
     {
+#pragma warning disable SA1401 // Fields should be private
+        protected long _totalAllocatedAmount;
+        protected long _totalSampledSize;
+#pragma warning restore SA1401 // Fields should be private
+
         // the key is the type+key of the allocation
         private Dictionary<string, AllocInfo> _sampledAllocations;
-        private long _totalAllocatedAmount;
-        private long _totalSampledSize;
 
-        public AllocSampler()
+        public UpscalerBase()
         {
             _sampledAllocations = new Dictionary<string, AllocInfo>();
             _totalAllocatedAmount = 0;
@@ -21,8 +24,6 @@ namespace AllocSimulator
 
         public void OnAllocationTick(string type, int key, long size, long allocationsAmount)
         {
-            // TODO: simulate the sub-sampler
-
             var dictKey = $"{type}+{key}";
             if (!_sampledAllocations.TryGetValue(dictKey, out var info))
             {
@@ -47,21 +48,22 @@ namespace AllocSimulator
 
         public IEnumerable<AllocInfo> GetAllocs()
         {
-            // implement the upscaling strategy
-            // -> ratio = total allocated amount / total sampled size
             foreach (var group in _sampledAllocations.Keys)
             {
                 var sampled = _sampledAllocations[group];
+
+                // let the child class implement the upscaling strategy
                 var upscaled = new AllocInfo()
                 {
                     Key = sampled.Key,
                     Type = sampled.Type,
-                    Size = (long)((sampled.Size * _totalAllocatedAmount) / _totalSampledSize),
-                    Count = (int)((sampled.Count * _totalAllocatedAmount) / _totalSampledSize),
                 };
+                OnUpscale(sampled, ref upscaled);
 
                 yield return upscaled;
             }
         }
+
+        protected abstract void OnUpscale(AllocInfo sampled, ref AllocInfo upscaled);
     }
 }


### PR DESCRIPTION
## Summary of changes
Compare Fixed and Poisson threshold sampling/upscaling strategies

## Reason for change
As of today, the results of sampling/upscaling allocations based on the fixed threshold used by AllocationTick does not provide a good statistical distribution. We need to simulate and tune the same kind of Poisson distribution used by Go and Java before trying to update the .NET runtime.

## Implementation details
Use the Go implementation for Poisson distribution (the Java port in C# does not seem to work as expected)

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->
