### PR TITLE
Initial work on configuration telemetry

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
@@ -27,7 +28,7 @@ namespace Datadog.Trace.Coverage.Collector
             _collectionContext = collectionContext;
             _isDebugEnabled = GlobalSettings.Instance.DebugEnabled;
 
-            if (DatadogLoggingFactory.GetConfiguration(GlobalConfigurationSource.Instance).File is { } fileConfig)
+            if (DatadogLoggingFactory.GetConfiguration(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry()).File is { } fileConfig)
             {
                 var loggerConfiguration = new LoggerConfiguration().Enrich.FromLogContext().MinimumLevel.Debug();
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/AnalyzeInstrumentationErrorsCommand.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.InstrumentedAssemblyGenerator;
 using Datadog.InstrumentedAssemblyVerification;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Tools.Runner.Checks;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -152,6 +153,6 @@ internal class AnalyzeInstrumentationErrorsCommand : Command<AnalyzeInstrumentat
             logDirectory = process?.GetProcessLogDirectory();
         }
 
-        return logDirectory ?? Logging.DatadogLoggingFactory.GetLogDirectory();
+        return logDirectory ?? Logging.DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance);
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/DictionaryConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/DictionaryConfigurationSource.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Tools.Runner.Checks
 {
@@ -17,6 +18,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         {
             _dictionary = dictionary;
         }
+
+        internal override ConfigurationOrigins Origin => ConfigurationOrigins.Code;
 
         public override string? GetString(string key)
         {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -19,6 +19,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.Util;
 using Spectre.Console;
@@ -294,7 +295,7 @@ namespace Datadog.Trace.Tools.Runner
             var configurationSource = new CompositeConfigurationSource()
             {
                 GlobalConfigurationSource.Instance,
-                new NameValueConfigurationSource(env)
+                new NameValueConfigurationSource(env, ConfigurationOrigins.EnvVars)
             };
 
             var tracerSettings = new TracerSettings(configurationSource);

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -65,7 +66,8 @@ namespace Datadog.Trace
                     return;
                 }
 
-                var azureAppServiceSettings = new ImmutableAzureAppServiceSettings(GlobalConfigurationSource.Instance);
+                // This is run from the loader, so no point recording telemetry as we're not going to send it anyway
+                var azureAppServiceSettings = new ImmutableAzureAppServiceSettings(GlobalConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
                 if (azureAppServiceSettings.IsUnsafeToTrace)
                 {
                     Log.Error("The Azure Site Extension doesn't have the required parameters to work. The API_KEY is likely missing. The trace_agent and dogstatsd process will not be started. Check your app configuration and restart the app service to try again.");

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -19,6 +19,7 @@ using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Telemetry;
 using Action = Datadog.Trace.AppSec.Rcm.Models.Asm.Action;
 
 namespace Datadog.Trace.AppSec
@@ -95,7 +96,7 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                _settings ??= new(source: null);
+                _settings ??= new(source: null, TelemetryFactoryV2.GetConfigTelemetry());
                 _configurationStatus ??= new ConfigurationStatus(string.Empty);
                 Log.Error(ex, "DDAS-0001-01: AppSec could not start because of an unexpected error. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.");
             }

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -27,35 +27,31 @@ namespace Datadog.Trace.AppSec
             var config = new ConfigurationBuilder(source, telemetry);
             BlockedHtmlTemplate = config
                                  .WithKeys(ConfigurationKeys.AppSec.HtmlBlockedTemplate)
-                                 .AsString()
-                                 .Get(SecurityConstants.BlockedHtmlTemplate);
+                                 .AsString(SecurityConstants.BlockedHtmlTemplate);
 
             BlockedJsonTemplate = config
                                  .WithKeys(ConfigurationKeys.AppSec.JsonBlockedTemplate)
-                                 .AsString()
-                                 .Get(SecurityConstants.BlockedJsonTemplate);
+                                 .AsString(SecurityConstants.BlockedJsonTemplate);
 
             // both should default to false
             var enabledEnvVar = config
                                .WithKeys(ConfigurationKeys.AppSec.Enabled)
-                               .AsBool()
-                               .Get();
+                               .AsBool();
 
             Enabled = enabledEnvVar ?? false;
             CanBeToggled = enabledEnvVar == null;
 
-            Rules = config.WithKeys(ConfigurationKeys.AppSec.Rules).AsString().Get();
-            CustomIpHeader = config.WithKeys(ConfigurationKeys.AppSec.CustomIpHeader).AsString().Get();
-            var extraHeaders = config.WithKeys(ConfigurationKeys.AppSec.ExtraHeaders).AsString().Get();
+            Rules = config.WithKeys(ConfigurationKeys.AppSec.Rules).AsString();
+            CustomIpHeader = config.WithKeys(ConfigurationKeys.AppSec.CustomIpHeader).AsString();
+            var extraHeaders = config.WithKeys(ConfigurationKeys.AppSec.ExtraHeaders).AsString();
             ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders!.Split(',') : Array.Empty<string>();
-            KeepTraces = config.WithKeys(ConfigurationKeys.AppSec.KeepTraces).AsBool().Get(true);
+            KeepTraces = config.WithKeys(ConfigurationKeys.AppSec.KeepTraces).AsBool(true);
 
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
-            TraceRateLimit = config.WithKeys(ConfigurationKeys.AppSec.TraceRateLimit).AsInt32().Get(100);
+            TraceRateLimit = config.WithKeys(ConfigurationKeys.AppSec.TraceRateLimit).AsInt32(100);
 
             WafTimeoutMicroSeconds = (ulong)config
                                            .WithKeys(ConfigurationKeys.AppSec.WafTimeout)
-                                           .AsString()
                                            .GetAs<int>(
                                                 getDefaultValue: () => 100_000, // Default timeout of 100 ms, only extreme conditions should cause timeout
                                                 converter: ParseWafTimeout,
@@ -63,13 +59,11 @@ namespace Datadog.Trace.AppSec
 
             ObfuscationParameterKeyRegex = config
                                           .WithKeys(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex)
-                                          .AsString()
-                                          .Get(SecurityConstants.ObfuscationParameterKeyRegexDefault, x => !string.IsNullOrWhiteSpace(x));
+                                          .AsString(SecurityConstants.ObfuscationParameterKeyRegexDefault, x => !string.IsNullOrWhiteSpace(x));
 
             ObfuscationParameterValueRegex = config
                                             .WithKeys(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex)
-                                            .AsString()
-                                            .Get(SecurityConstants.ObfuscationParameterValueRegexDefault, x => !string.IsNullOrWhiteSpace(x));
+                                            .AsString(SecurityConstants.ObfuscationParameterValueRegexDefault, x => !string.IsNullOrWhiteSpace(x));
         }
 
         public bool Enabled { get; }

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.AppSec
             var numberStyles = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.Any;
             if (int.TryParse(wafTimeoutString, numberStyles, CultureInfo.InvariantCulture, out var result))
             {
-                return ParsingResult<int>.Success(result);
+                return result;
             }
 
             wafTimeoutString = wafTimeoutString.Trim();
@@ -172,7 +172,7 @@ namespace Datadog.Trace.AppSec
 
             if (int.TryParse(intPart, numberStyles, CultureInfo.InvariantCulture, out result))
             {
-                return ParsingResult<int>.Success(result * multipler);
+                return result * multipler;
             }
 
             return ParsingResult<int>.Failure();

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -134,7 +134,8 @@ namespace Datadog.Trace.AppSec
         {
             if (string.IsNullOrWhiteSpace(wafTimeoutString))
             {
-                return ReturnFailure(wafTimeoutString);
+                Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
+                return ParsingResult<int>.Failure();
             }
 
             var numberStyles = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.Any;
@@ -175,12 +176,6 @@ namespace Datadog.Trace.AppSec
             }
 
             return ParsingResult<int>.Failure();
-
-            static ParsingResult<int> ReturnFailure(string timeoutString)
-            {
-                Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, timeoutString);
-                return ParsingResult<int>.Failure();
-            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -9,7 +9,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.AppSec
@@ -18,49 +21,55 @@ namespace Datadog.Trace.AppSec
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SecuritySettings>();
 
-        public SecuritySettings(IConfigurationSource? source)
+        public SecuritySettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
         {
             source ??= NullConfigurationSource.Instance;
-            BlockedHtmlTemplate = source.GetString(ConfigurationKeys.AppSec.HtmlBlockedTemplate) ?? SecurityConstants.BlockedHtmlTemplate;
-            BlockedJsonTemplate = source.GetString(ConfigurationKeys.AppSec.JsonBlockedTemplate) ?? SecurityConstants.BlockedJsonTemplate;
+            var config = new ConfigurationBuilder(source, telemetry);
+            BlockedHtmlTemplate = config
+                                 .WithKeys(ConfigurationKeys.AppSec.HtmlBlockedTemplate)
+                                 .AsString()
+                                 .Get(SecurityConstants.BlockedHtmlTemplate);
+
+            BlockedJsonTemplate = config
+                                 .WithKeys(ConfigurationKeys.AppSec.JsonBlockedTemplate)
+                                 .AsString()
+                                 .Get(SecurityConstants.BlockedJsonTemplate);
+
             // both should default to false
-            var enabledEnvVar = source.GetBool(ConfigurationKeys.AppSec.Enabled);
+            var enabledEnvVar = config
+                               .WithKeys(ConfigurationKeys.AppSec.Enabled)
+                               .AsBool()
+                               .Get();
+
             Enabled = enabledEnvVar ?? false;
             CanBeToggled = enabledEnvVar == null;
 
-            Rules = source.GetString(ConfigurationKeys.AppSec.Rules);
-            CustomIpHeader = source.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
-            var extraHeaders = source.GetString(ConfigurationKeys.AppSec.ExtraHeaders);
+            Rules = config.WithKeys(ConfigurationKeys.AppSec.Rules).AsString().Get();
+            CustomIpHeader = config.WithKeys(ConfigurationKeys.AppSec.CustomIpHeader).AsString().Get();
+            var extraHeaders = config.WithKeys(ConfigurationKeys.AppSec.ExtraHeaders).AsString().Get();
             ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders!.Split(',') : Array.Empty<string>();
-            KeepTraces = source.GetBool(ConfigurationKeys.AppSec.KeepTraces) ?? true;
+            KeepTraces = config.WithKeys(ConfigurationKeys.AppSec.KeepTraces).AsBool().Get(true);
 
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
-            TraceRateLimit = source.GetInt32(ConfigurationKeys.AppSec.TraceRateLimit) ?? 100;
+            TraceRateLimit = config.WithKeys(ConfigurationKeys.AppSec.TraceRateLimit).AsInt32().Get(100);
 
-            var wafTimeoutString = source.GetString(ConfigurationKeys.AppSec.WafTimeout);
-            const int defaultWafTimeout = 100_000;
-            if (string.IsNullOrWhiteSpace(wafTimeoutString))
-            {
-                WafTimeoutMicroSeconds = defaultWafTimeout;
-            }
-            else
-            {
-                // Default timeout of 100 ms, only extreme conditions should cause timeout
-                var wafTimeout = ParseWafTimeout(wafTimeoutString!);
-                if (wafTimeout <= 0)
-                {
-                    Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, wafTimeoutString);
-                    wafTimeout = defaultWafTimeout;
-                }
+            WafTimeoutMicroSeconds = (ulong)config
+                                           .WithKeys(ConfigurationKeys.AppSec.WafTimeout)
+                                           .AsString()
+                                           .GetAs<int>(
+                                                getDefaultValue: () => 100_000, // Default timeout of 100 ms, only extreme conditions should cause timeout
+                                                converter: ParseWafTimeout,
+                                                validator: wafTimeout => wafTimeout > 0);
 
-                WafTimeoutMicroSeconds = (ulong)wafTimeout;
-            }
+            ObfuscationParameterKeyRegex = config
+                                          .WithKeys(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex)
+                                          .AsString()
+                                          .Get(SecurityConstants.ObfuscationParameterKeyRegexDefault, x => !string.IsNullOrWhiteSpace(x));
 
-            var obfuscationParameterKeyRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex);
-            ObfuscationParameterKeyRegex = string.IsNullOrWhiteSpace(obfuscationParameterKeyRegex) ? SecurityConstants.ObfuscationParameterKeyRegexDefault : obfuscationParameterKeyRegex!;
-
-            var obfuscationParameterValueRegex = source.GetString(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex);
-            ObfuscationParameterValueRegex = string.IsNullOrWhiteSpace(obfuscationParameterValueRegex) ? SecurityConstants.ObfuscationParameterValueRegexDefault : obfuscationParameterValueRegex!;
+            ObfuscationParameterValueRegex = config
+                                            .WithKeys(ConfigurationKeys.AppSec.ObfuscationParameterValueRegex)
+                                            .AsString()
+                                            .Get(SecurityConstants.ObfuscationParameterValueRegexDefault, x => !string.IsNullOrWhiteSpace(x));
         }
 
         public bool Enabled { get; }
@@ -118,15 +127,20 @@ namespace Datadog.Trace.AppSec
 
         public static SecuritySettings FromDefaultSources()
         {
-            return new SecuritySettings(GlobalConfigurationSource.Instance);
+            return new SecuritySettings(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
         }
 
-        private static int ParseWafTimeout(string wafTimeoutString)
+        private static ParsingResult<int> ParseWafTimeout(string wafTimeoutString)
         {
+            if (string.IsNullOrWhiteSpace(wafTimeoutString))
+            {
+                return ReturnFailure(wafTimeoutString);
+            }
+
             var numberStyles = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.Any;
             if (int.TryParse(wafTimeoutString, numberStyles, CultureInfo.InvariantCulture, out var result))
             {
-                return result;
+                return ParsingResult<int>.Success(result);
             }
 
             wafTimeoutString = wafTimeoutString.Trim();
@@ -152,15 +166,21 @@ namespace Datadog.Trace.AppSec
 
             if (intPart == null)
             {
-                return -1;
+                return ParsingResult<int>.Failure();
             }
 
             if (int.TryParse(intPart, numberStyles, CultureInfo.InvariantCulture, out result))
             {
-                return result * multipler;
+                return ParsingResult<int>.Success(result * multipler);
             }
 
-            return -1;
+            return ParsingResult<int>.Failure();
+
+            static ParsingResult<int> ReturnFailure(string timeoutString)
+            {
+                Log.Warning("Ignoring '{WafTimeoutKey}' of '{WafTimeoutString}' because it was zero or less", ConfigurationKeys.AppSec.WafTimeout, timeoutString);
+                return ParsingResult<int>.Failure();
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -19,38 +19,38 @@ namespace Datadog.Trace.Ci.Configuration
         public CIVisibilitySettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {
             var config = new ConfigurationBuilder(source, telemetry);
-            Enabled = config.WithKeys(ConfigurationKeys.CIVisibility.Enabled).AsBool().Get(false);
-            Agentless = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessEnabled).AsBool().Get(false);
-            Logs = config.WithKeys(ConfigurationKeys.CIVisibility.Logs).AsBool().Get(false);
-            ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString().Get();
-            ApplicationKey = config.WithKeys(ConfigurationKeys.ApplicationKey).AsRedactedString().Get();
-            Site = config.WithKeys(ConfigurationKeys.Site).AsString().Get("datadoghq.com");
-            AgentlessUrl = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessUrl).AsString().Get();
+            Enabled = config.WithKeys(ConfigurationKeys.CIVisibility.Enabled).AsBool(false);
+            Agentless = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessEnabled).AsBool(false);
+            Logs = config.WithKeys(ConfigurationKeys.CIVisibility.Logs).AsBool(false);
+            ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
+            ApplicationKey = config.WithKeys(ConfigurationKeys.ApplicationKey).AsRedactedString();
+            Site = config.WithKeys(ConfigurationKeys.Site).AsString("datadoghq.com");
+            AgentlessUrl = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessUrl).AsString();
 
             // By default intake payloads has a 5MB limit
             MaximumAgentlessPayloadSize = 5 * 1024 * 1024;
 
-            ProxyHttps = config.WithKeys(ConfigurationKeys.Proxy.ProxyHttps).AsString().Get();
-            var proxyNoProxy = config.WithKeys(ConfigurationKeys.Proxy.ProxyNoProxy).AsString().Get() ?? string.Empty;
+            ProxyHttps = config.WithKeys(ConfigurationKeys.Proxy.ProxyHttps).AsString();
+            var proxyNoProxy = config.WithKeys(ConfigurationKeys.Proxy.ProxyNoProxy).AsString() ?? string.Empty;
             ProxyNoProxy = proxyNoProxy.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
             // Intelligent Test Runner
-            IntelligentTestRunnerEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled).AsBool().Get(true);
+            IntelligentTestRunnerEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled).AsBool(true);
 
             // Tests skipping
-            TestsSkippingEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.TestsSkippingEnabled).AsBool().Get();
+            TestsSkippingEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.TestsSkippingEnabled).AsBool();
 
             // Code coverage
-            CodeCoverageEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverage).AsBool().Get();
-            CodeCoverageSnkFilePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageSnkFile).AsString().Get();
-            CodeCoveragePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoveragePath).AsString().Get();
-            CodeCoverageEnableJitOptimizations = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations).AsBool().Get(true);
+            CodeCoverageEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverage).AsBool();
+            CodeCoverageSnkFilePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageSnkFile).AsString();
+            CodeCoveragePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoveragePath).AsString();
+            CodeCoverageEnableJitOptimizations = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations).AsBool(true);
 
             // Git upload
-            GitUploadEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.GitUploadEnabled).AsBool().Get();
+            GitUploadEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.GitUploadEnabled).AsBool();
 
             // Force evp proxy
-            ForceAgentsEvpProxy = config.WithKeys(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy).AsBool().Get(false);
+            ForceAgentsEvpProxy = config.WithKeys(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy).AsBool(false);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -53,6 +54,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         public string? GetString(string key)
         {
             return _sources.Select(source => source.GetString(key, NullConfigurationTelemetry.Instance, validator: null, recordValue: true))
@@ -66,6 +68,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         public int? GetInt32(string key)
         {
             return _sources.Select(source => source.GetInt32(key, NullConfigurationTelemetry.Instance, validator: null))
@@ -79,6 +82,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         public double? GetDouble(string key)
         {
             return _sources.Select(source => source.GetDouble(key, NullConfigurationTelemetry.Instance, validator: null))
@@ -92,6 +96,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         public bool? GetBool(string key)
         {
             return _sources.Select(source => source.GetBool(key, NullConfigurationTelemetry.Instance, validator: null))
@@ -99,6 +104,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         IEnumerator<IConfigurationSource> IEnumerable<IConfigurationSource>.GetEnumerator()
         {
             return _sources
@@ -109,6 +115,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _sources
@@ -119,6 +126,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key)
         {
             return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null))
@@ -126,6 +134,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings)
         {
             return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null, allowOptionalMappings))

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -4,9 +4,12 @@
 // </copyright>
 
 #nullable enable
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -14,9 +17,9 @@ namespace Datadog.Trace.Configuration
     /// <summary>
     /// Represents one or more configuration sources.
     /// </summary>
-    public class CompositeConfigurationSource : IConfigurationSource, IEnumerable<IConfigurationSource>
+    public class CompositeConfigurationSource : IConfigurationSource, IEnumerable<IConfigurationSource>, ITelemeteredConfigurationSource
     {
-        private readonly List<IConfigurationSource> _sources = new List<IConfigurationSource>();
+        private readonly List<ITelemeteredConfigurationSource> _sources = new();
 
         /// <summary>
         /// Adds a new configuration source to this instance.
@@ -26,7 +29,8 @@ namespace Datadog.Trace.Configuration
         {
             if (source == null) { ThrowHelper.ThrowArgumentNullException(nameof(source)); }
 
-            _sources.Add(source);
+            var telemeteredSource = source as ITelemeteredConfigurationSource ?? new CustomTelemeteredConfigurationSource(source);
+            _sources.Add(telemeteredSource);
         }
 
         /// <summary>
@@ -38,7 +42,8 @@ namespace Datadog.Trace.Configuration
         {
             if (item == null) { ThrowHelper.ThrowArgumentNullException(nameof(item)); }
 
-            _sources.Insert(index, item);
+            var telemeteredSource = item as ITelemeteredConfigurationSource ?? new CustomTelemeteredConfigurationSource(item);
+            _sources.Insert(index, telemeteredSource);
         }
 
         /// <summary>
@@ -50,8 +55,8 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public string? GetString(string key)
         {
-            return _sources.Select(source => source.GetString(key))
-                           .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetString(key, NullConfigurationTelemetry.Instance, validator: null, recordValue: true))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
 
         /// <summary>
@@ -63,8 +68,8 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public int? GetInt32(string key)
         {
-            return _sources.Select(source => source.GetInt32(key))
-                           .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetInt32(key, NullConfigurationTelemetry.Instance, validator: null))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
 
         /// <summary>
@@ -76,8 +81,8 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public double? GetDouble(string key)
         {
-            return _sources.Select(source => source.GetDouble(key))
-                           .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetDouble(key, NullConfigurationTelemetry.Instance, validator: null))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
 
         /// <summary>
@@ -89,34 +94,70 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public bool? GetBool(string key)
         {
-            return _sources.Select(source => source.GetBool(key))
-                           .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetBool(key, NullConfigurationTelemetry.Instance, validator: null))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
 
         /// <inheritdoc />
         IEnumerator<IConfigurationSource> IEnumerable<IConfigurationSource>.GetEnumerator()
         {
-            return _sources.GetEnumerator();
+            return _sources
+                  .Select(
+                       x => x as IConfigurationSource
+                         ?? ((CustomTelemeteredConfigurationSource)x).Source)
+                  .GetEnumerator();
         }
 
         /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return _sources.GetEnumerator();
+            return _sources
+                  .Select(
+                       x => x as IConfigurationSource
+                         ?? ((CustomTelemeteredConfigurationSource)x).Source)
+                  .GetEnumerator();
         }
 
         /// <inheritdoc />
         public IDictionary<string, string>? GetDictionary(string key)
         {
-            return _sources.Select(source => source.GetDictionary(key))
-                        .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
 
         /// <inheritdoc />
         public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings)
         {
-            return _sources.Select(source => source.GetDictionary(key, allowOptionalMappings))
-                        .FirstOrDefault(value => value != null);
+            return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null, allowOptionalMappings))
+                           .FirstOrDefault(value => value != null)?.Result;
         }
+
+        /// <inheritdoc />
+        ConfigurationResult<string>? ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+            => _sources.Select(source => source.GetString(key, telemetry, validator, recordValue)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<int>? ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+            => _sources.Select(source => source.GetInt32(key, telemetry, validator)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<double>? ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+            => _sources.Select(source => source.GetDouble(key, telemetry, validator)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<bool>? ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+            => _sources.Select(source => source.GetBool(key, telemetry, validator)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+            => _sources.Select(source => source.GetDictionary(key, telemetry, validator)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+            => _sources.Select(source => source.GetDictionary(key, telemetry, validator, allowOptionalMappings)).FirstOrDefault(value => value != null);
+
+        /// <inheritdoc />
+        ConfigurationResult<T>? ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+            => _sources.Select(source => source.GetAs<T>(key, telemetry, converter, validator, recordValue)).FirstOrDefault(value => value != null);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/EnvironmentConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/EnvironmentConfigurationSource.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Configuration
 {
@@ -15,6 +16,9 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public class EnvironmentConfigurationSource : StringConfigurationSource
     {
+        /// <inheritdoc />
+        internal override ConfigurationOrigins Origin { get; } = ConfigurationOrigins.EnvVars;
+
         /// <inheritdoc />
         public override string? GetString(string key)
         {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/EnvironmentConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/EnvironmentConfigurationSource.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.Configuration
 {
@@ -20,6 +21,7 @@ namespace Datadog.Trace.Configuration
         internal override ConfigurationOrigins Origin { get; } = ConfigurationOrigins.EnvVars;
 
         /// <inheritdoc />
+        [PublicApi]
         public override string? GetString(string key)
         {
             try

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
@@ -58,8 +58,7 @@ internal class GlobalConfigurationSource
             // if environment variable is not set, look for default file name in the current directory
             var configurationFileName = new ConfigurationBuilder(configurationSource, telemetry)
                                        .WithKeys(ConfigurationKeys.ConfigurationFileName, "DD_DOTNET_TRACER_CONFIG_FILE")
-                                       .AsString()
-                                       .Get(
+                                       .AsString(
                                             getDefaultValue: () => Path.Combine(baseDirectory ?? GetCurrentDirectory(), "datadog.json"),
                                             validator: null);
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/GlobalConfigurationSource.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Configuration;
 
@@ -35,7 +36,7 @@ internal class GlobalConfigurationSource
 
 #if NETFRAMEWORK
             // on .NET Framework only, also read from app.config/web.config
-            new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings)
+            new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings, ConfigurationOrigins.AppConfig)
 #endif
         };
 
@@ -59,7 +60,7 @@ internal class GlobalConfigurationSource
             if (string.Equals(Path.GetExtension(configurationFileName), ".JSON", StringComparison.OrdinalIgnoreCase) &&
                 File.Exists(configurationFileName))
             {
-                jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName);
+                jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName, ConfigurationOrigins.DdConfig);
                 return true;
             }
         }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/IConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/IConfigurationSource.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.Configuration
 {
@@ -20,6 +21,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         string? GetString(string key);
 
         /// <summary>
@@ -28,6 +30,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         int? GetInt32(string key);
 
         /// <summary>
@@ -36,6 +39,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         double? GetDouble(string key);
 
         /// <summary>
@@ -44,6 +48,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         bool? GetBool(string key);
 
         /// <summary>
@@ -52,6 +57,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         IDictionary<string, string>? GetDictionary(string key);
 
         /// <summary>
@@ -61,6 +67,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="key">The key that identifies the setting.</param>
         /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        [PublicApi]
         IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -12,6 +12,7 @@ using System.IO;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
+using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
@@ -33,6 +34,7 @@ namespace Datadog.Trace.Configuration
         /// class with the specified JSON string.
         /// </summary>
         /// <param name="json">A JSON string that contains configuration values.</param>
+        [PublicApi]
         public JsonConfigurationSource(string json)
             : this(json, ConfigurationOrigins.Code)
         {
@@ -52,6 +54,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="filename">A JSON file that contains configuration values.</param>
         /// <returns>The newly created configuration source.</returns>
+        [PublicApi]
         public static JsonConfigurationSource FromFile(string filename)
             => FromFile(filename, ConfigurationOrigins.Code);
 
@@ -70,7 +73,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or null if not found.</returns>
         string? IConfigurationSource.GetString(string key)
         {
-            return GetValue<string>(key);
+            return GetValueInternal<string>(key);
         }
 
         /// <summary>
@@ -82,7 +85,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or null if not found.</returns>
         int? IConfigurationSource.GetInt32(string key)
         {
-            return GetValue<int?>(key);
+            return GetValueInternal<int?>(key);
         }
 
         /// <summary>
@@ -94,7 +97,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or null if not found.</returns>
         double? IConfigurationSource.GetDouble(string key)
         {
-            return GetValue<double?>(key);
+            return GetValueInternal<double?>(key);
         }
 
         /// <summary>
@@ -104,9 +107,10 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or null if not found.</returns>
+        [PublicApi]
         bool? IConfigurationSource.GetBool(string key)
         {
-            return GetValue<bool?>(key);
+            return GetValueInternal<bool?>(key);
         }
 
         /// <summary>
@@ -116,7 +120,10 @@ namespace Datadog.Trace.Configuration
         /// <typeparam name="T">The type to convert the setting value into.</typeparam>
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or the default value of T if not found.</returns>
-        public T? GetValue<T>(string key)
+        [PublicApi]
+        public T? GetValue<T>(string key) => GetValueInternal<T>(key);
+
+        internal T? GetValueInternal<T>(string key)
         {
             JToken? token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
 
@@ -189,7 +196,7 @@ namespace Datadog.Trace.Configuration
                 }
             }
 
-            return StringConfigurationSource.ParseCustomKeyValues(token.ToString(), allowOptionalMappings);
+            return StringConfigurationSource.ParseCustomKeyValuesInternal(token.ToString(), allowOptionalMappings);
         }
 
         /// <inheritdoc />
@@ -383,7 +390,7 @@ namespace Datadog.Trace.Configuration
                     }
                 }
 
-                var result = StringConfigurationSource.ParseCustomKeyValues(tokenAsString, allowOptionalMappings);
+                var result = StringConfigurationSource.ParseCustomKeyValuesInternal(tokenAsString, allowOptionalMappings);
                 return Validate(result);
             }
             catch (InvalidCastException)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -20,10 +22,11 @@ namespace Datadog.Trace.Configuration
     /// Represents a configuration source that retrieves
     /// values from the provided JSON string.
     /// </summary>
-    public class JsonConfigurationSource : IConfigurationSource
+    public class JsonConfigurationSource : IConfigurationSource, ITelemeteredConfigurationSource
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(JsonConfigurationSource));
         private readonly JObject? _configuration;
+        private readonly ConfigurationOrigins _origin;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonConfigurationSource"/>
@@ -31,10 +34,16 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="json">A JSON string that contains configuration values.</param>
         public JsonConfigurationSource(string json)
+            : this(json, ConfigurationOrigins.Code)
+        {
+        }
+
+        internal JsonConfigurationSource(string json, ConfigurationOrigins origin)
         {
             if (json is null) { ThrowHelper.ThrowArgumentNullException(nameof(json)); }
 
             _configuration = (JObject?)JsonConvert.DeserializeObject(json);
+            _origin = origin;
         }
 
         /// <summary>
@@ -44,9 +53,12 @@ namespace Datadog.Trace.Configuration
         /// <param name="filename">A JSON file that contains configuration values.</param>
         /// <returns>The newly created configuration source.</returns>
         public static JsonConfigurationSource FromFile(string filename)
+            => FromFile(filename, ConfigurationOrigins.Code);
+
+        internal static JsonConfigurationSource FromFile(string filename, ConfigurationOrigins origin)
         {
-            string json = File.ReadAllText(filename);
-            return new JsonConfigurationSource(json);
+            var json = File.ReadAllText(filename);
+            return new JsonConfigurationSource(json, origin);
         }
 
         /// <summary>
@@ -178,6 +190,219 @@ namespace Datadog.Trace.Configuration
             }
 
             return StringConfigurationSource.ParseCustomKeyValues(token.ToString(), allowOptionalMappings);
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<string>? ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+
+            try
+            {
+                var value = token?.Value<string>();
+                if (value is not null)
+                {
+                    if (validator is null || validator(value))
+                    {
+                        telemetry.Record(key, value, recordValue, _origin);
+                        return ConfigurationResult<string>.Valid(value);
+                    }
+
+                    telemetry.Record(key, value, recordValue, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    return ConfigurationResult<string>.Invalid(value);
+                }
+            }
+            catch (Exception)
+            {
+                telemetry.Record(key, token?.ToString(), recordValue, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                throw; // Exising behaviour
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<int>? ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+
+            try
+            {
+                var value = token?.Value<int?>();
+                if (value.HasValue)
+                {
+                    if (validator is null || validator(value.Value))
+                    {
+                        telemetry.Record(key, value.Value, _origin);
+                        return ConfigurationResult<int>.Valid(value.Value);
+                    }
+
+                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    return ConfigurationResult<int>.Invalid(value.Value);
+                }
+            }
+            catch (Exception)
+            {
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonInt32Error);
+                throw; // Exising behaviour
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<double>? ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+
+            try
+            {
+                var value = token?.Value<double?>();
+                if (value.HasValue)
+                {
+                    if (validator is null || validator(value.Value))
+                    {
+                        telemetry.Record(key, value.Value, _origin);
+                        return ConfigurationResult<double>.Valid(value.Value);
+                    }
+
+                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    return ConfigurationResult<double>.Invalid(value.Value);
+                }
+            }
+            catch (Exception)
+            {
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonDoubleError);
+                throw; // Exising behaviour
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<bool>? ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+
+            try
+            {
+                var value = token?.Value<bool?>();
+                if (value.HasValue)
+                {
+                    if (validator is null || validator(value.Value))
+                    {
+                        telemetry.Record(key, value.Value, _origin);
+                        return ConfigurationResult<bool>.Valid(value.Value);
+                    }
+
+                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    return ConfigurationResult<bool>.Invalid(value.Value);
+                }
+            }
+            catch (Exception)
+            {
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonBooleanError);
+                throw; // Exising behaviour
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<T>? ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+
+            try
+            {
+                var valueAsString = token?.Value<string>();
+                if (valueAsString is not null)
+                {
+                    var value = converter(valueAsString);
+                    if (value.IsValid)
+                    {
+                        if (validator is null || validator(value.Result))
+                        {
+                            telemetry.Record(key, valueAsString, recordValue, _origin);
+                            return ConfigurationResult<T>.Valid(value.Result);
+                        }
+
+                        telemetry.Record(key, valueAsString, recordValue, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                        return ConfigurationResult<T>.Invalid(value.Result);
+                    }
+
+                    telemetry.Record(key, valueAsString, recordValue, _origin, ConfigurationTelemetryErrorCode.ParsingCustomError);
+                }
+            }
+            catch (Exception)
+            {
+                telemetry.Record(key, token?.ToString(), recordValue, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                throw; // Exising behaviour
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+            => GetDictionary(key, telemetry, validator, allowOptionalMappings: false);
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+            => GetDictionary(key, telemetry, validator, allowOptionalMappings);
+
+        private ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+        {
+            var token = _configuration?.SelectToken(key, errorWhenNoMatch: false);
+            if (token == null)
+            {
+                return null;
+            }
+
+            var tokenAsString = token.ToString();
+
+            try
+            {
+                if (token.Type == JTokenType.Object)
+                {
+                    try
+                    {
+                        var dictionary = token.ToObject<ConcurrentDictionary<string, string>>();
+                        if (dictionary is null)
+                        {
+                            return null;
+                        }
+
+                        return Validate(dictionary);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, "Unable to parse configuration value for {ConfigurationKey} as key-value pairs of strings.", key);
+                        telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                        return null;
+                    }
+                }
+
+                var result = StringConfigurationSource.ParseCustomKeyValues(tokenAsString, allowOptionalMappings);
+                return Validate(result);
+            }
+            catch (InvalidCastException)
+            {
+                telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                throw; // Exising behaviour
+            }
+
+            ConfigurationResult<IDictionary<string, string>>? Validate(IDictionary<string, string> dictionary)
+            {
+                if (validator is null || validator(dictionary))
+                {
+                    telemetry.Record(key, tokenAsString, recordValue: true, _origin);
+                    return ConfigurationResult<IDictionary<string, string>>.Valid(dictionary);
+                }
+
+                telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                return ConfigurationResult<IDictionary<string, string>>.Invalid(dictionary);
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
@@ -215,13 +216,13 @@ namespace Datadog.Trace.Configuration
                         return ConfigurationResult<string>.Valid(value);
                     }
 
-                    telemetry.Record(key, value, recordValue, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    telemetry.Record(key, value, recordValue, _origin, TelemetryErrorCode.FailedValidation);
                     return ConfigurationResult<string>.Invalid(value);
                 }
             }
             catch (Exception)
             {
-                telemetry.Record(key, token?.ToString(), recordValue, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                telemetry.Record(key, token?.ToString(), recordValue, _origin, TelemetryErrorCode.JsonStringError);
                 throw; // Exising behaviour
             }
 
@@ -244,13 +245,13 @@ namespace Datadog.Trace.Configuration
                         return ConfigurationResult<int>.Valid(value.Value);
                     }
 
-                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    telemetry.Record(key, value.Value, _origin, TelemetryErrorCode.FailedValidation);
                     return ConfigurationResult<int>.Invalid(value.Value);
                 }
             }
             catch (Exception)
             {
-                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonInt32Error);
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, TelemetryErrorCode.JsonInt32Error);
                 throw; // Exising behaviour
             }
 
@@ -273,13 +274,13 @@ namespace Datadog.Trace.Configuration
                         return ConfigurationResult<double>.Valid(value.Value);
                     }
 
