### PR TITLE
[Profiler] Make sure we catch tests that crashed in CI

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -123,6 +123,10 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                     return ("dotnet", $"{applicationPath} {arguments}");
                 }
 
+                // By default catchsegv/libsegfault.so reports only SIGSEGV signal.
+                // This environment variable allows us to catch and report signals that may crash the application.
+                Environment.CustomEnvironmentVariables.Add("SEGFAULT_SIGNALS", "all");
+
                 // catchsegv is a tool that catches the segmentation fault and displays useful information: callstack, registers...
                 return ("catchsegv", $"dotnet {applicationPath} {arguments}");
             }

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -231,6 +231,7 @@ partial class Build
                                 .SetNoWarnDotNetCore3()
                                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                                 .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
+                                .EnableCrashDumps()
                                 .SetFilter(filter)
                                 .SetProcessLogOutput(true)
                                 .SetProcessEnvironmentVariable("DD_TESTING_OUPUT_DIR", ProfilerBuildDataDirectory)


### PR DESCRIPTION
## Summary of changes

Make sure we catch tests that crashed in CI by
- Enabling crash dumps for the tests
- Instruct `catchsegv` to catch all signal that may crash the application (SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE and SIGSYS)

## Reason for change

Recently, there were profiler tests that ended up in a crash on alpine an centos.
On Centos, we use `catchsegv` (based on `libSegFault.so`) to catch signals and report the callstack that lead to the crash.
On Alpine, we have ... nothing.

## Implementation details

* Call `EnableCrashDumps` to instruct the Clr to generate a memory dump when a crash occurs.
* Add the environment variable `SEGFAULT_SIGNALS` with the value `all` to instruct `catchsegv/libSegFault.so` to catch and report any signals that crashed the tests (SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE and SIGSYS)

## Test coverage

## Other details
<!-- Fixes #{issue} -->
