### PR TITLE
Exclude more high-cardinality dependencies from telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using Datadog.Trace.Debugger.Configurations;
 
 namespace Datadog.Trace.Telemetry
 {
@@ -34,9 +35,13 @@ namespace Datadog.Trace.Telemetry
         internal void AssemblyLoaded(AssemblyName assembly, string moduleVersionId)
         {
             // exclude dlls we're not interested in which have a "random" component
-            // ASP.NET sites generate an App_Web_*.dll with a random string for
+            // - ASP.NET site dlls's e.g. App_Web_*.dll
+            // - Assemblies without a version or explicitly version 0.0.0.0 (and have 8 aplphnumeric values)
+            // - Assemblies created by expression evaluation in VB.NET (expression_host_, Expressions12334324)
+            // - Dlls loaded from asp.net temp directory
             var assemblyName = assembly.Name;
             if (assemblyName is null or ""
+             || assembly.Version is null
              || IsTempPathPattern(assemblyName)
              || (assemblyName[0] == 'A'
               && (assemblyName.StartsWith("App_Web_", StringComparison.Ordinal)
@@ -45,15 +50,22 @@ namespace Datadog.Trace.Telemetry
                || assemblyName.StartsWith("App_LocalResources.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_global.asax.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_Code.", StringComparison.Ordinal)
+               || assemblyName.StartsWith("App_Browsers.", StringComparison.Ordinal)
                || assemblyName.StartsWith("App_WebReferences.", StringComparison.Ordinal)))
-             || IsGuid(assemblyName))
+             || assemblyName.StartsWith("CompiledRazorTemplates.Dynamic.RazorEngine_", StringComparison.Ordinal)
+             || assemblyName.StartsWith("EntityFrameworkDynamicProxies-", StringComparison.Ordinal)
+             || assemblyName.StartsWith("expression_host_", StringComparison.Ordinal)
+             || (assemblyName.StartsWith("Expressions", StringComparison.Ordinal) && IsHexString(assemblyName, 11))
+             || (assembly.Version is { Major: 0, Minor: 0, Build: 0, Revision: 0 } && IsZeroVersionAssemblyPattern(assemblyName))
+             || IsGuid(assemblyName)
+             || IsZxPattern(assemblyName))
             {
                 return;
             }
 
             var key = new DependencyTelemetryData(name: assemblyName)
             {
-                Version = assembly.Version?.ToString(),
+                Version = assembly.Version.ToString(),
                 Hash = moduleVersionId,
             };
 
@@ -109,16 +121,29 @@ namespace Datadog.Trace.Telemetry
                 && IsBase32Char(assemblyName[9])
                 && IsBase32Char(assemblyName[10])
                 && IsBase32Char(assemblyName[11]);
+        }
 
-            static bool IsBase32Char(char c)
+        private static bool IsZxPattern(string assemblyName)
+        {
+            // zx_01aab0f40246424bb7ebaaf80635953b
+            return assemblyName.Length == 35
+                && assemblyName[0] == 'z'
+                && assemblyName[1] == 'x'
+                && assemblyName[2] == '_'
+                && IsHexString(assemblyName, 3);
+        }
+
+        private static bool IsHexString(string assemblyName, int start)
+        {
+            for (int i = assemblyName.Length - 1; i >= start; i--)
             {
-                return c switch
+                if (!IsHexChar(assemblyName[i]))
                 {
-                    >= 'a' and <= 'z' => true,
-                    >= '0' and <= '5' => true,
-                    _ => false
-                };
+                    return false;
+                }
             }
+
+            return true;
         }
 
         private static bool IsGuid(string assemblyName)
@@ -127,12 +152,47 @@ namespace Datadog.Trace.Telemetry
             {
                 // Simple implementation to remove guids
                 case 36 when assemblyName[8] == '-' && assemblyName[13] == '-' && assemblyName[18] == '-' && assemblyName[23] == '-':
+                // Remove Guids with brackets
+                case 38 when assemblyName[9] == '-' && assemblyName[14] == '-' && assemblyName[19] == '-' && assemblyName[24] == '-':
                 // and other weird use cases like ℛ*710fa04a-6428-4dd1-85a0-0419c142709b#5-0 where the suffix can be up to 7 chars long
                 case >= 42 when assemblyName[10] == '-' && assemblyName[15] == '-' && assemblyName[20] == '-' && assemblyName[25] == '-':
                     return true;
                 default:
                     return false;
             }
