### PR TITLE
[CI Visibility] Update ci specs and add codefresh support

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -364,6 +364,14 @@ namespace Datadog.Trace.Ci
             {
                 SetupBuddyEnvironment(gitInfo);
             }
+            else if (EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshBuildId) != null)
+            {
+                SetupCodefreshEnvironment(gitInfo);
+                VariablesToBypass = new Dictionary<string, string>();
+                SetEnvironmentVariablesIfNotEmpty(
+                    VariablesToBypass,
+                    Constants.CodefreshBuildId);
+            }
             else
             {
                 Branch = gitInfo.Branch;
@@ -1014,6 +1022,29 @@ namespace Datadog.Trace.Ci
             WorkspacePath = gitInfo.SourceRoot;
         }
 
+        private void SetupCodefreshEnvironment(GitInfo gitInfo)
+        {
+            IsCI = true;
+            Provider = "codefresh";
+            PipelineId = EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshBuildId);
+            PipelineName = EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshPipelineName);
+            PipelineUrl = EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshBuildUrl);
+            JobName = EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshStepName);
+            Branch = EnvironmentHelpers.GetEnvironmentVariable(Constants.CodefreshBranch) ?? gitInfo.Branch;
+
+            Commit = gitInfo.Commit;
+            Repository = gitInfo.Repository;
+            Message = gitInfo.Message;
+            AuthorName = gitInfo.AuthorName;
+            AuthorEmail = gitInfo.AuthorEmail;
+            AuthorDate = gitInfo.AuthorDate;
+            CommitterName = gitInfo.CommitterName;
+            CommitterEmail = gitInfo.CommitterEmail;
+            CommitterDate = gitInfo.CommitterDate;
+            SourceRoot = gitInfo.SourceRoot;
+            WorkspacePath = gitInfo.SourceRoot;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CleanBranchAndTag()
         {
@@ -1268,6 +1299,13 @@ namespace Datadog.Trace.Ci
             public const string BuddyExecutionRevisionMessage = "BUDDY_EXECUTION_REVISION_MESSAGE";
             public const string BuddyExecutionRevisionCommitterName = "BUDDY_EXECUTION_REVISION_COMMITTER_NAME";
             public const string BuddyExecutionRevisionCommitterEmail = "BUDDY_EXECUTION_REVISION_COMMITTER_EMAIL";
+
+            // Codefresh CI Environment variables
+            public const string CodefreshBuildId = "CF_BUILD_ID";
+            public const string CodefreshPipelineName = "CF_PIPELINE_NAME";
+            public const string CodefreshBuildUrl = "CF_BUILD_URL";
+            public const string CodefreshStepName = "CF_STEP_NAME";
+            public const string CodefreshBranch = "CF_BRANCH";
 
             // Datadog Custom CI Environment variables
             public const string DDGitBranch = "DD_GIT_BRANCH";

--- a/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -72,6 +73,10 @@ namespace Datadog.Trace.Ci
         public string StageName { get; private set; }
 
         public string WorkspacePath { get; private set; }
+
+        public string NodeName { get; private set; }
+
+        public string[] NodeLabels { get; private set; }
 
         public CodeOwners CodeOwners { get; private set; }
 
@@ -191,6 +196,12 @@ namespace Datadog.Trace.Ci
             SetTagIfNotNullOrEmpty(span, CommonTags.CIPipelineUrl, PipelineUrl);
             SetTagIfNotNullOrEmpty(span, CommonTags.CIJobUrl, JobUrl);
             SetTagIfNotNullOrEmpty(span, CommonTags.CIJobName, JobName);
+            SetTagIfNotNullOrEmpty(span, CommonTags.CINodeName, NodeName);
+            if (NodeLabels is { } nodeLabels)
+            {
+                SetTagIfNotNullOrEmpty(span, CommonTags.CINodeLabels, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(nodeLabels));
+            }
+
             SetTagIfNotNullOrEmpty(span, CommonTags.StageName, StageName);
             SetTagIfNotNullOrEmpty(span, CommonTags.CIWorkspacePath, WorkspacePath);
             SetTagIfNotNullOrEmpty(span, CommonTags.GitRepository, Repository);
@@ -689,6 +700,10 @@ namespace Datadog.Trace.Ci
                     PipelineName = jobNameParts[0];
                 }
             }
