### PR TITLE
Fix rare and random crash on linux

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -4,7 +4,7 @@ SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunw
 
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
-    GIT_TAG gleocadie/backtrace2_2
+    GIT_TAG gleocadie/backtrace2_3
     GIT_PROGRESS true
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""


### PR DESCRIPTION
## Summary of changes

Fix rare crash we observed in the CI on Alpine and Centos for the profiler.

## Reason for change

We must not crash.

## Implementation details
After investigating with @kevingosse , we suspected libunwind to do unsafe memory read. We found https://github.com/libunwind/libunwind/pull/454 where Valgrind was able to find an UMR (Uninitialized Memory Read).

We cherry-picked the fix in our libunwind fork (`gleocadie/backtrace2_3`) and when a new release of libunwind is out we will update it.

## Test coverage

Ran ~10 times the jobs in CI, no  crash so far.
## Other details
<!-- Fixes #{issue} -->
