### PR TITLE
Update dockerfile to build native code with clang-16

### DIFF
--- a/tracer/build/_build/docker/centos7.build.dockerfile
+++ b/tracer/build/_build/docker/centos7.build.dockerfile
@@ -12,7 +12,8 @@ RUN yum update -y \
       wget \
       libcurl \
       libcurl-devel \
-      devtoolset-7
+      devtoolset-11 \
+      python3
 
 #install cmake version
 RUN wget https://cmake.org/files/v3.13/cmake-3.13.4.tar.gz && \
@@ -27,8 +28,8 @@ RUN cd .. && \
     rm -rf cmake-3.*
 
 # build and install llvm/clang
-RUN source scl_source enable devtoolset-7 && \
-    git clone --depth 1 --branch release/9.x https://github.com/llvm/llvm-project.git && \
+RUN source scl_source enable devtoolset-11 && \
+    git clone --depth 1 --branch release/16.x https://github.com/llvm/llvm-project.git && \
     cd llvm-project && \
     mkdir build && \
     cd build && \

--- a/tracer/build/_build/docker/centos7.dockerfile
+++ b/tracer/build/_build/docker/centos7.dockerfile
@@ -1,4 +1,4 @@
-﻿FROM gleocadie/centos7-clang9:v2 as base
+﻿FROM gleocadie/centos7-clang16 as base
 
 ARG DOTNETSDK_VERSION
 


### PR DESCRIPTION
## Summary of changes

Update centos docker image to be able to compile native code with Clang 16.

## Reason for change

* Benefit from the new version of clang and optimization
* Benefit from update in the tooling (ex: clang-tidy for static analysis)
* Allow native code be compiled against C++20 and benefit from features (ex: concepts, code less complex when using containers...)

## Implementation details
* Update `centos7.build.dockerfile` to build a clang-16-based image.
* Update `centos7.dockerfile` to use that image :)

## Test coverage

## Other details
<!-- Fixes #{issue} -->
