### PR TITLE
Add checksums for release artifacts

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -29,46 +29,19 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: "Get current version"
-        id: versions
-        run: ./tracer/build.sh OutputCurrentVersionToGitHub
-
       - name: "Download build assets from Azure Pipelines"
         id: assets
         run: ./tracer/build.sh DownloadReleaseArtifacts
         env:
-          TargetBranch: ${{ github.event.ref }}
+          TargetBranch: refs/heads/master
           CommitSha: "${{ github.event.inputs.forced_commit_id }}"
+          Version: 2.28.0
 
-      - name: "Generate release notes"
-        id: release_notes
-        run: ./tracer/build.sh GenerateReleaseNotes
-        env:
-          PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
-
-      - name: "Rename vNext milestone"
-        id: rename
-        # We don't rename vNext/vNext-v1 for hotfix releases
-        if: ${{ !contains(github.event.ref, 'hotfix') }}
-        run: ./tracer/build.sh RenameVNextMilestone
-        env:
-          Version: ${{steps.versions.outputs.full_version}}
-
-      - name: "Create and push git tag"
-        run: |
-          git tag "v${{steps.versions.outputs.full_version}}"
-          git push origin "v${{steps.versions.outputs.full_version}}"
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
+      - name: Archive results for checking
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          name: "${{steps.versions.outputs.full_version}}"
-          tag_name: "v${{steps.versions.outputs.full_version}}"
-          prerelease: ${{steps.versions.outputs.isprerelease}}
-          body: ${{steps.release_notes.outputs.release_notes}}
-          fail_on_unmatched_files: true
-          files: |
+          name: code-coverage-report
+          path: |
             ${{steps.assets.outputs.artifacts_path}}/*.deb
             ${{steps.assets.outputs.artifacts_path}}/*.rpm
             ${{steps.assets.outputs.artifacts_path}}/*.tar.gz
@@ -76,22 +49,3 @@ jobs:
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
             ${{steps.assets.outputs.sha_path}}
-
-      - name: "Publish nuget packages to nuget.org"
-        working-directory: ${{steps.assets.outputs.artifacts_path}}
-        run: |
-          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-      
-      - name: "Trigger Docker Base Images Github Pipeline"
-        run: |
-          curl \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token $GITHUB_TOKEN"\
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
-          -d '{"event_type": "Trigger Workflow","inputs":{"targetBranch":"$targetBranch","commitSha":"$commitSha"}}'
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          targetBranch: ${{ github.event.ref }}
-          commitSha: "${{ github.event.inputs.forced_commit_id }}"

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -29,19 +29,46 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
+      - name: "Get current version"
+        id: versions
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
+
       - name: "Download build assets from Azure Pipelines"
         id: assets
         run: ./tracer/build.sh DownloadReleaseArtifacts
         env:
-          TargetBranch: refs/heads/master
+          TargetBranch: ${{ github.event.ref }}
           CommitSha: "${{ github.event.inputs.forced_commit_id }}"
-          Version: 2.28.0
 
-      - name: Archive results for checking
-        uses: actions/upload-artifact@v3
+      - name: "Generate release notes"
+        id: release_notes
+        run: ./tracer/build.sh GenerateReleaseNotes
+        env:
+          PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
+
+      - name: "Rename vNext milestone"
+        id: rename
+        # We don't rename vNext/vNext-v1 for hotfix releases
+        if: ${{ !contains(github.event.ref, 'hotfix') }}
+        run: ./tracer/build.sh RenameVNextMilestone
+        env:
+          Version: ${{steps.versions.outputs.full_version}}
+
+      - name: "Create and push git tag"
+        run: |
+          git tag "v${{steps.versions.outputs.full_version}}"
+          git push origin "v${{steps.versions.outputs.full_version}}"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
         with:
-          name: code-coverage-report
-          path: |
+          draft: true
+          name: "${{steps.versions.outputs.full_version}}"
+          tag_name: "v${{steps.versions.outputs.full_version}}"
+          prerelease: ${{steps.versions.outputs.isprerelease}}
+          body: ${{steps.release_notes.outputs.release_notes}}
+          fail_on_unmatched_files: true
+          files: |
             ${{steps.assets.outputs.artifacts_path}}/*.deb
             ${{steps.assets.outputs.artifacts_path}}/*.rpm
             ${{steps.assets.outputs.artifacts_path}}/*.tar.gz
@@ -49,3 +76,22 @@ jobs:
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
             ${{steps.assets.outputs.sha_path}}
+
+      - name: "Publish nuget packages to nuget.org"
+        working-directory: ${{steps.assets.outputs.artifacts_path}}
+        run: |
+          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+      
+      - name: "Trigger Docker Base Images Github Pipeline"
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: token $GITHUB_TOKEN"\
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
+          -d '{"event_type": "Trigger Workflow","inputs":{"targetBranch":"$targetBranch","commitSha":"$commitSha"}}'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          targetBranch: ${{ github.event.ref }}
+          commitSha: "${{ github.event.inputs.forced_commit_id }}"

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -75,6 +75,7 @@ jobs:
             ${{steps.assets.outputs.artifacts_path}}/*.zip
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
+            ${{steps.assets.outputs.sha_path}}
 
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1357,31 +1357,6 @@ partial class Build
 
         if (!string.IsNullOrEmpty(commitSha))
         {
-            var foundSha = false;
-            var maxCommitsBack = 20;
-            // basic verification, to ensure that the provided commitsha is actually on this branch
-            for (var i = 0; i < maxCommitsBack; i++)
-            {
-                var sha = GitTasks.Git($"log {TargetBranch}~{i} -1 --pretty=%H")
-                        .FirstOrDefault(x => x.Type == OutputType.Std)
-                        .Text;
-
-                if (string.Equals(commitSha, sha, StringComparison.OrdinalIgnoreCase))
-                {
-                    // OK, this SHA is definitely on this branch
-                    foundSha = true;
-                    break;
-                }
-            }
-
-            if (!foundSha)
-            {
-                Logger.Error($"Error: The commit {commitSha} could not be found in the last {maxCommitsBack} of the branch {TargetBranch}" +
-                                $"Ensure that the commit sha you have provided is correct, and you are running the create_release action from the correct branch");
-                throw new Exception($"The commit {commitSha} could not found in the latest {maxCommitsBack} of target branch {TargetBranch}");
-            }
-
-
             Logger.Info($"Finding build for commit sha: {commitSha}");
             var build = builds
                 .FirstOrDefault(b => string.Equals(b.SourceVersion, commitSha, StringComparison.OrdinalIgnoreCase));

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1357,6 +1357,31 @@ partial class Build
 
         if (!string.IsNullOrEmpty(commitSha))
         {
+            var foundSha = false;
+            var maxCommitsBack = 20;
+            // basic verification, to ensure that the provided commitsha is actually on this branch
+            for (var i = 0; i < maxCommitsBack; i++)
+            {
+                var sha = GitTasks.Git($"log {TargetBranch}~{i} -1 --pretty=%H")
+                        .FirstOrDefault(x => x.Type == OutputType.Std)
+                        .Text;
+
+                if (string.Equals(commitSha, sha, StringComparison.OrdinalIgnoreCase))
+                {
+                    // OK, this SHA is definitely on this branch
+                    foundSha = true;
+                    break;
+                }
+            }
+
+            if (!foundSha)
+            {
+                Logger.Error($"Error: The commit {commitSha} could not be found in the last {maxCommitsBack} of the branch {TargetBranch}" +
+                                $"Ensure that the commit sha you have provided is correct, and you are running the create_release action from the correct branch");
+                throw new Exception($"The commit {commitSha} could not found in the latest {maxCommitsBack} of target branch {TargetBranch}");
+            }
+
+
             Logger.Info($"Finding build for commit sha: {commitSha}");
             var build = builds
                 .FirstOrDefault(b => string.Equals(b.SourceVersion, commitSha, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary of changes

Adds a sha512.txt file with checksums to the release artifacts

## Reason for change

It's a good idea. Fixes #4032

## Implementation details

Generate the 512 sha for all the release artifacts and store in a sha512.txt file. You can verify a release artifact using this file (on Linux) by downloading the artifacts, and running the following in the same directory:

```
sha512sum -c sha512.txt --ignore-missing
```

## Test coverage

Hacked together a test using the "draft release action" for our previous release: [sha512.txt](https://github.com/DataDog/dd-trace-dotnet/files/11234266/sha512.txt)

## Other details
Closes #4032 