+        }
+
+        private static bool IsHexChar(char c)
+        {
+            return c switch
+            {
+                >= '0' and <= '9' => true,
+                >= 'a' and <= 'f' => true,
+                _ => false
+            };
+        }
+
+        private static bool IsZeroVersionAssemblyPattern(string assemblyName)
+        {
+            return assemblyName.Length == 8
+                && IsBase32Char(assemblyName[0])
+                && IsBase32Char(assemblyName[1])
+                && IsBase32Char(assemblyName[2])
+                && IsBase32Char(assemblyName[3])
+                && IsBase32Char(assemblyName[4])
+                && IsBase32Char(assemblyName[5])
+                && IsBase32Char(assemblyName[6])
+                && IsBase32Char(assemblyName[7]);
+        }
+
+        private static bool IsBase32Char(char c)
+        {
+            return c switch
+            {
+                >= 'a' and <= 'z' => true,
+                >= '0' and <= '5' => true,
+                _ => false
+            };
         }
 
         private void SetHasChanges()

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/DependencyTelemetryCollectorTests.cs
@@ -93,12 +93,19 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData("App_global.asax.zt8edv4m")]
         [InlineData("App_Web_login.cshtml.6331810a.tvsbhzc3")]
         [InlineData("App_GlobalResources.9ccedwue")]
+        [InlineData("App_Browsers.6lthavvf")]
         [InlineData("App_Code.hhzpytyv")]
         [InlineData("App_Theme_Standard.6wkna0wf")]
         [InlineData("App_WebReferences.dvkaf7ph")]
+        [InlineData("CompiledRazorTemplates.Dynamic.RazorEngine_bfb5873170324b4c87d3e556e474eb87")]
+        [InlineData("expression_host_931769d0530d485abda6293dc21820f8")]
+        [InlineData("Expressions63eb484b939a686b78b792fb")]
+        [InlineData("EntityFrameworkDynamicProxies-pi-entityframework")]
+        [InlineData("zx_6c427a9d1b38402ea2ec25be277b3521")]
         [InlineData("0018eae6-bd49-41a4-9bd2-6be3a6544a15")]
         [InlineData("005ec706-91d7-4237-9466-bac51a64d90f")]
         [InlineData("00821386-7d9a-499b-8e7f-53dbbefcaf3d")]
+        [InlineData("{00821386-7d9a-499b-8e7f-53dbbefcaf3d}")]
         [InlineData("ℛ*00093a17-a657-432d-ad25-13cf53f44319#2-0")]
         [InlineData("ℛ*71ccc5b6-6f30-4c09-9e23-4e7ac5a9ad31#13-0")]
         [InlineData("ℛ*1887feb5-1546-46da-a64e-07cba2cb32fa#112-0")]
@@ -146,6 +153,34 @@ namespace Datadog.Trace.Tests.Telemetry
                 collector.AssemblyLoaded(ignoredName, "some-guid");
 
                 collector.HasChanges().Should().BeFalse($"{name} is a temp file name");
+            }
+        }
+
+        [Fact]
+        public void DoesNotHaveChangesWhenAssemblyVersionIsNull()
+        {
+            var name = "My.Assembly";
+            var ignoredName = CreateAssemblyName(null, name: name);
+
+            var collector = new DependencyTelemetryCollector();
+            collector.AssemblyLoaded(ignoredName, "some-guid");
+
+            collector.HasChanges().Should().BeFalse($"{name} has a null version");
+        }
+
+        [Fact]
+        public void DoesNotHaveChangesWhenAssemblyVersionIsZeroAndHasRandom8CharName()
+        {
+            for (var i = 0; i < 1_000; i++)
+            {
+                // Path.GetRandomFileName() returns a name with the right format, so truncate
+                var name = Path.GetRandomFileName().Substring(0, 8);
+                var ignoredName = CreateAssemblyName(new Version(0, 0, 0, 0), name: name);
+
+                var collector = new DependencyTelemetryCollector();
+                collector.AssemblyLoaded(ignoredName, "some-guid");
+
+                collector.HasChanges().Should().BeFalse($"{name} has a zero version");
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Excludes some more patterns from deps collection

## Reason for change

Want to exclude:

- `zx_6c427a9d1b38402ea2ec25be277b3521` (we think from ZXIng.NET)
- `expression_host_7aa0188300004a44b765222fa50fa160` (VB.NET expression compilation)
- `Expressions63eb54fecf4ea5c4ac7ce416` (as above?)
- `{005ec706-91d7-4237-9466-bac51a64d90f}` - guid with brackets
- `App_Browsers.*` ASP.NET stuff
- `EntityFrameworkDynamicProxies-*`  - EF
- `CompiledRazorTemplates.Dynamic.RazorEngine_` - Razor
- `01dgt4z0` where Version = `0.0.0.0` (not sure where these come from, but there's a lot!)

## Implementation details

Add exclusions based on prefixes + also checking hex values. Hopefully the impact isn't too significant.

## Test coverage

Added some extra unit tests for the new patterns

## Other details
cc @anderruiz for visibility
