### PR TITLE
Bump DatadogTestLogger version to 0.0.38

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -47,6 +47,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.37" ExcludeAssets="compile" />
+    <PackageReference Include="DatadogTestLogger" Version="0.0.38" ExcludeAssets="compile" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -45,7 +45,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" $(DD_LOGGER_ENABLED) != 'false' ">
-    <PackageReference Include="DatadogTestLogger" Version="0.0.37" ExcludeAssets="compile"/>
+    <PackageReference Include="DatadogTestLogger" Version="0.0.38" ExcludeAssets="compile"/>
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
## Summary of changes

Bump DatadogTestLogger version to 0.0.38