-                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    telemetry.Record(key, value.Value, _origin, TelemetryErrorCode.FailedValidation);
                     return ConfigurationResult<double>.Invalid(value.Value);
                 }
             }
             catch (Exception)
             {
-                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonDoubleError);
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, TelemetryErrorCode.JsonDoubleError);
                 throw; // Exising behaviour
             }
 
@@ -302,13 +303,13 @@ namespace Datadog.Trace.Configuration
                         return ConfigurationResult<bool>.Valid(value.Value);
                     }
 
-                    telemetry.Record(key, value.Value, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                    telemetry.Record(key, value.Value, _origin, TelemetryErrorCode.FailedValidation);
                     return ConfigurationResult<bool>.Invalid(value.Value);
                 }
             }
             catch (Exception)
             {
-                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonBooleanError);
+                telemetry.Record(key, token?.ToString(), recordValue: true, _origin, TelemetryErrorCode.JsonBooleanError);
                 throw; // Exising behaviour
             }
 
@@ -334,16 +335,16 @@ namespace Datadog.Trace.Configuration
                             return ConfigurationResult<T>.Valid(value.Result);
                         }
 
-                        telemetry.Record(key, valueAsString, recordValue, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                        telemetry.Record(key, valueAsString, recordValue, _origin, TelemetryErrorCode.FailedValidation);
                         return ConfigurationResult<T>.Invalid(value.Result);
                     }
 
-                    telemetry.Record(key, valueAsString, recordValue, _origin, ConfigurationTelemetryErrorCode.ParsingCustomError);
+                    telemetry.Record(key, valueAsString, recordValue, _origin, TelemetryErrorCode.ParsingCustomError);
                 }
             }
             catch (Exception)
             {
-                telemetry.Record(key, token?.ToString(), recordValue, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                telemetry.Record(key, token?.ToString(), recordValue, _origin, TelemetryErrorCode.JsonStringError);
                 throw; // Exising behaviour
             }
 
@@ -385,7 +386,7 @@ namespace Datadog.Trace.Configuration
                     catch (Exception e)
                     {
                         Log.Error(e, "Unable to parse configuration value for {ConfigurationKey} as key-value pairs of strings.", key);
-                        telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                        telemetry.Record(key, tokenAsString, recordValue: true, _origin, TelemetryErrorCode.JsonStringError);
                         return null;
                     }
                 }
@@ -395,7 +396,7 @@ namespace Datadog.Trace.Configuration
             }
             catch (InvalidCastException)
             {
-                telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.JsonStringError);
+                telemetry.Record(key, tokenAsString, recordValue: true, _origin, TelemetryErrorCode.JsonStringError);
                 throw; // Exising behaviour
             }
 
@@ -407,7 +408,7 @@ namespace Datadog.Trace.Configuration
                     return ConfigurationResult<IDictionary<string, string>>.Valid(dictionary);
                 }
 
-                telemetry.Record(key, tokenAsString, recordValue: true, _origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                telemetry.Record(key, tokenAsString, recordValue: true, _origin, TelemetryErrorCode.FailedValidation);
                 return ConfigurationResult<IDictionary<string, string>>.Invalid(dictionary);
             }
         }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NameValueConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NameValueConfigurationSource.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System.Collections.Specialized;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Configuration
 {
@@ -23,9 +24,17 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="nameValueCollection">The collection that will be wrapped by this configuration source.</param>
         public NameValueConfigurationSource(NameValueCollection nameValueCollection)
+            : this(nameValueCollection, ConfigurationOrigins.Code)
+        {
+        }
+
+        internal NameValueConfigurationSource(NameValueCollection nameValueCollection, ConfigurationOrigins origin)
         {
             _nameValueCollection = nameValueCollection;
+            Origin = origin;
         }
+
+        internal override ConfigurationOrigins Origin { get; }
 
         /// <inheritdoc />
         public override string? GetString(string key)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NameValueConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NameValueConfigurationSource.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.Configuration
 {
@@ -37,6 +38,7 @@ namespace Datadog.Trace.Configuration
         internal override ConfigurationOrigins Origin { get; }
 
         /// <inheritdoc />
+        [PublicApi]
         public override string? GetString(string key)
         {
             return _nameValueCollection[key];

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.SourceGenerators;
 
 namespace Datadog.Trace.Configuration
 {
@@ -31,9 +32,10 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
         /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
+        [PublicApi]
         public static IDictionary<string, string>? ParseCustomKeyValues(string? data)
         {
-            return ParseCustomKeyValues(data, allowOptionalMappings: false);
+            return ParseCustomKeyValuesInternal(data, allowOptionalMappings: false);
         }
 
         /// <summary>
@@ -43,8 +45,13 @@ namespace Datadog.Trace.Configuration
         /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
         /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
         /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
+        [PublicApi]
         [return: NotNullIfNotNull(nameof(data))]
         public static IDictionary<string, string>? ParseCustomKeyValues(string? data, bool allowOptionalMappings)
+            => ParseCustomKeyValuesInternal(data, allowOptionalMappings);
+
+        [return: NotNullIfNotNull(nameof(data))]
+        internal static IDictionary<string, string>? ParseCustomKeyValuesInternal(string? data, bool allowOptionalMappings)
         {
             // A null return value means the key was not present,
             // and CompositeConfigurationSource depends on this behavior
@@ -102,6 +109,7 @@ namespace Datadog.Trace.Configuration
         public abstract string? GetString(string key);
 
         /// <inheritdoc />
+        [PublicApi]
         public virtual int? GetInt32(string key)
         {
             var value = GetString(key);
@@ -113,6 +121,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         public double? GetDouble(string key)
         {
             var value = GetString(key);
@@ -123,6 +132,7 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
+        [PublicApi]
         public virtual bool? GetBool(string key)
         {
             var value = GetString(key);
@@ -134,9 +144,10 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="key">The key</param>
         /// <returns><see cref="ConcurrentDictionary{TKey, TValue}"/> containing all of the key-value pairs.</returns>
+        [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key)
         {
-            return ParseCustomKeyValues(GetString(key), allowOptionalMappings: false);
+            return ParseCustomKeyValuesInternal(GetString(key), allowOptionalMappings: false);
         }
 
         /// <summary>
@@ -145,9 +156,10 @@ namespace Datadog.Trace.Configuration
         /// <param name="key">The key</param>
         /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
         /// <returns><see cref="ConcurrentDictionary{TKey, TValue}"/> containing all of the key-value pairs.</returns>
+        [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings)
         {
-            return ParseCustomKeyValues(GetString(key), allowOptionalMappings);
+            return ParseCustomKeyValuesInternal(GetString(key), allowOptionalMappings);
         }
 
         /// <inheritdoc />
@@ -296,7 +308,7 @@ namespace Datadog.Trace.Configuration
             // We record the original dictionary value here instead of serializing the _parsed_ value
             // Currently we have no validation of the dictionary values during parsing, so there's no way to get
             // a validation error that needs recording at this stage
-            var result = ParseCustomKeyValues(value, allowOptionalMappings);
+            var result = ParseCustomKeyValuesInternal(value, allowOptionalMappings);
 
             if (validator is null || validator(result))
             {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Configuration
 {
@@ -178,7 +179,7 @@ namespace Datadog.Trace.Configuration
                 return ConfigurationResult<string>.Valid(value);
             }
 
-            telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+            telemetry.Record(key, value, recordValue, Origin, TelemetryErrorCode.FailedValidation);
             return ConfigurationResult<string>.Invalid(value);
         }
 
@@ -200,11 +201,11 @@ namespace Datadog.Trace.Configuration
                     return ConfigurationResult<int>.Valid(result);
                 }
 
-                telemetry.Record(key, result, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                telemetry.Record(key, result, Origin, TelemetryErrorCode.FailedValidation);
                 return ConfigurationResult<int>.Invalid(result);
             }
 
-            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingInt32Error);
+            telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingInt32Error);
             return null;
         }
 
@@ -226,11 +227,11 @@ namespace Datadog.Trace.Configuration
                     return ConfigurationResult<double>.Valid(result);
                 }
 
-                telemetry.Record(key, result, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                telemetry.Record(key, result, Origin, TelemetryErrorCode.FailedValidation);
                 return ConfigurationResult<double>.Invalid(result);
             }
 
-            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingDoubleError);
+            telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingDoubleError);
             return null;
         }
 
@@ -253,11 +254,11 @@ namespace Datadog.Trace.Configuration
                     return ConfigurationResult<bool>.Valid(result.Value);
                 }
 
-                telemetry.Record(key, result.Value, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                telemetry.Record(key, result.Value, Origin, TelemetryErrorCode.FailedValidation);
                 return ConfigurationResult<bool>.Invalid(result.Value);
             }
 
-            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingBooleanError);
+            telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingBooleanError);
             return null;
         }
 
@@ -280,11 +281,11 @@ namespace Datadog.Trace.Configuration
                     return ConfigurationResult<T>.Valid(result.Result);
                 }
 
-                telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                telemetry.Record(key, value, recordValue, Origin, TelemetryErrorCode.FailedValidation);
                 return ConfigurationResult<T>.Invalid(result.Result);
             }
 
-            telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.ParsingCustomError);
+            telemetry.Record(key, value, recordValue, Origin, TelemetryErrorCode.ParsingCustomError);
             return null;
         }
 
@@ -316,7 +317,7 @@ namespace Datadog.Trace.Configuration
                 return ConfigurationResult<IDictionary<string, string>>.Valid(result);
             }
 
-            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+            telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.FailedValidation);
             return ConfigurationResult<IDictionary<string, string>>.Invalid(result);
         }
     }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -7,7 +7,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Configuration
@@ -16,9 +19,11 @@ namespace Datadog.Trace.Configuration
     /// A base <see cref="IConfigurationSource"/> implementation
     /// for string-only configuration sources.
     /// </summary>
