### PR TITLE
[Profiler] Make sure the memory dump is copied when a profiler test failed

### DIFF
--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -245,6 +245,8 @@ partial class Build
         finally
         {
             CopyDumpsTo(ProfilerBuildDataDirectory);
+            // A crashed occured on linux and the memory dump copy failed due a lack of permission.
+            Chmod.Value.Invoke("-R 777 " + ProfilerBuildDataDirectory);
         }
     }
 


### PR DESCRIPTION
## Summary of changes

Make sure we get the memory dump of the process when a profiler test fails

## Reason for change

Today, when a test profiler test application fails on linux (centos and alpine), the memory dump file copied to `profiler/build_data/dumps` cannot be accessed by AzDo due to a permission issue.

## Implementation details

Make sure `profiler/build_data` is accessible by setting `777` as permission for the folder.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
