### PR TITLE
Add more nullable annotations to settings objects

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -18,25 +20,26 @@ namespace Datadog.Trace.AppSec
 
         private bool _enabled = false;
 
-        public SecuritySettings(IConfigurationSource source)
+        public SecuritySettings(IConfigurationSource? source)
         {
-            BlockedHtmlTemplate = source?.GetString(ConfigurationKeys.AppSec.HtmlBlockedTemplate) ?? SecurityConstants.BlockedHtmlTemplate;
-            BlockedJsonTemplate = source?.GetString(ConfigurationKeys.AppSec.JsonBlockedTemplate) ?? SecurityConstants.BlockedJsonTemplate;
+            source ??= NullConfigurationSource.Instance;
+            BlockedHtmlTemplate = source.GetString(ConfigurationKeys.AppSec.HtmlBlockedTemplate) ?? SecurityConstants.BlockedHtmlTemplate;
+            BlockedJsonTemplate = source.GetString(ConfigurationKeys.AppSec.JsonBlockedTemplate) ?? SecurityConstants.BlockedJsonTemplate;
             // both should default to false
-            var enabledEnvVar = source?.GetBool(ConfigurationKeys.AppSec.Enabled);
+            var enabledEnvVar = source.GetBool(ConfigurationKeys.AppSec.Enabled);
             _enabled = enabledEnvVar ?? false;
             CanBeEnabled = enabledEnvVar == null || enabledEnvVar.Value;
 
-            Rules = source?.GetString(ConfigurationKeys.AppSec.Rules);
-            CustomIpHeader = source?.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
-            var extraHeaders = source?.GetString(ConfigurationKeys.AppSec.ExtraHeaders);
+            Rules = source.GetString(ConfigurationKeys.AppSec.Rules);
+            CustomIpHeader = source.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
+            var extraHeaders = source.GetString(ConfigurationKeys.AppSec.ExtraHeaders);
             ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders.Split(',') : Array.Empty<string>();
-            KeepTraces = source?.GetBool(ConfigurationKeys.AppSec.KeepTraces) ?? true;
+            KeepTraces = source.GetBool(ConfigurationKeys.AppSec.KeepTraces) ?? true;
 
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
-            TraceRateLimit = source?.GetInt32(ConfigurationKeys.AppSec.TraceRateLimit) ?? 100;
+            TraceRateLimit = source.GetInt32(ConfigurationKeys.AppSec.TraceRateLimit) ?? 100;
 
-            var wafTimeoutString = source?.GetString(ConfigurationKeys.AppSec.WafTimeout);
+            var wafTimeoutString = source.GetString(ConfigurationKeys.AppSec.WafTimeout);
             const int defaultWafTimeout = 100_000;
             if (string.IsNullOrWhiteSpace(wafTimeoutString))
             {
@@ -55,10 +58,10 @@ namespace Datadog.Trace.AppSec
                 WafTimeoutMicroSeconds = (ulong)wafTimeout;
             }
 
-            var obfuscationParameterKeyRegex = source?.GetString(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex);
+            var obfuscationParameterKeyRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex);
             ObfuscationParameterKeyRegex = string.IsNullOrWhiteSpace(obfuscationParameterKeyRegex) ? SecurityConstants.ObfuscationParameterKeyRegexDefault : obfuscationParameterKeyRegex;
 
-            var obfuscationParameterValueRegex = source?.GetString(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex);
+            var obfuscationParameterValueRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex);
             ObfuscationParameterValueRegex = string.IsNullOrWhiteSpace(obfuscationParameterValueRegex) ? SecurityConstants.ObfuscationParameterValueRegexDefault : obfuscationParameterValueRegex;
         }
 
@@ -71,7 +74,7 @@ namespace Datadog.Trace.AppSec
 
         public bool CanBeEnabled { get; }
 
-        public string CustomIpHeader { get; }
+        public string? CustomIpHeader { get; }
 
         /// <summary>
         /// Gets keys indicating the optional custom appsec headers the user wants to send.
@@ -82,7 +85,7 @@ namespace Datadog.Trace.AppSec
         /// Gets the path to a user-defined WAF Rules file.
         /// Default is null, meaning uses embedded rule set
         /// </summary>