-    public abstract class StringConfigurationSource : IConfigurationSource
+    public abstract class StringConfigurationSource : IConfigurationSource, ITelemeteredConfigurationSource
     {
         private static readonly char[] DictionarySeparatorChars = { ',' };
+
+        internal abstract ConfigurationOrigins Origin { get; }
 
         /// <summary>
         /// Returns a <see cref="IDictionary{TKey, TValue}"/> from parsing
@@ -38,6 +43,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
         /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
         /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
+        [return: NotNullIfNotNull(nameof(data))]
         public static IDictionary<string, string>? ParseCustomKeyValues(string? data, bool allowOptionalMappings)
         {
             // A null return value means the key was not present,
@@ -142,6 +148,164 @@ namespace Datadog.Trace.Configuration
         public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings)
         {
             return ParseCustomKeyValues(GetString(key), allowOptionalMappings);
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<string>? ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (validator is null || validator(value))
+            {
+                telemetry.Record(key, value, recordValue, Origin);
+                return ConfigurationResult<string>.Valid(value);
+            }
+
+            telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+            return ConfigurationResult<string>.Invalid(value);
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<int>? ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (int.TryParse(value, out var result))
+            {
+                if (validator is null || validator(result))
+                {
+                    telemetry.Record(key, result, Origin);
+                    return ConfigurationResult<int>.Valid(result);
+                }
+
+                telemetry.Record(key, result, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                return ConfigurationResult<int>.Invalid(result);
+            }
+
+            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingInt32Error);
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<double>? ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
+            {
+                if (validator is null || validator(result))
+                {
+                    telemetry.Record(key, result, Origin);
+                    return ConfigurationResult<double>.Valid(result);
+                }
+
+                telemetry.Record(key, result, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                return ConfigurationResult<double>.Invalid(result);
+            }
+
+            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingDoubleError);
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<bool>? ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            var result = value.ToBoolean();
+            if (result.HasValue)
+            {
+                if (validator is null || validator(result.Value))
+                {
+                    telemetry.Record(key, result.Value, Origin);
+                    return ConfigurationResult<bool>.Valid(result.Value);
+                }
+
+                telemetry.Record(key, result.Value, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                return ConfigurationResult<bool>.Invalid(result.Value);
+            }
+
+            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.ParsingBooleanError);
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<T>? ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            var result = converter(value);
+            if (result.IsValid)
+            {
+                if (validator is null || validator(result.Result))
+                {
+                    telemetry.Record(key, value, recordValue, Origin);
+                    return ConfigurationResult<T>.Valid(result.Result);
+                }
+
+                telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+                return ConfigurationResult<T>.Invalid(result.Result);
+            }
+
+            telemetry.Record(key, value, recordValue, Origin, ConfigurationTelemetryErrorCode.ParsingCustomError);
+            return null;
+        }
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+            => GetDictionary(key, telemetry, validator, allowOptionalMappings: false);
+
+        /// <inheritdoc />
+        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+            => GetDictionary(key, telemetry, validator, allowOptionalMappings);
+
+        private ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+        {
+            var value = GetString(key);
+
+            if (value is null)
+            {
+                return null;
+            }
+
+            // We record the original dictionary value here instead of serializing the _parsed_ value
+            // Currently we have no validation of the dictionary values during parsing, so there's no way to get
+            // a validation error that needs recording at this stage
+            var result = ParseCustomKeyValues(value, allowOptionalMappings);
+
+            if (validator is null || validator(result))
+            {
+                telemetry.Record(key, value, recordValue: true, Origin);
+                return ConfigurationResult<IDictionary<string, string>>.Valid(result);
+            }
+
+            telemetry.Record(key, value, recordValue: true, Origin, ConfigurationTelemetryErrorCode.FailedValidation);
+            return ConfigurationResult<IDictionary<string, string>>.Invalid(result);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -1,0 +1,300 @@
+﻿// <copyright file="ConfigurationBuilder.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal readonly struct ConfigurationBuilder
+{
+    private readonly ITelemeteredConfigurationSource _source;
+    private readonly IConfigurationTelemetry _telemetry;
+
+    public ConfigurationBuilder(IConfigurationSource source, IConfigurationTelemetry telemetry)
+    {
+        // If the source _isn't_ an ITelemeteredConfigurationSource, it's because it's a custom
+        // IConfigurationSource implementation, so we treat that as a "Code" origin.
+        _source = source as ITelemeteredConfigurationSource ?? new CustomTelemeteredConfigurationSource(source);
+        _telemetry = telemetry;
+    }
+
+    public HasKeys WithKeys(string key) => new(_source, _telemetry, key);
+
+    public HasKeys WithKeys(string key, string fallbackKey) => new(_source, _telemetry, key, fallbackKey);
+
+    public HasKeys WithKeys(string key, string fallbackKey1, string fallbackKey2) => new(_source, _telemetry, key, fallbackKey1, fallbackKey2);
+
+    public HasKeys WithKeys(string key, string fallbackKey1, string fallbackKey2, string fallbackKey3) => new(_source, _telemetry, key, fallbackKey1, fallbackKey2, fallbackKey3);
+
+    internal readonly struct HasKeys
+    {
+        public HasKeys(ITelemeteredConfigurationSource source, IConfigurationTelemetry telemetry, string key, string? fallbackKey1 = null, string? fallbackKey2 = null, string? fallbackKey3 = null)
+        {
+            Source = source;
+            Telemetry = telemetry;
+            Key = key;
+            FallbackKey1 = fallbackKey1;
+            FallbackKey2 = fallbackKey2;
+            FallbackKey3 = fallbackKey3;
+        }
+
+        private ITelemeteredConfigurationSource Source { get; }
+
+        private IConfigurationTelemetry Telemetry { get; }
+
+        private string Key { get; }
+
+        private string? FallbackKey1 { get; }
+
+        private string? FallbackKey2 { get; }
+
+        private string? FallbackKey3 { get; }
+
+        public StringAccessor AsString() => new(this, recordValue: true);
+
+        public StringAccessor AsRedactedString() => new(this, recordValue: false);
+
+        public BoolAccessor AsBool() => new(this);
+
+        public Int32Accessor AsInt32() => new(this);
+
+        public DictionaryAccessor AsDictionary() => new(this);
+
+        public DoubleAccessor AsDouble() => new(this);
+
+        internal readonly struct StringAccessor
+        {
+            private readonly HasKeys _keys;
+            private readonly bool _recordValue;
+
+            public StringAccessor(HasKeys keys, bool recordValue)
+            {
+                _keys = keys;
+                _recordValue = recordValue;
+            }
+
+            public string? Get() => Get(getDefaultValue: null, validator: null);
+
+            public string Get(string defaultValue) => Get(defaultValue, validator: null);
+
+            public string? Get(Func<string, bool> validator) => Get(getDefaultValue: null, validator);
+
+            public string Get(string defaultValue, Func<string, bool>? validator)
+                => Get(() => defaultValue, validator);
+
+            [return: NotNullIfNotNull(nameof(getDefaultValue))]
+            public string? Get(Func<string>? getDefaultValue, Func<string, bool>? validator)
+            {
+                var result = _keys.Source.GetString(_keys.Key, _keys.Telemetry, validator, _recordValue)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetString(_keys.FallbackKey1, _keys.Telemetry, validator, _recordValue))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetString(_keys.FallbackKey2, _keys.Telemetry, validator, _recordValue))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetString(_keys.FallbackKey3, _keys.Telemetry, validator, _recordValue));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // don't have a valid value
+                if (getDefaultValue is null)
+                {
+                    return null;
+                }
+
+                var defaultValue = getDefaultValue();
+                _keys.Telemetry.Record(_keys.Key, defaultValue, _recordValue, ConfigurationOrigins.Default);
+                return defaultValue;
+            }
+
+            [return: NotNullIfNotNull(nameof(getDefaultValue))]
+            public T? GetAs<T>(Func<T>? getDefaultValue, Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
+            {
+                var result = _keys.Source.GetAs<T>(_keys.Key, _keys.Telemetry, converter, validator, _recordValue)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetAs<T>(_keys.FallbackKey1, _keys.Telemetry, converter, validator, _recordValue))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetAs<T>(_keys.FallbackKey2, _keys.Telemetry, converter, validator, _recordValue))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetAs<T>(_keys.FallbackKey3, _keys.Telemetry, converter, validator, _recordValue));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // don't have a valid value
+                if (getDefaultValue is null)
+                {
+                    return default;
+                }
+
+                var defaultValue = getDefaultValue();
+                _keys.Telemetry.Record(_keys.Key, defaultValue?.ToString(), _recordValue, ConfigurationOrigins.Default);
+                return defaultValue!;
+            }
+        }
+
+        internal readonly struct BoolAccessor
+        {
+            private readonly HasKeys _keys;
+
+            public BoolAccessor(HasKeys keys)
+            {
+                _keys = keys;
+            }
+
+            public bool? Get() => Get(getDefaultValue: null, validator: null);
+
+            public bool Get(bool defaultValue) => Get(() => defaultValue, validator: null).Value;
+
+            public bool? Get(Func<bool, bool> validator) => Get(null, validator);
+
+            public bool Get(bool defaultValue, Func<bool, bool>? validator)
+                => Get(() => defaultValue, validator).Value;
+
+            [return: NotNullIfNotNull(nameof(getDefaultValue))] // This doesn't work with nullables, but it still expresses intent
+            public bool? Get(Func<bool>? getDefaultValue, Func<bool, bool>? validator)
+            {
+                var result = _keys.Source.GetBool(_keys.Key, _keys.Telemetry, validator)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetBool(_keys.FallbackKey1, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetBool(_keys.FallbackKey2, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetBool(_keys.FallbackKey3, _keys.Telemetry, validator));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // don't have a default value
+                if (getDefaultValue is null)
+                {
+                    return null;
+                }
+
+                var defaultValue = getDefaultValue();
+                _keys.Telemetry.Record(_keys.Key, defaultValue, ConfigurationOrigins.Default);
+                return defaultValue;
+            }
+        }
+
+        internal readonly struct Int32Accessor
+        {
+            private readonly HasKeys _keys;
+
+            public Int32Accessor(HasKeys keys)
+            {
+                _keys = keys;
+            }
+
+            public int? Get() => Get(defaultValue: null, validator: null);
+
+            public int Get(int defaultValue) => Get(defaultValue, validator: null).Value;
+
+            public int? Get(Func<int, bool> validator) => Get(null, validator);
+
+            [return: NotNullIfNotNull(nameof(defaultValue))] // This doesn't work with nullables, but it still expresses intent
+            public int? Get(int? defaultValue, Func<int, bool>? validator)
+            {
+                var result = _keys.Source.GetInt32(_keys.Key, _keys.Telemetry, validator)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetInt32(_keys.FallbackKey1, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetInt32(_keys.FallbackKey2, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetInt32(_keys.FallbackKey3, _keys.Telemetry, validator));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // don't have a default value
+                if (defaultValue is null)
+                {
+                    return null;
+                }
+
+                _keys.Telemetry.Record(_keys.Key, defaultValue.Value, ConfigurationOrigins.Default);
+                return defaultValue.Value;
+            }
+        }
+
+        internal readonly struct DictionaryAccessor
+        {
+            private readonly HasKeys _keys;
+
+            public DictionaryAccessor(HasKeys keys)
+            {
+                _keys = keys;
+            }
+
+            public IDictionary<string, string>? Get() => Get(allowOptionalMappings: false);
+
+            public IDictionary<string, string>? Get(bool allowOptionalMappings)
+            {
+                // TODO: Handle/allow default values + validation?
+                var result = _keys.Source.GetDictionary(_keys.Key, _keys.Telemetry, validator: null, allowOptionalMappings)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetDictionary(_keys.FallbackKey1, _keys.Telemetry, validator: null, allowOptionalMappings))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetDictionary(_keys.FallbackKey2, _keys.Telemetry, validator: null, allowOptionalMappings))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetDictionary(_keys.FallbackKey3, _keys.Telemetry, validator: null, allowOptionalMappings));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // Horrible that we have to stringify the dictionary, but that's all that's available in the telemetry api
+                // _keys.Telemetry.Record(_keys.Key, string.Join(", ", defaultValue.Select(kvp => $"{kvp.Key}:{kvp.Value}")), ConfigurationOrigins.Default);
+                // return defaultValue;
+                return null;
+            }
+        }
+
+        internal readonly struct DoubleAccessor
+        {
+            private readonly HasKeys _keys;
+
+            public DoubleAccessor(HasKeys keys)
+            {
+                _keys = keys;
+            }
+
+            public double? Get() => Get(defaultValue: null, validator: null);
+
+            public double Get(double defaultValue) => Get(defaultValue, validator: null).Value;
+
+            public double? Get(Func<double, bool> validator) => Get(null, validator);
+
+            [return: NotNullIfNotNull(nameof(defaultValue))]
+            public double? Get(double? defaultValue, Func<double, bool>? validator)
+            {
+                var result = _keys.Source.GetDouble(_keys.Key, _keys.Telemetry, validator)
+                          ?? (_keys.FallbackKey1 is null ? null : _keys.Source.GetDouble(_keys.FallbackKey1, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey2 is null ? null : _keys.Source.GetDouble(_keys.FallbackKey2, _keys.Telemetry, validator))
+                          ?? (_keys.FallbackKey3 is null ? null : _keys.Source.GetDouble(_keys.FallbackKey3, _keys.Telemetry, validator));
+
+                // We have a valid value
+                if (result is { Result: { } value, IsValid: true })
+                {
+                    return value;
+                }
+
+                // don't have a default value
+                if (defaultValue is null)
+                {
+                    return null;
+                }
+
+                _keys.Telemetry.Record(_keys.Key, defaultValue.Value, ConfigurationOrigins.Default);
+                return defaultValue.Value;
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="ConfigurationOrigins.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.ComponentModel;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal enum ConfigurationOrigins
+{
+    /// <summary>
+    /// Configuration that is set through environment variables
+    /// </summary>
+    [Description("env_var")]
+    EnvVars,
+
+    /// <summary>
+    /// Configuration that is set through the customer application
+    /// </summary>
+    [Description("code")]
+    Code,
+
+    /// <summary>
+    /// Configuration that is set by the dd.yaml file or json
+    /// </summary>
+    [Description("dd_config")]
+    DdConfig,
+
+    /// <summary>
+    /// Configuration that is set using remote config
+    /// </summary>
+    [Description("remote_config")]
+    RemoteConfig,
+
+    /// <summary>
+    /// Configuration that is set using web.config or app.config
+    /// </summary>
+    [Description("app.config")]
+    AppConfig,
+
+    /// <summary>
+    /// Set when the user has not set any configuration for the key, or when the configuration
+    /// is erroneous and we fallback to the default
+    /// </summary>
+    [Description("default")]
+    Default,
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ConfigurationResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal readonly record struct ConfigurationResult<T>
+{
+    private ConfigurationResult(T result, bool isValid)
+    {
+        Result = result;
+        IsValid = isValid;
+    }
+
+    /// <summary>
+    /// Gets the extracted configuration value.
+    /// </summary>
+    public T Result { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Result"/> result passed validation.
+    /// </summary>
+    public bool IsValid { get; }
+
+    public static ConfigurationResult<T> Valid(T result) => new(result, isValid: true);
+
+    public static ConfigurationResult<T> Invalid(T result) => new(result, isValid: false);
+
+    public static ConfigurationResult<T>? NotFound() => null;
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetry.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Concurrent;
 using System.Threading;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Configuration.Telemetry;
 
@@ -24,19 +25,19 @@ internal class ConfigurationTelemetry : IConfigurationTelemetry
         Double
     }
 
-    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
         => _entries.Enqueue(
             recordValue
                 ? ConfigurationTelemetryEntry.String(key, value, origin, error)
                 : ConfigurationTelemetryEntry.Redacted(key, origin, error));
 
-    public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, bool value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
         => _entries.Enqueue(ConfigurationTelemetryEntry.Bool(key, value, origin, error));
 
-    public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, double value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
         => _entries.Enqueue(ConfigurationTelemetryEntry.Number(key, value, origin, error));
 
-    public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, int value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
         => _entries.Enqueue(ConfigurationTelemetryEntry.Number(key, value, origin, error));
 
     // TODO: finalize public API
@@ -46,7 +47,7 @@ internal class ConfigurationTelemetry : IConfigurationTelemetry
     public class ConfigurationTelemetryEntry
     {
         // internal for testing
-        private ConfigurationTelemetryEntry(string key, ConfigurationOrigins origin, ConfigurationTelemetryEntryType type, ConfigurationTelemetryErrorCode? error, string? stringValue = null, bool? boolValue = null, int? intValue = null, double? doubleValue = null)
+        private ConfigurationTelemetryEntry(string key, ConfigurationOrigins origin, ConfigurationTelemetryEntryType type, TelemetryErrorCode? error, string? stringValue = null, bool? boolValue = null, int? intValue = null, double? doubleValue = null)
         {
             Key = key;
             Origin = origin;
@@ -63,7 +64,7 @@ internal class ConfigurationTelemetry : IConfigurationTelemetry
 
         public ConfigurationOrigins Origin { get; }
 
-        public ConfigurationTelemetryErrorCode? Error { get; }
+        public TelemetryErrorCode? Error { get; }
 
         public long SeqId { get; }
 
@@ -77,19 +78,19 @@ internal class ConfigurationTelemetry : IConfigurationTelemetry
 
         public double? DoubleValue { get; }
 
-        public static ConfigurationTelemetryEntry String(string key, string? value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+        public static ConfigurationTelemetryEntry String(string key, string? value, ConfigurationOrigins origin, TelemetryErrorCode? error)
             => new(key, origin, ConfigurationTelemetryEntryType.String, error, stringValue: value);
 
-        public static ConfigurationTelemetryEntry Redacted(string key, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+        public static ConfigurationTelemetryEntry Redacted(string key, ConfigurationOrigins origin, TelemetryErrorCode? error)
             => new(key, origin, ConfigurationTelemetryEntryType.Redacted, error, stringValue: null);
 
-        public static ConfigurationTelemetryEntry Bool(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+        public static ConfigurationTelemetryEntry Bool(string key, bool value, ConfigurationOrigins origin, TelemetryErrorCode? error)
             => new(key, origin, ConfigurationTelemetryEntryType.Bool, error, boolValue: value);
 
-        public static ConfigurationTelemetryEntry Number(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+        public static ConfigurationTelemetryEntry Number(string key, int value, ConfigurationOrigins origin, TelemetryErrorCode? error)
             => new(key, origin, ConfigurationTelemetryEntryType.Int, error, intValue: value);
 
-        public static ConfigurationTelemetryEntry Number(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+        public static ConfigurationTelemetryEntry Number(string key, double value, ConfigurationOrigins origin, TelemetryErrorCode? error)
             => new(key, origin, ConfigurationTelemetryEntryType.Double, error, doubleValue: value);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetry.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="ConfigurationTelemetry.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal class ConfigurationTelemetry : IConfigurationTelemetry
+{
+    private static long _seqId;
+    private ConcurrentQueue<ConfigurationTelemetryEntry> _entries = new();
+
+    public enum ConfigurationTelemetryEntryType
+    {
+        String,
+        Redacted,
+        Bool,
+        Int,
+        Double
+    }
+
+    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        => _entries.Enqueue(
+            recordValue
+                ? ConfigurationTelemetryEntry.String(key, value, origin, error)
+                : ConfigurationTelemetryEntry.Redacted(key, origin, error));
+
+    public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        => _entries.Enqueue(ConfigurationTelemetryEntry.Bool(key, value, origin, error));
+
+    public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        => _entries.Enqueue(ConfigurationTelemetryEntry.Number(key, value, origin, error));
+
+    public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        => _entries.Enqueue(ConfigurationTelemetryEntry.Number(key, value, origin, error));
+
+    // TODO: finalize public API
+    public ConcurrentQueue<ConfigurationTelemetryEntry>? GetLatest()
+        => Interlocked.Exchange(ref _entries, new());
+
+    public class ConfigurationTelemetryEntry
+    {
+        // internal for testing
+        private ConfigurationTelemetryEntry(string key, ConfigurationOrigins origin, ConfigurationTelemetryEntryType type, ConfigurationTelemetryErrorCode? error, string? stringValue = null, bool? boolValue = null, int? intValue = null, double? doubleValue = null)
+        {
+            Key = key;
+            Origin = origin;
+            Error = error;
+            StringValue = stringValue;
+            BoolValue = boolValue;
+            IntValue = intValue;
+            DoubleValue = doubleValue;
+            Type = type;
+            SeqId = Interlocked.Increment(ref _seqId);
+        }
+
+        public string Key { get; }
+
+        public ConfigurationOrigins Origin { get; }
+
+        public ConfigurationTelemetryErrorCode? Error { get; }
+
+        public long SeqId { get; }
+
+        public ConfigurationTelemetryEntryType Type { get; }
+
+        public string? StringValue { get; }
+
+        public bool? BoolValue { get; }
+
+        public int? IntValue { get; }
+
+        public double? DoubleValue { get; }
+
+        public static ConfigurationTelemetryEntry String(string key, string? value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+            => new(key, origin, ConfigurationTelemetryEntryType.String, error, stringValue: value);
+
+        public static ConfigurationTelemetryEntry Redacted(string key, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+            => new(key, origin, ConfigurationTelemetryEntryType.Redacted, error, stringValue: null);
+
+        public static ConfigurationTelemetryEntry Bool(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+            => new(key, origin, ConfigurationTelemetryEntryType.Bool, error, boolValue: value);
+
+        public static ConfigurationTelemetryEntry Number(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+            => new(key, origin, ConfigurationTelemetryEntryType.Int, error, intValue: value);
+
+        public static ConfigurationTelemetryEntry Number(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error)
+            => new(key, origin, ConfigurationTelemetryEntryType.Double, error, doubleValue: value);
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetryErrorCode.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationTelemetryErrorCode.cs
@@ -1,0 +1,47 @@
+// <copyright file="ConfigurationTelemetryErrorCode.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.ComponentModel;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal enum ConfigurationTelemetryErrorCode
+{
+    /// <summary>
+    /// No error, should not be used
+    /// </summary>
+    None = 0,
+
+    [Description("Error parsing value as boolean")]
+    ParsingBooleanError = 1,
+
+    [Description("Error parsing value as int32")]
+    ParsingInt32Error = 2,
+
+    [Description("Error parsing value as double")]
+    ParsingDoubleError = 3,
+
+    [Description("Invalid value")]
+    FailedValidation = 4,
+
+    [Description("Error reading value as string from JSON")]
+    JsonStringError = 5,
+
+    [Description("Error reading value as int from JSON")]
+    JsonInt32Error = 6,
+
+    [Description("Error reading value as double from JSON")]
+    JsonDoubleError = 7,
+
+    [Description("Error reading value as boolean from JSON")]
+    JsonBooleanError = 8,
+
+    [Description("Error reading value as dictionary from JSON")]
+    JsonDictionaryError = 9,
+
+    [Description("Error parsing value")]
+    ParsingCustomError = 10,
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
@@ -1,0 +1,175 @@
+﻿// <copyright file="CustomTelemeteredConfigurationSource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Configuration;
+
+internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationSource
+{
+    public CustomTelemeteredConfigurationSource(IConfigurationSource source)
+    {
+        Source = source;
+    }
+
+    public IConfigurationSource Source { get; }
+
+    public ConfigurationResult<string>? GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var result = Source.GetString(key);
+#pragma warning restore DD0002
+        if (result is null)
+        {
+            return null;
+        }
+
+        if (validator is null || validator(result))
+        {
+            telemetry.Record(key, result, recordValue, ConfigurationOrigins.Code);
+            return ConfigurationResult<string>.Valid(result);
+        }
+
+        telemetry.Record(key, result, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        return ConfigurationResult<string>.Invalid(result);
+    }
+
+    public ConfigurationResult<int>? GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var result = Source.GetInt32(key);
+#pragma warning restore DD0002
+        if (result is null)
+        {
+            return null;
+        }
+
+        if (validator is null || validator(result.Value))
+        {
+            telemetry.Record(key, result.Value, ConfigurationOrigins.Code);
+            return ConfigurationResult<int>.Valid(result.Value);
+        }
+
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        return ConfigurationResult<int>.Invalid(result.Value);
+    }
+
+    public ConfigurationResult<double>? GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var result = Source.GetDouble(key);
+#pragma warning restore DD0002
+        if (result is null)
+        {
+            return null;
+        }
+
+        if (validator is null || validator(result.Value))
+        {
+            telemetry.Record(key, result.Value, ConfigurationOrigins.Code);
+            return ConfigurationResult<double>.Valid(result.Value);
+        }
+
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        return ConfigurationResult<double>.Invalid(result.Value);
+    }
+
+    public ConfigurationResult<bool>? GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var result = Source.GetBool(key);
+#pragma warning restore DD0002
+        if (result is null)
+        {
+            return null;
+        }
+
+        if (validator is null || validator(result.Value))
+        {
+            telemetry.Record(key, result.Value, ConfigurationOrigins.Code);
+            return ConfigurationResult<bool>.Valid(result.Value);
+        }
+
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        return ConfigurationResult<bool>.Invalid(result.Value);
+    }
+
+    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+        => GetDictionary(key, telemetry, validator, allowOptionalMappings: false);
+
+    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var result = Source.GetDictionary(key, allowOptionalMappings);
+#pragma warning restore DD0002
+        if (result is null)
+        {
+            return null;
+        }
+
+        // This is horrible. We _could_ call Source.GetString(), but as this is a custom implementation,
+        // there's no reason that has to give back the "raw" dictionary value, so this is probably th best we can do
+        string stringifiedDictionary;
+        if (result.Count > 0)
+        {
+            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+            foreach (var kvp in result)
+            {
+                sb.Append(kvp.Key).Append(':').Append(kvp.Value).Append(',');
+            }
+
+            // Remove trailing comma
+            stringifiedDictionary = sb.ToString(0, length: sb.Length - 1);
+            StringBuilderCache.Release(sb);
+        }
+        else
+        {
+            stringifiedDictionary = string.Empty;
+        }
+
+        if (validator is null || validator(result))
+        {
+            telemetry.Record(key, stringifiedDictionary, recordValue: true, ConfigurationOrigins.Code);
+            return ConfigurationResult<IDictionary<string, string>>.Valid(result);
+        }
+
+        telemetry.Record(key, stringifiedDictionary, recordValue: true, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        return ConfigurationResult<IDictionary<string, string>>.Invalid(result);
+    }
+
+    public ConfigurationResult<T>? GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+    {
+#pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
+        var value = Source.GetString(key);
+#pragma warning restore DD0002
+
+        if (value is null)
+        {
+            return null;
+        }
+
+        var result = converter(value);
+        if (result.IsValid)
+        {
+            if (validator is null || validator(result.Result))
+            {
+                telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code);
+                return ConfigurationResult<T>.Valid(result.Result);
+            }
+
+            telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+            return ConfigurationResult<T>.Invalid(result.Result);
+        }
+
+        telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.ParsingCustomError);
+        return null;
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration;
@@ -38,7 +39,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
             return ConfigurationResult<string>.Valid(result);
         }
 
-        telemetry.Record(key, result, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        telemetry.Record(key, result, recordValue, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
         return ConfigurationResult<string>.Invalid(result);
     }
 
@@ -58,7 +59,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
             return ConfigurationResult<int>.Valid(result.Value);
         }
 
-        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
         return ConfigurationResult<int>.Invalid(result.Value);
     }
 
@@ -78,7 +79,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
             return ConfigurationResult<double>.Valid(result.Value);
         }
 
-        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
         return ConfigurationResult<double>.Invalid(result.Value);
     }
 
@@ -98,7 +99,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
             return ConfigurationResult<bool>.Valid(result.Value);
         }
 
-        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        telemetry.Record(key, result.Value, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
         return ConfigurationResult<bool>.Invalid(result.Value);
     }
 
@@ -141,7 +142,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
             return ConfigurationResult<IDictionary<string, string>>.Valid(result);
         }
 
-        telemetry.Record(key, stringifiedDictionary, recordValue: true, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+        telemetry.Record(key, stringifiedDictionary, recordValue: true, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
         return ConfigurationResult<IDictionary<string, string>>.Invalid(result);
     }
 
@@ -165,11 +166,11 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
                 return ConfigurationResult<T>.Valid(result.Result);
             }
 
-            telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.FailedValidation);
+            telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, TelemetryErrorCode.FailedValidation);
             return ConfigurationResult<T>.Invalid(result.Result);
         }
 
-        telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, ConfigurationTelemetryErrorCode.ParsingCustomError);
+        telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, TelemetryErrorCode.ParsingCustomError);
         return null;
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
@@ -6,16 +6,17 @@
 #nullable enable
 
 using System.Diagnostics.CodeAnalysis;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Configuration.Telemetry;
 
 internal interface IConfigurationTelemetry
 {
-    void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+    void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, TelemetryErrorCode? error = null);
 
-    void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+    void Record(string key, bool value, ConfigurationOrigins origin, TelemetryErrorCode? error = null);
 
-    void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+    void Record(string key, double value, ConfigurationOrigins origin, TelemetryErrorCode? error = null);
 
-    void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+    void Record(string key, int value, ConfigurationOrigins origin, TelemetryErrorCode? error = null);
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationTelemetry.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="IConfigurationTelemetry.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal interface IConfigurationTelemetry
+{
+    void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+
+    void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+
+    void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+
+    void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null);
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ITelemeteredConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ITelemeteredConfigurationSource.cs
@@ -1,0 +1,109 @@
+﻿// <copyright file="ITelemeteredConfigurationSource.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+/// <summary>
+/// A version of <see cref="IConfigurationSource"/> that also allows reports the source of the telemetry
+/// when a value is retrieved using a key.
+/// </summary>
+internal interface ITelemeteredConfigurationSource
+{
+    /// <summary>
+    /// Gets the <see cref="string"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <param name="recordValue">If <c>true</c> the value should be recorded in telemetry. If not, the source value should be redacted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<string>? GetString(
+        string key,
+        IConfigurationTelemetry telemetry,
+        Func<string, bool>? validator,
+        bool recordValue);
+
+    /// <summary>
+    /// Gets the <see cref="int"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<int>? GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator);
+
+    /// <summary>
+    /// Gets the <see cref="double"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<double>? GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator);
+
+    /// <summary>
+    /// Gets the <see cref="bool"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<bool>? GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator);
+
+    /// <summary>
+    /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator);
+
+    /// <summary>
+    /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings);
+
+    /// <summary>
+    /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
+    /// the setting with the specified key.
+    /// </summary>
+    /// <param name="key">The key that identifies the setting.</param>
+    /// <param name="telemetry">The context for recording telemetry.</param>
+    /// <param name="converter">A converter that parses the "raw" string configuration value into the expected value.</param>
+    /// <param name="validator">An optional validation function that must be applied to
+    /// a successfully extracted value to determine if it should be accepted</param>
+    /// <param name="recordValue">If <c>true</c> the value should be recorded in telemetry. If not, the source value should be redacted</param>
+    /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+    ConfigurationResult<T>? GetAs<T>(
+        string key,
+        IConfigurationTelemetry telemetry,
+        Func<string, ParsingResult<T>> converter,
+        Func<T, bool>? validator,
+        bool recordValue);
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="NullConfigurationTelemetry.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Configuration.Telemetry;
+
+internal class NullConfigurationTelemetry : IConfigurationTelemetry
+{
+    public static readonly NullConfigurationTelemetry Instance = new();
+
+    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    {
+    }
+
+    public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    {
+    }
+
+    public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    {
+    }
+
+    public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    {
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/NullConfigurationTelemetry.cs
@@ -5,25 +5,27 @@
 
 #nullable enable
 
+using Datadog.Trace.Telemetry;
+
 namespace Datadog.Trace.Configuration.Telemetry;
 
 internal class NullConfigurationTelemetry : IConfigurationTelemetry
 {
     public static readonly NullConfigurationTelemetry Instance = new();
 
-    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, string? value, bool recordValue, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
     {
     }
 
-    public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, bool value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
     {
     }
 
-    public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, double value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
     {
     }
 
-    public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+    public void Record(string key, int value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
     {
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ParsingResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ParsingResult.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="ParsingResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal readonly record struct ParsingResult<T>
+{
+    private ParsingResult(T result, bool isValid)
+    {
+        Result = result;
+        IsValid = isValid;
+    }
+
+    /// <summary>
+    /// Gets the extracted configuration value, if parsing was successful
+    /// </summary>
+    public T Result { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether parsing was successful, and so whether <see cref="Result"/> contains a valid value
+    /// </summary>
+    public bool IsValid { get; }
+
+    public static ParsingResult<T> Success(T result) => new(result, isValid: true);
+
+    public static ParsingResult<T> Failure() => new(default, isValid: false);
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ParsingResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ParsingResult.cs
@@ -23,6 +23,8 @@ internal readonly record struct ParsingResult<T>
     /// </summary>
     public bool IsValid { get; }
 
+    public static implicit operator ParsingResult<T>(T result) => Success(result);
+
     public static ParsingResult<T> Success(T result) => new(result, isValid: true);
 
     public static ParsingResult<T> Failure() => new(default, isValid: false);

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -101,38 +101,34 @@ namespace Datadog.Trace.Configuration
 
             // Get values from the config
             var config = new ConfigurationBuilder(source, telemetry);
-            var traceAgentUrl = config.WithKeys(ConfigurationKeys.AgentUri).AsString().Get();
-            var tracesPipeName = config.WithKeys(ConfigurationKeys.TracesPipeName).AsString().Get();
-            var tracesUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.TracesUnixDomainSocketPath).AsString().Get();
+            var traceAgentUrl = config.WithKeys(ConfigurationKeys.AgentUri).AsString();
+            var tracesPipeName = config.WithKeys(ConfigurationKeys.TracesPipeName).AsString();
+            var tracesUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.TracesUnixDomainSocketPath).AsString();
 
             var agentHost = config
                            .WithKeys(ConfigurationKeys.AgentHost, "DD_TRACE_AGENT_HOSTNAME", "DATADOG_TRACE_AGENT_HOSTNAME")
-                           .AsString()
-                           .Get();
+                           .AsString();
 
             var agentPort = config
                            .WithKeys(ConfigurationKeys.AgentPort, "DATADOG_TRACE_AGENT_PORT")
-                           .AsInt32()
-                           .Get();
+                           .AsInt32();
 
-            var dogStatsdPort = config.WithKeys(ConfigurationKeys.DogStatsdPort).AsInt32().Get(0);
-            var metricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString().Get();
-            var metricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString().Get();
+            var dogStatsdPort = config.WithKeys(ConfigurationKeys.DogStatsdPort).AsInt32(0);
+            var metricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString();
+            var metricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString();
 
             ConfigureTraceTransport(traceAgentUrl, tracesPipeName, agentHost, agentPort, tracesUnixDomainSocketPath);
             ConfigureMetricsTransport(traceAgentUrl, agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
 
             TracesPipeTimeoutMs = config
                                  .WithKeys(ConfigurationKeys.TracesPipeTimeoutMs)
-                                 .AsInt32()
-                                 .Get(500, value => value > 0)
+                                 .AsInt32(500, value => value > 0)
                                  .Value;
 
-            PartialFlushEnabled = config.WithKeys(ConfigurationKeys.PartialFlushEnabled).AsBool().Get(false);
+            PartialFlushEnabled = config.WithKeys(ConfigurationKeys.PartialFlushEnabled).AsBool(false);
             PartialFlushMinSpans = config
                                   .WithKeys(ConfigurationKeys.PartialFlushMinSpans)
-                                  .AsInt32()
-                                  .Get(500, value => value > 0).Value;
+                                  .AsInt32(500, value => value > 0).Value;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -10,6 +10,9 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
 using MetricsTransportType = Datadog.Trace.Vendors.StatsdClient.Transport.TransportType;
 
 namespace Datadog.Trace.Configuration
@@ -23,6 +26,7 @@ namespace Datadog.Trace.Configuration
         /// Allows overriding of file system access for tests.
         /// </summary>
         private readonly Func<string, bool> _fileExists;
+        private readonly IConfigurationTelemetry _telemetry;
 
         private int _partialFlushMinSpans;
         private Uri _agentUri;
@@ -60,8 +64,9 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Initializes a new instance of the <see cref="ExporterSettings"/> class with default values.
         /// </summary>
+        [PublicApi]
         public ExporterSettings()
-            : this(null)
+            : this(null, TelemetryFactoryV2.GetConfigTelemetry())
         {
         }
 
@@ -70,8 +75,14 @@ namespace Datadog.Trace.Configuration
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
+        [PublicApi]
         public ExporterSettings(IConfigurationSource? source)
-            : this(source, File.Exists)
+            : this(source, File.Exists, TelemetryFactoryV2.GetConfigTelemetry())
+        {
+        }
+
+        internal ExporterSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
+            : this(source, File.Exists, telemetry)
         {
         }
 
@@ -79,40 +90,49 @@ namespace Datadog.Trace.Configuration
         /// Initializes a new instance of the <see cref="ExporterSettings"/> class.
         /// Direct use in tests only.
         /// </summary>
-        internal ExporterSettings(IConfigurationSource? source, Func<string, bool> fileExists)
+        internal ExporterSettings(IConfigurationSource? source, Func<string, bool> fileExists, IConfigurationTelemetry telemetry)
         {
             _fileExists = fileExists;
+            _telemetry = telemetry;
 
             ValidationWarnings = new List<string>();
 
             source ??= NullConfigurationSource.Instance;
 
             // Get values from the config
-            var traceAgentUrl = source.GetString(ConfigurationKeys.AgentUri);
-            var tracesPipeName = source.GetString(ConfigurationKeys.TracesPipeName);
-            var tracesUnixDomainSocketPath = source.GetString(ConfigurationKeys.TracesUnixDomainSocketPath);
+            var config = new ConfigurationBuilder(source, telemetry);
+            var traceAgentUrl = config.WithKeys(ConfigurationKeys.AgentUri).AsString().Get();
+            var tracesPipeName = config.WithKeys(ConfigurationKeys.TracesPipeName).AsString().Get();
+            var tracesUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.TracesUnixDomainSocketPath).AsString().Get();
 
-            var tracesPipeTimeoutMs = source.GetInt32(ConfigurationKeys.TracesPipeTimeoutMs) ?? 0;
-            var agentHost = source.GetString(ConfigurationKeys.AgentHost) ??
-                        // backwards compatibility for names used in the past
-                        source.GetString("DD_TRACE_AGENT_HOSTNAME") ??
-                        source.GetString("DATADOG_TRACE_AGENT_HOSTNAME");
+            var agentHost = config
+                           .WithKeys(ConfigurationKeys.AgentHost, "DD_TRACE_AGENT_HOSTNAME", "DATADOG_TRACE_AGENT_HOSTNAME")
+                           .AsString()
+                           .Get();
 
-            var agentPort = source.GetInt32(ConfigurationKeys.AgentPort) ??
-                        // backwards compatibility for names used in the past
-                        source.GetInt32("DATADOG_TRACE_AGENT_PORT");
+            var agentPort = config
+                           .WithKeys(ConfigurationKeys.AgentPort, "DATADOG_TRACE_AGENT_PORT")
+                           .AsInt32()
+                           .Get();
 
-            var dogStatsdPort = source.GetInt32(ConfigurationKeys.DogStatsdPort) ?? 0;
-            var metricsPipeName = source.GetString(ConfigurationKeys.MetricsPipeName);
-            var metricsUnixDomainSocketPath = source.GetString(ConfigurationKeys.MetricsUnixDomainSocketPath);
-            var partialFlushMinSpans = source.GetInt32(ConfigurationKeys.PartialFlushMinSpans);
+            var dogStatsdPort = config.WithKeys(ConfigurationKeys.DogStatsdPort).AsInt32().Get(0);
+            var metricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString().Get();
+            var metricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString().Get();
 
             ConfigureTraceTransport(traceAgentUrl, tracesPipeName, agentHost, agentPort, tracesUnixDomainSocketPath);
             ConfigureMetricsTransport(traceAgentUrl, agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
 
-            TracesPipeTimeoutMs = tracesPipeTimeoutMs > 0 ? tracesPipeTimeoutMs : 500;
-            PartialFlushEnabled = source.GetBool(ConfigurationKeys.PartialFlushEnabled) ?? false;
-            PartialFlushMinSpans = partialFlushMinSpans > 0 ? partialFlushMinSpans.Value : 500;
+            TracesPipeTimeoutMs = config
+                                 .WithKeys(ConfigurationKeys.TracesPipeTimeoutMs)
+                                 .AsInt32()
+                                 .Get(500, value => value > 0)
+                                 .Value;
+
+            PartialFlushEnabled = config.WithKeys(ConfigurationKeys.PartialFlushEnabled).AsBool().Get(false);
+            PartialFlushMinSpans = config
+                                  .WithKeys(ConfigurationKeys.PartialFlushMinSpans)
+                                  .AsInt32()
+                                  .Get(500, value => value > 0).Value;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -28,13 +28,11 @@ namespace Datadog.Trace.Configuration
         {
             DebugEnabled = new ConfigurationBuilder(source, telemetry)
                           .WithKeys(ConfigurationKeys.DebugEnabled)
-                          .AsBool()
-                          .Get(false);
+                          .AsBool(false);
 
             DiagnosticSourceEnabled = new ConfigurationBuilder(source, telemetry)
                                      .WithKeys(ConfigurationKeys.DiagnosticSourceEnabled)
-                                     .AsBool()
-                                     .Get(true);
+                                     .AsBool(true);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -6,7 +6,7 @@
 #nullable enable
 
 using System;
-using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
 
@@ -26,22 +26,17 @@ namespace Datadog.Trace.Configuration
         public static readonly string DefaultHttpClientExclusions = "logs.datadoghq, services.visualstudio, applicationinsights.azure, blob.core.windows.net/azure-webjobs, azurewebsites.net/admin, /azure-webjobs-hosts/".ToUpperInvariant();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ImmutableAzureAppServiceSettings"/> class with default values.
-        /// </summary>
-        public ImmutableAzureAppServiceSettings()
-            : this(null)
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableAzureAppServiceSettings"/> class
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
-        public ImmutableAzureAppServiceSettings(IConfigurationSource? source)
+        /// <param name="telemetry"><see cref="IConfigurationTelemetry"/> instance for recording telemetry</param>
+        public ImmutableAzureAppServiceSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
         {
             source ??= NullConfigurationSource.Instance;
-            var apiKey = source.GetString(Configuration.ConfigurationKeys.ApiKey);
+            // TODO: This is retrieved from other places too... need to work out how to not replace config
+            var config = new ConfigurationBuilder(source, telemetry);
+            var apiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString().Get();
             if (string.IsNullOrEmpty(apiKey))
             {
                 Log.Error("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
@@ -49,18 +44,18 @@ namespace Datadog.Trace.Configuration
             }
 
             // Azure App Services Basis
-            SubscriptionId = GetSubscriptionId(source);
-            ResourceGroup = source.GetString(ConfigurationKeys.AzureAppService.ResourceGroupKey);
-            SiteName = source.GetString(ConfigurationKeys.AzureAppService.SiteNameKey);
+            SubscriptionId = GetSubscriptionId(source, telemetry);
+            ResourceGroup = config.WithKeys(ConfigurationKeys.AzureAppService.ResourceGroupKey).AsString().Get();
+            SiteName = config.WithKeys(ConfigurationKeys.AzureAppService.SiteNameKey).AsString().Get();
             ResourceId = CompileResourceId();
 
-            InstanceId = source.GetString(ConfigurationKeys.AzureAppService.InstanceIdKey) ?? "unknown";
-            InstanceName = source.GetString(ConfigurationKeys.AzureAppService.InstanceNameKey) ?? "unknown";
-            OperatingSystem = source.GetString(ConfigurationKeys.AzureAppService.OperatingSystemKey) ?? "unknown";
-            SiteExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey) ?? "unknown";
+            InstanceId = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceIdKey).AsString().Get("unknown");
+            InstanceName = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceNameKey).AsString().Get("unknown");
+            OperatingSystem = config.WithKeys(ConfigurationKeys.AzureAppService.OperatingSystemKey).AsString().Get("unknown");
+            SiteExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey).AsString().Get("unknown");
 
-            FunctionsWorkerRuntime = source.GetString(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey);
-            FunctionsExtensionVersion = source.GetString(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey);
+            FunctionsWorkerRuntime = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey).AsString().Get();
+            FunctionsExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey).AsString().Get();
 
             if (FunctionsWorkerRuntime is not null || FunctionsExtensionVersion is not null)
             {
@@ -89,9 +84,9 @@ namespace Datadog.Trace.Configuration
 
             Runtime = FrameworkDescription.Instance.Name;
 
-            DebugModeEnabled = source.GetString(Configuration.ConfigurationKeys.DebugEnabled)?.ToBoolean() ?? false;
-            CustomTracingEnabled = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomTracing)?.ToBoolean() ?? false;
-            NeedsDogStatsD = source.GetString(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics)?.ToBoolean() ?? false;
+            DebugModeEnabled = config.WithKeys(Configuration.ConfigurationKeys.DebugEnabled).AsBool().Get(false);
+            CustomTracingEnabled = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomTracing).AsBool().Get(false);
+            NeedsDogStatsD = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics).AsBool().Get(false);
         }
 
         public bool DebugModeEnabled { get; }
@@ -171,9 +166,13 @@ namespace Datadog.Trace.Configuration
             return resourceId;
         }
 
-        private string? GetSubscriptionId(IConfigurationSource source)
+        private string? GetSubscriptionId(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {
-            var websiteOwner = source.GetString(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey);
+            var websiteOwner = new ConfigurationBuilder(source, telemetry)
+                              .WithKeys(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey)
+                              .AsString()
+                              .Get(websiteOwner => websiteOwner.IndexOf('+') > 0);
+
             if (!string.IsNullOrWhiteSpace(websiteOwner))
             {
                 var plusSplit = websiteOwner!.Split('+');

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.Configuration
         {
             var websiteOwner = new ConfigurationBuilder(source, telemetry)
                               .WithKeys(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey)
-                              .AsString(websiteOwner => websiteOwner.IndexOf('+') > 0);
+                              .AsString(websiteOwner => !string.IsNullOrWhiteSpace(websiteOwner));
 
             if (!string.IsNullOrWhiteSpace(websiteOwner))
             {

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Configuration
             source ??= NullConfigurationSource.Instance;
             // TODO: This is retrieved from other places too... need to work out how to not replace config
             var config = new ConfigurationBuilder(source, telemetry);
-            var apiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString().Get();
+            var apiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
             if (string.IsNullOrEmpty(apiKey))
             {
                 Log.Error("The Azure Site Extension will not work if you have not configured DD_API_KEY.");
@@ -45,17 +45,17 @@ namespace Datadog.Trace.Configuration
 
             // Azure App Services Basis
             SubscriptionId = GetSubscriptionId(source, telemetry);
-            ResourceGroup = config.WithKeys(ConfigurationKeys.AzureAppService.ResourceGroupKey).AsString().Get();
-            SiteName = config.WithKeys(ConfigurationKeys.AzureAppService.SiteNameKey).AsString().Get();
+            ResourceGroup = config.WithKeys(ConfigurationKeys.AzureAppService.ResourceGroupKey).AsString();
+            SiteName = config.WithKeys(ConfigurationKeys.AzureAppService.SiteNameKey).AsString();
             ResourceId = CompileResourceId();
 
-            InstanceId = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceIdKey).AsString().Get("unknown");
-            InstanceName = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceNameKey).AsString().Get("unknown");
-            OperatingSystem = config.WithKeys(ConfigurationKeys.AzureAppService.OperatingSystemKey).AsString().Get("unknown");
-            SiteExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey).AsString().Get("unknown");
+            InstanceId = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceIdKey).AsString("unknown");
+            InstanceName = config.WithKeys(ConfigurationKeys.AzureAppService.InstanceNameKey).AsString("unknown");
+            OperatingSystem = config.WithKeys(ConfigurationKeys.AzureAppService.OperatingSystemKey).AsString("unknown");
+            SiteExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.SiteExtensionVersionKey).AsString("unknown");
 
-            FunctionsWorkerRuntime = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey).AsString().Get();
-            FunctionsExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey).AsString().Get();
+            FunctionsWorkerRuntime = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey).AsString();
+            FunctionsExtensionVersion = config.WithKeys(ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey).AsString();
 
             if (FunctionsWorkerRuntime is not null || FunctionsExtensionVersion is not null)
             {
@@ -84,9 +84,9 @@ namespace Datadog.Trace.Configuration
 
             Runtime = FrameworkDescription.Instance.Name;
 
-            DebugModeEnabled = config.WithKeys(Configuration.ConfigurationKeys.DebugEnabled).AsBool().Get(false);
-            CustomTracingEnabled = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomTracing).AsBool().Get(false);
-            NeedsDogStatsD = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics).AsBool().Get(false);
+            DebugModeEnabled = config.WithKeys(Configuration.ConfigurationKeys.DebugEnabled).AsBool(false);
+            CustomTracingEnabled = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomTracing).AsBool(false);
+            NeedsDogStatsD = config.WithKeys(ConfigurationKeys.AzureAppService.AasEnableCustomMetrics).AsBool(false);
         }
 
         public bool DebugModeEnabled { get; }
