### PR TITLE
[Installer] Remove the CLR Profiler settings from W3SVC

### DIFF
--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -21,14 +21,6 @@
     </ComponentGroup>
   
     <ComponentGroup Id="Shared.EnvironmentVariables.IIS" Directory="INSTALLFOLDER">
-      <Component Id="Shared.Registry.EnvironmentVariables.W3SVC" Guid="{702DB265-F33E-47F4-A6B0-E21FA0FC21C1}" Win64="$(var.Win64)">
-        <CreateFolder/>
-        <RegistryKey Root="HKLM"
-                     Key="System\CurrentControlSet\Services\W3SVC">
-          <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]CORECLR_ENABLE_PROFILING=1[~]CORECLR_PROFILER=$(var.ProfilerCLSID)" Action="append"/>
-        </RegistryKey>
-      </Component>
-
       <Component Id="Shared.Registry.EnvironmentVariables.WAS" Guid="{6CF8AB88-240E-4A0A-B630-43119C064AD4}" Win64="$(var.Win64)">
         <RegistryKey Root="HKLM"
                      Key="System\CurrentControlSet\Services\WAS">


### PR DESCRIPTION
## Summary of changes
Removes the installer directive that adds the CLR Profiler settings to the W3SVC service

## Reason for change
Previously, we were setting the CLR Profiler settings in both the WAS and the W3SVC. We had to set the W3SVC service to cover IIS versions 6 and below, since the WAS was introduced in IIS version 7, but this is no longer needed. Now that the minimum version of .NET Framework that we support is .NET Framework 4.6.1, and the corresponding minimum OS version is Windows Server 2008 R2 SP1, we will only encounter IIS 7+.

Resources:
- https://techcommunity.microsoft.com/t5/iis-support-blog/iis-services-http-sys-w3svc-was-w3wp-oh-my/ba-p/287856
- https://learn.microsoft.com/en-us/iis/manage/provisioning-and-managing-iis/features-of-the-windows-process-activation-service-was
- https://learn.microsoft.com/en-us/lifecycle/products/internet-information-services-iis
- https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies#net-framework-461

## Implementation details
Removes the lines.

## Test coverage
Existing integration tests and smoke tests should pass

## Other details
N/A
