### PR TITLE
Set GraphQL7 Sample fixed packages version

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.GraphQL7/Samples.GraphQL7.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GraphQL7/Samples.GraphQL7.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">7.3.0</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">7.3.1</ApiVersion>
     <DefineConstants Condition="$(ApiVersion) &gt;= 7.0.0">$(DefineConstants);GRAPHQL_7_0</DefineConstants>
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->

--- a/tracer/test/test-applications/integrations/Samples.GraphQL7/Samples.GraphQL7.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GraphQL7/Samples.GraphQL7.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(ApiVersion) &gt;= 7.0.0">
-    <PackageReference Include="GraphQL.Server.All" Version="$(ApiVersion)" />
-    <PackageReference Include="GraphQL.NewtonsoftJson" Version="$(ApiVersion)" />
+    <PackageReference Include="GraphQL.Server.All" Version="7.0.0" />
+    <PackageReference Include="GraphQL.NewtonsoftJson" Version="7.0.0" />
   </ItemGroup>
 
   <!-- Files shared with Samples.GraphQL4 -->


### PR DESCRIPTION
## Summary of changes
Use fixed version `7.0.0` for `GraphQL.Server.All` and `GraphQL.NewtonsoftJson` in the sample `Samples.GraphQL7`.

## Reason for change
Some packages used like `GraphQL.Server.All` don't have the same release schedule than `GraphQL`.