@@ -170,8 +170,7 @@ namespace Datadog.Trace.Configuration
         {
             var websiteOwner = new ConfigurationBuilder(source, telemetry)
                               .WithKeys(ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey)
-                              .AsString()
-                              .Get(websiteOwner => websiteOwner.IndexOf('+') > 0);
+                              .AsString(websiteOwner => websiteOwner.IndexOf('+') > 0);
 
             if (!string.IsNullOrWhiteSpace(websiteOwner))
             {

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Agent;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Configuration
 {
@@ -21,8 +23,9 @@ namespace Datadog.Trace.Configuration
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
+        [PublicApi]
         public ImmutableExporterSettings(IConfigurationSource source)
-            : this(new ExporterSettings(source))
+            : this(new ExporterSettings(source, TelemetryFactoryV2.GetConfigTelemetry()))
         {
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration.Schema;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Util;
@@ -140,6 +141,7 @@ namespace Datadog.Trace.Configuration
             }
 
             DbmPropagationMode = settings.DbmPropagationMode;
+            Telemetry = settings.Telemetry;
         }
 
         /// <summary>
@@ -456,6 +458,8 @@ namespace Datadog.Trace.Configuration
         /// Gets the metadata schema version
         /// </summary>
         internal SchemaVersion MetadataSchemaVersion { get; }
+
+        internal IConfigurationTelemetry Telemetry { get; }
 
         /// <summary>
         /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -6,6 +6,9 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -20,7 +23,13 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="integrationName">The integration name.</param>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
+        [PublicApi]
         public IntegrationSettings(string integrationName, IConfigurationSource? source)
+            : this(integrationName, source, TelemetryFactoryV2.GetConfigTelemetry())
+        {
+        }
+
+        internal IntegrationSettings(string integrationName, IConfigurationSource? source, IConfigurationTelemetry telemetry)
         {
             if (integrationName is null)
             {
@@ -34,17 +43,28 @@ namespace Datadog.Trace.Configuration
                 return;
             }
 
-            Enabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.Enabled, integrationName)) ??
-                      source.GetBool(string.Format("DD_{0}_ENABLED", integrationName));
+            var config = new ConfigurationBuilder(source, telemetry);
+            Enabled = config
+                     .WithKeys(
+                          string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),
+                          string.Format("DD_{0}_ENABLED", integrationName))
+                     .AsBool()
+                     .Get();
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
-            AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName)) ??
-                               source.GetBool(string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName));
+            AnalyticsEnabled = config
+                              .WithKeys(
+                                   string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName),
+                                   string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName))
+                              .AsBool()
+                              .Get();
 
-            AnalyticsSampleRate = source.GetDouble(string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName)) ??
-                                  source.GetDouble(string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName)) ??
-                                  // default value
-                                  1.0;
+            AnalyticsSampleRate = config
+                                 .WithKeys(
+                                      string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName),
+                                      string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName))
+                                 .AsDouble()
+                                 .Get(1.0);
 #pragma warning restore 618
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -48,23 +48,20 @@ namespace Datadog.Trace.Configuration
                      .WithKeys(
                           string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),
                           string.Format("DD_{0}_ENABLED", integrationName))
-                     .AsBool()
-                     .Get();
+                     .AsBool();
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabled = config
                               .WithKeys(
                                    string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName),
                                    string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName))
-                              .AsBool()
-                              .Get();
+                              .AsBool();
 
             AnalyticsSampleRate = config
                                  .WithKeys(
                                       string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName),
                                       string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName))
-                                 .AsDouble()
-                                 .Get(1.0);
+                                 .AsDouble(1.0);
 #pragma warning restore 618
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -159,8 +159,8 @@ namespace Datadog.Trace.Configuration
                                         () => SchemaVersion.V0,
                                         converter: x => x switch
                                         {
-                                            "v1" or "V1" => ParsingResult<SchemaVersion>.Success(SchemaVersion.V1),
-                                            "v0" or "V0" => ParsingResult<SchemaVersion>.Success(SchemaVersion.V0),
+                                            "v1" or "V1" => SchemaVersion.V1,
+                                            "v0" or "V0" => SchemaVersion.V0,
                                             _ => ParsingResult<SchemaVersion>.Failure(),
                                         },
                                         validator: null);
@@ -380,9 +380,7 @@ namespace Datadog.Trace.Configuration
                                 .AsString()
                                 .GetAs(
                                      () => DbmPropagationLevel.Disabled,
-                                     converter: x => ToDbmPropagationInput(x) is { } mode
-                                                         ? ParsingResult<DbmPropagationLevel>.Success(mode)
-                                                         : ParsingResult<DbmPropagationLevel>.Failure(),
+                                     converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 
             TraceId128BitGenerationEnabled = config

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -11,10 +11,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Schema;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.Configuration
@@ -55,30 +58,55 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         public TracerSettings(IConfigurationSource? source)
+        : this(source, TelemetryFactoryV2.GetConfigTelemetry())
+        {
+        }
+
+        internal TracerSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
         {
             var commaSeparator = new[] { ',' };
             source ??= NullConfigurationSource.Instance;
+            Telemetry = telemetry;
+            var config = new ConfigurationBuilder(source, Telemetry);
 
-            Environment = source.GetString(ConfigurationKeys.Environment);
+            Environment = config
+                         .WithKeys(ConfigurationKeys.Environment)
+                         .AsString()
+                         .Get();
 
-            ServiceName = source.GetString(ConfigurationKeys.ServiceName) ??
-                          // backwards compatibility for names used in the past
-                          source.GetString("DD_SERVICE_NAME");
+            ServiceName = config
+                         .WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
+                         .AsString()
+                         .Get();
 
-            ServiceVersion = source.GetString(ConfigurationKeys.ServiceVersion);
+            ServiceVersion = config
+                            .WithKeys(ConfigurationKeys.ServiceVersion)
+                            .AsString()
+                            .Get();
 
-            GitCommitSha = source.GetString(ConfigurationKeys.GitCommitSha);
+            GitCommitSha = config
+                          .WithKeys(ConfigurationKeys.GitCommitSha)
+                          .AsString()
+                          .Get();
 
-            GitRepositoryUrl = source.GetString(ConfigurationKeys.GitRepositoryUrl);
+            GitRepositoryUrl = config
+                              .WithKeys(ConfigurationKeys.GitRepositoryUrl)
+                              .AsString()
+                              .Get();
 
-            GitMetadataEnabled = source.GetBool(ConfigurationKeys.GitMetadataEnabled) ?? true;
+            GitMetadataEnabled = config
+                                .WithKeys(ConfigurationKeys.GitMetadataEnabled)
+                                .AsBool()
+                                .Get(defaultValue: true);
 
-            TraceEnabled = source.GetBool(ConfigurationKeys.TraceEnabled) ??
-                           // default value
-                           true;
+            TraceEnabled = config
+                          .WithKeys(ConfigurationKeys.TraceEnabled)
+                          .AsBool()
+                          .Get(defaultValue: true);
 
-            var disabledIntegrationNames = source.GetString(ConfigurationKeys.DisabledIntegrations)
-                                                 ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
+            var disabledIntegrationNames = config.WithKeys(ConfigurationKeys.DisabledIntegrations)
+                                                               .AsString().Get()
+                                                              ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
                                            Enumerable.Empty<string>();
 
             DisabledIntegrationNames = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
@@ -88,138 +116,182 @@ namespace Datadog.Trace.Configuration
             Exporter = new ExporterSettings(source);
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
-            AnalyticsEnabled = source.GetBool(ConfigurationKeys.GlobalAnalyticsEnabled) ??
-                               // default value
-                               false;
+            AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled).AsBool()
+                                                   .Get(defaultValue: false);
 #pragma warning restore 618
 
-            MaxTracesSubmittedPerSecond = source.GetInt32(ConfigurationKeys.TraceRateLimit) ??
 #pragma warning disable 618 // this parameter has been replaced but may still be used
-                                          source.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
+            MaxTracesSubmittedPerSecond = config
+                                         .WithKeys(ConfigurationKeys.TraceRateLimit, ConfigurationKeys.MaxTracesSubmittedPerSecond)
 #pragma warning restore 618
-                                          // default value
-                                          100;
+                                         .AsInt32()
+                                         .Get(defaultValue: 100);
 
-            GlobalTags = source.GetDictionary(ConfigurationKeys.GlobalTags) ??
+            GlobalTags = config
                          // backwards compatibility for names used in the past
-                         source.GetDictionary("DD_TRACE_GLOBAL_TAGS") ??
+                        .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
+                        .AsDictionary()
+                        .Get()
+                         // Filter out tags with empty keys or empty values, and trim whitespace
+                       ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                        .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
                          // default value (empty)
-                         new ConcurrentDictionary<string, string>();
+                      ?? (IDictionary<string, string>)new ConcurrentDictionary<string, string>();
 
-            // Filter out tags with empty keys or empty values, and trim whitespace
-            GlobalTags = GlobalTags.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
-                                   .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
-
-            var inputHeaderTags = source.GetDictionary(ConfigurationKeys.HeaderTags, allowOptionalMappings: true) ??
+            var inputHeaderTags = config
+                                 .WithKeys(ConfigurationKeys.HeaderTags)
+                                 .AsDictionary()
+                                 .Get(allowOptionalMappings: true) ??
                                   // default value (empty)
                                   new Dictionary<string, string>();
 
-            var headerTagsNormalizationFixEnabled = source.GetBool(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled) ?? true;
+            var headerTagsNormalizationFixEnabled = config
+                                                   .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
+                                                   .AsBool()
+                                                   .Get(defaultValue: true);
+
             // Filter out tags with empty keys or empty values, and trim whitespaces
             HeaderTags = InitializeHeaderTags(inputHeaderTags, headerTagsNormalizationFixEnabled);
-            MetadataSchemaVersion = ParseMetadataSchemaVersion(source.GetString(ConfigurationKeys.MetadataSchemaVersion));
+            MetadataSchemaVersion = config
+                                   .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
+                                   .AsString()
+                                   .GetAs(
+                                        () => SchemaVersion.V0,
+                                        converter: x => x switch
+                                        {
+                                            "v1" or "V1" => ParsingResult<SchemaVersion>.Success(SchemaVersion.V1),
+                                            "v0" or "V0" => ParsingResult<SchemaVersion>.Success(SchemaVersion.V0),
+                                            _ => ParsingResult<SchemaVersion>.Failure(),
+                                        },
+                                        validator: null);
 
-            ServiceNameMappings = source.GetDictionary(ConfigurationKeys.ServiceNameMappings)
-                                            ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
-                                            ?.ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
+            ServiceNameMappings = config
+                                     .WithKeys(ConfigurationKeys.ServiceNameMappings)
+                                     .AsDictionary()
+                                     .Get()
+                                    ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                                    .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
-            TracerMetricsEnabled = source.GetBool(ConfigurationKeys.TracerMetricsEnabled) ??
-                                   // default value
-                                   false;
+            TracerMetricsEnabled = config
+                                  .WithKeys(ConfigurationKeys.TracerMetricsEnabled)
+                                  .AsBool()
+                                  .Get(defaultValue: false);
 
-            StatsComputationEnabled = source.GetBool(ConfigurationKeys.StatsComputationEnabled) ?? false;
+            StatsComputationEnabled = config
+                                     .WithKeys(ConfigurationKeys.StatsComputationEnabled)
+                                     .AsBool()
+                                     .Get(defaultValue: false);
 
-            StatsComputationInterval = source.GetInt32(ConfigurationKeys.StatsComputationInterval) ?? 10;
+            StatsComputationInterval = config.WithKeys(ConfigurationKeys.StatsComputationInterval).AsInt32().Get(defaultValue: 10);
 
-            RuntimeMetricsEnabled = source.GetBool(ConfigurationKeys.RuntimeMetricsEnabled) ??
-                                    false;
+            RuntimeMetricsEnabled = config.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool().Get(defaultValue: false);
 
-            CustomSamplingRules = source.GetString(ConfigurationKeys.CustomSamplingRules);
+            CustomSamplingRules = config.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString().Get();
 
-            SpanSamplingRules = source.GetString(ConfigurationKeys.SpanSamplingRules);
+            SpanSamplingRules = config.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString().Get();
 
-            GlobalSamplingRate = source.GetDouble(ConfigurationKeys.GlobalSamplingRate);
+            GlobalSamplingRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble().Get();
 
-            StartupDiagnosticLogEnabled = source.GetBool(ConfigurationKeys.StartupDiagnosticLogEnabled) ??
-                                          // default value
-                                          true;
+            StartupDiagnosticLogEnabled = config.WithKeys(ConfigurationKeys.StartupDiagnosticLogEnabled).AsBool().Get(defaultValue: true);
 
-            var httpServerErrorStatusCodes = source.GetString(ConfigurationKeys.HttpServerErrorStatusCodes) ??
-                                             // Default value
-                                             "500-599";
+            var httpServerErrorStatusCodes = config
+                                            .WithKeys(ConfigurationKeys.HttpServerErrorStatusCodes)
+                                            .AsString()
+                                            .Get(defaultValue: "500-599");
 
             HttpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodes);
 
-            var httpClientErrorStatusCodes = source.GetString(ConfigurationKeys.HttpClientErrorStatusCodes) ??
-                                             // Default value
-                                             "400-499";
+            var httpClientErrorStatusCodes = config
+                                            .WithKeys(ConfigurationKeys.HttpClientErrorStatusCodes)
+                                            .AsString()
+                                            .Get(defaultValue: "400-499");
+
             HttpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodes);
 
-            TraceBufferSize = source.GetInt32(ConfigurationKeys.BufferSize)
-                           ?? 1024 * 1024 * 10; // 10MB
+            TraceBufferSize = config
+                             .WithKeys(ConfigurationKeys.BufferSize)
+                             .AsInt32()
+                             .Get(defaultValue: 1024 * 1024 * 10); // 10MB
 
-            TraceBatchInterval = source.GetInt32(ConfigurationKeys.SerializationBatchInterval)
-                              ?? 100;
+            TraceBatchInterval = config
+                                .WithKeys(ConfigurationKeys.SerializationBatchInterval)
+                                .AsInt32()
+                                .Get(defaultValue: 100);
 
-            RouteTemplateResourceNamesEnabled = source.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
-                                             ?? true;
+            RouteTemplateResourceNamesEnabled = config
+                                               .WithKeys(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
+                                               .AsBool()
+                                               .Get(defaultValue: true);
 
-            ExpandRouteTemplatesEnabled = source.GetBool(ConfigurationKeys.ExpandRouteTemplatesEnabled)
-                                          // disabled by default if route template resource names enabled
-                                       ?? !RouteTemplateResourceNamesEnabled;
+            ExpandRouteTemplatesEnabled = config
+                                         .WithKeys(ConfigurationKeys.ExpandRouteTemplatesEnabled)
+                                         .AsBool()
+                                         .Get(defaultValue: !RouteTemplateResourceNamesEnabled); // disabled by default if route template resource names enabled
 
-            KafkaCreateConsumerScopeEnabled = source.GetBool(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
-                                           ?? true; // default
+            KafkaCreateConsumerScopeEnabled = config
+                                             .WithKeys(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
+                                             .AsBool()
+                                             .Get(defaultValue: true);
 
-            DelayWcfInstrumentationEnabled = source.GetBool(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
-                                          ?? false;
+            DelayWcfInstrumentationEnabled = config
+                                            .WithKeys(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
+                                            .AsBool()
+                                            .Get(defaultValue: false);
 
-            WcfObfuscationEnabled = source.GetBool(ConfigurationKeys.FeatureFlags.WcfObfuscationEnabled)
-                                 ?? true; // default value
+            WcfObfuscationEnabled = config
+                                   .WithKeys(ConfigurationKeys.FeatureFlags.WcfObfuscationEnabled)
+                                   .AsBool()
+                                   .Get(defaultValue: true);
 
-            ObfuscationQueryStringRegex = source.GetString(ConfigurationKeys.ObfuscationQueryStringRegex) ?? DefaultObfuscationQueryStringRegex;
+            ObfuscationQueryStringRegex = config
+                                         .WithKeys(ConfigurationKeys.ObfuscationQueryStringRegex)
+                                         .AsString()
+                                         .Get(defaultValue: DefaultObfuscationQueryStringRegex);
 
-            QueryStringReportingEnabled = source.GetBool(ConfigurationKeys.QueryStringReportingEnabled) ?? true;
+            QueryStringReportingEnabled = config
+                                         .WithKeys(ConfigurationKeys.QueryStringReportingEnabled)
+                                         .AsBool()
+                                         .Get(defaultValue: true);
 
-            QueryStringReportingSize = source.GetInt32(ConfigurationKeys.QueryStringReportingSize) ?? 5000; // 5000 being the tag value length limit
+            QueryStringReportingSize = config
+                                      .WithKeys(ConfigurationKeys.QueryStringReportingSize)
+                                      .AsInt32()
+                                      .Get(defaultValue: 5000); // 5000 being the tag value length limit
 
-            ObfuscationQueryStringRegexTimeout = source.GetDouble(ConfigurationKeys.ObfuscationQueryStringRegexTimeout) is { } x and > 0 ? x : 200;
+            ObfuscationQueryStringRegexTimeout = config
+                                                .WithKeys(ConfigurationKeys.ObfuscationQueryStringRegexTimeout)
+                                                .AsDouble()
+                                                .Get(200, val1 => val1 is > 0).Value;
 
-            IsActivityListenerEnabled = source.GetBool(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled) ??
-                                        source.GetBool("DD_TRACE_ACTIVITY_LISTENER_ENABLED") ??
-                                        // default value
-                                        false;
+            IsActivityListenerEnabled = config
+                                       .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "DD_TRACE_ACTIVITY_LISTENER_ENABLED")
+                                       .AsBool()
+                                       .Get(false);
 
-            var propagationStyleInject = source.GetString(ConfigurationKeys.PropagationStyleInject) ??
-                                         source.GetString("DD_PROPAGATION_STYLE_INJECT") ?? // deprecated setting name
-                                         source.GetString(ConfigurationKeys.PropagationStyle);
+            var propagationStyleInject = config
+                                        .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
+                                        .AsString()
+                                        .Get();
 
             PropagationStyleInject = TrimSplitString(propagationStyleInject, commaSeparator);
 
             if (PropagationStyleInject.Length == 0)
             {
                 // default value
-                PropagationStyleInject = new[]
-                                         {
-                                             ContextPropagationHeaderStyle.W3CTraceContext,
-                                             ContextPropagationHeaderStyle.Datadog
-                                         };
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
-            var propagationStyleExtract = source.GetString(ConfigurationKeys.PropagationStyleExtract) ??
-                                          source.GetString("DD_PROPAGATION_STYLE_EXTRACT") ?? // deprecated setting name
-                                          source.GetString(ConfigurationKeys.PropagationStyle);
+            var propagationStyleExtract = config
+                                         .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
+                                         .AsString()
+                                         .Get();
 
             PropagationStyleExtract = TrimSplitString(propagationStyleExtract, commaSeparator);
 
             if (PropagationStyleExtract.Length == 0)
             {
                 // default value
-                PropagationStyleExtract = new[]
-                                          {
-                                              ContextPropagationHeaderStyle.W3CTraceContext,
-                                              ContextPropagationHeaderStyle.Datadog
-                                          };
+                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
             // If Activity support is enabled, we must enable the W3C Trace Context propagators.
@@ -236,32 +308,53 @@ namespace Datadog.Trace.Configuration
 
             LogSubmissionSettings = new DirectLogSubmissionSettings(source);
 
-            TraceMethods = source.GetString(ConfigurationKeys.TraceMethods) ??
-                           // Default value
-                           string.Empty;
+            TraceMethods = config
+                          .WithKeys(ConfigurationKeys.TraceMethods)
+                          .AsString()
+                          .Get(string.Empty);
 
-            var grpcTags = source.GetDictionary(ConfigurationKeys.GrpcTags, allowOptionalMappings: true) ??
+            var grpcTags = config
+                          .WithKeys(ConfigurationKeys.GrpcTags)
+                          .AsDictionary()
+                          .Get(allowOptionalMappings: true)
                            // default value (empty)
-                           new Dictionary<string, string>();
+                        ?? new Dictionary<string, string>();
 
             // Filter out tags with empty keys or empty values, and trim whitespaces
             GrpcTags = InitializeHeaderTags(grpcTags, headerTagsNormalizationFixEnabled: true);
 
-            var outgoingTagPropagationHeaderMaxLength = source.GetInt32(ConfigurationKeys.TagPropagation.HeaderMaxLength);
+            OutgoingTagPropagationHeaderMaxLength = config
+                                                   .WithKeys(ConfigurationKeys.TagPropagation.HeaderMaxLength)
+                                                   .AsInt32()
+                                                   .Get(
+                                                        Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength,
+                                                        x => x is >= 0 and <= Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength)
+                                                   .Value;
 
-            OutgoingTagPropagationHeaderMaxLength = outgoingTagPropagationHeaderMaxLength is >= 0 and <= Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength ? (int)outgoingTagPropagationHeaderMaxLength : Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength;
+            IpHeader = config
+                      .WithKeys(ConfigurationKeys.IpHeader, ConfigurationKeys.AppSec.CustomIpHeader)
+                      .AsString()
+                      .Get();
 
-            IpHeader = source.GetString(ConfigurationKeys.IpHeader) ?? source.GetString(ConfigurationKeys.AppSec.CustomIpHeader);
+            IpHeaderEnabled = config
+                             .WithKeys(ConfigurationKeys.IpHeaderEnabled)
+                             .AsBool()
+                             .Get(false);
 
-            IpHeaderEnabled = source.GetBool(ConfigurationKeys.IpHeaderEnabled) ?? false;
+            IsDataStreamsMonitoringEnabled = config
+                                            .WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled)
+                                            .AsBool()
+                                            .Get(false);
 
-            IsDataStreamsMonitoringEnabled = source.GetBool(ConfigurationKeys.DataStreamsMonitoring.Enabled) ??
-                                             // default value
-                                             false;
+            IsRareSamplerEnabled = config
+                                  .WithKeys(ConfigurationKeys.RareSamplerEnabled)
+                                  .AsBool()
+                                  .Get(false);
 
-            IsRareSamplerEnabled = source.GetBool(ConfigurationKeys.RareSamplerEnabled) ?? false;
-
-            IsRunningInAzureAppService = source.GetString(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)?.ToBoolean() ?? false;
+            IsRunningInAzureAppService = config
+                                        .WithKeys(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)
+                                        .AsBool()
+                                        .Get(false);
             if (IsRunningInAzureAppService)
             {
                 AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(source);
@@ -271,21 +364,38 @@ namespace Datadog.Trace.Configuration
                 }
             }
 
-            var urlSubstringSkips = source.GetString(ConfigurationKeys.HttpClientExcludedUrlSubstrings) ??
-                                    // default value
-                                    (IsRunningInAzureAppService ? ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions :
-                                     Serverless.Metadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : null);
+            var urlSubstringSkips = config
+                                   .WithKeys(ConfigurationKeys.HttpClientExcludedUrlSubstrings)
+                                   .AsString()
+                                   .Get(
+                                        IsRunningInAzureAppService ? ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions :
+                                        Serverless.Metadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : string.Empty);
 
-            HttpClientExcludedUrlSubstrings = urlSubstringSkips != null
+            HttpClientExcludedUrlSubstrings = !string.IsNullOrEmpty(urlSubstringSkips)
                                                   ? TrimSplitString(urlSubstringSkips.ToUpperInvariant(), commaSeparator)
                                                   : Array.Empty<string>();
 
-            var dbmPropagationMode = source.GetString(ConfigurationKeys.DbmPropagationMode);
-            DbmPropagationMode = dbmPropagationMode == null ? DbmPropagationLevel.Disabled : ValidateDbmPropagationInput(dbmPropagationMode);
+            DbmPropagationMode = config
+                                .WithKeys(ConfigurationKeys.DbmPropagationMode)
+                                .AsString()
+                                .GetAs(
+                                     () => DbmPropagationLevel.Disabled,
+                                     converter: x => ToDbmPropagationInput(x) is { } mode
+                                                         ? ParsingResult<DbmPropagationLevel>.Success(mode)
+                                                         : ParsingResult<DbmPropagationLevel>.Failure(),
+                                     validator: null);
 
-            TraceId128BitGenerationEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled) ?? false;
-            TraceId128BitLoggingEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled) ?? false;
+            TraceId128BitGenerationEnabled = config
+                                            .WithKeys(ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled)
+                                            .AsBool()
+                                            .Get(false);
+            TraceId128BitLoggingEnabled = config
+                                         .WithKeys(ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled)
+                                         .AsBool()
+                                         .Get(false);
         }
+
+        internal IConfigurationTelemetry Telemetry { get; }
 
         /// <summary>
         /// Gets or sets the default environment name applied to all spans.
@@ -722,13 +832,6 @@ namespace Datadog.Trace.Configuration
             return headerTags;
         }
 
