### PR TITLE
[Profiler] Free the error structure on profile_add

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -404,8 +404,9 @@ void LibddprofExporter::Add(std::shared_ptr<Sample> const& sample)
     // TODO: add timestamps when available
 
     auto add_res = ddog_prof_Profile_add(profile, ffiSample);
-    if (add_res.tag == DDOG_PROF_PROFILE_ADD_RESULT_ERR) {
-        on_leave{ddog_Error_drop(&add_res.err);};
+    if (add_res.tag == DDOG_PROF_PROFILE_ADD_RESULT_ERR)
+    {
+        on_leave { ddog_Error_drop(&add_res.err); };
         auto errorMessage = ddog_Error_message(&add_res.err);
         Log::Warn("Failed to add a sample: ", std::string_view(errorMessage.ptr, errorMessage.len));
         return;
@@ -601,7 +602,6 @@ bool LibddprofExporter::Export()
             exported = false;
             Log::Error("Unable to create a request to send the profile.");
         }
-
     }
 
     return exported;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -403,7 +403,13 @@ void LibddprofExporter::Add(std::shared_ptr<Sample> const& sample)
 
     // TODO: add timestamps when available
 
-    auto result = ddog_prof_Profile_add(profile, ffiSample);
+    auto add_res = ddog_prof_Profile_add(profile, ffiSample);
+    if (add_res.tag == DDOG_PROF_PROFILE_ADD_RESULT_ERR) {
+        on_leave{ddog_Error_drop(&add_res.err);};
+        auto errorMessage = ddog_Error_message(&add_res.err);
+        Log::Warn("Failed to add add a profile: ", std::string_view(errorMessage.ptr, errorMessage.len));
+        return;
+    }
     profileInfoScope.profileInfo.samplesCount++;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -407,7 +407,7 @@ void LibddprofExporter::Add(std::shared_ptr<Sample> const& sample)
     if (add_res.tag == DDOG_PROF_PROFILE_ADD_RESULT_ERR) {
         on_leave{ddog_Error_drop(&add_res.err);};
         auto errorMessage = ddog_Error_message(&add_res.err);
-        Log::Warn("Failed to add add a profile: ", std::string_view(errorMessage.ptr, errorMessage.len));
+        Log::Warn("Failed to add a sample: ", std::string_view(errorMessage.ptr, errorMessage.len));
         return;
     }
     profileInfoScope.profileInfo.samplesCount++;

--- a/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LibddprofExporterTest.cpp
@@ -81,6 +81,7 @@ TEST(LibddprofExporterTest, CheckProfileIsWrittenToDisk)
     // Add samples to only one application
     auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
     auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
+
     auto sample1 = CreateSample(firstRid,
                                 callstack1,
                                 labels1,

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.cpp
@@ -47,6 +47,9 @@ std::vector<std::pair<std::string, std::string>> CreateCallstack(int depth)
 
 std::shared_ptr<Sample> CreateSample(std::string_view runtimeId, const std::vector<std::pair<std::string, std::string>>& callstack, const std::vector<std::pair<std::string, std::string>>& labels, std::int64_t value)
 {
+    // For now sample contains only one value `value`.
+    // If we change the number of values, do not forget to change this.
+    Sample::ValuesCount = 1;
     auto sample = std::make_shared<Sample>(runtimeId);
 
     for (auto& [module, frame] : callstack)


### PR DESCRIPTION
## Summary of changes

When encountering an error in the ddog_prof_Profile_add, we need to free the associated error structure. 

## Reason for change

The risk is to have a leak if we do not free the error structure.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
