### PR TITLE
Fix IAST tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -246,12 +246,17 @@ namespace Datadog.Trace.Security.IntegrationTests
             return WaitForSpans(agent, expectedSpans, phase, minDateTime, url);
         }
 
-        protected async Task<IImmutableList<MockSpan>> SendRequestsAsync(MockTracerAgent agent, params string[] urls)
+        protected Task<IImmutableList<MockSpan>> SendRequestsAsync(MockTracerAgent agent, params string[] urls)
+        {
+            return SendRequestsAsync(agent, 1, urls);
+        }
+
+        protected async Task<IImmutableList<MockSpan>> SendRequestsAsync(MockTracerAgent agent, int expectedSpansPerRequest, params string[] urls)
         {
             var spans = new List<MockSpan>();
             foreach (var url in urls)
             {
-                spans.AddRange(await SendRequestsAsync(agent, url, null, 1, 1, string.Empty));
+                spans.AddRange(await SendRequestsAsync(agent, url, null, 1, expectedSpansPerRequest, string.Empty));
             }
 
             return spans.ToImmutableList();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -53,6 +53,12 @@ namespace Datadog.Trace.Security.IntegrationTests
             // adding these header so we can later assert it was collected properly
             _httpClient.DefaultRequestHeaders.Add(XffHeader, MainIp);
             _httpClient.DefaultRequestHeaders.Add("user-agent", "Mistake Not...");
+
+#if NETCOREAPP2_1
+            // Keep-alive is causing some weird failures on aspnetcore 2.1
+            _httpClient.DefaultRequestHeaders.ConnectionClose = true;
+#endif
+
             _jsonSerializerSettingsOrderProperty = new JsonSerializerSettings { ContractResolver = new OrderedContractResolver() };
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 10_000_000.ToString());
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -221,7 +221,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
         protected async Task TestWeakHashing(string filename, MockTracerAgent agent)
         {
             var url = "/Iast/WeakHashing";
-            var spans = await SendRequestsAsync(agent, new string[] { url });
+            var spans = await SendRequestsAsync(agent, expectedSpansPerRequest: 2, url);
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddIastScrubbing();


### PR DESCRIPTION
## Summary of changes

Two fixes:
 - Individual requests to the aspnetcore app create 2 spans, not one.
 - Disable HTTP keep-alive because it seems aspnetcore 2.1 executes the request twice when the connection is reset.