-        private static SchemaVersion ParseMetadataSchemaVersion(string? value) =>
-            value switch
-            {
-                "v1" or "V1" => SchemaVersion.V1,
-                _ => SchemaVersion.V0,
-            };
-
         internal static string[] TrimSplitString(string? textValues, char[] separators)
         {
             if (string.IsNullOrWhiteSpace(textValues))
@@ -802,29 +905,25 @@ namespace Datadog.Trace.Configuration
             return httpErrorCodesArray;
         }
 
-        internal static DbmPropagationLevel ValidateDbmPropagationInput(string inputValue)
+        internal static DbmPropagationLevel? ToDbmPropagationInput(string inputValue)
         {
-            DbmPropagationLevel propagationValue;
-
             if (inputValue.Equals("disabled", StringComparison.OrdinalIgnoreCase))
             {
-                propagationValue = DbmPropagationLevel.Disabled;
+                return DbmPropagationLevel.Disabled;
             }
             else if (inputValue.Equals("service", StringComparison.OrdinalIgnoreCase))
             {
-                propagationValue = DbmPropagationLevel.Service;
+                return DbmPropagationLevel.Service;
             }
             else if (inputValue.Equals("full", StringComparison.OrdinalIgnoreCase))
             {
-                propagationValue = DbmPropagationLevel.Full;
+                return DbmPropagationLevel.Full;
             }
             else
             {
-                propagationValue = DbmPropagationLevel.Disabled;
-                Log.Warning("Wrong setting '{0}' for DD_DBM_PROPAGATION_MODE supported values include: disabled, service or full.", inputValue);
+                Log.Warning("Wrong setting '{PropagationInput}' for DD_DBM_PROPAGATION_MODE supported values include: disabled, service or full", inputValue);
+                return null;
             }
-
-            return propagationValue;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -306,7 +306,7 @@ namespace Datadog.Trace.Configuration
                 DisabledIntegrationNames.Add(nameof(Configuration.IntegrationId.OpenTelemetry));
             }
 
-            LogSubmissionSettings = new DirectLogSubmissionSettings(source);
+            LogSubmissionSettings = new DirectLogSubmissionSettings(source, Telemetry);
 
             TraceMethods = config
                           .WithKeys(ConfigurationKeys.TraceMethods)

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -357,7 +357,7 @@ namespace Datadog.Trace.Configuration
                                         .Get(false);
             if (IsRunningInAzureAppService)
             {
-                AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(source);
+                AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(source, Telemetry);
                 if (AzureAppServiceMetadata.IsUnsafeToTrace)
                 {
                     TraceEnabled = false;

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Configuration
 
             DisabledIntegrationNames = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
 
-            Integrations = new IntegrationSettingsCollection(source);
+            Integrations = new IntegrationSettingsCollection(source, Telemetry);
 
             Exporter = new ExporterSettings(source, Telemetry);
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -113,7 +113,7 @@ namespace Datadog.Trace.Configuration
 
             Integrations = new IntegrationSettingsCollection(source);
 
-            Exporter = new ExporterSettings(source);
+            Exporter = new ExporterSettings(source, Telemetry);
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled).AsBool()

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -71,41 +71,34 @@ namespace Datadog.Trace.Configuration
 
             Environment = config
                          .WithKeys(ConfigurationKeys.Environment)
-                         .AsString()
-                         .Get();
+                         .AsString();
 
             ServiceName = config
                          .WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
-                         .AsString()
-                         .Get();
+                         .AsString();
 
             ServiceVersion = config
                             .WithKeys(ConfigurationKeys.ServiceVersion)
-                            .AsString()
-                            .Get();
+                            .AsString();
 
             GitCommitSha = config
                           .WithKeys(ConfigurationKeys.GitCommitSha)
-                          .AsString()
-                          .Get();
+                          .AsString();
 
             GitRepositoryUrl = config
                               .WithKeys(ConfigurationKeys.GitRepositoryUrl)
-                              .AsString()
-                              .Get();
+                              .AsString();
 
             GitMetadataEnabled = config
                                 .WithKeys(ConfigurationKeys.GitMetadataEnabled)
-                                .AsBool()
-                                .Get(defaultValue: true);
+                                .AsBool(defaultValue: true);
 
             TraceEnabled = config
                           .WithKeys(ConfigurationKeys.TraceEnabled)
-                          .AsBool()
-                          .Get(defaultValue: true);
+                          .AsBool(defaultValue: true);
 
             var disabledIntegrationNames = config.WithKeys(ConfigurationKeys.DisabledIntegrations)
-                                                               .AsString().Get()
+                                                               .AsString()
                                                               ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
                                            Enumerable.Empty<string>();
 
@@ -116,22 +109,20 @@ namespace Datadog.Trace.Configuration
             Exporter = new ExporterSettings(source, Telemetry);
 
 #pragma warning disable 618 // App analytics is deprecated, but still used
-            AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled).AsBool()
-                                                   .Get(defaultValue: false);
+            AnalyticsEnabled = config.WithKeys(ConfigurationKeys.GlobalAnalyticsEnabled)
+                                                   .AsBool(defaultValue: false);
 #pragma warning restore 618
 
 #pragma warning disable 618 // this parameter has been replaced but may still be used
             MaxTracesSubmittedPerSecond = config
                                          .WithKeys(ConfigurationKeys.TraceRateLimit, ConfigurationKeys.MaxTracesSubmittedPerSecond)
 #pragma warning restore 618
-                                         .AsInt32()
-                                         .Get(defaultValue: 100);
+                                         .AsInt32(defaultValue: 100);
 
             GlobalTags = config
                          // backwards compatibility for names used in the past
                         .WithKeys(ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
                         .AsDictionary()
-                        .Get()
                          // Filter out tags with empty keys or empty values, and trim whitespace
                        ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                         .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
@@ -140,21 +131,18 @@ namespace Datadog.Trace.Configuration
 
             var inputHeaderTags = config
                                  .WithKeys(ConfigurationKeys.HeaderTags)
-                                 .AsDictionary()
-                                 .Get(allowOptionalMappings: true) ??
+                                 .AsDictionary(allowOptionalMappings: true) ??
                                   // default value (empty)
                                   new Dictionary<string, string>();
 
             var headerTagsNormalizationFixEnabled = config
                                                    .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
-                                                   .AsBool()
-                                                   .Get(defaultValue: true);
+                                                   .AsBool(defaultValue: true);
 
             // Filter out tags with empty keys or empty values, and trim whitespaces
             HeaderTags = InitializeHeaderTags(inputHeaderTags, headerTagsNormalizationFixEnabled);
             MetadataSchemaVersion = config
                                    .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
-                                   .AsString()
                                    .GetAs(
                                         () => SchemaVersion.V0,
                                         converter: x => x switch
@@ -168,110 +156,92 @@ namespace Datadog.Trace.Configuration
             ServiceNameMappings = config
                                      .WithKeys(ConfigurationKeys.ServiceNameMappings)
                                      .AsDictionary()
-                                     .Get()
                                     ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                     .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
             TracerMetricsEnabled = config
                                   .WithKeys(ConfigurationKeys.TracerMetricsEnabled)
-                                  .AsBool()
-                                  .Get(defaultValue: false);
+                                  .AsBool(defaultValue: false);
 
             StatsComputationEnabled = config
                                      .WithKeys(ConfigurationKeys.StatsComputationEnabled)
-                                     .AsBool()
-                                     .Get(defaultValue: false);
+                                     .AsBool(defaultValue: false);
 
-            StatsComputationInterval = config.WithKeys(ConfigurationKeys.StatsComputationInterval).AsInt32().Get(defaultValue: 10);
+            StatsComputationInterval = config.WithKeys(ConfigurationKeys.StatsComputationInterval).AsInt32(defaultValue: 10);
 
-            RuntimeMetricsEnabled = config.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool().Get(defaultValue: false);
+            RuntimeMetricsEnabled = config.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool(defaultValue: false);
 
-            CustomSamplingRules = config.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString().Get();
+            CustomSamplingRules = config.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString();
 
-            SpanSamplingRules = config.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString().Get();
+            SpanSamplingRules = config.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString();
 
-            GlobalSamplingRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble().Get();
+            GlobalSamplingRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble();
 
-            StartupDiagnosticLogEnabled = config.WithKeys(ConfigurationKeys.StartupDiagnosticLogEnabled).AsBool().Get(defaultValue: true);
+            StartupDiagnosticLogEnabled = config.WithKeys(ConfigurationKeys.StartupDiagnosticLogEnabled).AsBool(defaultValue: true);
 
             var httpServerErrorStatusCodes = config
                                             .WithKeys(ConfigurationKeys.HttpServerErrorStatusCodes)
-                                            .AsString()
-                                            .Get(defaultValue: "500-599");
+                                            .AsString(defaultValue: "500-599");
 
             HttpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodes);
 
             var httpClientErrorStatusCodes = config
                                             .WithKeys(ConfigurationKeys.HttpClientErrorStatusCodes)
-                                            .AsString()
-                                            .Get(defaultValue: "400-499");
+                                            .AsString(defaultValue: "400-499");
 
             HttpClientErrorStatusCodes = ParseHttpCodesToArray(httpClientErrorStatusCodes);
 
             TraceBufferSize = config
                              .WithKeys(ConfigurationKeys.BufferSize)
-                             .AsInt32()
-                             .Get(defaultValue: 1024 * 1024 * 10); // 10MB
+                             .AsInt32(defaultValue: 1024 * 1024 * 10); // 10MB
 
             TraceBatchInterval = config
                                 .WithKeys(ConfigurationKeys.SerializationBatchInterval)
-                                .AsInt32()
-                                .Get(defaultValue: 100);
+                                .AsInt32(defaultValue: 100);
 
             RouteTemplateResourceNamesEnabled = config
                                                .WithKeys(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
-                                               .AsBool()
-                                               .Get(defaultValue: true);
+                                               .AsBool(defaultValue: true);
 
             ExpandRouteTemplatesEnabled = config
                                          .WithKeys(ConfigurationKeys.ExpandRouteTemplatesEnabled)
-                                         .AsBool()
-                                         .Get(defaultValue: !RouteTemplateResourceNamesEnabled); // disabled by default if route template resource names enabled
+                                         .AsBool(defaultValue: !RouteTemplateResourceNamesEnabled); // disabled by default if route template resource names enabled
 
             KafkaCreateConsumerScopeEnabled = config
                                              .WithKeys(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
-                                             .AsBool()
-                                             .Get(defaultValue: true);
+                                             .AsBool(defaultValue: true);
 
             DelayWcfInstrumentationEnabled = config
                                             .WithKeys(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
-                                            .AsBool()
-                                            .Get(defaultValue: false);
+                                            .AsBool(defaultValue: false);
 
             WcfObfuscationEnabled = config
                                    .WithKeys(ConfigurationKeys.FeatureFlags.WcfObfuscationEnabled)
-                                   .AsBool()
-                                   .Get(defaultValue: true);
+                                   .AsBool(defaultValue: true);
 
             ObfuscationQueryStringRegex = config
                                          .WithKeys(ConfigurationKeys.ObfuscationQueryStringRegex)
-                                         .AsString()
-                                         .Get(defaultValue: DefaultObfuscationQueryStringRegex);
+                                         .AsString(defaultValue: DefaultObfuscationQueryStringRegex);
 
             QueryStringReportingEnabled = config
                                          .WithKeys(ConfigurationKeys.QueryStringReportingEnabled)
-                                         .AsBool()
-                                         .Get(defaultValue: true);
+                                         .AsBool(defaultValue: true);
 
             QueryStringReportingSize = config
                                       .WithKeys(ConfigurationKeys.QueryStringReportingSize)
-                                      .AsInt32()
-                                      .Get(defaultValue: 5000); // 5000 being the tag value length limit
+                                      .AsInt32(defaultValue: 5000); // 5000 being the tag value length limit
 
             ObfuscationQueryStringRegexTimeout = config
                                                 .WithKeys(ConfigurationKeys.ObfuscationQueryStringRegexTimeout)
-                                                .AsDouble()
-                                                .Get(200, val1 => val1 is > 0).Value;
+                                                .AsDouble(200, val1 => val1 is > 0).Value;
 
             IsActivityListenerEnabled = config
                                        .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "DD_TRACE_ACTIVITY_LISTENER_ENABLED")
-                                       .AsBool()
-                                       .Get(false);
+                                       .AsBool(false);
 
             var propagationStyleInject = config
                                         .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
-                                        .AsString()
-                                        .Get();
+                                        .AsString();
 
             PropagationStyleInject = TrimSplitString(propagationStyleInject, commaSeparator);
 
@@ -283,8 +253,7 @@ namespace Datadog.Trace.Configuration
 
             var propagationStyleExtract = config
                                          .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
-                                         .AsString()
-                                         .Get();
+                                         .AsString();
 
             PropagationStyleExtract = TrimSplitString(propagationStyleExtract, commaSeparator);
 
@@ -310,13 +279,11 @@ namespace Datadog.Trace.Configuration
 
             TraceMethods = config
                           .WithKeys(ConfigurationKeys.TraceMethods)
-                          .AsString()
-                          .Get(string.Empty);
+                          .AsString(string.Empty);
 
             var grpcTags = config
                           .WithKeys(ConfigurationKeys.GrpcTags)
-                          .AsDictionary()
-                          .Get(allowOptionalMappings: true)
+                          .AsDictionary(allowOptionalMappings: true)
                            // default value (empty)
                         ?? new Dictionary<string, string>();
 
@@ -325,36 +292,30 @@ namespace Datadog.Trace.Configuration
 
             OutgoingTagPropagationHeaderMaxLength = config
                                                    .WithKeys(ConfigurationKeys.TagPropagation.HeaderMaxLength)
-                                                   .AsInt32()
-                                                   .Get(
+                                                   .AsInt32(
                                                         Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength,
                                                         x => x is >= 0 and <= Tagging.TagPropagation.OutgoingTagPropagationHeaderMaxLength)
                                                    .Value;
 
             IpHeader = config
                       .WithKeys(ConfigurationKeys.IpHeader, ConfigurationKeys.AppSec.CustomIpHeader)
-                      .AsString()
-                      .Get();
+                      .AsString();
 
             IpHeaderEnabled = config
                              .WithKeys(ConfigurationKeys.IpHeaderEnabled)
-                             .AsBool()
-                             .Get(false);
+                             .AsBool(false);
 
             IsDataStreamsMonitoringEnabled = config
                                             .WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled)
-                                            .AsBool()
-                                            .Get(false);
+                                            .AsBool(false);
 
             IsRareSamplerEnabled = config
                                   .WithKeys(ConfigurationKeys.RareSamplerEnabled)
-                                  .AsBool()
-                                  .Get(false);
+                                  .AsBool(false);
 
             IsRunningInAzureAppService = config
                                         .WithKeys(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)
-                                        .AsBool()
-                                        .Get(false);
+                                        .AsBool(false);
             if (IsRunningInAzureAppService)
             {
                 AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(source, Telemetry);
@@ -366,8 +327,7 @@ namespace Datadog.Trace.Configuration
 
             var urlSubstringSkips = config
                                    .WithKeys(ConfigurationKeys.HttpClientExcludedUrlSubstrings)
-                                   .AsString()
-                                   .Get(
+                                   .AsString(
                                         IsRunningInAzureAppService ? ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions :
                                         Serverless.Metadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : string.Empty);
 
@@ -377,7 +337,6 @@ namespace Datadog.Trace.Configuration
 
             DbmPropagationMode = config
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
-                                .AsString()
                                 .GetAs(
                                      () => DbmPropagationLevel.Disabled,
                                      converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
@@ -385,12 +344,10 @@ namespace Datadog.Trace.Configuration
 
             TraceId128BitGenerationEnabled = config
                                             .WithKeys(ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled)
-                                            .AsBool()
-                                            .Get(false);
+                                            .AsBool(false);
             TraceId128BitLoggingEnabled = config
                                          .WithKeys(ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled)
-                                         .AsBool()
-                                         .Get(false);
+                                         .AsBool(false);
         }
 
         internal IConfigurationTelemetry Telemetry { get; }

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -27,38 +27,33 @@ namespace Datadog.Trace.Debugger
             source ??= NullConfigurationSource.Instance;
             var config = new ConfigurationBuilder(source, telemetry);
 
-            Enabled = config.WithKeys(ConfigurationKeys.Debugger.Enabled).AsBool().Get(false);
+            Enabled = config.WithKeys(ConfigurationKeys.Debugger.Enabled).AsBool(false);
 
             MaximumDepthOfMembersToCopy = config
                                          .WithKeys(ConfigurationKeys.Debugger.MaxDepthToSerialize)
-                                         .AsInt32()
-                                         .Get(DefaultMaxDepthToSerialize, maxDepth => maxDepth > 0)
+                                         .AsInt32(DefaultMaxDepthToSerialize, maxDepth => maxDepth > 0)
                                          .Value;
 
             MaxSerializationTimeInMilliseconds = config
                                                 .WithKeys(ConfigurationKeys.Debugger.MaxTimeToSerialize)
-                                                .AsInt32()
-                                                .Get(
+                                                .AsInt32(
                                                      DefaultMaxSerializationTimeInMilliseconds,
                                                      serializationTimeThreshold => serializationTimeThreshold > 0)
                                                 .Value;
 
             UploadBatchSize = config
                              .WithKeys(ConfigurationKeys.Debugger.UploadBatchSize)
-                             .AsInt32()
-                             .Get(DefaultUploadBatchSize, batchSize => batchSize > 0)
+                             .AsInt32(DefaultUploadBatchSize, batchSize => batchSize > 0)
                              .Value;
 
             DiagnosticsIntervalSeconds = config
                                         .WithKeys(ConfigurationKeys.Debugger.DiagnosticsInterval)
-                                        .AsInt32()
-                                        .Get(DefaultDiagnosticsIntervalSeconds, interval => interval > 0)
+                                        .AsInt32(DefaultDiagnosticsIntervalSeconds, interval => interval > 0)
                                         .Value;
 
             UploadFlushIntervalMilliseconds = config
                                              .WithKeys(ConfigurationKeys.Debugger.UploadFlushInterval)
-                                             .AsInt32()
-                                             .Get(DefaultUploadFlushIntervalMilliseconds, flushInterval => flushInterval >= 0)
+                                             .AsInt32(DefaultUploadFlushIntervalMilliseconds, flushInterval => flushInterval >= 0)
                                              .Value;
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -5,6 +5,8 @@
 
 #nullable enable
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Debugger
 {
@@ -20,44 +22,44 @@ namespace Datadog.Trace.Debugger
         private const int DefaultDiagnosticsIntervalSeconds = 5;
         private const int DefaultUploadFlushIntervalMilliseconds = 0;
 
-        public DebuggerSettings()
-            : this(configurationSource: null)
+        public DebuggerSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
         {
-        }
+            source ??= NullConfigurationSource.Instance;
+            var config = new ConfigurationBuilder(source, telemetry);
 
-        public DebuggerSettings(IConfigurationSource? configurationSource)
-        {
-            Enabled = configurationSource?.GetBool(ConfigurationKeys.Debugger.Enabled) ?? false;
+            Enabled = config.WithKeys(ConfigurationKeys.Debugger.Enabled).AsBool().Get(false);
 
-            var maxDepth = configurationSource?.GetInt32(ConfigurationKeys.Debugger.MaxDepthToSerialize);
-            MaximumDepthOfMembersToCopy =
-                maxDepth is null or <= 0
-                    ? DefaultMaxDepthToSerialize
-                    : maxDepth.Value;
+            MaximumDepthOfMembersToCopy = config
+                                         .WithKeys(ConfigurationKeys.Debugger.MaxDepthToSerialize)
+                                         .AsInt32()
+                                         .Get(DefaultMaxDepthToSerialize, maxDepth => maxDepth > 0)
+                                         .Value;
 
-            var serializationTimeThreshold = configurationSource?.GetInt32(ConfigurationKeys.Debugger.MaxTimeToSerialize);
-            MaxSerializationTimeInMilliseconds =
-                serializationTimeThreshold is null or <= 0
-                    ? DefaultMaxSerializationTimeInMilliseconds
-                    : serializationTimeThreshold.Value;
+            MaxSerializationTimeInMilliseconds = config
+                                                .WithKeys(ConfigurationKeys.Debugger.MaxTimeToSerialize)
+                                                .AsInt32()
+                                                .Get(
+                                                     DefaultMaxSerializationTimeInMilliseconds,
+                                                     serializationTimeThreshold => serializationTimeThreshold > 0)
+                                                .Value;
 
-            var batchSize = configurationSource?.GetInt32(ConfigurationKeys.Debugger.UploadBatchSize);
-            UploadBatchSize =
-                batchSize is null or <= 0
-                    ? DefaultUploadBatchSize
-                    : batchSize.Value;
+            UploadBatchSize = config
+                             .WithKeys(ConfigurationKeys.Debugger.UploadBatchSize)
+                             .AsInt32()
+                             .Get(DefaultUploadBatchSize, batchSize => batchSize > 0)
+                             .Value;
 
-            var interval = configurationSource?.GetInt32(ConfigurationKeys.Debugger.DiagnosticsInterval);
-            DiagnosticsIntervalSeconds =
-                interval is null or <= 0
-                    ? DefaultDiagnosticsIntervalSeconds
-                    : interval.Value;
+            DiagnosticsIntervalSeconds = config
+                                        .WithKeys(ConfigurationKeys.Debugger.DiagnosticsInterval)
+                                        .AsInt32()
+                                        .Get(DefaultDiagnosticsIntervalSeconds, interval => interval > 0)
+                                        .Value;
 
-            var flushInterval = configurationSource?.GetInt32(ConfigurationKeys.Debugger.UploadFlushInterval);
-            UploadFlushIntervalMilliseconds =
-                flushInterval is null or < 0
-                    ? DefaultUploadFlushIntervalMilliseconds
-                    : flushInterval.Value;
+            UploadFlushIntervalMilliseconds = config
+                                             .WithKeys(ConfigurationKeys.Debugger.UploadFlushInterval)
+                                             .AsInt32()
+                                             .Get(DefaultUploadFlushIntervalMilliseconds, flushInterval => flushInterval >= 0)
+                                             .Value;
         }
 
         public bool Enabled { get; }
@@ -72,14 +74,14 @@ namespace Datadog.Trace.Debugger
 
         public int UploadFlushIntervalMilliseconds { get; }
 
-        public static DebuggerSettings FromSource(IConfigurationSource source)
+        public static DebuggerSettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {
-            return new DebuggerSettings(source);
+            return new DebuggerSettings(source, telemetry);
         }
 
         public static DebuggerSettings FromDefaultSource()
         {
-            return FromSource(GlobalConfigurationSource.Instance);
+            return FromSource(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
         }
     }
 }

--- a/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
@@ -6,6 +6,8 @@
 #nullable enable
 
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Iast.Settings;
 
@@ -17,20 +19,30 @@ internal class IastSettings
     public const int MaxConcurrentRequestDefault = 2;
     public const int RequestSamplingDefault = 30;
 
-    public IastSettings(IConfigurationSource source)
+    public IastSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
-        WeakCipherAlgorithms = source.GetString(ConfigurationKeys.Iast.WeakCipherAlgorithms) ?? WeakCipherAlgorithmsDefault;
+        var config = new ConfigurationBuilder(source, telemetry);
+        WeakCipherAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakCipherAlgorithms).AsString().Get(WeakCipherAlgorithmsDefault);
         WeakCipherAlgorithmsArray = WeakCipherAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        WeakHashAlgorithms = source.GetString(ConfigurationKeys.Iast.WeakHashAlgorithms) ?? WeakHashAlgorithmsDefault;
+        WeakHashAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakHashAlgorithms).AsString().Get(WeakHashAlgorithmsDefault);
         WeakHashAlgorithmsArray = WeakHashAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        Enabled = (source.GetBool(ConfigurationKeys.Iast.Enabled) ?? false);
-        DeduplicationEnabled = source.GetBool(ConfigurationKeys.Iast.IsIastDeduplicationEnabled) ?? true;
-        RequestSampling = source.GetInt32(ConfigurationKeys.Iast.RequestSampling) is { } requestSampling and > 0 and <= 100
-            ? requestSampling : RequestSamplingDefault;
-        MaxConcurrentRequests = source.GetInt32(ConfigurationKeys.Iast.MaxConcurrentRequests) is { } concurrentRequests and > 0
-            ? concurrentRequests : MaxConcurrentRequestDefault;
-        VulnerabilitiesPerRequest = source.GetInt32(ConfigurationKeys.Iast.VulnerabilitiesPerRequest) is { } vulnerabilities and > 0
-            ? vulnerabilities : VulnerabilitiesPerRequestDefault;
+        Enabled = config.WithKeys(ConfigurationKeys.Iast.Enabled).AsBool().Get(false);
+        DeduplicationEnabled = config.WithKeys(ConfigurationKeys.Iast.IsIastDeduplicationEnabled).AsBool().Get(true);
+        RequestSampling = config
+                         .WithKeys(ConfigurationKeys.Iast.RequestSampling)
+                         .AsInt32()
+                         .Get(RequestSamplingDefault, x => x is > 0 and <= 100)
+                         .Value;
+        MaxConcurrentRequests = config
+                               .WithKeys(ConfigurationKeys.Iast.MaxConcurrentRequests)
+                               .AsInt32()
+                               .Get(MaxConcurrentRequestDefault, x => x > 0)
+                               .Value;
+        VulnerabilitiesPerRequest = config
+                                   .WithKeys(ConfigurationKeys.Iast.VulnerabilitiesPerRequest)
+                                   .AsInt32()
+                                   .Get(VulnerabilitiesPerRequestDefault, x => x > 0)
+                                   .Value;
     }
 
     public bool Enabled { get; set; }
@@ -53,6 +65,6 @@ internal class IastSettings
 
     public static IastSettings FromDefaultSources()
     {
-        return new IastSettings(GlobalConfigurationSource.Instance);
+        return new IastSettings(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
     }
 }

--- a/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
@@ -22,26 +22,23 @@ internal class IastSettings
     public IastSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
         var config = new ConfigurationBuilder(source, telemetry);
-        WeakCipherAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakCipherAlgorithms).AsString().Get(WeakCipherAlgorithmsDefault);
+        WeakCipherAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakCipherAlgorithms).AsString(WeakCipherAlgorithmsDefault);
         WeakCipherAlgorithmsArray = WeakCipherAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        WeakHashAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakHashAlgorithms).AsString().Get(WeakHashAlgorithmsDefault);
