### PR TITLE
[Profiler] Run Profiler Unit tests ASAN with leak detection enabled

### DIFF
--- a/profiler/test/Datadog.Profiler.Native.Tests/AppDomainStoreHelper.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AppDomainStoreHelper.cpp
@@ -11,10 +11,10 @@ AppDomainInfo::AppDomainInfo()
 {
 }
 
-AppDomainInfo::AppDomainInfo(ProcessID pid, const std::string& name)
+AppDomainInfo::AppDomainInfo(ProcessID pid, std::string name)
     :
     Pid{pid},
-    AppDomainName{name}
+    AppDomainName{std::move(name)}
 {
 }
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/AppDomainStoreHelper.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AppDomainStoreHelper.h
@@ -9,7 +9,7 @@ class AppDomainInfo
 {
 public:
     AppDomainInfo();
-    AppDomainInfo(ProcessID pid, const std::string& name);
+    AppDomainInfo(ProcessID pid, std::string name);
 
 public:
     ProcessID Pid;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -3,6 +3,7 @@
 
 #include "gtest/gtest.h"
 
+#include <memory>
 #include <vector>
 #include <unordered_map>
 #include <chrono>
@@ -82,16 +83,16 @@ RawCpuSample GetRawCpuSample(
 TEST(WallTimeProviderTest, CheckNoMissingSample)
 {
 // collect samples and check none are missing on the provider side (just count)
-    auto frameStore = new FrameStoreHelper(true, "Frame", 1);
-    auto appDomainStore = new AppDomainStoreHelper(2);
-    auto threadscpuManager = new ThreadsCpuManagerHelper();
+    auto frameStore = FrameStoreHelper(true, "Frame", 1);
+    auto appDomainStore = AppDomainStoreHelper(2);
+    auto threadscpuManager = ThreadsCpuManagerHelper();
     MockRuntimeIdStore runtimeIdStore;
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, threadscpuManager, frameStore, appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -110,10 +111,10 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
 {
 // add samples and check their appdomain, and pid labels
 // Note: thread labels cannot be checked because ThreadInfo is nullptr
-    auto frameStore = new FrameStoreHelper(true, "Frame", 1);
-    auto appDomainStore = new AppDomainStoreHelper(2);
+    auto frameStore = FrameStoreHelper(true, "Frame", 1);
+    auto appDomainStore = AppDomainStoreHelper(2);
     auto [configuration, mockConfiguration] = CreateConfiguration();
-    auto threadscpuManager = new ThreadsCpuManagerHelper();
+    auto threadscpuManager = ThreadsCpuManagerHelper();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string firstExpectedRuntimeId = "MyRid";
@@ -122,7 +123,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     std::string secondExpectedRuntimeId = "OtherRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(2))).WillRepeatedly(::testing::Return(secondExpectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, threadscpuManager, frameStore, appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -193,16 +194,16 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
 TEST(WallTimeProviderTest, CheckFrames)
 {
 // add samples and check their frames
-    auto frameStore = new FrameStoreHelper(true, "Frame", 4);
-    auto appDomainStore = new AppDomainStoreHelper(1);
+    auto frameStore = FrameStoreHelper(true, "Frame", 4);
+    auto appDomainStore = AppDomainStoreHelper(1);
     auto [configuration, mockConfiguration] = CreateConfiguration();
-    auto threadscpuManager = new ThreadsCpuManagerHelper();
+    auto threadscpuManager = ThreadsCpuManagerHelper();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, threadscpuManager, frameStore, appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -251,16 +252,16 @@ TEST(WallTimeProviderTest, CheckFrames)
 TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
 {
     // add samples and check their frames
-    auto frameStore = new FrameStoreHelper(true, "Frame", 1);
-    auto appDomainStore = new AppDomainStoreHelper(1);
+    auto frameStore = FrameStoreHelper(true, "Frame", 1);
+    auto appDomainStore = AppDomainStoreHelper(1);
     auto [configuration, mockConfiguration] = CreateConfiguration();
-    auto threadscpuManager = new ThreadsCpuManagerHelper();
+    auto threadscpuManager = ThreadsCpuManagerHelper();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, threadscpuManager, frameStore, appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -295,13 +296,13 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
 TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
 {
     // add samples and check their frames
-    auto frameStore = new FrameStoreHelper(true, "Frame", 1);
-    auto appDomainStore = new AppDomainStoreHelper(1);
-    auto threadscpuManager = new ThreadsCpuManagerHelper();
+    auto frameStore = FrameStoreHelper(true, "Frame", 1);
+    auto appDomainStore = AppDomainStoreHelper(1);
+    auto threadscpuManager = ThreadsCpuManagerHelper();
     RuntimeIdStoreHelper runtimeIdStore;
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
-    CpuTimeProvider provider(0, threadscpuManager, frameStore, appDomainStore, &runtimeIdStore, &mockConfiguration);
+    CpuTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -718,7 +718,7 @@ partial class Build
 
             if (sanitizer is SanitizerKind.Asan)
             {
-                envVars["ASAN_OPTIONS"] = "detect_leaks=0";
+                envVars["ASAN_OPTIONS"] = "detect_leaks=1";
             }
             else if (sanitizer is SanitizerKind.Ubsan)
             {

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -37,12 +37,12 @@ partial class Build : NukeBuild
                 GenerateConditionVariableBasedOnGitChange("isDebuggerChanged", new[]
                 {
                     "tracer/src/Datadog.Trace/Debugger",
-                    "tracer/src/Datadog.Tracer.Native", 
+                    "tracer/src/Datadog.Tracer.Native",
                     "tracer/test/Datadog.Trace.Debugger.IntegrationTests",
                     "tracer/test/test-applications/debugger",
                     "tracer/build/_build/Build.Steps.Debugger.cs"
                 }, new string[] { });
-                GenerateConditionVariableBasedOnGitChange("isProfilerChanged", new[] { "profiler/src" }, new string[] { });
+                GenerateConditionVariableBasedOnGitChange("isProfilerChanged", new[] { "profiler/src", "profiler/test" }, new string[] { });
 
                 void GenerateConditionVariableBasedOnGitChange(string variableName, string[] filters, string[] exclusionFilters)
                 {
@@ -106,8 +106,8 @@ partial class Build : NukeBuild
 
                 Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                 AzurePipelines.Instance.SetVariable("integration_tests_windows_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
-            }            
-            
+            }
+
             void GenerateIntegrationTestsDebuggerWindowsMatrix()
             {
                 var targetFrameworks = TestingFrameworksDebugger;
@@ -130,10 +130,10 @@ partial class Build : NukeBuild
                         {
                             foreach (var optimize in optimizations)
                             {
-                                matrix.Add($"{targetPlatform}_{framework}_{debugType}_{optimize}", 
+                                matrix.Add($"{targetPlatform}_{framework}_{debugType}_{optimize}",
                                            new
                                            {
-                                               framework = framework, 
+                                               framework = framework,
                                                targetPlatform = targetPlatform,
                                                debugType = debugType,
                                                optimize = optimize,
@@ -145,8 +145,8 @@ partial class Build : NukeBuild
 
                 Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                 AzurePipelines.Instance.SetVariable("integration_tests_windows_debugger_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
-            }            
-            
+            }
+
             void GenerateIntegrationTestsWindowsAzureFunctionsMatrix()
             {
                 // TODO: test on both x86 and x64?
@@ -250,10 +250,10 @@ partial class Build : NukeBuild
                     {
                         foreach (var optimize in optimizations)
                         {
-                            matrix.Add($"{baseImage}_{framework}_{optimize}", 
+                            matrix.Add($"{baseImage}_{framework}_{optimize}",
                                        new
                                        {
-                                           publishTargetFramework = framework, 
+                                           publishTargetFramework = framework,
                                            baseImage = baseImage,
                                            optimize = optimize,
                                        });
@@ -353,7 +353,7 @@ partial class Build : NukeBuild
                 GenerateLinuxNuGetSmokeTestsMatrix();
                 GenerateLinuxNuGetSmokeTestsArm64Matrix();
                 GenerateWindowsNuGetSmokeTestsMatrix();
-                
+
                 // dotnet tool smoke tests
                 GenerateWindowsDotnetToolSmokeTestsMatrix();
                 GenerateLinuxDotnetToolSmokeTestsMatrix();
@@ -363,7 +363,7 @@ partial class Build : NukeBuild
 
                 // msi smoke tests
                 GenerateWindowsMsiSmokeTestsMatrix();
-                
+
                 // tracer home smoke tests
                 GenerateWindowsTracerHomeSmokeTestsMatrix();
 
@@ -688,7 +688,7 @@ partial class Build : NukeBuild
                             });
                     }
                 }
-                
+
                 void GenerateLinuxDotnetToolSmokeTestsMatrix()
                 {
                     var matrix = new Dictionary<string, object>();
@@ -854,14 +854,14 @@ partial class Build : NukeBuild
                             });
                     }
                 }
-                
+
                 void GenerateWindowsMsiSmokeTestsMatrix()
                 {
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
-                    var platforms = new(MSBuildTargetPlatform platform, bool enable32Bit)[] { 
-                        (MSBuildTargetPlatform.x64, false), 
-                        (MSBuildTargetPlatform.x64, true), 
+                    var platforms = new(MSBuildTargetPlatform platform, bool enable32Bit)[] {
+                        (MSBuildTargetPlatform.x64, false),
+                        (MSBuildTargetPlatform.x64, true),
                         (MSBuildTargetPlatform.x86, true)
                     };
                     var runtimeImages = new (string publishFramework, string runtimeTag)[]
@@ -923,7 +923,7 @@ partial class Build : NukeBuild
                     Logger.Info(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetVariable("tracer_home_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
-                
+
                 void GenerateWindowsNuGetSmokeTestsMatrix()
                 {
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";


### PR DESCRIPTION
## Summary of changes

Profiler unit tests are run with the Address Sanitizer but not with leak detection enabled.

## Reason for change

Until today, leak detection was disabled when the profiler unit tests were run with Clang Address Sanitizer (avoiding failing the build for false positive).
But a recent coding issue introduced a memory leak. If the leak detection was activated we could have caught it.

## Implementation details

+ Activate lead detection when running the unit tests with ASAN
+ Fix unit tests that leaks
+ clean up code

## Test coverage

Current tests must pass
## Other details

Tried on my local machine and I was able to reproduce the memory leak and catch it.
<!-- Fixes #{issue} -->