-        public string Rules { get; }
+        public string? Rules { get; }
 
         /// <summary>
         /// Gets a value indicating whether traces should be mark traces with manual keep below trace rate limit
@@ -136,7 +139,7 @@ namespace Datadog.Trace.AppSec
             wafTimeoutString = wafTimeoutString.Trim();
 
             int multipler = 1;
-            string intPart = null;
+            string? intPart = null;
 
             if (wafTimeoutString.EndsWith("ms"))
             {

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.AppSec
             Rules = source.GetString(ConfigurationKeys.AppSec.Rules);
             CustomIpHeader = source.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
             var extraHeaders = source.GetString(ConfigurationKeys.AppSec.ExtraHeaders);
-            ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders.Split(',') : Array.Empty<string>();
+            ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders!.Split(',') : Array.Empty<string>();
             KeepTraces = source.GetBool(ConfigurationKeys.AppSec.KeepTraces) ?? true;
 
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
@@ -48,7 +48,7 @@ namespace Datadog.Trace.AppSec
             else
             {
                 // Default timeout of 100 ms, only extreme conditions should cause timeout
-                var wafTimeout = ParseWafTimeout(wafTimeoutString);
+                var wafTimeout = ParseWafTimeout(wafTimeoutString!);
                 if (wafTimeout <= 0)
                 {
                     Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
@@ -59,10 +59,10 @@ namespace Datadog.Trace.AppSec
             }
 
             var obfuscationParameterKeyRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex);
-            ObfuscationParameterKeyRegex = string.IsNullOrWhiteSpace(obfuscationParameterKeyRegex) ? SecurityConstants.ObfuscationParameterKeyRegexDefault : obfuscationParameterKeyRegex;
+            ObfuscationParameterKeyRegex = string.IsNullOrWhiteSpace(obfuscationParameterKeyRegex) ? SecurityConstants.ObfuscationParameterKeyRegexDefault : obfuscationParameterKeyRegex!;
 
             var obfuscationParameterValueRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex);