+        WeakHashAlgorithms = config.WithKeys(ConfigurationKeys.Iast.WeakHashAlgorithms).AsString(WeakHashAlgorithmsDefault);
         WeakHashAlgorithmsArray = WeakHashAlgorithms.Split(new char[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
-        Enabled = config.WithKeys(ConfigurationKeys.Iast.Enabled).AsBool().Get(false);
-        DeduplicationEnabled = config.WithKeys(ConfigurationKeys.Iast.IsIastDeduplicationEnabled).AsBool().Get(true);
+        Enabled = config.WithKeys(ConfigurationKeys.Iast.Enabled).AsBool(false);
+        DeduplicationEnabled = config.WithKeys(ConfigurationKeys.Iast.IsIastDeduplicationEnabled).AsBool(true);
         RequestSampling = config
                          .WithKeys(ConfigurationKeys.Iast.RequestSampling)
-                         .AsInt32()
-                         .Get(RequestSamplingDefault, x => x is > 0 and <= 100)
+                         .AsInt32(RequestSamplingDefault, x => x is > 0 and <= 100)
                          .Value;
         MaxConcurrentRequests = config
                                .WithKeys(ConfigurationKeys.Iast.MaxConcurrentRequests)
-                               .AsInt32()
-                               .Get(MaxConcurrentRequestDefault, x => x > 0)
+                               .AsInt32(MaxConcurrentRequestDefault, x => x > 0)
                                .Value;
         VulnerabilitiesPerRequest = config
                                    .WithKeys(ConfigurationKeys.Iast.VulnerabilitiesPerRequest)
-                                   .AsInt32()
-                                   .Get(VulnerabilitiesPerRequestDefault, x => x > 0)
+                                   .AsInt32(VulnerabilitiesPerRequestDefault, x => x > 0)
                                    .Value;
     }
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -65,9 +65,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                                              .AsString()
                                              .GetAs(
                                                   () => DefaultMinimumLevel,
-                                                  converter: x => DirectSubmissionLogLevelExtensions.Parse(x) is { } val
-                                                                      ? ParsingResult<DirectSubmissionLogLevel>.Success(val)
-                                                                      : ParsingResult<DirectSubmissionLogLevel>.Failure(),
+                                                  converter: x => DirectSubmissionLogLevelExtensions.Parse(x) ?? ParsingResult<DirectSubmissionLogLevel>.Failure(),
                                                   validator: null);
 
             var globalTags = config

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -37,24 +37,20 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             DirectLogSubmissionHost = config
                                      .WithKeys(ConfigurationKeys.DirectLogSubmission.Host)
-                                     .AsString()
-                                     .Get(HostMetadata.Instance.Hostname);
+                                     .AsString(HostMetadata.Instance.Hostname);
             DirectLogSubmissionSource = config
                                        .WithKeys(ConfigurationKeys.DirectLogSubmission.Source)
-                                       .AsString()
-                                       .Get(DefaultSource);
+                                       .AsString(DefaultSource);
 
             DirectLogSubmissionUrl = config
                                     .WithKeys(ConfigurationKeys.DirectLogSubmission.Url)
-                                    .AsString()
-                                    .Get(
+                                    .AsString(
                                          getDefaultValue: () =>
                                          {
                                              // They didn't provide a URL, use the default (With DD_SITE if provided)
                                              var ddSite = config
                                                          .WithKeys(ConfigurationKeys.Site)
-                                                         .AsString()
-                                                         .Get(DefaultSite, x => !string.IsNullOrEmpty(x));
+                                                         .AsString(DefaultSite, x => !string.IsNullOrEmpty(x));
 
                                              return $"{IntakePrefix}{ddSite}{IntakeSuffix}";
                                          },
@@ -62,7 +58,6 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             DirectLogSubmissionMinimumLevel = config
                                              .WithKeys(ConfigurationKeys.DirectLogSubmission.MinimumLevel)
-                                             .AsString()
                                              .GetAs(
                                                   () => DefaultMinimumLevel,
                                                   converter: x => DirectSubmissionLogLevelExtensions.Parse(x) ?? ParsingResult<DirectSubmissionLogLevel>.Failure(),
@@ -70,8 +65,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             var globalTags = config
                             .WithKeys(ConfigurationKeys.DirectLogSubmission.GlobalTags, ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
-                            .AsDictionary()
-                            .Get();
+                            .AsDictionary();
 
             DirectLogSubmissionGlobalTags = globalTags?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                                        .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
@@ -80,34 +74,30 @@ namespace Datadog.Trace.Logging.DirectSubmission
             var logSubmissionIntegrations = config
                                            .WithKeys(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations)
                                            .AsString()
-                                           .Get()
                                           ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
                                             Enumerable.Empty<string>();
             DirectLogSubmissionEnabledIntegrations = new HashSet<string>(logSubmissionIntegrations, StringComparer.OrdinalIgnoreCase);
 
             DirectLogSubmissionBatchSizeLimit = config
                                                .WithKeys(ConfigurationKeys.DirectLogSubmission.BatchSizeLimit)
-                                               .AsInt32()
-                                               .Get(DefaultBatchSizeLimit, x => x > 0)
+                                               .AsInt32(DefaultBatchSizeLimit, x => x > 0)
                                                .Value;
 
             DirectLogSubmissionQueueSizeLimit = config
                                                .WithKeys(ConfigurationKeys.DirectLogSubmission.QueueSizeLimit)
-                                               .AsInt32()
-                                               .Get(DefaultQueueSizeLimit, x => x > 0)
+                                               .AsInt32(DefaultQueueSizeLimit, x => x > 0)
                                                .Value;
 
             var seconds = config
                      .WithKeys(ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds)
-                     .AsInt32()
-                     .Get(DefaultBatchPeriodSeconds, x => x > 0)
+                     .AsInt32(DefaultBatchPeriodSeconds, x => x > 0)
                      .Value;
 
             DirectLogSubmissionBatchPeriod = TimeSpan.FromSeconds(seconds);
 
-            ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString().Get();
+            ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
 
-            LogsInjectionEnabled = config.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool().Get();
+            LogsInjectionEnabled = config.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevelExtensions.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevelExtensions.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 _ => Unknown,
             };
 
-        public static DirectSubmissionLogLevel Parse(string? value, DirectSubmissionLogLevel defaultLevel)
+        public static DirectSubmissionLogLevel? Parse(string? value)
             => value?.ToUpperInvariant() switch
             {
                 "TRACE" => DirectSubmissionLogLevel.Verbose,
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 "ERROR" => DirectSubmissionLogLevel.Error,
                 "CRITICAL" => DirectSubmissionLogLevel.Fatal,
                 "FATAL" => DirectSubmissionLogLevel.Fatal,
-                _ => defaultLevel
+                _ => null
             };
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -7,6 +7,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.Logging
                     LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 }
 
-                var config = DatadogLoggingFactory.GetConfiguration(GlobalConfigurationSource.Instance);
+                var config = DatadogLoggingFactory.GetConfiguration(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
 
                 if (config.File is { LogFileRetentionDays: > 0 } fileConfig)
                 {

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -27,7 +27,6 @@ internal static class DatadogLoggingFactory
         var logSinkOptions = new ConfigurationBuilder(source, telemetry)
                             .WithKeys(ConfigurationKeys.LogSinks)
                             .AsString()
-                            .Get()
                            ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
         FileLoggingConfiguration? fileConfig = null;
@@ -38,8 +37,7 @@ internal static class DatadogLoggingFactory
 
         var rateLimit = new ConfigurationBuilder(source, telemetry)
                        .WithKeys(ConfigurationKeys.LogRateLimit)
-                       .AsInt32()
-                       .Get(DefaultRateLimit, x => x >= 0)
+                       .AsInt32(DefaultRateLimit, x => x >= 0)
                        .Value;
 
         return new DatadogLoggingConfiguration(rateLimit, fileConfig);
@@ -137,11 +135,11 @@ internal static class DatadogLoggingFactory
 
     private static string GetLogDirectory(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
-        var logDirectory = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.LogDirectory).AsString().Get();
+        var logDirectory = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.LogDirectory).AsString();
         if (string.IsNullOrEmpty(logDirectory))
         {
 #pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
-            var nativeLogFile = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.ProfilerLogPath).AsString().Get();
+            var nativeLogFile = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.ProfilerLogPath).AsString();
 #pragma warning restore 618
 
             if (!string.IsNullOrEmpty(nativeLogFile))
@@ -215,7 +213,6 @@ internal static class DatadogLoggingFactory
         // get file details
         var maxLogFileSize = new ConfigurationBuilder(source, telemetry)
                             .WithKeys(ConfigurationKeys.MaxLogFileSize)
-                            .AsString()
                             .GetAs(
                                  () => DefaultMaxLogFileSize,
                                  converter: x => long.TryParse(x, out var maxLogSize)
@@ -225,8 +222,7 @@ internal static class DatadogLoggingFactory
 
         var logFileRetentionDays = new ConfigurationBuilder(source, telemetry)
                                   .WithKeys(ConfigurationKeys.LogFileRetentionDays)
-                                  .AsInt32()
-                                  .Get(32, x => x >= 0)
+                                  .AsInt32(32, x => x >= 0)
                                   .Value;
 
         return new FileLoggingConfiguration(maxLogFileSize, logDirectory, logFileRetentionDays);

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -8,6 +8,8 @@
 using System;
 using System.IO;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.Internal.Configuration;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
@@ -20,22 +22,25 @@ internal static class DatadogLoggingFactory
     private const int DefaultRateLimit = 0;
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
 
-    public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source)
+    public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
-        var logSinkOptions = source.GetString(ConfigurationKeys.LogSinks)
-                                   ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+        var logSinkOptions = new ConfigurationBuilder(source, telemetry)
+                            .WithKeys(ConfigurationKeys.LogSinks)
+                            .AsString()
+                            .Get()
+                           ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
         FileLoggingConfiguration? fileConfig = null;
         if (logSinkOptions is null || Contains(logSinkOptions, LogSinkOptions.File))
         {
-            fileConfig = GetFileLoggingConfiguration(source);
+            fileConfig = GetFileLoggingConfiguration(source, telemetry);
         }
 
-        var rateLimit = source.GetInt32(ConfigurationKeys.LogRateLimit) switch
-        {
-            >= 0 and { } r => r,
-            _ => DefaultRateLimit,
-        };
+        var rateLimit = new ConfigurationBuilder(source, telemetry)
+                       .WithKeys(ConfigurationKeys.LogRateLimit)
+                       .AsInt32()
+                       .Get(DefaultRateLimit, x => x >= 0)
+                       .Value;
 
         return new DatadogLoggingConfiguration(rateLimit, fileConfig);
 
@@ -127,16 +132,16 @@ internal static class DatadogLoggingFactory
     }
 
     // Internal for testing
-    internal static string GetLogDirectory()
-        => GetLogDirectory(GlobalConfigurationSource.CreateDefaultConfigurationSource());
+    internal static string GetLogDirectory(IConfigurationTelemetry telemetry)
+        => GetLogDirectory(GlobalConfigurationSource.CreateDefaultConfigurationSource(), telemetry);
 
-    private static string GetLogDirectory(IConfigurationSource source)
+    private static string GetLogDirectory(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
-        var logDirectory = source.GetString(ConfigurationKeys.LogDirectory);
+        var logDirectory = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.LogDirectory).AsString().Get();
         if (string.IsNullOrEmpty(logDirectory))
         {
 #pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
-            var nativeLogFile = source.GetString(ConfigurationKeys.ProfilerLogPath);
+            var nativeLogFile = new ConfigurationBuilder(source, telemetry).WithKeys(ConfigurationKeys.ProfilerLogPath).AsString().Get();
 #pragma warning restore 618
 
             if (!string.IsNullOrEmpty(nativeLogFile))
@@ -190,12 +195,12 @@ internal static class DatadogLoggingFactory
         return logDirectory!;
     }
 
-    private static FileLoggingConfiguration? GetFileLoggingConfiguration(IConfigurationSource source)
+    private static FileLoggingConfiguration? GetFileLoggingConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
         string? logDirectory = null;
         try
         {
-            logDirectory = GetLogDirectory(source);
+            logDirectory = GetLogDirectory(source, telemetry);
         }
         catch
         {
@@ -208,14 +213,21 @@ internal static class DatadogLoggingFactory
         }
 
         // get file details
-        var maxLogSizeVar = source.GetString(ConfigurationKeys.MaxLogFileSize);
-        var maxLogFileSize = long.TryParse(maxLogSizeVar, out var maxLogSize) ? maxLogSize : DefaultMaxLogFileSize;
+        var maxLogFileSize = new ConfigurationBuilder(source, telemetry)
+                            .WithKeys(ConfigurationKeys.MaxLogFileSize)
+                            .AsString()
+                            .GetAs(
+                                 () => DefaultMaxLogFileSize,
+                                 converter: x => long.TryParse(x, out var maxLogSize)
+                                                     ? ParsingResult<long>.Success(maxLogSize)
+                                                     : ParsingResult<long>.Failure(),
+                                 validator: x => x >= 0);
 
-        var logFileRetentionDays = source.GetInt32(ConfigurationKeys.LogFileRetentionDays) switch
-        {
-            >= 0 and var d => d,
-            _ => 32,
-        };
+        var logFileRetentionDays = new ConfigurationBuilder(source, telemetry)
+                                  .WithKeys(ConfigurationKeys.LogFileRetentionDays)
+                                  .AsInt32()
+                                  .Get(32, x => x >= 0)
+                                  .Value;
 
         return new FileLoggingConfiguration(maxLogFileSize, logDirectory, logFileRetentionDays);
     }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -219,7 +219,7 @@ internal static class DatadogLoggingFactory
                             .GetAs(
                                  () => DefaultMaxLogFileSize,
                                  converter: x => long.TryParse(x, out var maxLogSize)
-                                                     ? ParsingResult<long>.Success(maxLogSize)
+                                                     ? maxLogSize
                                                      : ParsingResult<long>.Failure(),
                                  validator: x => x >= 0);
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                               .WithKeys(ConfigurationKeys.Rcm.PollInterval, ConfigurationKeys.Rcm.PollIntervalInternal)
 #pragma warning restore CS0618
                               .AsInt32()
-                              .Get(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is <= 0 or > 5000);
+                              .Get(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is > 0 and <= 5000);
 
             PollInterval = TimeSpan.FromMilliseconds(pollInterval.Value);
         }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -7,6 +7,8 @@
 
 using System;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
@@ -14,12 +16,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
     {
         internal const int DefaultPollIntervalMilliseconds = 5000;
 
-        public RemoteConfigurationSettings()
-            : this(configurationSource: null)
-        {
-        }
-
-        public RemoteConfigurationSettings(IConfigurationSource? configurationSource)
+        public RemoteConfigurationSettings(IConfigurationSource? configurationSource, IConfigurationTelemetry telemetry)
         {
             configurationSource ??= NullConfigurationSource.Instance;
 
@@ -27,16 +24,12 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             RuntimeId = Util.RuntimeId.Get();
             TracerVersion = TracerConstants.ThreePartVersion;
 
-            var pollInterval =
-                configurationSource.GetInt32(ConfigurationKeys.Rcm.PollInterval)
+            var pollInterval = new ConfigurationBuilder(configurationSource, telemetry)
 #pragma warning disable CS0618
-                    ?? configurationSource.GetInt32(ConfigurationKeys.Rcm.PollIntervalInternal);
+                              .WithKeys(ConfigurationKeys.Rcm.PollInterval, ConfigurationKeys.Rcm.PollIntervalInternal)
 #pragma warning restore CS0618
-
-            pollInterval =
-                pollInterval is null or <= 0 or > 5000
-                    ? DefaultPollIntervalMilliseconds
-                    : pollInterval.Value;
+                              .AsInt32()
+                              .Get(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is <= 0 or > 5000);
 
             PollInterval = TimeSpan.FromMilliseconds(pollInterval.Value);
         }
@@ -49,14 +42,10 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public TimeSpan PollInterval { get; }
 
-        public static RemoteConfigurationSettings FromSource(IConfigurationSource source)
-        {
-            return new RemoteConfigurationSettings(source);
-        }
+        public static RemoteConfigurationSettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry)
+            => new(source, telemetry);
 
         public static RemoteConfigurationSettings FromDefaultSource()
-        {
-            return FromSource(GlobalConfigurationSource.Instance);
-        }
+            => FromSource(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -28,8 +28,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 #pragma warning disable CS0618
                               .WithKeys(ConfigurationKeys.Rcm.PollInterval, ConfigurationKeys.Rcm.PollIntervalInternal)
 #pragma warning restore CS0618
-                              .AsInt32()
-                              .Get(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is > 0 and <= 5000);
+                              .AsInt32(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is > 0 and <= 5000);
 
             PollInterval = TimeSpan.FromMilliseconds(pollInterval.Value);
         }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryErrorCode.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryErrorCode.cs
@@ -1,4 +1,4 @@
-// <copyright file="ConfigurationTelemetryErrorCode.cs" company="Datadog">
+﻿// <copyright file="TelemetryErrorCode.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -6,9 +6,9 @@
 #nullable enable
 using System.ComponentModel;
 
-namespace Datadog.Trace.Configuration.Telemetry;
+namespace Datadog.Trace.Telemetry;
 
-internal enum ConfigurationTelemetryErrorCode
+internal enum TelemetryErrorCode
 {
     /// <summary>
     /// No error, should not be used
@@ -44,4 +44,16 @@ internal enum ConfigurationTelemetryErrorCode
 
     [Description("Error parsing value")]
     ParsingCustomError = 10,
+
+    [Description("Error configuring Tracer")]
+    TracerConfigurationError = 11,
+
+    [Description("Error configuring AppSec")]
+    AppsecConfigurationError = 12,
+
+    [Description("Error configuring Continuous Profiler")]
+    ContinuousProfilerConfigurationError = 13,
+
+    [Description("Error configuring Dynamic Instrumentation")]
+    DynamicInstrumentationConfigurationError = 14,
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Telemetry
 {
     internal class TelemetryFactory
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Datadog.Trace.Telemetry.TelemetryFactory>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
 
         private static readonly ConfigurationTelemetryCollector Configuration = new();
         private static readonly DependencyTelemetryCollector Dependencies = new();
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Telemetry
 
         internal static ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings)
         {
-            var settings = TelemetrySettings.FromDefaultSources();
+            var settings = TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, TelemetryFactoryV2.GetConfigTelemetry());
             if (settings.TelemetryEnabled)
             {
                 try

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactoryV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactoryV2.cs
@@ -1,0 +1,19 @@
+// <copyright file="TelemetryFactoryV2.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.Configuration.Telemetry;
+
+namespace Datadog.Trace.Telemetry;
+
+internal class TelemetryFactoryV2
+{
+    private static readonly ConfigurationTelemetry ConfigTelemetry = new();
+
+    // when we enable config telemetry, switch this to returning the real instance
+    internal static IConfigurationTelemetry GetConfigTelemetry()
+        // => ConfigTelemetry;
+        => NullConfigurationTelemetry.Instance;
+}

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -54,15 +54,13 @@ namespace Datadog.Trace.Telemetry
             // TODO: we already fetch this, so this will overwrite the telemetry.... Need a solution to that...
             var apiKey = config
                         .WithKeys(ConfigurationKeys.ApiKey)
-                        .AsRedactedString()
-                        .Get();
+                        .AsRedactedString();
 
             var haveApiKey = !string.IsNullOrEmpty(apiKey);
 
             var agentlessEnabled = config
                                   .WithKeys(ConfigurationKeys.Telemetry.AgentlessEnabled)
-                                  .AsBool()
-                                  .Get(
+                                  .AsBool(
                                        defaultValue: haveApiKey, // if there's an API key, we can use agentless mode by default, otherwise we can only use the agent
                                        validator: isEnabled =>
                                        {
@@ -77,15 +75,13 @@ namespace Datadog.Trace.Telemetry
 
             var agentProxyEnabled = config
                                    .WithKeys(ConfigurationKeys.Telemetry.AgentProxyEnabled)
-                                   .AsBool()
-                                   .Get(() => isAgentAvailable() ?? true, validator: null)
+                                   .AsBool(() => isAgentAvailable() ?? true, validator: null)
                                    .Value;
 
             // enabled by default if we have any transports
             var telemetryEnabled = config
                                   .WithKeys(ConfigurationKeys.Telemetry.Enabled)
-                                  .AsBool()
-                                  .Get(agentlessEnabled || agentProxyEnabled);
+                                  .AsBool(agentlessEnabled || agentProxyEnabled);
 
             AgentlessSettings? agentless = null;
             if (telemetryEnabled && agentlessEnabled)
@@ -93,16 +89,14 @@ namespace Datadog.Trace.Telemetry
                 // We have an API key, so try to send directly to intake
                 var agentlessUri = config
                                   .WithKeys(ConfigurationKeys.Telemetry.Uri)
-                                  .AsString()
-                                  .Get(
+                                  .AsString(
                                        getDefaultValue: () =>
                                        {
                                            // use the default intake. Use DD_SITE if provided, otherwise use default
                                            // TODO: we already fetch this, so this will overwrite the telemetry.... Need a solution to that...
                                            var ddSite = config
                                                        .WithKeys(ConfigurationKeys.Site)
-                                                       .AsString()
-                                                       .Get(
+                                                       .AsString(
                                                             defaultValue: "datadoghq.com",
                                                             validator: siteFromEnv => !string.IsNullOrEmpty(siteFromEnv));
                                            return $"{TelemetryConstants.TelemetryIntakePrefix}.{ddSite}/";
@@ -129,8 +123,7 @@ namespace Datadog.Trace.Telemetry
 
             var heartbeatInterval = config
                                    .WithKeys(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds)
-                                   .AsInt32()
-                                   .Get(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
+                                   .AsInt32(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
                                    .Value;
 
             return new TelemetrySettings(telemetryEnabled, configurationError, agentless, agentProxyEnabled, TimeSpan.FromSeconds(heartbeatInterval));

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -8,6 +8,7 @@
 using System;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry
@@ -42,76 +43,95 @@ namespace Datadog.Trace.Telemetry
 
         public bool AgentProxyEnabled { get; }
 
-        public static TelemetrySettings FromDefaultSources()
-            => FromSource(GlobalConfigurationSource.Instance, IsAgentAvailable);
+        public static TelemetrySettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry)
+            => FromSource(source, telemetry, IsAgentAvailable);
 
-        public static TelemetrySettings FromSource(IConfigurationSource source, Func<bool?> isAgentAvailable)
+        public static TelemetrySettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry, Func<bool?> isAgentAvailable)
         {
             string? configurationError = null;
+            var config = new ConfigurationBuilder(source, telemetry);
 
-            var apiKey = source.GetString(ConfigurationKeys.ApiKey);
-            var agentlessExplicitlyEnabled = source.GetBool(ConfigurationKeys.Telemetry.AgentlessEnabled);
-            var agentProxyEnabled = source.GetBool(ConfigurationKeys.Telemetry.AgentProxyEnabled)
-                                 ?? isAgentAvailable()
-                                 ?? true;
+            // TODO: we already fetch this, so this will overwrite the telemetry.... Need a solution to that...
+            var apiKey = config
+                        .WithKeys(ConfigurationKeys.ApiKey)
+                        .AsRedactedString()
+                        .Get();
 
-            var agentlessEnabled = false;
+            var haveApiKey = !string.IsNullOrEmpty(apiKey);
 
-            if (agentlessExplicitlyEnabled == true)
-            {
-                if (string.IsNullOrEmpty(apiKey))
-                {
-                    configurationError = "Telemetry configuration error: Agentless mode was enabled, but no API key was available.";
-                }
-                else
-                {
-                    agentlessEnabled = true;
-                }
-            }
-            else if (agentlessExplicitlyEnabled is null)
-            {
-                // if there's an API key, we can use agentless mode, otherwise we can only use the agent
-                agentlessEnabled = !string.IsNullOrEmpty(apiKey);
-            }
+            var agentlessEnabled = config
+                                  .WithKeys(ConfigurationKeys.Telemetry.AgentlessEnabled)
+                                  .AsBool()
+                                  .Get(
+                                       defaultValue: haveApiKey, // if there's an API key, we can use agentless mode by default, otherwise we can only use the agent
+                                       validator: isEnabled =>
+                                       {
+                                           if (isEnabled && !haveApiKey)
+                                           {
+                                               configurationError = "Telemetry configuration error: Agentless mode was enabled, but no API key was available.";
+                                               return false;
+                                           }
+
+                                           return true;
+                                       });
+
+            var agentProxyEnabled = config
+                                   .WithKeys(ConfigurationKeys.Telemetry.AgentProxyEnabled)
+                                   .AsBool()
+                                   .Get(() => isAgentAvailable() ?? true, validator: null)
+                                   .Value;
 
             // enabled by default if we have any transports
-            var telemetryEnabled = source.GetBool(ConfigurationKeys.Telemetry.Enabled)
-                                ?? (agentlessEnabled || agentProxyEnabled);
+            var telemetryEnabled = config
+                                  .WithKeys(ConfigurationKeys.Telemetry.Enabled)
+                                  .AsBool()
+                                  .Get(agentlessEnabled || agentProxyEnabled);
 
             AgentlessSettings? agentless = null;
             if (telemetryEnabled && agentlessEnabled)
             {
                 // We have an API key, so try to send directly to intake
-                Uri agentlessUri;
+                var agentlessUri = config
+                                  .WithKeys(ConfigurationKeys.Telemetry.Uri)
+                                  .AsString()
+                                  .Get(
+                                       getDefaultValue: () =>
+                                       {
+                                           // use the default intake. Use DD_SITE if provided, otherwise use default
+                                           // TODO: we already fetch this, so this will overwrite the telemetry.... Need a solution to that...
+                                           var ddSite = config
+                                                       .WithKeys(ConfigurationKeys.Site)
+                                                       .AsString()
+                                                       .Get(
+                                                            defaultValue: "datadoghq.com",
+                                                            validator: siteFromEnv => !string.IsNullOrEmpty(siteFromEnv));
+                                           return $"{TelemetryConstants.TelemetryIntakePrefix}.{ddSite}/";
+                                       },
+                                       validator: requestedTelemetryUri =>
+                                       {
+                                           if (string.IsNullOrEmpty(requestedTelemetryUri)
+                                            || !Uri.TryCreate(requestedTelemetryUri, UriKind.Absolute, out _))
+                                           {
+                                               // URI parsing failed
+                                               configurationError = configurationError is null
+                                                                        ? $"Telemetry configuration error: The provided telemetry Uri '{requestedTelemetryUri}' was not a valid absolute Uri. Using default intake Uri."
+                                                                        : configurationError + $", The provided telemetry Uri '{requestedTelemetryUri}' was not a valid absolute Uri. Using default intake Uri.";
+                                               return false;
+                                           }
 
-                var requestedTelemetryUri = source.GetString(ConfigurationKeys.Telemetry.Uri);
-                if (!string.IsNullOrEmpty(requestedTelemetryUri)
-                 && Uri.TryCreate(requestedTelemetryUri, UriKind.Absolute, out var telemetryUri))
-                {
-                    // telemetry URI provided and well-formed
-                    agentlessUri = UriHelpers.Combine(telemetryUri, "/");
-                }
-                else
-                {
-                    if (!string.IsNullOrEmpty(requestedTelemetryUri))
-                    {
-                        // URI parsing failed
-                        configurationError = configurationError is null
-                                                 ? $"Telemetry configuration error: The provided telemetry Uri '{requestedTelemetryUri}' was not a valid absolute Uri. Using default intake Uri."
-                                                 : configurationError + ", The provided telemetry Uri '{requestedTelemetryUri}' was not a valid absolute Uri. Using default intake Uri.";
-                    }
+                                           return true;
+                                       });
 
-                    // use the default intake. Use DD_SITE if provided, otherwise use default
-                    var siteFromEnv = source.GetString(ConfigurationKeys.Site);
-                    var ddSite = string.IsNullOrEmpty(siteFromEnv) ? "datadoghq.com" : siteFromEnv;
-                    agentlessUri = new Uri($"{TelemetryConstants.TelemetryIntakePrefix}.{ddSite}/");
-                }
-
-                agentless = new AgentlessSettings(agentlessUri, apiKey!);
+                // The uri is already validated in the above code, so this won't fail
+                var finalUri = UriHelpers.Combine(new Uri(agentlessUri, UriKind.Absolute), "/");
+                agentless = new AgentlessSettings(finalUri, apiKey!);
             }
 
-            var rawInterval = source.GetInt32(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds);
-            var heartbeatInterval = rawInterval is { } interval and > 0 and <= 3600 ? interval : 60;
+            var heartbeatInterval = config
+                                   .WithKeys(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds)
+                                   .AsInt32()
+                                   .Get(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
+                                   .Value;
 
             return new TelemetrySettings(telemetryEnabled, configurationError, agentless, agentProxyEnabled, TimeSpan.FromSeconds(heartbeatInterval));
         }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.TestHelpers;
@@ -38,7 +39,7 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 
     protected bool? EnableSecurity { get; }
 
-    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(), $"{GetType().Name}Logs");
+    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance), $"{GetType().Name}Logs");
 
     public override void Dispose()
     {

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -5,6 +5,7 @@
 
 using System.IO;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -24,5 +25,5 @@ public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
         SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
     }
 
-    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(), $"{GetType().Name}Logs");
+    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance), $"{GetType().Name}Logs");
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -21,7 +22,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.RequestSampling, 50 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(50, iastSettings.RequestSampling);
     }
 
@@ -32,7 +33,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.RequestSampling, 150 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(IastSettings.RequestSamplingDefault, iastSettings.RequestSampling);
     }
 
@@ -43,7 +44,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.RequestSampling, -1 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(IastSettings.RequestSamplingDefault, iastSettings.RequestSampling);
     }
 
@@ -54,7 +55,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.MaxConcurrentRequests, 5 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(IastSettings.RequestSamplingDefault, iastSettings.RequestSampling);
     }
 
@@ -65,7 +66,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.MaxConcurrentRequests, -1 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(IastSettings.MaxConcurrentRequestDefault, iastSettings.MaxConcurrentRequests);
     }
 
@@ -76,7 +77,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.VulnerabilitiesPerRequest, 5 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(5, iastSettings.VulnerabilitiesPerRequest);
     }
 
@@ -87,7 +88,7 @@ public class IastSettingsTests : SettingsTestsBase
         {
             { ConfigurationKeys.Iast.VulnerabilitiesPerRequest, -1 }
         });
-        var iastSettings = new IastSettings(settings);
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
         Assert.Equal(IastSettings.VulnerabilitiesPerRequestDefault, iastSettings.VulnerabilitiesPerRequest);
     }
 
@@ -96,7 +97,7 @@ public class IastSettingsTests : SettingsTestsBase
     public void WeakCipherAlgorithms(string value, string expected)
     {
         var source = CreateConfigurationSource((ConfigurationKeys.Iast.WeakCipherAlgorithms, value));
-        var settings = new IastSettings(source);
+        var settings = new IastSettings(source, NullConfigurationTelemetry.Instance);
 
         settings.WeakCipherAlgorithms.Should().Be(expected);
         settings.WeakCipherAlgorithmsArray.Should().BeEquivalentTo(expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries));
@@ -107,7 +108,7 @@ public class IastSettingsTests : SettingsTestsBase
     public void WeakHashAlgorithms(string value, string expected)
     {
         var source = CreateConfigurationSource((ConfigurationKeys.Iast.WeakHashAlgorithms, value));
-        var settings = new IastSettings(source);
+        var settings = new IastSettings(source, NullConfigurationTelemetry.Instance);
 
         settings.WeakHashAlgorithms.Should().Be(expected);
         settings.WeakHashAlgorithmsArray.Should().BeEquivalentTo(expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries));
@@ -118,7 +119,7 @@ public class IastSettingsTests : SettingsTestsBase
     public void Enabled(string value, bool expected)
     {
         var source = CreateConfigurationSource((ConfigurationKeys.Iast.Enabled, value));
-        var settings = new IastSettings(source);
+        var settings = new IastSettings(source, NullConfigurationTelemetry.Instance);
 
         settings.Enabled.Should().Be(expected);
     }
