### PR TITLE
[Profiler] Fix missing CPU samples

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -155,15 +155,17 @@ uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
     return cpuTime;
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime)
+bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
     bool isRunning = false;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))
     {
         cpuTime = 0;
+        failed = true;
         return false;
     }
 
+    failed = false;
     return isRunning;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -19,6 +19,6 @@ namespace OsSpecificApi
 {
    std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
    uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
-   bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime);
+   bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
    int32_t GetProcessorCount();
 } // namespace OsSpecificApi

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -244,15 +244,21 @@ void StackSamplerLoop::CpuProfilingIteration()
         _targetThread = _pManagedThreadList->LoopNext(_iteratorCpuTime);
         if (_targetThread != nullptr)
         {
+            // detect Windows API call failure
+            bool failure = false;
+
             // sample only if the thread is currently running on a core
             uint64_t currentConsumption = 0;
             uint64_t lastConsumption = _targetThread->GetCpuConsumptionMilliseconds();
-            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption);
-            // Note: it is not possible to get this information on Windows 32-bit
-            //       so true is returned if this thread consumed some CPU since
-            //       the last iteration
+            bool isRunning = OsSpecificApi::IsRunning(_targetThread.get(), currentConsumption, failure);
+            // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
+            //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
-    #if BIT64  // nothing to do for Windows 64-bit
+    #if BIT64  // Windows 64-bit
+            if (failure)
+            {
+                isRunning = (lastConsumption < currentConsumption);
+            }
     #else  // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);
     #endif


### PR DESCRIPTION
## Summary of changes
Check Windows API errors that could lead to skip sampling threads and add error log

## Reason for change
A customer gets profiles without any CPU sample.

## Implementation details
If IsRunning is returning false, no thread could have CPU sample. The only reasonable reason seems to come from an error returned by undocumented NtQueryInformationThread method. This patch is logging this kind of situation and tried, like in 32 bit, to sample based on CPU consumption difference instead of running on/waiting for a core.
It is still possible that GetThreadTimes could also fails...

Test coverage
## Test coverage

## Other details
<!-- Fixes #{issue} -->