-            ObfuscationParameterValueRegex = string.IsNullOrWhiteSpace(obfuscationParameterValueRegex) ? SecurityConstants.ObfuscationParameterValueRegexDefault : obfuscationParameterValueRegex;
+            ObfuscationParameterValueRegex = string.IsNullOrWhiteSpace(obfuscationParameterValueRegex) ? SecurityConstants.ObfuscationParameterValueRegexDefault : obfuscationParameterValueRegex!;
         }
 
         public bool Enabled

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -16,38 +16,38 @@ namespace Datadog.Trace.Ci.Configuration
 
         public CIVisibilitySettings(IConfigurationSource source)
         {
-            Enabled = source?.GetBool(ConfigurationKeys.CIVisibility.Enabled) ?? false;
-            Agentless = source?.GetBool(ConfigurationKeys.CIVisibility.AgentlessEnabled) ?? false;
-            Logs = source?.GetBool(ConfigurationKeys.CIVisibility.Logs) ?? false;
-            ApiKey = source?.GetString(ConfigurationKeys.ApiKey);
-            ApplicationKey = source?.GetString(ConfigurationKeys.ApplicationKey);
-            Site = source?.GetString(ConfigurationKeys.Site) ?? "datadoghq.com";
-            AgentlessUrl = source?.GetString(ConfigurationKeys.CIVisibility.AgentlessUrl);
+            Enabled = source.GetBool(ConfigurationKeys.CIVisibility.Enabled) ?? false;
+            Agentless = source.GetBool(ConfigurationKeys.CIVisibility.AgentlessEnabled) ?? false;
+            Logs = source.GetBool(ConfigurationKeys.CIVisibility.Logs) ?? false;
+            ApiKey = source.GetString(ConfigurationKeys.ApiKey);
+            ApplicationKey = source.GetString(ConfigurationKeys.ApplicationKey);
+            Site = source.GetString(ConfigurationKeys.Site) ?? "datadoghq.com";
+            AgentlessUrl = source.GetString(ConfigurationKeys.CIVisibility.AgentlessUrl);
 
             // By default intake payloads has a 5MB limit
             MaximumAgentlessPayloadSize = 5 * 1024 * 1024;
 
-            ProxyHttps = source?.GetString(ConfigurationKeys.Proxy.ProxyHttps);
-            var proxyNoProxy = source?.GetString(ConfigurationKeys.Proxy.ProxyNoProxy) ?? string.Empty;
+            ProxyHttps = source.GetString(ConfigurationKeys.Proxy.ProxyHttps);
+            var proxyNoProxy = source.GetString(ConfigurationKeys.Proxy.ProxyNoProxy) ?? string.Empty;
             ProxyNoProxy = proxyNoProxy.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Intelligent Test Runner
-            IntelligentTestRunnerEnabled = source?.GetBool(ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled) ?? true;
+            IntelligentTestRunnerEnabled = source.GetBool(ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled) ?? true;
 
             // Tests skipping
-            TestsSkippingEnabled = source?.GetBool(ConfigurationKeys.CIVisibility.TestsSkippingEnabled);
+            TestsSkippingEnabled = source.GetBool(ConfigurationKeys.CIVisibility.TestsSkippingEnabled);
 
             // Code coverage
-            CodeCoverageEnabled = source?.GetBool(ConfigurationKeys.CIVisibility.CodeCoverage);
-            CodeCoverageSnkFilePath = source?.GetString(ConfigurationKeys.CIVisibility.CodeCoverageSnkFile);
-            CodeCoveragePath = source?.GetString(ConfigurationKeys.CIVisibility.CodeCoveragePath);
-            CodeCoverageEnableJitOptimizations = source?.GetBool(ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations) ?? true;
+            CodeCoverageEnabled = source.GetBool(ConfigurationKeys.CIVisibility.CodeCoverage);
+            CodeCoverageSnkFilePath = source.GetString(ConfigurationKeys.CIVisibility.CodeCoverageSnkFile);
+            CodeCoveragePath = source.GetString(ConfigurationKeys.CIVisibility.CodeCoveragePath);
+            CodeCoverageEnableJitOptimizations = source.GetBool(ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations) ?? true;
 
             // Git upload
-            GitUploadEnabled = source?.GetBool(ConfigurationKeys.CIVisibility.GitUploadEnabled);
+            GitUploadEnabled = source.GetBool(ConfigurationKeys.CIVisibility.GitUploadEnabled);
 
             // Force evp proxy
-            ForceAgentsEvpProxy = source?.GetBool(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy) ?? false;
+            ForceAgentsEvpProxy = source.GetBool(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy) ?? false;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -26,7 +28,7 @@ namespace Datadog.Trace.Configuration
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
-        internal GlobalSettings(IConfigurationSource source)
+        internal GlobalSettings(IConfigurationSource? source)
         {
             DebugEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
                            // default value

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -205,7 +205,7 @@ namespace Datadog.Trace.Configuration
                 var websiteOwner = source.GetString(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
                 if (!string.IsNullOrWhiteSpace(websiteOwner))
                 {
-                    var plusSplit = websiteOwner.Split('+');
+                    var plusSplit = websiteOwner!.Split('+');
                     if (plusSplit.Length > 0 && !string.IsNullOrWhiteSpace(plusSplit[0]))
                     {
                         return plusSplit[0];

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -41,77 +41,58 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         public ImmutableAzureAppServiceSettings(IConfigurationSource? source)
         {
-            try
+            source ??= NullConfigurationSource.Instance;
+            var apiKey = source.GetString(Configuration.ConfigurationKeys.ApiKey);
+            if (string.IsNullOrEmpty(apiKey))
             {
-                source ??= NullConfigurationSource.Instance;
-                var apiKey = source.GetString(Configuration.ConfigurationKeys.ApiKey);
-                if (apiKey is null)
-                {
-                    Log.Error("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
-                }
-                else
-                {
-                    // Azure App Services Basis
-                    SubscriptionId = GetSubscriptionId(source);
-                    ResourceGroup = source.GetString(ConfigurationKeys.AzureAppService.ResourceGroupKey);
-                    SiteName = source.GetString(ConfigurationKeys.AzureAppService.SiteNameKey);
-                    ResourceId = CompileResourceId();
-
-                    InstanceId = source.GetString(ConfigurationKeys.AzureAppService.InstanceIdKey) ?? "unknown";
-                    InstanceName = source.GetString(ConfigurationKeys.AzureAppService.InstanceNameKey) ?? "unknown";
-                    OperatingSystem = source.GetString(ConfigurationKeys.AzureAppService.OperatingSystemKey) ?? "unknown";
-                    SiteExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey) ?? "unknown";
-
-                    FunctionsWorkerRuntime = source.GetString(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey);
-                    FunctionsExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey);
-
-                    if (FunctionsWorkerRuntime is not null || FunctionsExtensionVersion is not null)
-                    {
-                        AzureContext = AzureContext.AzureFunctions;
-                    }
-
-                    switch (AzureContext)
-                    {
-                        case AzureContext.AzureFunctions:
-                            SiteKind = "functionapp";
-                            SiteType = "function";
-                            IsFunctionsApp = true;
-                            IsIsolatedFunctionsApp = FunctionsWorkerRuntime?.EndsWith("-isolated", StringComparison.OrdinalIgnoreCase) == true;
-                            PlatformStrategy.ShouldSkipClientSpan = ShouldSkipClientSpanWithinFunctions;
-                            break;
-                        case AzureContext.AzureAppService:
-                            SiteKind = "app";
-                            SiteType = "app";
-                            IsFunctionsApp = false;
-                            break;
-                        default:
-                            SiteKind = "unknown";
-                            SiteType = "unknown";
-                            break;
-                    }
-
-                    Runtime = FrameworkDescription.Instance.Name;
-
-                    DebugModeEnabled = source.GetString(Configuration.ConfigurationKeys.DebugEnabled)?.ToBoolean() ?? false;
-                    CustomTracingEnabled = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomTracing)?.ToBoolean() ?? false;
-                    NeedsDogStatsD = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics)?.ToBoolean() ?? false;
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Unable to initialize AzureAppServices metadata.");
+                Log.Error("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
+                IsUnsafeToTrace = true;
             }
 
-            IsUnsafeToTrace = true;
-            // Set non-nullable properties
+            // Azure App Services Basis
+            SubscriptionId = GetSubscriptionId(source);
+            ResourceGroup = source.GetString(ConfigurationKeys.AzureAppService.ResourceGroupKey);
+            SiteName = source.GetString(ConfigurationKeys.AzureAppService.SiteNameKey);
+            ResourceId = CompileResourceId();
+
+            InstanceId = source.GetString(ConfigurationKeys.AzureAppService.InstanceIdKey) ?? "unknown";
+            InstanceName = source.GetString(ConfigurationKeys.AzureAppService.InstanceNameKey) ?? "unknown";
+            OperatingSystem = source.GetString(ConfigurationKeys.AzureAppService.OperatingSystemKey) ?? "unknown";
+            SiteExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey) ?? "unknown";
+
+            FunctionsWorkerRuntime = source.GetString(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey);
+            FunctionsExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey);
+
+            if (FunctionsWorkerRuntime is not null || FunctionsExtensionVersion is not null)
+            {
+                AzureContext = AzureContext.AzureFunctions;
+            }
+
+            switch (AzureContext)
+            {
+                case AzureContext.AzureFunctions:
+                    SiteKind = "functionapp";
+                    SiteType = "function";
+                    IsFunctionsApp = true;
+                    IsIsolatedFunctionsApp = FunctionsWorkerRuntime?.EndsWith("-isolated", StringComparison.OrdinalIgnoreCase) == true;
+                    PlatformStrategy.ShouldSkipClientSpan = ShouldSkipClientSpanWithinFunctions;
+                    break;
+                case AzureContext.AzureAppService:
+                    SiteKind = "app";
+                    SiteType = "app";
+                    IsFunctionsApp = false;
+                    break;
+                default:
+                    SiteKind = "unknown";
+                    SiteType = "unknown";
+                    break;
+            }
+
             Runtime = FrameworkDescription.Instance.Name;
-            SiteType ??= "unknown";
-            SiteKind ??= "unknown";
-            InstanceId ??= "unknown";
-            InstanceName ??= "unknown";
-            OperatingSystem ??= "unknown";
-            SiteExtensionVersion ??= "unknown";
+
+            DebugModeEnabled = source.GetString(Configuration.ConfigurationKeys.DebugEnabled)?.ToBoolean() ?? false;
+            CustomTracingEnabled = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomTracing)?.ToBoolean() ?? false;
+            NeedsDogStatsD = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics)?.ToBoolean() ?? false;
         }
 
         public bool DebugModeEnabled { get; }