@@ -128,7 +129,7 @@ public class IastSettingsTests : SettingsTestsBase
     public void DeduplicationEnabled(string value, bool expected)
     {
         var source = CreateConfigurationSource((ConfigurationKeys.Iast.IsIastDeduplicationEnabled, value));
-        var settings = new IastSettings(source);
+        var settings = new IastSettings(source, NullConfigurationTelemetry.Instance);
 
         settings.DeduplicationEnabled.Should().Be(expected);
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/OverheadControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/OverheadControllerTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Iast;
 using Datadog.Trace.Iast.Settings;
 using Xunit;
@@ -20,7 +21,7 @@ public class OverheadControllerTests
         {
             { ConfigurationKeys.Iast.RequestSampling, 50 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
         Assert.True(instance.AcquireRequest());
@@ -34,7 +35,7 @@ public class OverheadControllerTests
         {
             { ConfigurationKeys.Iast.RequestSampling, 100 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.True(instance.AcquireRequest());
         instance.ReleaseRequest();
@@ -50,7 +51,7 @@ public class OverheadControllerTests
         {
             { ConfigurationKeys.Iast.RequestSampling, 25 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
@@ -65,7 +66,7 @@ public class OverheadControllerTests
             { ConfigurationKeys.Iast.MaxConcurrentRequests, 1 },
             { ConfigurationKeys.Iast.RequestSampling, 100 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
@@ -81,7 +82,7 @@ public class OverheadControllerTests
             { ConfigurationKeys.Iast.MaxConcurrentRequests, 2 },
             { ConfigurationKeys.Iast.RequestSampling, 100 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.True(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
@@ -97,7 +98,7 @@ public class OverheadControllerTests
             { ConfigurationKeys.Iast.MaxConcurrentRequests, 2 },
             { ConfigurationKeys.Iast.RequestSampling, 50 }
         });
-        var instance = new OverheadController(new IastSettings(settings));
+        var instance = new OverheadController(new IastSettings(settings, NullConfigurationTelemetry.Instance));
         Assert.True(instance.AcquireRequest());
         Assert.False(instance.AcquireRequest());
         Assert.True(instance.AcquireRequest());

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -5,6 +5,7 @@
 
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void WafTimeoutInvalid(string value)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.WafTimeout, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             Assert.Equal(100_000ul, settings.WafTimeoutMicroSeconds);
         }
@@ -40,7 +41,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void WafTimeoutValid(string value, ulong expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.WafTimeout, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             Assert.Equal(expected, settings.WafTimeoutMicroSeconds);
         }
@@ -50,7 +51,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void BlockedHtmlTemplate(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.HtmlBlockedTemplate, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.BlockedHtmlTemplate.Should().Be(expected);
         }
@@ -60,7 +61,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void BlockedJsonTemplate(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.JsonBlockedTemplate, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.BlockedJsonTemplate.Should().Be(expected);
         }
@@ -70,7 +71,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void Enabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().Be(expected);
         }
@@ -82,7 +83,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void CanBeToggled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CanBeToggled.Should().Be(expected);
         }
@@ -93,7 +94,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void Rules(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Rules, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Rules.Should().Be(expected);
         }
@@ -103,7 +104,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void CustomIpHeader(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.CustomIpHeader, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CustomIpHeader.Should().Be(expected);
         }
@@ -116,7 +117,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void ExtraHeaders(string value, string[] expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ExtraHeaders, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ExtraHeaders.Should().BeEquivalentTo(expected);
         }
@@ -126,7 +127,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void KeepTraces(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.KeepTraces, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.KeepTraces.Should().Be(expected);
         }
@@ -136,7 +137,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void TraceRateLimit(string value, int expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.TraceRateLimit, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.TraceRateLimit.Should().Be(expected);
         }
@@ -146,7 +147,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void ObfuscationParameterKeyRegex(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ObfuscationParameterKeyRegex.Should().Be(expected);
         }
@@ -156,7 +157,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         public void ObfuscationParameterValueRegex(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterValueRegex, value));
-            var settings = new SecuritySettings(source);
+            var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ObfuscationParameterValueRegex.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Xunit.Abstractions;
 
@@ -43,7 +44,7 @@ namespace Datadog.Trace.TestHelpers
             _targetFramework = Assembly.GetAssembly(anchorType).GetCustomAttribute<TargetFrameworkAttribute>();
             _output = output;
             MonitoringHome = GetMonitoringHomePath();
-            LogDirectory = DatadogLoggingFactory.GetLogDirectory();
+            LogDirectory = DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance);
 
             var parts = _targetFramework.FrameworkName.Split(',');
             _runtime = parts[0];

--- a/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogEntryWatcher.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.TestHelpers;
@@ -26,7 +27,7 @@ public class LogEntryWatcher : IDisposable
 
     public LogEntryWatcher(string logFilePattern, string logDirectory = null)
     {
-        var logPath = logDirectory ?? DatadogLoggingFactory.GetLogDirectory();
+        var logPath = logDirectory ?? DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance);
         _fileWatcher = new FileSystemWatcher { Path = logPath, Filter = logFilePattern, EnableRaisingEvents = true };
         _readers = new();
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -5,6 +5,7 @@
 
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -18,7 +19,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void Enabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Enabled, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().Be(expected);
         }
@@ -28,7 +29,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void Agentless(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessEnabled, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Agentless.Should().Be(expected);
         }
@@ -38,7 +39,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void Logs(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Logs, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Logs.Should().Be(expected);
         }
@@ -48,7 +49,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ApiKey(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ApiKey.Should().Be(expected);
         }
@@ -58,7 +59,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ApplicationKey(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.ApplicationKey, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ApplicationKey.Should().Be(expected);
         }
@@ -68,7 +69,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void Site(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Site, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Site.Should().Be(expected);
         }
@@ -78,7 +79,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void AgentlessUrl(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessUrl, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.AgentlessUrl.Should().Be(expected);
         }
@@ -87,7 +88,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void MaximumAgentlessPayloadSize()
         {
             var source = CreateConfigurationSource();
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.MaximumAgentlessPayloadSize.Should().Be(5 * 1024 * 1024);
         }
@@ -97,7 +98,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ProxyHttps(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyHttps, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ProxyHttps.Should().Be(expected);
         }
@@ -110,7 +111,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ProxyNoProxy(string value, string[] expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyNoProxy, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ProxyNoProxy.Should().BeEquivalentTo(expected);
         }
@@ -120,7 +121,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void IntelligentTestRunnerEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.IntelligentTestRunnerEnabled.Should().Be(expected);
         }
@@ -130,7 +131,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void TestsSkippingEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.TestsSkippingEnabled, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.TestsSkippingEnabled.Should().Be(expected);
         }
@@ -140,7 +141,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CodeCoverageEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverage, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CodeCoverageEnabled.Should().Be(expected);
         }
@@ -150,7 +151,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CodeCoverageSnkFilePath(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageSnkFile, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CodeCoverageSnkFilePath.Should().Be(expected);
         }
@@ -160,7 +161,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CodeCoveragePath(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoveragePath, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CodeCoveragePath.Should().Be(expected);
         }
@@ -170,7 +171,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CodeCoverageEnableJitOptimizations(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CodeCoverageEnableJitOptimizations.Should().Be(expected);
         }
@@ -180,7 +181,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void GitUploadEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.GitUploadEnabled, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.GitUploadEnabled.Should().Be(expected);
         }
@@ -190,7 +191,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ForceAgentsEvpProxy(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, value));
-            var settings = new CIVisibilitySettings(source);
+            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ForceAgentsEvpProxy.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
@@ -1,0 +1,326 @@
+﻿// <copyright file="CompositeConfigurationSourceTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+public class CompositeConfigurationSourceTests
+{
+    private readonly CompositeConfigurationSource _source;
+    private readonly NullConfigurationTelemetry _telemetry = new();
+
+    public CompositeConfigurationSourceTests()
+    {
+        _source = new CompositeConfigurationSource()
+        {
+            new NameValueConfigurationSource(new NameValueCollection
+            {
+                { "string1", "source1_value1" },
+                // { "string2", "source1_value2" },
+                // { "string3", "source1_value3" },
+                // { "string4", "source1_value4" },
+                { "int1", "11" },
+                // { "int2", "12" },
+                // { "int3", "13" },
+                // { "int4", "14" },
+                { "double1", "1.1" },
+                // { "double2", "1.2" },
+                // { "double3", "1.3" },
+                // { "double4", "1.4" },
+                { "bool1", "true" },
+                // { "bool2", "true" },
+                // { "bool3", "true" },
+                // { "bool4", "true" },
+                { "dict1", "source1_a:value1,source1_b:value1" },
+                // { "dict2", "source1_a:value2,source1_b:value2" },
+                // { "dict3", "source1_a:value3,source1_b:value3" },
+                // { "dict4", "source1_a:value4,source1_b:value4" },
+            }),
+            new NameValueConfigurationSource(new NameValueCollection
+            {
+                { "string1", "source2_value1" },
+                { "string2", "source2_value2" },
+                // { "string3", "source2_value3" },
+                // { "string4", "source2_value4" },
+                { "int1", "21" },
+                { "int2", "22" },
+                // { "int3", "23" },
+                // { "int4", "24" },
+                { "double1", "2.1" },
+                { "double2", "2.2" },
+                // { "double3", "2.3" },
+                // { "double4", "2.4" },
+                { "bool1", "false" },
+                { "bool2", "false" },
+                // { "bool3", "false" },
+                // { "bool4", "false" },
+                { "dict1", "source2_a:value1,source2_b:value1" },
+                { "dict2", "source2_a:value2,source2_b:value2" },
+                // { "dict3", "source2_a:value3,source2_b:value3" },
+                // { "dict4", "source2_a:value4,source2_b:value4" },
+            }),
+            new NameValueConfigurationSource(new NameValueCollection
+            {
+                { "string1", "source3_value1" },
+                { "string2", "source3_value2" },
+                { "string3", "source3_value3" },
+                // { "string4", "source3_value4" },
+                { "int1", "31" },
+                { "int2", "32" },
+                { "int3", "33" },
+                // { "int4", "34" },
+                { "double1", "3.1" },
+                { "double2", "3.2" },
+                { "double3", "3.3" },
+                // { "double4", "3.4" },
+                { "bool1", "true" },
+                { "bool2", "true" },
+                { "bool3", "true" },
+                // { "bool4", "true" },
+                { "dict1", "source3_a:value1,source3_b:value1" },
+                { "dict2", "source3_a:value2,source3_b:value2" },
+                { "dict3", "source3_a:value3,source3_b:value3" },
+                // { "dict4", "source3_a:value4,source3_b:value4" },
+            }),
+            new NameValueConfigurationSource(new NameValueCollection
+            {
+                { "string1", "source4_value1" },
+                { "string2", "source4_value2" },
+                { "string3", "source4_value3" },
+                { "string4", "source4_value4" },
+                { "int1", "41" },
+                { "int2", "42" },
+                { "int3", "43" },
+                { "int4", "44" },
+                { "double1", "4.1" },
+                { "double2", "4.2" },
+                { "double3", "4.3" },
+                { "double4", "4.4" },
+                { "bool1", "false" },
+                { "bool2", "false" },
+                { "bool3", "false" },
+                { "bool4", "false" },
+                { "dict1", "source4_a:value1,source4_b:value1" },
+                { "dict2", "source4_a:value2,source4_b:value2" },
+                { "dict3", "source4_a:value3,source4_b:value3" },
+                { "dict4", "source4_a:value4,source4_b:value4" },
+            }),
+        };
+    }
+
+    [Theory]
+    [InlineData("string1", "source1_value1")]
+    [InlineData("string2", "source2_value2")]
+    [InlineData("string3", "source3_value3")]
+    [InlineData("string4", "source4_value4")]
+    public void GetsTheExpectedStringInAllCases(string key, string expected)
+    {
+        var actual = ((ITelemeteredConfigurationSource)_source).GetString(key, _telemetry, validator: null, recordValue: true);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("string1")]
+    [InlineData("string2")]
+    [InlineData("string3")]
+    [InlineData("string4")]
+    public void GetsTheSameStringInAllCases(string key)
+    {
+        var expected = ((IConfigurationSource)_source).GetString(key);
+        var actual = ((ITelemeteredConfigurationSource)_source).GetString(key, _telemetry, validator: null, recordValue: true);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("string1")]
+    [InlineData("string2")]
+    [InlineData("string3")]
+    [InlineData("string4")]
+    public void AttemptsToGrabStringFromEverySource(string key)
+    {
+        var telemetry = new StubTelemetry();
+        var actual = ((ITelemeteredConfigurationSource)_source).GetString(key, telemetry, validator: null, recordValue: true);
+        telemetry.Accesses[key].Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("int1", 11)]
+    [InlineData("int2", 22)]
+    [InlineData("int3", 33)]
+    [InlineData("int4", 44)]
+    public void GetsTheExpectedIntInAllCases(string key, int expected)
+    {
+        var actual = ((ITelemeteredConfigurationSource)_source).GetInt32(key, _telemetry, validator: null);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("int1")]
+    [InlineData("int2")]
+    [InlineData("int3")]
+    [InlineData("int4")]
+    public void GetsTheSameIntInAllCases(string key)
+    {
+        var expected = ((IConfigurationSource)_source).GetInt32(key);
+        var actual = ((ITelemeteredConfigurationSource)_source).GetInt32(key, _telemetry, validator: null);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("int1")]
+    [InlineData("int2")]
+    [InlineData("int3")]
+    [InlineData("int4")]
+    public void AttemptsToGrabIntFromEverySource(string key)
+    {
+        var telemetry = new StubTelemetry();
+        var actual = ((ITelemeteredConfigurationSource)_source).GetInt32(key, telemetry, validator: null);
+        telemetry.Accesses[key].Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("double1", 1.1)]
+    [InlineData("double2", 2.2)]
+    [InlineData("double3", 3.3)]
+    [InlineData("double4", 4.4)]
+    public void GetsTheExpectedDoubleInAllCases(string key, double expected)
+    {
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDouble(key, _telemetry, validator: null);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("double1")]
+    [InlineData("double2")]
+    [InlineData("double3")]
+    [InlineData("double4")]
+    public void GetsTheSameDoubleInAllCases(string key)
+    {
+        var expected = ((IConfigurationSource)_source).GetDouble(key);
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDouble(key, _telemetry, validator: null);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("double1")]
+    [InlineData("double2")]
+    [InlineData("double3")]
+    [InlineData("double4")]
+    public void AttemptsToGrabDoubleFromEverySource(string key)
+    {
+        var telemetry = new StubTelemetry();
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDouble(key, telemetry, validator: null);
+        telemetry.Accesses[key].Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("bool1", true)]
+    [InlineData("bool2", false)]
+    [InlineData("bool3", true)]
+    [InlineData("bool4", false)]
+    public void GetsTheExpectedBoolInAllCases(string key, bool expected)
+    {
+        var actual = ((ITelemeteredConfigurationSource)_source).GetBool(key, _telemetry, validator: null);
+        actual?.Result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("bool1")]
+    [InlineData("bool2")]
+    [InlineData("bool3")]
+    [InlineData("bool4")]
+    public void GetsTheSameBoolInAllCases(string key)
+    {
+        var expected = ((IConfigurationSource)_source).GetBool(key);
+        var actual = ((ITelemeteredConfigurationSource)_source).GetBool(key, _telemetry, validator: null);
+        ((bool?)actual?.Result).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("bool1")]
+    [InlineData("bool2")]
+    [InlineData("bool3")]
+    [InlineData("bool4")]
+    public void AttemptsToGrabBoolFromEverySource(string key)
+    {
+        var telemetry = new StubTelemetry();
+        var actual = ((ITelemeteredConfigurationSource)_source).GetBool(key, telemetry, validator: null);
+        telemetry.Accesses[key].Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData("dict1", "source1_a", "source1_b")]
+    [InlineData("dict2", "source2_a", "source2_b")]
+    [InlineData("dict3", "source3_a", "source3_b")]
+    [InlineData("dict4", "source4_a", "source4_b")]
+    public void GetsTheExpectedDictionaryInAllCases(string key, params string[] expectedKeys)
+    {
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDictionary(key, _telemetry, validator: null);
+        actual?.Result.Should().ContainKeys(expectedKeys);
+    }
+
+    [Theory]
+    [InlineData("dict1")]
+    [InlineData("dict2")]
+    [InlineData("dict3")]
+    [InlineData("dict4")]
+    public void GetsTheSameDictionaryInAllCases(string key)
+    {
+        var expected = ((IConfigurationSource)_source).GetDictionary(key);
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDictionary(key, _telemetry, validator: null);
+        actual?.Result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [InlineData("dict1")]
+    [InlineData("dict2")]
+    [InlineData("dict3")]
+    [InlineData("dict4")]
+    public void AttemptsToGrabDictionaryFromEverySource(string key)
+    {
+        var telemetry = new StubTelemetry();
+        var actual = ((ITelemeteredConfigurationSource)_source).GetDictionary(key, telemetry, validator: null);
+        telemetry.Accesses[key].Should().Be(1);
+    }
+
+    internal class StubTelemetry : IConfigurationTelemetry
+    {
+        public Dictionary<string, int> Accesses { get; } = new();
+
+        public void Record(string key, string value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+            => IncrementAccess(key);
+
+        public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+            => IncrementAccess(key);
+
+        public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+            => IncrementAccess(key);
+
+        public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+            => IncrementAccess(key);
+
+        public void SetErrorOnCurrentEntry(string key, ConfigurationTelemetryErrorCode error)
+        {
+        }
+
+        private void IncrementAccess(string key)
+        {
+            if (Accesses.TryGetValue(key, out var i))
+            {
+                Accesses[key] = i + 1;
+            }
+            else
+            {
+                Accesses[key] = 1;
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 using FluentAssertions;
 using Xunit;
 
@@ -295,19 +296,19 @@ public class CompositeConfigurationSourceTests
     {
         public Dictionary<string, int> Accesses { get; } = new();
 
-        public void Record(string key, string value, bool recordValue, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        public void Record(string key, string value, bool recordValue, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
             => IncrementAccess(key);
 
-        public void Record(string key, bool value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        public void Record(string key, bool value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
             => IncrementAccess(key);
 
-        public void Record(string key, double value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        public void Record(string key, double value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
             => IncrementAccess(key);
 
-        public void Record(string key, int value, ConfigurationOrigins origin, ConfigurationTelemetryErrorCode? error = null)
+        public void Record(string key, int value, ConfigurationOrigins origin, TelemetryErrorCode? error = null)
             => IncrementAccess(key);
 
-        public void SetErrorOnCurrentEntry(string key, ConfigurationTelemetryErrorCode error)
+        public void SetErrorOnCurrentEntry(string key, TelemetryErrorCode error)
         {
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -39,6 +40,7 @@ namespace Datadog.Trace.Tests.Configuration
         public static IEnumerable<object[]> GetGlobalDefaultTestData()
         {
             yield return new object[] { CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { CreateGlobalFunc(s => s.DiagnosticSourceEnabled), true };
         }
 
         public static IEnumerable<object[]> GetGlobalTestData()
@@ -254,7 +256,7 @@ namespace Datadog.Trace.Tests.Configuration
         [MemberData(nameof(GetGlobalDefaultTestData))]
         public void GlobalDefaultSetting(Func<GlobalSettings, object> settingGetter, object expectedValue)
         {
-            var settings = new GlobalSettings();
+            var settings = new GlobalSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }
@@ -269,7 +271,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var collection = new NameValueCollection { { key, value } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var settings = new GlobalSettings(source);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }
@@ -286,7 +288,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             // save original value so we can restore later
             Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-            var settings = new GlobalSettings(source);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
 
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ExporterSettingsTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using FluentAssertions;
 using Xunit;
 using MetricsTransportType = Datadog.Trace.Vendors.StatsdClient.Transport.TransportType;
@@ -298,12 +299,12 @@ namespace Datadog.Trace.Tests.Configuration
 
         private ExporterSettings Setup(string key, string value)
         {
-            return new ExporterSettings(BuildSource(key + ":" + value), NoFile());
+            return new ExporterSettings(BuildSource(key + ":" + value), NoFile(), NullConfigurationTelemetry.Instance);
         }
 
         private ExporterSettings Setup(Func<string, bool> fileExistsMock, params string[] config)
         {
-            return new ExporterSettings(BuildSource(config), fileExistsMock);
+            return new ExporterSettings(BuildSource(config), fileExistsMock, NullConfigurationTelemetry.Instance);
         }
 
         private NameValueConfigurationSource BuildSource(params string[] config)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void DebugEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DebugEnabled, value));
-            var settings = new GlobalSettings(source);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DebugEnabled.Should().Be(expected);
         }
@@ -27,7 +28,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void DiagnosticSourceEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DiagnosticSourceEnabled, value));
-            var settings = new GlobalSettings(source);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DiagnosticSourceEnabled.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -20,7 +21,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void IsUnsafeToTrace(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.IsUnsafeToTrace.Should().Be(expected);
         }
@@ -36,7 +37,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void SubscriptionId(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.SubscriptionId.Should().Be(expected);
         }
@@ -46,7 +47,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void ResourceGroup(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.ResourceGroupKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ResourceGroup.Should().Be(expected);
         }
@@ -56,7 +57,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void SiteName(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteNameKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.SiteName.Should().Be(expected);
         }
@@ -75,7 +76,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (ConfigurationKeys.AzureAppService.ResourceGroupKey, resourceGroup),
                 (ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, subscriptionId));
 
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ResourceId.Should().Be(expected);
         }
@@ -85,7 +86,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void InstanceId(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.InstanceIdKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.InstanceId.Should().Be(expected);
         }
@@ -95,7 +96,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void InstanceName(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.InstanceNameKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.InstanceName.Should().Be(expected);
         }
@@ -105,7 +106,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void OperatingSystem(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.OperatingSystemKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.OperatingSystem.Should().Be(expected);
         }
@@ -115,7 +116,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void SiteExtensionVersion(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteExtensionVersionKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.SiteExtensionVersion.Should().Be(expected);
         }
@@ -125,7 +126,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void FunctionsWorkerRuntime(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.FunctionsWorkerRuntime.Should().Be(expected);
         }
@@ -135,7 +136,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void FunctionsExtensionVersion(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.FunctionsExtensionVersion.Should().Be(expected);
         }
@@ -149,7 +150,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, functionsWorkerRuntime),
                 (ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, functionsExtensionVersion));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.AzureContext.Should().Be((AzureContext)expected);
         }
@@ -158,7 +159,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void Runtime()
         {
             var source = CreateConfigurationSource();
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.Runtime.Should().Be(FrameworkDescription.Instance.Name);
         }
@@ -168,7 +169,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void DebugModeEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DebugEnabled, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DebugModeEnabled.Should().Be(expected);
         }
@@ -178,7 +179,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void CustomTracingEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AasEnableCustomTracing, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.CustomTracingEnabled.Should().Be(expected);
         }
@@ -188,7 +189,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void NeedsDogStatsD(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AasEnableCustomMetrics, value));
-            var settings = new ImmutableAzureAppServiceSettings(source);
+            var settings = new ImmutableAzureAppServiceSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.NeedsDogStatsD.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -22,7 +23,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void RuntimeId()
         {
             var source = CreateConfigurationSource();
-            var settings = new RemoteConfigurationSettings(source);
+            var settings = new RemoteConfigurationSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.RuntimeId.Should().Be(Datadog.Trace.Util.RuntimeId.Get());
         }
@@ -31,7 +32,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void TracerVersion()
         {
             var source = CreateConfigurationSource();
-            var settings = new RemoteConfigurationSettings(source);
+            var settings = new RemoteConfigurationSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.TracerVersion.Should().Be(TracerConstants.ThreePartVersion);
         }
@@ -55,7 +56,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (ConfigurationKeys.Rcm.PollIntervalInternal, fallbackValue));
 #pragma warning restore CS0618
 
-            var settings = new RemoteConfigurationSettings(source);
+            var settings = new RemoteConfigurationSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.PollInterval.Should().Be(TimeSpan.FromMilliseconds(expected));
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -43,8 +43,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsString()
-                            .Get(Default);
+                            .AsString(Default);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -61,8 +60,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsString()
-                            .Get(Default, x => !string.IsNullOrEmpty(x));
+                            .AsString(Default, x => !string.IsNullOrEmpty(x));
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -108,8 +106,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsBool()
-                            .Get(Default);
+                            .AsBool(Default);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -126,8 +123,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsBool()
-                            .Get(Default, x => x);
+                            .AsBool(Default, x => x);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -176,8 +172,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsInt32()
-                            .Get(Default);
+                            .AsInt32(Default);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -194,8 +189,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsInt32()
-                            .Get(Default, x => x > 0);
+                            .AsInt32(Default, x => x > 0);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -238,8 +232,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsDouble()
-                            .Get(Default);
+                            .AsDouble(Default);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -256,8 +249,7 @@ public class ConfigurationBuilderTests
                 var expected = Naive(key);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsDouble()
-                            .Get(Default, x => x > 0);
+                            .AsDouble(Default, x => x > 0);
                 actual.Should().Be(expected, $"using key '{key}'");
             }
 
@@ -302,8 +294,7 @@ public class ConfigurationBuilderTests
                 var expected = _source.GetDictionary(key, allowOptionalMappings);
                 var actual = new ConfigurationBuilder(_source, _telemetry)
                             .WithKeys(key)
