### PR TITLE
Capture the sample output in IAST tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -185,6 +185,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             : base("AspNetCore2", outputHelper, "/shutdown", testName: testName)
         {
             Fixture = fixture;
+            fixture.SetOutput(outputHelper);
             IastEnabled = enableIast;
             IsIastDeduplicationEnabled = isIastDeduplicationEnabled;
             VulnerabilitiesPerRequest = vulnerabilitiesPerRequest;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -209,6 +209,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             : base("AspNetCore5", outputHelper, "/shutdown", testName: testName)
         {
             Fixture = fixture;
+            fixture.SetOutput(outputHelper);
             IastEnabled = enableIast;
             IsIastDeduplicationEnabled = isIastDeduplicationEnabled;
             VulnerabilitiesPerRequest = vulnerabilitiesPerRequest;


### PR DESCRIPTION
## Summary of changes

Follow-up of https://github.com/DataDog/dd-trace-dotnet/pull/3997. Increasing the log level is great, but it's even better if we actually capture those logs.