+
+            // Node
+            NodeName = EnvironmentHelpers.GetEnvironmentVariable(Constants.JenkinsNodeName);
+            NodeLabels = EnvironmentHelpers.GetEnvironmentVariable(Constants.JenkinsNodeLabels)?.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private void SetupGitlabEnvironment()
@@ -731,6 +746,13 @@ namespace Datadog.Trace.Ci
 
             // Clean pipeline url
             PipelineUrl = PipelineUrl?.Replace("/-/pipelines/", "/pipelines/");
+
+            // Node
+            NodeName = EnvironmentHelpers.GetEnvironmentVariable(Constants.GitlabRunnerId);
+            if (EnvironmentHelpers.GetEnvironmentVariable(Constants.GitlabRunnerTags) is { } runnerTags)
+            {
+                NodeLabels = Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(runnerTags);
+            }
         }
 
         private void SetupAppveyorEnvironment()
@@ -912,6 +934,24 @@ namespace Datadog.Trace.Ci
             AuthorEmail = EnvironmentHelpers.GetEnvironmentVariable(Constants.BuildKiteBuildAuthorEmail);
             CommitterName = EnvironmentHelpers.GetEnvironmentVariable(Constants.BuildKiteBuildCreator);
             CommitterEmail = EnvironmentHelpers.GetEnvironmentVariable(Constants.BuildKiteBuildCreatorEmail);
+
+            // Node
+            NodeName = EnvironmentHelpers.GetEnvironmentVariable(Constants.BuildKiteAgentId);
+            var lstNodeLabels = new List<string>();
+            foreach (DictionaryEntry envvar in EnvironmentHelpers.GetEnvironmentVariables())
+            {
+                if (envvar.Key is string key && key.StartsWith(Constants.BuildKiteAgentMetadata, StringComparison.OrdinalIgnoreCase))
+                {
+                    var name = key.Replace(Constants.BuildKiteAgentMetadata, string.Empty)?.ToLowerInvariant();
+                    var value = envvar.Value?.ToString();
+                    lstNodeLabels.Add($"{name}:{value}");
+                }
+            }
+
+            if (lstNodeLabels.Count > 0)
+            {
+                NodeLabels = lstNodeLabels.ToArray();
+            }
         }
 
         private void SetupBitriseEnvironment()
@@ -1085,6 +1125,8 @@ namespace Datadog.Trace.Ci
             public const string JenkinsBuildNumber = "BUILD_NUMBER";
             public const string JenkinsBuildUrl = "BUILD_URL";
             public const string JenkinsJobName = "JOB_NAME";
+            public const string JenkinsNodeName = "NODE_NAME";
+            public const string JenkinsNodeLabels = "NODE_LABELS";
 
             // Gitlab Environment variables
             public const string GitlabCI = "GITLAB_CI";
@@ -1106,6 +1148,8 @@ namespace Datadog.Trace.Ci
             public const string GitlabCommitMessage = "CI_COMMIT_MESSAGE";
             public const string GitlabCommitAuthor = "CI_COMMIT_AUTHOR";
             public const string GitlabCommitTimestamp = "CI_COMMIT_TIMESTAMP";
+            public const string GitlabRunnerId = "CI_RUNNER_ID";
+            public const string GitlabRunnerTags = "CI_RUNNER_TAGS";
 
             // Appveyor CI Environment variables
             public const string Appveyor = "APPVEYOR";
@@ -1190,6 +1234,8 @@ namespace Datadog.Trace.Ci
             public const string BuildKiteBuildAuthorEmail = "BUILDKITE_BUILD_AUTHOR_EMAIL";
             public const string BuildKiteBuildCreator = "BUILDKITE_BUILD_CREATOR";
             public const string BuildKiteBuildCreatorEmail = "BUILDKITE_BUILD_CREATOR_EMAIL";
+            public const string BuildKiteAgentId = "BUILDKITE_AGENT_ID";
+            public const string BuildKiteAgentMetadata = "BUILDKITE_AGENT_META_DATA_";
 
             // Bitrise CI Environment variables
             public const string BitriseBuildSlug = "BITRISE_BUILD_SLUG";

--- a/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CommonTags.cs
@@ -106,6 +106,16 @@ namespace Datadog.Trace.Ci.Tags
         public const string CIJobName = "ci.job.name";
 
         /// <summary>