@@ -154,7 +135,7 @@ namespace Datadog.Trace.Configuration
 
         public string Runtime { get; }
 
-        private static bool ShouldSkipClientSpanWithinFunctions(Scope scope)
+        private static bool ShouldSkipClientSpanWithinFunctions(Scope? scope)
         {
             // Ignore isolated client spans within azure functions
             return scope == null;
@@ -164,35 +145,28 @@ namespace Datadog.Trace.Configuration
         {
             string? resourceId = null;
 
-            try
+            var success = true;
+            if (SubscriptionId == null)
             {
-                var success = true;
-                if (SubscriptionId == null)
-                {
-                    success = false;
-                    Log.Warning("Could not successfully retrieve the subscription ID from variable: {Variable}", ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
-                }
-
-                if (SiteName == null)
-                {
-                    success = false;
-                    Log.Warning("Could not successfully retrieve the deployment ID from variable: {Variable}", ConfigurationKeys.AzureAppService.SiteNameKey);
-                }
-
-                if (ResourceGroup == null)
-                {
-                    success = false;
-                    Log.Warning("Could not successfully retrieve the resource group name from variable: {Variable}", ConfigurationKeys.AzureAppService.ResourceGroupKey);
-                }
-
-                if (success)
-                {
-                    resourceId = $"/subscriptions/{SubscriptionId}/resourcegroups/{ResourceGroup}/providers/microsoft.web/sites/{SiteName}".ToLowerInvariant();
-                }
+                success = false;
+                Log.Warning("Could not successfully retrieve the subscription ID from variable: {Variable}", ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
             }
-            catch (Exception ex)
+
+            if (SiteName == null)
             {
-                Log.Error(ex, "Could not successfully setup the resource ID for Azure App Services.");
+                success = false;
+                Log.Warning("Could not successfully retrieve the deployment ID from variable: {Variable}", ConfigurationKeys.AzureAppService.SiteNameKey);
+            }
+
+            if (ResourceGroup == null)
+            {
+                success = false;
+                Log.Warning("Could not successfully retrieve the resource group name from variable: {Variable}", ConfigurationKeys.AzureAppService.ResourceGroupKey);
+            }
+
+            if (success)
+            {
+                resourceId = $"/subscriptions/{SubscriptionId}/resourcegroups/{ResourceGroup}/providers/microsoft.web/sites/{SiteName}".ToLowerInvariant();
             }
 
             return resourceId;
@@ -200,21 +174,14 @@ namespace Datadog.Trace.Configuration
 
         private string? GetSubscriptionId(IConfigurationSource source)
         {
-            try
+            var websiteOwner = source.GetString(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
+            if (!string.IsNullOrWhiteSpace(websiteOwner))
             {
-                var websiteOwner = source.GetString(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
-                if (!string.IsNullOrWhiteSpace(websiteOwner))
+                var plusSplit = websiteOwner!.Split('+');
+                if (plusSplit.Length > 0 && !string.IsNullOrWhiteSpace(plusSplit[0]))
                 {
-                    var plusSplit = websiteOwner!.Split('+');
-                    if (plusSplit.Length > 0 && !string.IsNullOrWhiteSpace(plusSplit[0]))
-                    {
-                        return plusSplit[0];
-                    }
+                    return plusSplit[0];
                 }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Could not successfully retrieve the subscription ID for Azure App Services.");
             }
 
             return null;

--- a/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
@@ -19,17 +19,17 @@ internal class IastSettings
 
     public IastSettings(IConfigurationSource source)
     {
-        WeakCipherAlgorithms = source?.GetString(ConfigurationKeys.Iast.WeakCipherAlgorithms) ?? WeakCipherAlgorithmsDefault;
+        WeakCipherAlgorithms = source.GetString(ConfigurationKeys.Iast.WeakCipherAlgorithms) ?? WeakCipherAlgorithmsDefault;
         WeakCipherAlgorithmsArray = WeakCipherAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        WeakHashAlgorithms = source?.GetString(ConfigurationKeys.Iast.WeakHashAlgorithms) ?? WeakHashAlgorithmsDefault;
+        WeakHashAlgorithms = source.GetString(ConfigurationKeys.Iast.WeakHashAlgorithms) ?? WeakHashAlgorithmsDefault;
         WeakHashAlgorithmsArray = WeakHashAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        Enabled = (source?.GetBool(ConfigurationKeys.Iast.Enabled) ?? false);
-        DeduplicationEnabled = source?.GetBool(ConfigurationKeys.Iast.IsIastDeduplicationEnabled) ?? true;
-        RequestSampling = source?.GetInt32(ConfigurationKeys.Iast.RequestSampling) is { } requestSampling and > 0 and <= 100
+        Enabled = (source.GetBool(ConfigurationKeys.Iast.Enabled) ?? false);
+        DeduplicationEnabled = source.GetBool(ConfigurationKeys.Iast.IsIastDeduplicationEnabled) ?? true;
+        RequestSampling = source.GetInt32(ConfigurationKeys.Iast.RequestSampling) is { } requestSampling and > 0 and <= 100
             ? requestSampling : RequestSamplingDefault;
-        MaxConcurrentRequests = source?.GetInt32(ConfigurationKeys.Iast.MaxConcurrentRequests) is { } concurrentRequests and > 0
+        MaxConcurrentRequests = source.GetInt32(ConfigurationKeys.Iast.MaxConcurrentRequests) is { } concurrentRequests and > 0
             ? concurrentRequests : MaxConcurrentRequestDefault;
-        VulnerabilitiesPerRequest = source?.GetInt32(ConfigurationKeys.Iast.VulnerabilitiesPerRequest) is { } vulnerabilities and > 0
+        VulnerabilitiesPerRequest = source.GetInt32(ConfigurationKeys.Iast.VulnerabilitiesPerRequest) is { } vulnerabilities and > 0
             ? vulnerabilities : VulnerabilitiesPerRequestDefault;
     }
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -34,11 +34,12 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public DirectLogSubmissionSettings(IConfigurationSource? source)
         {
-            DirectLogSubmissionHost = source?.GetString(ConfigurationKeys.DirectLogSubmission.Host)
+            source ??= NullConfigurationSource.Instance;
+            DirectLogSubmissionHost = source.GetString(ConfigurationKeys.DirectLogSubmission.Host)
                                    ?? HostMetadata.Instance.Hostname;
-            DirectLogSubmissionSource = source?.GetString(ConfigurationKeys.DirectLogSubmission.Source) ?? DefaultSource;
+            DirectLogSubmissionSource = source.GetString(ConfigurationKeys.DirectLogSubmission.Source) ?? DefaultSource;
 
-            var overriddenSubmissionUrl = source?.GetString(ConfigurationKeys.DirectLogSubmission.Url);
+            var overriddenSubmissionUrl = source.GetString(ConfigurationKeys.DirectLogSubmission.Url);
             if (!string.IsNullOrEmpty(overriddenSubmissionUrl))
             {
                 // if they provide a url, use it
@@ -47,7 +48,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             else
             {
                 // They didn't provide a URL, use the default (With DD_SITE if provided)
-                var specificSite = source?.GetString(ConfigurationKeys.Site);
+                var specificSite = source.GetString(ConfigurationKeys.Site);
                 var ddSite = string.IsNullOrEmpty(specificSite)
                                  ? DefaultSite
                                  : specificSite;
@@ -56,12 +57,12 @@ namespace Datadog.Trace.Logging.DirectSubmission
             }
 
             DirectLogSubmissionMinimumLevel = DirectSubmissionLogLevelExtensions.Parse(
-                source?.GetString(ConfigurationKeys.DirectLogSubmission.MinimumLevel), DefaultMinimumLevel);
+                source.GetString(ConfigurationKeys.DirectLogSubmission.MinimumLevel), DefaultMinimumLevel);
 
-            var globalTags = source?.GetDictionary(ConfigurationKeys.DirectLogSubmission.GlobalTags)
-                          ?? source?.GetDictionary(ConfigurationKeys.GlobalTags)
+            var globalTags = source.GetDictionary(ConfigurationKeys.DirectLogSubmission.GlobalTags)
+                          ?? source.GetDictionary(ConfigurationKeys.GlobalTags)
                              // backwards compatibility for names used in the past
-                          ?? source?.GetDictionary("DD_TRACE_GLOBAL_TAGS");
+                          ?? source.GetDictionary("DD_TRACE_GLOBAL_TAGS");
 
             DirectLogSubmissionGlobalTags = globalTags?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                                        .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -20,9 +20,9 @@ internal static class DatadogLoggingFactory
     private const int DefaultRateLimit = 0;
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
 
-    public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource? source)
+    public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source)
     {
-        var logSinkOptions = source?.GetString(ConfigurationKeys.LogSinks)
+        var logSinkOptions = source.GetString(ConfigurationKeys.LogSinks)
                                    ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
         FileLoggingConfiguration? fileConfig = null;
@@ -31,7 +31,7 @@ internal static class DatadogLoggingFactory
             fileConfig = GetFileLoggingConfiguration(source);
         }
 
-        var rateLimit = source?.GetInt32(ConfigurationKeys.LogRateLimit) switch
+        var rateLimit = source.GetInt32(ConfigurationKeys.LogRateLimit) switch
         {
             >= 0 and { } r => r,
             _ => DefaultRateLimit,
@@ -130,13 +130,13 @@ internal static class DatadogLoggingFactory
     internal static string GetLogDirectory()
         => GetLogDirectory(GlobalConfigurationSource.CreateDefaultConfigurationSource());
 
-    private static string GetLogDirectory(IConfigurationSource? source)
+    private static string GetLogDirectory(IConfigurationSource source)
     {
-        var logDirectory = source?.GetString(ConfigurationKeys.LogDirectory);
+        var logDirectory = source.GetString(ConfigurationKeys.LogDirectory);
         if (string.IsNullOrEmpty(logDirectory))
         {
 #pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
-            var nativeLogFile = source?.GetString(ConfigurationKeys.ProfilerLogPath);
+            var nativeLogFile = source.GetString(ConfigurationKeys.ProfilerLogPath);
 #pragma warning restore 618
 
             if (!string.IsNullOrEmpty(nativeLogFile))
@@ -190,7 +190,7 @@ internal static class DatadogLoggingFactory
         return logDirectory!;
     }
 
-    private static FileLoggingConfiguration? GetFileLoggingConfiguration(IConfigurationSource? source)
+    private static FileLoggingConfiguration? GetFileLoggingConfiguration(IConfigurationSource source)
     {
         string? logDirectory = null;
         try
@@ -208,10 +208,10 @@ internal static class DatadogLoggingFactory
         }
 
         // get file details
-        var maxLogSizeVar = source?.GetString(ConfigurationKeys.MaxLogFileSize);
+        var maxLogSizeVar = source.GetString(ConfigurationKeys.MaxLogFileSize);
         var maxLogFileSize = long.TryParse(maxLogSizeVar, out var maxLogSize) ? maxLogSize : DefaultMaxLogFileSize;
 
-        var logFileRetentionDays = source?.GetInt32(ConfigurationKeys.LogFileRetentionDays) switch
+        var logFileRetentionDays = source.GetInt32(ConfigurationKeys.LogFileRetentionDays) switch
         {
             >= 0 and var d => d,
             _ => 32,

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -21,14 +21,16 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public RemoteConfigurationSettings(IConfigurationSource? configurationSource)
         {
+            configurationSource ??= NullConfigurationSource.Instance;
+
             Id = Guid.NewGuid().ToString();
             RuntimeId = Util.RuntimeId.Get();
             TracerVersion = TracerConstants.ThreePartVersion;
 
             var pollInterval =
-                configurationSource?.GetInt32(ConfigurationKeys.Rcm.PollInterval)
+                configurationSource.GetInt32(ConfigurationKeys.Rcm.PollInterval)
 #pragma warning disable CS0618
-                    ?? configurationSource?.GetInt32(ConfigurationKeys.Rcm.PollIntervalInternal);
+                    ?? configurationSource.GetInt32(ConfigurationKeys.Rcm.PollIntervalInternal);
 #pragma warning restore CS0618
 
             pollInterval =

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -45,13 +45,13 @@ namespace Datadog.Trace.Telemetry
         public static TelemetrySettings FromDefaultSources()
             => FromSource(GlobalConfigurationSource.Instance, IsAgentAvailable);
 
-        public static TelemetrySettings FromSource(IConfigurationSource? source, Func<bool?> isAgentAvailable)
+        public static TelemetrySettings FromSource(IConfigurationSource source, Func<bool?> isAgentAvailable)
         {
             string? configurationError = null;
 
-            var apiKey = source?.GetString(ConfigurationKeys.ApiKey);
-            var agentlessExplicitlyEnabled = source?.GetBool(ConfigurationKeys.Telemetry.AgentlessEnabled);
-            var agentProxyEnabled = source?.GetBool(ConfigurationKeys.Telemetry.AgentProxyEnabled)
+            var apiKey = source.GetString(ConfigurationKeys.ApiKey);
+            var agentlessExplicitlyEnabled = source.GetBool(ConfigurationKeys.Telemetry.AgentlessEnabled);
+            var agentProxyEnabled = source.GetBool(ConfigurationKeys.Telemetry.AgentProxyEnabled)
                                  ?? isAgentAvailable()
                                  ?? true;
 
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Telemetry
             }
 
             // enabled by default if we have any transports
-            var telemetryEnabled = source?.GetBool(ConfigurationKeys.Telemetry.Enabled)
+            var telemetryEnabled = source.GetBool(ConfigurationKeys.Telemetry.Enabled)
                                 ?? (agentlessEnabled || agentProxyEnabled);
 
             AgentlessSettings? agentless = null;
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Telemetry
                 // We have an API key, so try to send directly to intake
                 Uri agentlessUri;
 
-                var requestedTelemetryUri = source?.GetString(ConfigurationKeys.Telemetry.Uri);
+                var requestedTelemetryUri = source.GetString(ConfigurationKeys.Telemetry.Uri);
                 if (!string.IsNullOrEmpty(requestedTelemetryUri)
                  && Uri.TryCreate(requestedTelemetryUri, UriKind.Absolute, out var telemetryUri))
                 {
@@ -102,7 +102,7 @@ namespace Datadog.Trace.Telemetry
                     }
 
                     // use the default intake. Use DD_SITE if provided, otherwise use default
-                    var siteFromEnv = source?.GetString(ConfigurationKeys.Site);
+                    var siteFromEnv = source.GetString(ConfigurationKeys.Site);
                     var ddSite = string.IsNullOrEmpty(siteFromEnv) ? "datadoghq.com" : siteFromEnv;
                     agentlessUri = new Uri($"{TelemetryConstants.TelemetryIntakePrefix}.{ddSite}/");
                 }
@@ -110,7 +110,7 @@ namespace Datadog.Trace.Telemetry
                 agentless = new AgentlessSettings(agentlessUri, apiKey!);
             }
 
-            var rawInterval = source?.GetInt32(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds);
+            var rawInterval = source.GetInt32(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds);
             var heartbeatInterval = rawInterval is { } interval and > 0 and <= 3600 ? interval : 60;
 
             return new TelemetrySettings(telemetryEnabled, configurationError, agentless, agentProxyEnabled, TimeSpan.FromSeconds(heartbeatInterval));

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -169,10 +169,9 @@ namespace Datadog.Trace.Tests.Telemetry
             using var scope = new AssertionScope();
             data[ConfigTelemetryData.AasConfigurationError].Should().BeOfType<bool>().Subject.Should().BeTrue();
             data[ConfigTelemetryData.CloudHosting].Should().Be("Azure");
-            // TODO: Don't we want to collect these anyway? If so, need to update AzureAppServices behaviour
-            data[ConfigTelemetryData.AasAppType].Should().BeNull();
-            data[ConfigTelemetryData.AasFunctionsRuntimeVersion].Should().BeNull();
-            data[ConfigTelemetryData.AasSiteExtensionVersion].Should().BeNull();
+            data[ConfigTelemetryData.AasAppType].Should().Be("function");
+            data[ConfigTelemetryData.AasFunctionsRuntimeVersion].Should().Be("~3");
+            data[ConfigTelemetryData.AasSiteExtensionVersion].Should().Be("1.5.0");
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

- Add `#nullable enable` where not currently used
- Fix resulting incorrect NRTs
- Use `NullConfigurationSource.Instance` to avoid repeated null checks
- Remove `source?.` where `source` is always non-null (internal APIs only)

## Reason for change

Follow up from #4009

## Implementation details

Add `#nullable enable` and fix the errors

## Test coverage

Not a functional change

## Other details

AAS settings required a bit of reworking to ensure the non-null properties are always set