-                            .AsDictionary()
-                            .Get(allowOptionalMappings);
+                            .AsDictionary(allowOptionalMappings);
                 if (expected is null)
                 {
                     actual.Should().BeNull();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -1,0 +1,318 @@
+﻿// <copyright file="ConfigurationBuilderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+public class ConfigurationBuilderTests
+{
+    public class StringTests
+    {
+        private const string Default = "Some default";
+        private readonly NameValueCollection _collection;
+        private readonly NameValueConfigurationSource _source;
+        private readonly NullConfigurationTelemetry _telemetry = new();
+
+        public StringTests()
+        {
+            _collection = new NameValueCollection()
+            {
+                { "key", "value" },
+                { "key_with_null_value", null },
+                { "key_with_empty_value", string.Empty },
+            };
+            _source = new NameValueConfigurationSource(_collection);
+        }
+
+        [Fact]
+        public void GetString_WorksTheSameAsNaiveApproachWithDefault()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsString()
+                            .Get(Default);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            string Naive(string key) => _source.GetString(key) ?? Default;
+        }
+
+        [Fact]
+        public void GetString_WorksTheSameAsNaiveApproachWithValidation()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsString()
+                            .Get(Default, x => !string.IsNullOrEmpty(x));
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            string Naive(string key)
+            {
+                var value = _source.GetString(key);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    return value;
+                }
+
+                return Default;
+            }
+        }
+    }
+
+    public class BoolTests
+    {
+        private const bool Default = true;
+        private readonly NameValueCollection _collection;
+        private readonly NameValueConfigurationSource _source;
+        private readonly NullConfigurationTelemetry _telemetry = new();
+
+        public BoolTests()
+        {
+            _collection = new NameValueCollection()
+            {
+                { "key_True", "true" },
+                { "key_False", "false" },
+                { "key_with_null_value", null },
+                { "key_with_empty_value", string.Empty },
+            };
+            _source = new NameValueConfigurationSource(_collection);
+        }
+
+        [Fact]
+        public void GetBool_WorksTheSameAsNaiveApproachWithDefault()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsBool()
+                            .Get(Default);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            bool Naive(string key) => _source.GetBool(key) ?? Default;
+        }
+
+        [Fact]
+        public void GetBool_WorksTheSameAsNaiveApproachWithValidation()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsBool()
+                            .Get(Default, x => x);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            bool Naive(string key)
+            {
+                var value = _source.GetBool(key);
+                // not much validation we can do here!
+                if (value is true)
+                {
+                    return true;
+                }
+
+                return Default;
+            }
+        }
+    }
+
+    public class Int32Tests
+    {
+        private const int Default = 42;
+        private readonly NameValueCollection _collection;
+        private readonly NameValueConfigurationSource _source;
+        private readonly NullConfigurationTelemetry _telemetry = new();
+
+        public Int32Tests()
+        {
+            _collection = new NameValueCollection()
+            {
+                { "key", "123" },
+                { "negative", "-123" },
+                { "zero", "0" },
+                { "invalid", "fdsfds" },
+                { "key_with_null_value", null },
+                { "key_with_empty_value", string.Empty },
+            };
+            _source = new NameValueConfigurationSource(_collection);
+        }
+
+        [Fact]
+        public void GetInt32_WorksTheSameAsNaiveApproachWithDefault()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsInt32()
+                            .Get(Default);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            int Naive(string key) => _source.GetInt32(key) ?? Default;
+        }
+
+        [Fact]
+        public void GetInt32_WorksTheSameAsNaiveApproachWithValidation()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsInt32()
+                            .Get(Default, x => x > 0);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            int Naive(string key)
+            {
+                var value = _source.GetInt32(key);
+                return value is > 0 ? value.Value : Default;
+            }
+        }
+    }
+
+    public class DoubleTests
+    {
+        private const double Default = 42.0;
+        private readonly NameValueCollection _collection;
+        private readonly NameValueConfigurationSource _source;
+        private readonly NullConfigurationTelemetry _telemetry = new();
+
+        public DoubleTests()
+        {
+            _collection = new NameValueCollection()
+            {
+                { "key", "1.23" },
+                { "negative", "-12.3" },
+                { "zero", "0" },
+                { "invalid", "fdsfds" },
+                { "key_with_null_value", null },
+                { "key_with_empty_value", string.Empty },
+            };
+            _source = new NameValueConfigurationSource(_collection);
+        }
+
+        [Fact]
+        public void GetInt32_WorksTheSameAsNaiveApproachWithDefault()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsDouble()
+                            .Get(Default);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            double Naive(string key) => _source.GetDouble(key) ?? Default;
+        }
+
+        [Fact]
+        public void GetInt32_WorksTheSameAsNaiveApproachWithValidation()
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = Naive(key);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsDouble()
+                            .Get(Default, x => x > 0);
+                actual.Should().Be(expected, $"using key '{key}'");
+            }
+
+            double Naive(string key)
+            {
+                var value = _source.GetDouble(key);
+                return value is > 0 ? value.Value : Default;
+            }
+        }
+    }
+
+    public class DictionaryTests
+    {
+        private readonly NameValueCollection _collection;
+        private readonly NameValueConfigurationSource _source;
+        private readonly NullConfigurationTelemetry _telemetry = new();
+
+        public DictionaryTests()
+        {
+            _collection = new NameValueCollection()
+            {
+                { "key_no_spaces", "key1:value1,key2:value2,key3:value3" },
+                { "key_with_spaces", "key1:value1, key2:value2, key3:value3" },
+                { "trailing_semicolon", "key1:value1,key2:value2, key3:value3," },
+                { "optional_mappings", "key1:,key2:, key3:value3," },
+                { "single_value", "key1" },
+                { "key_with_null_value", null },
+                { "key_with_empty_value", string.Empty },
+            };
+            _source = new NameValueConfigurationSource(_collection);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GetDictionary_WorksTheSameAsNaiveApproachWithDefault(bool allowOptionalMappings)
+        {
+            var keys = _collection.AllKeys.Concat(new[] { "unknown" });
+
+            foreach (var key in keys)
+            {
+                var expected = _source.GetDictionary(key, allowOptionalMappings);
+                var actual = new ConfigurationBuilder(_source, _telemetry)
+                            .WithKeys(key)
+                            .AsDictionary()
+                            .Get(allowOptionalMappings);
+                if (expected is null)
+                {
+                    actual.Should().BeNull();
+                }
+                else
+                {
+                    actual.Should().Equal(expected, $"using key '{key}'");
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 using FluentAssertions;
 using Xunit;
 
@@ -23,12 +24,12 @@ public class ConfigurationTelemetryTests
         {
             new("string1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
             new("string2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i)),
-            new("string3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), error: ConfigurationTelemetryErrorCode.FailedValidation),
+            new("string3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), error: TelemetryErrorCode.FailedValidation),
             new("string4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i)),
             new("string4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
             new("redacted1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i), recordValue: false),
             new("redacted2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i), recordValue: false),
-            new("redacted3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), recordValue: false, ConfigurationTelemetryErrorCode.FailedValidation),
+            new("redacted3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), recordValue: false, TelemetryErrorCode.FailedValidation),
             new("redacted4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i), recordValue: false),
             new("redacted4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i), recordValue: false),
         };
@@ -117,7 +118,7 @@ public class ConfigurationTelemetryTests
             SeqId = entry.SeqId;
         }
 
-        public ConfigDto(string name, object value, ConfigurationOrigins origin, long seqId, bool recordValue = true, ConfigurationTelemetryErrorCode? error = null)
+        public ConfigDto(string name, object value, ConfigurationOrigins origin, long seqId, bool recordValue = true, TelemetryErrorCode? error = null)
         {
             Name = name;
             Value = value;
@@ -135,7 +136,7 @@ public class ConfigurationTelemetryTests
 
         public ConfigurationOrigins Origin { get; set; }
 
-        public ConfigurationTelemetryErrorCode? Error { get; set; }
+        public TelemetryErrorCode? Error { get; set; }
 
         public long SeqId { get; set; }
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
@@ -1,0 +1,142 @@
+﻿// <copyright file="ConfigurationTelemetryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Datadog.Trace.Configuration.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+public class ConfigurationTelemetryTests
+{
+    [Fact]
+    public void Record_RecordsTelemetryValues()
+    {
+        var i = 0;
+        var stringValues = new List<ConfigDto>
+        {
+            new("string1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+            new("string2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i)),
+            new("string3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), error: ConfigurationTelemetryErrorCode.FailedValidation),
+            new("string4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i)),
+            new("string4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
+            new("redacted1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i), recordValue: false),
+            new("redacted2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i), recordValue: false),
+            new("redacted3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), recordValue: false, ConfigurationTelemetryErrorCode.FailedValidation),
+            new("redacted4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i), recordValue: false),
+            new("redacted4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i), recordValue: false),
+        };
+
+        var boolValues = new List<ConfigDto>
+        {
+            new("bool", false, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
+            new("bool", true, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+        };
+
+        var intValues = new List<ConfigDto>
+        {
+            new("int", 123, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
+            new("int", 42, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+        };
+
+        var doubleValues = new List<ConfigDto>
+        {
+            new("double", 123.0, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
+            new("double", 42.0, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+        };
+
+        var telemetry = new ConfigurationTelemetry();
+        foreach (var val in stringValues)
+        {
+            telemetry.Record(val.Name, (string)val.Value, recordValue: val.RecordValue, val.Origin, val.Error);
+        }
+
+        foreach (var val in boolValues)
+        {
+            telemetry.Record(val.Name, (bool)val.Value, val.Origin, val.Error);
+        }
+
+        foreach (var val in intValues)
+        {
+            telemetry.Record(val.Name, (int)val.Value, val.Origin, val.Error);
+        }
+
+        foreach (var val in doubleValues)
+        {
+            telemetry.Record(val.Name, (double)val.Value, val.Origin, val.Error);
+        }
+
+        var expected = stringValues
+                      .Select(
+                           x =>
+                           {
+                               if (!x.RecordValue)
+                               {
+                                   x.Value = "<redacted>";
+                               }
+
+                               return x;
+                           })
+                      .Concat(boolValues)
+                      .Concat(intValues)
+                      .Concat(doubleValues)
+                      .OrderBy(x => x.SeqId)
+                      .ToList();
+
+        var actual = telemetry.GetLatest()
+                              .Select(x => new ConfigDto(x))
+                              .OrderBy(x => x.SeqId)
+                              .ToList();
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    internal class ConfigDto
+    {
+        public ConfigDto(ConfigurationTelemetry.ConfigurationTelemetryEntry entry)
+        {
+            Name = entry.Key;
+            Value = entry.Type switch
+            {
+                ConfigurationTelemetry.ConfigurationTelemetryEntryType.String => entry.StringValue,
+                ConfigurationTelemetry.ConfigurationTelemetryEntryType.Redacted => "<redacted>",
+                ConfigurationTelemetry.ConfigurationTelemetryEntryType.Bool => entry.BoolValue,
+                ConfigurationTelemetry.ConfigurationTelemetryEntryType.Int => entry.IntValue,
+                ConfigurationTelemetry.ConfigurationTelemetryEntryType.Double => entry.DoubleValue,
+                _ => new InvalidOperationException("Unknown entry type" + entry.Type),
+            };
+            RecordValue = entry.Type != ConfigurationTelemetry.ConfigurationTelemetryEntryType.Redacted;
+            Origin = entry.Origin;
+            Error = entry.Error;
+            SeqId = entry.SeqId;
+        }
+
+        public ConfigDto(string name, object value, ConfigurationOrigins origin, long seqId, bool recordValue = true, ConfigurationTelemetryErrorCode? error = null)
+        {
+            Name = name;
+            Value = value;
+            RecordValue = recordValue;
+            Origin = origin;
+            Error = error;
+            SeqId = seqId;
+        }
+
+        public string Name { get; set; }
+
+        public object Value { get; set; }
+
+        public bool RecordValue { get; }
+
+        public ConfigurationOrigins Origin { get; set; }
+
+        public ConfigurationTelemetryErrorCode? Error { get; set; }
+
+        public long SeqId { get; set; }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using FluentAssertions;
 using Xunit;
@@ -19,10 +20,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData(null)]
         public void InvalidMaxDepthToSerialize_DefaultUsed(string value)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.MaxDepthToSerialize, value },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.MaxDepthToSerialize, value }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.MaximumDepthOfMembersToCopy.Should().Be(3);
         }
@@ -34,10 +34,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData(null)]
         public void InvalidSerializationTimeThreshold_DefaultUsed(string value)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.MaxTimeToSerialize, value },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.MaxTimeToSerialize, value }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.MaxSerializationTimeInMilliseconds.Should().Be(200);
         }
@@ -48,10 +47,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData("false")]
         public void DebuggerDisabled(string enabled)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.Enabled, enabled },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.Enabled, enabled }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().BeFalse();
         }
@@ -59,12 +57,14 @@ namespace Datadog.Trace.Tests.Debugger
         [Fact]
         public void DebuggerSettings_UseSettings()
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.Enabled, "true" },
-                { ConfigurationKeys.Debugger.MaxDepthToSerialize, "100" },
-                { ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000" },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new()
+                {
+                    { ConfigurationKeys.Debugger.Enabled, "true" },
+                    { ConfigurationKeys.Debugger.MaxDepthToSerialize, "100" },
+                    { ConfigurationKeys.Debugger.MaxTimeToSerialize, "1000" },
+                }),
+                NullConfigurationTelemetry.Instance);
 
             settings.Enabled.Should().BeTrue();
             settings.MaximumDepthOfMembersToCopy.Should().Be(100);
@@ -78,10 +78,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData(null)]
         public void InvalidUploadBatchSize_DefaultUsed(string value)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.UploadBatchSize, value },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.UploadBatchSize, value }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.UploadBatchSize.Should().Be(100);
         }
@@ -93,10 +92,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData(null)]
         public void InvalidDiagnosticsInterval_DefaultUsed(string value)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.DiagnosticsInterval, value },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DiagnosticsInterval, value }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.DiagnosticsIntervalSeconds.Should().Be(5);
         }
@@ -108,10 +106,9 @@ namespace Datadog.Trace.Tests.Debugger
         [InlineData(null)]
         public void InvalidUploadFlushInterval_DefaultUsed(string value)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.UploadFlushInterval, value },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.UploadFlushInterval, value }, }),
+                NullConfigurationTelemetry.Instance);
 
             settings.UploadFlushIntervalMilliseconds.Should().Be(0);
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -9,6 +9,7 @@ using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Configurations;
 using Datadog.Trace.Debugger.Configurations.Models;
@@ -27,7 +28,9 @@ public class LiveDebuggerTests
     [Fact]
     public async Task DebuggerEnabled_ServicesCalled()
     {
-        var settings = DebuggerSettings.FromSource(new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.Enabled, "1" }, }));
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.Enabled, "1" }, }),
+            NullConfigurationTelemetry.Instance);
 
         var discoveryService = new DiscoveryServiceMock();
         var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();
@@ -47,7 +50,9 @@ public class LiveDebuggerTests
     [Fact]
     public async Task DebuggerDisabled_ServicesNotCalled()
     {
-        var settings = DebuggerSettings.FromSource(new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.Enabled, "0" }, }));
+        var settings = DebuggerSettings.FromSource(
+            new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.Enabled, "0" }, }),
+            NullConfigurationTelemetry.Instance);
 
         var discoveryService = new DiscoveryServiceMock();
         var rcmSubscriptionManagerMock = new RcmSubscriptionManagerMock();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Snapshots;
 using Newtonsoft.Json.Linq;
@@ -61,10 +62,9 @@ namespace Datadog.Trace.Tests.Debugger
 
         private SnapshotSlicer GetSlicer(int maxDepth, int maxSize)
         {
-            var settings = new DebuggerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.Debugger.MaxDepthToSerialize, maxDepth.ToString() },
-            }));
+            var settings = new DebuggerSettings(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.MaxDepthToSerialize, maxDepth.ToString() }, }),
+                NullConfigurationTelemetry.Instance);
 
             return SnapshotSlicer.Create(settings, maxSize);
         }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using FluentAssertions;
 using Xunit;
@@ -35,7 +36,7 @@ public class DatadogLoggingFactoryTests
 #pragma warning restore CS0618
                 });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
             config.File?.LogDirectory.Should().Be(logDirectory);
         }
@@ -58,7 +59,7 @@ public class DatadogLoggingFactoryTests
 #pragma warning restore CS0618
                 });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
             config.File?.LogDirectory.Should().Be(obsoleteLogDirectory);
         }
@@ -79,7 +80,7 @@ public class DatadogLoggingFactoryTests
 #pragma warning restore CS0618
                 });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
             config.File?.LogDirectory.Should().NotBeNullOrWhiteSpace();
         }
@@ -92,7 +93,7 @@ public class DatadogLoggingFactoryTests
 
             var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogDirectory, logDirectory } });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
             config.File?.LogDirectory.Should().Be(logDirectory);
             Directory.Exists(logDirectory).Should().BeTrue();
@@ -106,7 +107,7 @@ public class DatadogLoggingFactoryTests
         {
             var source = new NameValueConfigurationSource(new());
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
         }
 
@@ -119,7 +120,7 @@ public class DatadogLoggingFactoryTests
         {
             var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeTrue();
         }
 
@@ -132,7 +133,7 @@ public class DatadogLoggingFactoryTests
         {
             var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.HasValue.Should().BeFalse();
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.Internal.Configuration;
 using Datadog.Trace.Util;
@@ -267,10 +268,9 @@ namespace Datadog.Trace.Tests.Logging
             // make sure we can't write to it
             IsDirectoryWritable(directory).Should().BeFalse();
 
-            var config = DatadogLoggingFactory.GetConfiguration(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.LogDirectory, directory }
-            }));
+            var config = DatadogLoggingFactory.GetConfiguration(
+                new NameValueConfigurationSource(new() { { ConfigurationKeys.LogDirectory, directory } }),
+                NullConfigurationTelemetry.Instance);
             var logger = DatadogLoggingFactory.CreateFromConfiguration(config, DomainMetadata.Instance);
             logger.Should().NotBeNull();
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
@@ -129,7 +130,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             }
 
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.Host, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionHost.Should().Be(expected);
         }
@@ -139,7 +140,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionSource(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.Source, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionSource.Should().Be(expected);
         }
@@ -151,7 +152,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionMinimumLevel(string value, object expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.MinimumLevel, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionMinimumLevel.Should().Be((DirectSubmissionLogLevel)expected);
         }
@@ -163,7 +164,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionEnabledIntegrations(string value, string[] expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionEnabledIntegrations.Should().BeEquivalentTo(expected);
         }
@@ -178,7 +179,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionBatchSizeLimit(string value, int expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.BatchSizeLimit, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionBatchSizeLimit.Should().Be(expected);
         }
@@ -193,7 +194,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionQueueSizeLimit(string value, int expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.QueueSizeLimit, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionQueueSizeLimit.Should().Be(expected);
         }
@@ -208,7 +209,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void DirectLogSubmissionBatchPeriod(string value, int expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.DirectLogSubmissionBatchPeriod.Should().Be(TimeSpan.FromSeconds(expected));
         }
@@ -218,7 +219,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void ApiKey(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.ApiKey.Should().Be(expected);
         }
@@ -228,7 +229,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         public void LogsInjectionEnabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.LogsInjectionEnabled, value));
-            var settings = new DirectLogSubmissionSettings(source);
+            var settings = new DirectLogSubmissionSettings(source, NullConfigurationTelemetry.Instance);
 
             settings.LogsInjectionEnabled.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectSubmissionLogLevelExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectSubmissionLogLevelExtensionsTests.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
 
             foreach (var value in allValues)
             {
-                var parsed = DirectSubmissionLogLevelExtensions.Parse(value.ToString(), defaultLevel: (DirectSubmissionLogLevel)123);
+                var parsed = DirectSubmissionLogLevelExtensions.Parse(value.ToString());
                 parsed.Should().Be(value);
             }
         }
@@ -52,8 +52,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [InlineData("verbose")]
         public void Parse_ReturnsExpectedForKnownValues(string value)
         {
-            var defaultValue = (DirectSubmissionLogLevel)123;
-            var parsed = DirectSubmissionLogLevelExtensions.Parse(value, defaultValue);
+            var parsed = DirectSubmissionLogLevelExtensions.Parse(value);
             parsed.Should().Be(DirectSubmissionLogLevel.Verbose);
         }
 
@@ -62,11 +61,10 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [InlineData(null)]
         [InlineData("INVALID")]
         [InlineData("NOT_A_LEVEL")]
-        public void Parse_ReturnsDefaultForUnknownValues(string value)
+        public void Parse_ReturnsNullForUnknownValues(string value)
         {
-            var defaultValue = (DirectSubmissionLogLevel)123;
-            var parsed = DirectSubmissionLogLevelExtensions.Parse(value, defaultValue);
-            parsed.Should().Be(defaultValue);
+            var parsed = DirectSubmissionLogLevelExtensions.Parse(value);
+            parsed.Should().BeNull();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
@@ -206,7 +207,8 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
                         subscriptionId: "8c500027-5f00-400e-8f00-60000000000f",
                         deploymentId: "AzureExampleSiteName",
                         planResourceGroup: "apm-dotnet",
-                        siteResourceGroup: "apm-dotnet-site-resource-group"));
+                        siteResourceGroup: "apm-dotnet-site-resource-group"),
+                    NullConfigurationTelemetry.Instance);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -51,8 +51,11 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [InlineData(null)]
         public void InvalidApiKeyIsInvalid(string apiKey)
         {
-            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(Defaults));
-            tracerSettings.LogSubmissionSettings.ApiKey = apiKey;
+            var nameValueCollection = new NameValueCollection(Defaults);
+            nameValueCollection[ConfigurationKeys.ApiKey] = apiKey;
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(nameValueCollection));
+
             var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings);
 
             logSettings.IsEnabled.Should().BeFalse();

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -10,6 +10,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -48,7 +49,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void AzureContext_AzureAppService_Default()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(expected: AzureContext.AzureAppService, actual: metadata.AzureContext);
             Assert.Equal(expected: AppServiceKind, actual: metadata.SiteKind);
             Assert.Equal(expected: AppServiceType, actual: metadata.SiteType);
@@ -65,7 +66,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
                 functionsVersion: FunctionsVersion,
                 functionsRuntime: FunctionsRuntime);
 
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(expected: AzureContext.AzureFunctions, actual: metadata.AzureContext);
             Assert.Equal(expected: FunctionKind, actual: metadata.SiteKind);
             Assert.Equal(expected: FunctionType, actual: metadata.SiteType);
@@ -75,7 +76,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void ResourceId_Created_WhenAllRequirementsExist()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             var resourceId = metadata.ResourceId;
             Assert.Equal(expected: ExpectedResourceId, actual: resourceId);
         }
@@ -92,7 +93,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void OperatingSystem_Set()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(expected: "windows", actual: metadata.OperatingSystem);
         }
 
@@ -100,7 +101,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void InstanceId_Set()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(expected: "instance_id", actual: metadata.InstanceId);
         }
 
@@ -108,7 +109,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void InstanceName_Set()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(expected: "instance_name", actual: metadata.InstanceName);
         }
 
@@ -116,7 +117,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public void Runtime_Set()
         {
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(null, null, null, null);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.True(metadata.Runtime?.Length > 0);
         }
 
@@ -140,7 +141,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             // plan resource group actually doesn't matter for the resource id we build
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(subscriptionId, deploymentId, "some-resource-group", siteResourceGroup);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Null(metadata.ResourceId);
         }
 
@@ -158,7 +159,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             // plan resource group actually doesn't matter for the resource id we build
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", ddTraceDebug: ddTraceDebug);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(actual: metadata.DebugModeEnabled, expected: expectation);
         }
 
@@ -176,7 +177,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             // plan resource group actually doesn't matter for the resource id we build
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomMetrics: customMetrics);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(actual: metadata.NeedsDogStatsD, expected: expectation);
         }
 
@@ -194,7 +195,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             // plan resource group actually doesn't matter for the resource id we build
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues("subscription", "deploymentId", "some-resource-group", "siteResourceGroup", enableCustomTracing: customTracing);
-            var metadata = new ImmutableAzureAppServiceSettings(vars);
+            var metadata = new ImmutableAzureAppServiceSettings(vars, NullConfigurationTelemetry.Instance);
             Assert.Equal(actual: metadata.CustomTracingEnabled, expected: expectation);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
@@ -308,6 +308,7 @@ namespace Datadog.Trace.Configuration
         public virtual int? GetInt32(string key) { }
         public abstract string? GetString(string key);
         public static System.Collections.Generic.IDictionary<string, string>? ParseCustomKeyValues(string? data) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("data")]
         public static System.Collections.Generic.IDictionary<string, string>? ParseCustomKeyValues(string? data, bool allowOptionalMappings) { }
     }
     public class TracerSettings

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -108,7 +108,7 @@ namespace Datadog.Trace.Tests.Telemetry
             {
                 { ConfigurationKeys.Iast.Enabled, enabled.ToString() },
             });
-            collector.RecordIastSettings(new IastSettings(source));
+            collector.RecordIastSettings(new IastSettings(source, NullConfigurationTelemetry.Instance));
 
             var data = collector.GetConfigurationData()
                                 .ToDictionary(x => x.Name, x => x.Value);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -13,6 +13,7 @@ using System.Security.Permissions;
 #endif
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.PlatformHelpers;
@@ -121,13 +122,15 @@ namespace Datadog.Trace.Tests.Telemetry
             const string env = "serializer-tests";
             const string serviceVersion = "1.2.3";
             var settings = new TracerSettings() { ServiceName = ServiceName, Environment = env, ServiceVersion = serviceVersion, IsRunningInAzureAppService = true };
-            settings.AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(new NameValueConfigurationSource(new NameValueCollection
+            settings.AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(
+                new NameValueConfigurationSource(new NameValueCollection
                 {
                     { ConfigurationKeys.ApiKey, "SomeValue" },
                     { ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1" },
                     { ConfigurationKeys.AzureAppService.SiteExtensionVersionKey, "1.5.0" },
                     { ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, "~3" },
-                }));
+                }),
+                NullConfigurationTelemetry.Instance);
 
             var collector = new ConfigurationTelemetryCollector();
 
@@ -150,14 +153,16 @@ namespace Datadog.Trace.Tests.Telemetry
             const string env = "serializer-tests";
             const string serviceVersion = "1.2.3";
             var settings = new TracerSettings() { ServiceName = ServiceName, Environment = env, ServiceVersion = serviceVersion, IsRunningInAzureAppService = true };
-            settings.AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(new NameValueConfigurationSource(new NameValueCollection
-            {
-                // Without a DD_API_KEY, AAS does not consider it safe to trace
-                // { ConfigurationKeys.ApiKey, "SomeValue" },
-                { ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1" },
-                { ConfigurationKeys.AzureAppService.SiteExtensionVersionKey, "1.5.0" },
-                { ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, "~3" },
-            }));
+            settings.AzureAppServiceMetadata = new ImmutableAzureAppServiceSettings(
+                new NameValueConfigurationSource(new NameValueCollection
+                {
+                    // Without a DD_API_KEY, AAS does not consider it safe to trace
+                    // { ConfigurationKeys.ApiKey, "SomeValue" },
+                    { ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1" },
+                    { ConfigurationKeys.AzureAppService.SiteExtensionVersionKey, "1.5.0" },
+                    { ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, "~3" },
+                }),
+                NullConfigurationTelemetry.Instance);
 
             var collector = new ConfigurationTelemetryCollector();
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Tests.Telemetry
             {
                 { ConfigurationKeys.AppSec.Enabled, enabled.ToString() },
             });
-            collector.RecordSecuritySettings(new SecuritySettings(source));
+            collector.RecordSecuritySettings(new SecuritySettings(source, NullConfigurationTelemetry.Instance));
 
             var data = collector.GetConfigurationData()
                                 .ToDictionary(x => x.Name, x => x.Value);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -31,7 +32,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(expected);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -45,7 +46,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Enabled, "1" }
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
         }
@@ -59,7 +60,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -76,7 +77,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Site, domain },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be($"https://instrumentation-telemetry-intake.{domain}/");
@@ -93,7 +94,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Uri, url },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
 
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -113,7 +114,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
@@ -135,7 +136,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, apiKey },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
             var expectAgentless = enabled && !string.IsNullOrEmpty(apiKey);
 
             if (expectAgentless)
@@ -166,7 +167,7 @@ namespace Datadog.Trace.Tests.Telemetry
             });
             var hasApiKey = !string.IsNullOrEmpty(apiKey);
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
             using var s = new AssertionScope();
 
             settings.TelemetryEnabled.Should().Be(true);
@@ -210,7 +211,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, agentlessEnabled == true ? "SOME_KEY" : null },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
 
             var expectEnabled = enabled != false;
             var expectAgentless = expectEnabled && agentlessEnabled == true;
@@ -243,7 +244,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.AgentProxyEnabled, agentProxyEnabled?.ToString() }
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => agentAvailable);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => agentAvailable, telemetry: new NullConfigurationTelemetry());
 
             settings.AgentProxyEnabled.Should().Be(expected);
         }
@@ -262,7 +263,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "SOME_KEY" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true);
+            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
 
             using var s = new AssertionScope();
             settings.TelemetryEnabled.Should().Be(expected);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -289,7 +289,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void HeartbeatInterval(string value, int expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds, value));
-            var settings = TelemetrySettings.FromSource(source, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
 
             settings.HeartbeatInterval.Should().Be(TimeSpan.FromSeconds(expected));
         }


### PR DESCRIPTION
## Summary of changes

- Adds a new `ITelemeteredConfigurationSource` which should internally supersede the existing (public) `IConfigurationSource` for internal usages
- Introduced `ConfigurationBuilder` as the new canonical way to access configuration.
- Converted all usages of `IConfigurationSource` to use `ConfigurationBuilder` as a PoC 
- Use a "null" telemetry implementation for now, but also introduce a "real" implementation
- Mark `IConfigurationSource` as a "public API" so that we don't use it internally

## Reason for change

As part of the telemetry v2 API, we want to get insights into _how_ users are setting configuration values. That means we want to record:

- which source a config value came from
- Whether there was a parsing error in a source (e.g. an `int` setting couldn't be parsed)
- Whether there was a validation error in the final selected value (e.g. outside the acceptable range)
- When a value was subsequently changed

~~previously, we would stop reading settings from sources at the _first_ source that contains the variable. Now we always want to read all sources, and mark which sources were overridden and record when the value contained was invalid~~ This isn't the case now, we will still "stop" at the first value found, so there's no difference there.

From a public facing point of view, there should be no change in behaviour or API.

## Implementation details

This is only the very first part of the implementation (future work is described below), but wanted to get feedback on this before going further. From an internal-user point of view, the big change is that accessing configuration values changes from this:

```csharp
ServiceName = source.GetString(ConfigurationKeys.ServiceName)
                  ?? source.GetString("DD_SERVICE_NAME");

SomeConfig = source.GetDouble(ConfigurationKeys.SomeConfig ) is { } x and > 0 ? x : 200;
```

To this:

```csharp
var config = new ConfigurationBuilder(source, Telemetry);
ServiceName = config.WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
                    .AsString();

SomeConfig = config.WithKeys(ConfigurationKeys.SomeConfig)
                   .AsDouble(defaultValue: 200, val1 => val1 is > 0).Value;
```

The main reason for this builder pattern is to ensure we correctly collect the values we expect to at each point in the chain of sources.

Behind the scenes, the `ITelemeteredConfigurationSource` is doing essentially the same thing as the existing `IConfigurationSource` methods. The main difference is we need to record telemetry at different points in the parsing process (e.g. to record that a provided key value is not a valid `int`), so we generally _can't_ reuse the existing methods. Hence the duplicate implementation.

> There's quite a lot of duplication introduced in this PR, but I wanted to focus on the "public" API first to get feedback. Can refactor behind-the-scenes to reduce duplication later.

I've created a tentative telemetry sink (`ConfigurationTelemetry`) in this PR, as an idea about how it could work. This sink would then be passed to a telemetry collector, which will aggregate the various sources and send to the telemetry endpoint. For now, created a "null" sink that is a noop (and doesn't introduce extra allocations etc)

Also note that `IConfigurationSource` and all the implementations are `public`, so we can't change them and need to continue to support receiving them in the constructor etc 🙁 To work around that, I provided a `CustomTelemeteredConfigurationSource` that wraps the `IConfigurationSource`. We will need to deprecate all internal usages of `IConfigurationSource` to use `ConfigurationBuilder` instead. That's&hellip;a lot of places 😬 

There's still a lot of pending work to do if this PR is approved. I will split the subsequent work into multiple PRs.

## Outstanding work

For this PR:
- [x] Update all our existing usages of `IConfigurationSource` to use the `ConfigurationBuilder` 
- [x] Finalize the `ConfigurationTelemetry` implementation. Does it need to be thread safe (I don't think it does currently)? What API do we want for retrieving the added values in the collector?
  - It made sense to make this thread safe as it simplifies some other things
- [x] Replace the `NullConfigurationTelemetry` instance with `ConfigurationTelemetry`, and send to the collector.
  - Created a `TelemetryFactoryV2.GetConfigTelemetry()` which handles choosing which config type to use. For now, hard coded to use the "null" version.
- [x] Mark usages of `IConfigurationSource` as public api only, so we don't accidentally use the wrong one (we already have an analyzer + attribute we can use to detect that)

For follow up PRs:
- [ ] Send the `ConfigurationTelemetry` values to the telemetry API
- [ ] Figure out how to handle the situation where we retrieve configuration values more than once. e.g. if we read the same key directly from the `IConfigurationSource` in multiple places, we would record the telemetry multiple times. I don't _think_ this is an issue... it would just cause some duplication in the config values, but needs verifying
- [ ] Try to record more of the "validation" logic in `ExporterSettings` and `ImmutableDirectLogSummisionSettings` in config telemetry
- [ ] Record when users set telemetry values in code e.g. by doing `TracerSettings.Environment = "test"`. Will require source generator work to be feasible


## Test coverage

Just some initial unit tests to cover the new behavior at this point, but existing tests should extensively cover the changes in `TracerSettings` so should be pretty safe.

## Other details

Yes, I know "telemetered" is a horrendous, tortuous prefix. Please, someone find an alternative that means "has telemetry" and isn't "instrumented"