+        /// CI Node Name
+        /// </summary>
+        public const string CINodeName = "ci.node.name";
+
+        /// <summary>
+        /// CI Node Labels
+        /// </summary>
+        public const string CINodeLabels = "ci.node.labels";
+
+        /// <summary>
         /// CI Stage Name
         /// </summary>
         public const string StageName = "ci.stage.name";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -103,6 +103,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         value = value.Replace(".000", string.Empty);
                     }
 
+                    if (spanDataItem.Key == CommonTags.CINodeLabels)
+                    {
+                        var labelsExpected = Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(
+                            spanDataItem.Value);
+                        Array.Sort(labelsExpected);
+
+                        var labelsActual =
+                            Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(value);
+                        Array.Sort(labelsActual);
+
+                        Assert.True(labelsExpected.SequenceEqual(labelsActual));
+                        continue;
+                    }
+
                     Assert.Equal(spanDataItem.Value, value);
                 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/buildkite.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/buildkite.json
@@ -703,5 +703,39 @@
       "git.commit.sha": "buildkite-git-commit",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
     }
+  ],
+  [
+    {
+      "BUILDKITE": "true",
+      "BUILDKITE_AGENT_ID": "1a222222-e999-3636-8ddd-802222222222",
+      "BUILDKITE_AGENT_META_DATA_MYOTHERTAG": "my-other-value",
+      "BUILDKITE_AGENT_META_DATA_MYTAG": "my-value",
+      "BUILDKITE_BRANCH": "",
+      "BUILDKITE_BUILD_AUTHOR": "buildkite-git-commit-author-name",
+      "BUILDKITE_BUILD_AUTHOR_EMAIL": "buildkite-git-commit-author-email@datadoghq.com",
+      "BUILDKITE_BUILD_ID": "buildkite-pipeline-id",
+      "BUILDKITE_BUILD_NUMBER": "buildkite-pipeline-number",
+      "BUILDKITE_BUILD_URL": "buildkite-build-url",
+      "BUILDKITE_COMMIT": "buildkite-git-commit",
+      "BUILDKITE_JOB_ID": "buildkite-job-id",
+      "BUILDKITE_MESSAGE": "buildkite-git-commit-message",
+      "BUILDKITE_PIPELINE_SLUG": "buildkite-pipeline-name",
+      "BUILDKITE_TAG": ""
+    },
+    {
+      "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.url": "buildkite-build-url#buildkite-job-id",
+      "ci.node.labels": "[\"mytag:my-value\",\"myothertag:my-other-value\"]",
+      "ci.node.name": "1a222222-e999-3636-8ddd-802222222222",
+      "ci.pipeline.id": "buildkite-pipeline-id",
+      "ci.pipeline.name": "buildkite-pipeline-name",
+      "ci.pipeline.number": "buildkite-pipeline-number",
+      "ci.pipeline.url": "buildkite-build-url",
+      "ci.provider.name": "buildkite",
+      "git.commit.author.email": "buildkite-git-commit-author-email@datadoghq.com",
+      "git.commit.author.name": "buildkite-git-commit-author-name",
+      "git.commit.message": "buildkite-git-commit-message",
+      "git.commit.sha": "buildkite-git-commit"
+    }
   ]
 ]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/codefresh.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/codefresh.json
@@ -1,0 +1,162 @@
+[
+  [
+    {
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh"
+    }
+  ],
+  [
+    {
+      "CF_BRANCH": "origin/master",
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.branch": "master"
+    }
+  ],
+  [
+    {
+      "CF_BRANCH": "refs/heads/feature/one",
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.branch": "feature/one"
+    }
+  ],
+  [
+    {
+      "CF_BRANCH": "origin/tags/0.1.0",
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CF_BRANCH": "refs/heads/tags/0.1.0",
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.tag": "0.1.0"
+    }
+  ],
+  [
+    {
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "CF_BUILD_ID": "6410367cee516146a4c4c66e",
+      "CF_BUILD_URL": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "CF_PIPELINE_NAME": "My simple project/Example Java Project Pipeline",
+      "CF_STEP_NAME": "mah-job-name",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_GIT_TAG": "0.0.2"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CF_BUILD_ID\":\"6410367cee516146a4c4c66e\"}",
+      "ci.job.name": "mah-job-name",
+      "ci.pipeline.id": "6410367cee516146a4c4c66e",
+      "ci.pipeline.name": "My simple project/Example Java Project Pipeline",
+      "ci.pipeline.url": "https://g.codefresh.io/build/6410367cee516146a4c4c66e",
+      "ci.provider.name": "codefresh",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git",
+      "git.tag": "0.0.2"
+    }
+  ]
+]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/gitlab.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/gitlab.json
@@ -888,5 +888,41 @@
       "git.commit.sha": "gitlab-git-commit",
       "git.repository_url": "https://gitlab.com/DataDog/dogweb.git"
     }
