### PR TITLE
[Profiler] Fix possible memory leak

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -132,7 +132,9 @@ private:
     void ExportToDisk(const std::string& applicationName, SerializedProfile const& encodedProfile, int idx);
     void SaveMetricsToDisk(const std::string& content) const;
 
-    static bool Send(ddog_prof_Exporter_Request* request, ddog_prof_Exporter* exporter) ;
+    // we *must* pass the reference to the pointer
+    // the Send function in rust takes the ownership, free the memory and set the pointer to null (avoid double free)
+    static bool Send(ddog_prof_Exporter_Request*& request, ddog_prof_Exporter* exporter) ;
     static void AddUpscalingRules(ddog_prof_Profile* profile, std::vector<UpscalingInfo> const& upscalingInfos);
     static fs::path CreatePprofOutputPath(IConfiguration* configuration);
 


### PR DESCRIPTION
## Summary of changes

Fix 2 possible memory leaks.

## Reason for change

It leaks memory 😛 while using the libdatadog API.

## Implementation details

- `ProfileAutoDelete` must be created just after getting the `profile` object. Otherwise, if the profile is empty (object is created but no callstack), the object will leak.
- Call drop on the request: It was not done before because Clang Address Sanitizer suspected a double-free. This double was introduced due a subtlety of the Rust API.

## Test coverage

Current validates this.

## Other details
<!-- Fixes #{issue} -->
