### PR TITLE
Fix BadImageFormatException that occurred when trace annotations were used in conjunction with DD_TRACE_DEBUG

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -111,6 +111,11 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     bool isStatic = !(caller->method_signature.CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS);
     std::vector<trace::TypeSignature> methodArguments = caller->method_signature.GetMethodArguments();
     std::vector<trace::TypeSignature> traceAnnotationArguments;
+
+    // DO NOT move the definition of these buffers into an inner scope. It will cause memory corruption since they are referenced in a TypeSignature that is used later in this function.
+    COR_SIGNATURE runtimeMethodHandleBuffer[10];
+    COR_SIGNATURE runtimeTypeHandleBuffer[10];
+
     int numArgs = caller->method_signature.NumberOfArguments();
     auto metaEmit = module_metadata.metadata_emit;
     auto metaImport = module_metadata.metadata_import;
@@ -307,9 +312,6 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     }
     else
     {
-        COR_SIGNATURE runtimeMethodHandleBuffer[10];
-        COR_SIGNATURE runtimeTypeHandleBuffer[10];
-
         // Load the methodDef token to produce a RuntimeMethodHandle on the stack
         reWriterWrapper.LoadToken(caller->id);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ddTraceMethodsString += ";Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]";
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);
-
+            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
             // Don't bother with telemetry when two assemblies are loaded because we could get unreliable results
             MockTelemetryAgent<TelemetryData> telemetry = _twoAssembliesLoaded ? null : this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())


### PR DESCRIPTION
## Summary of changes

In #3955, a seemingly insignificant and helpful refactoring [was made in method_rewriter.cpp](https://github.com/DataDog/dd-trace-dotnet/pull/3955/files#diff-955180a276ab7fe361e8873e9cc3e119bae6314cb389b74b2c7a3543c2bca172L114-L312): the definition of two variables, `runtimeMethodHandleBuffer` and `runtimeTypeHandleBuffer` was moved into an inner scope, thereby moving the variable definitions closer to where the variables were actually used. 

Unfortunately, this refactoring was not so innocent after all, as these buffers are allocated on the stack, and pointers to them [are indirectly placed](https://github.com/DataDog/dd-trace-dotnet/blob/32d16311ecae3cf0db5c23a8368ce210cdb858ac/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp#L329-L340) in a `std::vector<trace::TypeSignature>` that is [used outside of the aforementioned scope](https://github.com/DataDog/dd-trace-dotnet/blob/32d16311ecae3cf0db5c23a8368ce210cdb858ac/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp#L381), leading to memory corruption.

The reason this issue did not cause any tests to fail is that coincidentally, the [only code that gets executed](https://github.com/DataDog/dd-trace-dotnet/blob/32d16311ecae3cf0db5c23a8368ce210cdb858ac/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp#L344-L378) between the moment the buffers go out of scope and the moment they are used is surrounded by an `if statement` that checks if `DD_TRACE_DEBUG` is enabled. If `DD_TRACE_DEBUG` is not enabled (which is the case in our integration tests), by sheer luck (or lack thereof), the stack does not get tarnished, and the code executes as expected.

## Reason for change
Fix #4035.

## Test coverage
In f07a3a49fe565c749947ddda9fbfbf962cbbd802, I changed some Trace Annotation integration tests to enable `DD_TRACE_DEBUG`. [I manually ran just this change in CI](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=135157&view=ms.vss-test-web.build-test-results-tab&runId=11309212&resultId=100036&paneView=attachments) and validated that indeed, without this fix, the test fail due to the same `BadImageFormatException` that is reported in #4035.

Also tested the fix locally with [this repro](https://github.com/DataDog/dd-trace-dotnet/tree/pierre/badimageformat-2.28) (thanks @pierotibou !)