+  ],
+  [
+    {
+      "CI_COMMIT_AUTHOR": "John Doe <john@doe.com>",
+      "CI_COMMIT_MESSAGE": "gitlab-git-commit-message",
+      "CI_COMMIT_SHA": "gitlab-git-commit",
+      "CI_COMMIT_TIMESTAMP": "2021-07-21T11:43:07-04:00",
+      "CI_JOB_ID": "gitlab-job-id",
+      "CI_JOB_NAME": "gitlab-job-name",
+      "CI_JOB_STAGE": "gitlab-stage-name",
+      "CI_JOB_URL": "gitlab-job-url",
+      "CI_PIPELINE_ID": "gitlab-pipeline-id",
+      "CI_PIPELINE_IID": "gitlab-pipeline-number",
+      "CI_PROJECT_PATH": "gitlab-pipeline-name",
+      "CI_PROJECT_URL": "gitlab-project-url",
+      "CI_RUNNER_ID": "9393040",
+      "CI_RUNNER_TAGS": "[\"arch:arm64\",\"linux\"]",
+      "GITLAB_CI": "gitlab"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"gitlab-project-url\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.name": "gitlab-job-name",
+      "ci.job.url": "gitlab-job-url",
+      "ci.node.labels": "[\"arch:arm64\",\"linux\"]",
+      "ci.node.name": "9393040",
+      "ci.pipeline.id": "gitlab-pipeline-id",
+      "ci.pipeline.name": "gitlab-pipeline-name",
+      "ci.pipeline.number": "gitlab-pipeline-number",
+      "ci.provider.name": "gitlab",
+      "ci.stage.name": "gitlab-stage-name",
+      "git.commit.author.date": "2021-07-21T11:43:07-04:00",
+      "git.commit.author.email": "john@doe.com",
+      "git.commit.author.name": "John Doe",
+      "git.commit.message": "gitlab-git-commit-message",
+      "git.commit.sha": "gitlab-git-commit"
+    }
   ]
 ]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/jenkins.json
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Data/jenkins.json
@@ -686,5 +686,28 @@
       "git.commit.sha": "jenkins-git-commit",
       "git.repository_url": "https://github.com/DataDog/dogweb.git"
     }
+  ],
+  [
+    {
+      "BUILD_NUMBER": "jenkins-pipeline-number",
+      "BUILD_TAG": "jenkins-pipeline-id",
+      "BUILD_URL": "jenkins-pipeline-url",
+      "DD_CUSTOM_TRACE_ID": "jenkins-custom-trace-id",
+      "GIT_COMMIT": "jenkins-git-commit",
+      "JENKINS_URL": "jenkins",
+      "JOB_URL": "jenkins-job-url",
+      "NODE_LABELS": "built-in linux",
+      "NODE_NAME": "my-node"
+    },
+    {
+      "_dd.ci.env_vars": "{\"DD_CUSTOM_TRACE_ID\":\"jenkins-custom-trace-id\"}",
+      "ci.node.labels": "[\"built-in\",\"linux\"]",
+      "ci.node.name": "my-node",
+      "ci.pipeline.id": "jenkins-pipeline-id",
+      "ci.pipeline.number": "jenkins-pipeline-number",
+      "ci.pipeline.url": "jenkins-pipeline-url",
+      "ci.provider.name": "jenkins",
+      "git.commit.sha": "jenkins-git-commit"
+    }
   ]
 ]


### PR DESCRIPTION
## Summary of changes

This PR updates the CI environment variables parser with the latest from the CI spec repo. This includes:

- Add support for Codefresh CI provider.
- Add support for Node name and Node labels.
- Update json test data from the ci spec repo.

