### PR TITLE
[Tracer] Add telemetry for new DD_TRACE_SPAN_ATTRIBUTE_SCHEMA configuration

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Telemetry
 
             var settings = _settings.Settings;
 
-            var data = new List<TelemetryValue>(27 + (settings.IsRunningInAzureAppService ? 5 : 0))
+            var data = new List<TelemetryValue>(28 + (settings.IsRunningInAzureAppService ? 5 : 0))
             {
                 new(ConfigTelemetryData.Platform, value: FrameworkDescription.Instance.ProcessArchitecture),
                 new(ConfigTelemetryData.Enabled, value: settings.TraceEnabled),
@@ -130,6 +130,7 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.AgentTraceTransport, value: settings.Exporter.TracesTransport.ToString()),
                 new(ConfigTelemetryData.Debug, value: GlobalSettings.Instance.DebugEnabled),
                 new(ConfigTelemetryData.NativeTracerVersion, value: Instrumentation.GetNativeTracerVersion()),
+                new(ConfigTelemetryData.MetadataSchemaVersion, value: settings.MetadataSchemaVersion),
 #pragma warning disable CS0618
                 new(ConfigTelemetryData.AnalyticsEnabled, value: settings.AnalyticsEnabled),
 #pragma warning restore CS0618

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.Telemetry
         public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
         public const string NativeTracerVersion = "native_tracer_version";
+        public const string MetadataSchemaVersion = "span_attribute_schema";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";
         public const string SamplingRules = "sampling_rules";

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Telemetry
         public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
         public const string NativeTracerVersion = "native_tracer_version";
-        public const string MetadataSchemaVersion = "span_attribute_schema";
+        public const string MetadataSchemaVersion = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";
         public const string SamplingRules = "sampling_rules";

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -317,6 +317,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("native_tracer_version");
                     writer.WriteValue(Instrumentation.GetNativeTracerVersion());
 
+                    writer.WritePropertyName("span_attribute_schema");
+                    writer.WriteValue(instanceSettings.MetadataSchemaVersion);
+
                     writer.WritePropertyName("platform");
                     writer.WriteValue(FrameworkDescription.Instance.ProcessArchitecture);
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -317,7 +317,7 @@ namespace Datadog.Trace
                     writer.WritePropertyName("native_tracer_version");
                     writer.WriteValue(Instrumentation.GetNativeTracerVersion());
 
-                    writer.WritePropertyName("span_attribute_schema");
+                    writer.WritePropertyName("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA");
                     writer.WriteValue(instanceSettings.MetadataSchemaVersion);
 
                     writer.WritePropertyName("platform");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using VerifyXunit;
@@ -75,6 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 await VerifyHelper.VerifySpans(spans, settings);
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.AwsSqs);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,6 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             }
 
             telemetry.AssertIntegrationEnabled(IntegrationId.AdoNet);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -80,6 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         [SkippableFact]
@@ -101,6 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -63,6 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
             telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         [SkippableFact]
@@ -85,6 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Sqlite);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -90,6 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.MySql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
 
         private void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
@@ -127,6 +129,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -68,6 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.MySql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         [SkippableFact]
@@ -88,6 +90,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.MySql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
 
         private static int GetSpanCount(string packageVersionString)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -65,6 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, actualSpanCount);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.Npgsql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         [SkippableFact]
@@ -85,6 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Npgsql);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -51,6 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
 
         private void RunTest(string metadataSchemaVersion)
@@ -71,6 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -70,6 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         [SkippableFact]
@@ -91,6 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -5,6 +5,7 @@
 
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -51,6 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.NotEmpty(spans);
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Sqlite);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
 
         private void RunTest(string metadataSchemaVersion)
@@ -71,6 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             Assert.Equal(expectedSpanCount, spans.Count);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
             telemetry.AssertIntegrationEnabled(IntegrationId.Sqlite);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -69,6 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseFileName(nameof(AerospikeTests) + $".Schema{metadataSchemaVersion.ToUpper()}");
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.Aerospike);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -91,6 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 dbTags.Should().Be(10);
                 containerTags.Should().Be(4);
                 telemetry.AssertIntegrationEnabled(IntegrationId.CosmosDb);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions.Execution;
 using VerifyXunit;
@@ -81,6 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.Couchbase);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -55,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.Couchbase);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -145,6 +146,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
 
@@ -163,6 +165,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Assert.Empty(spans);
             telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -153,6 +154,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
 
@@ -170,6 +172,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Assert.Empty(spans);
             telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -151,6 +152,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
                 ValidateSpans(spans, (span) => span.Resource, expected);
                 telemetry.AssertIntegrationEnabled(IntegrationId.ElasticsearchNet);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
 
@@ -168,6 +170,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Assert.Empty(spans);
             telemetry.AssertIntegrationDisabled(IntegrationId.ElasticsearchNet);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -406,6 +407,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.Grpc);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
             catch (ExitCodeException)
             {
@@ -446,6 +448,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     Assert.Empty(spans);
                     telemetry.AssertIntegrationDisabled(IntegrationId.Grpc);
+                    telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
                 }
             }
             catch (ExitCodeException)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -165,6 +166,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var scope = new AssertionScope();
                 telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
                 // ignore for now auto enabled for simplicity
                 telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: IsUsingSocketHandler(instrumentation), autoEnabled: null);
                 telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: IsUsingWinHttpHandler(instrumentation), autoEnabled: null);
@@ -205,6 +207,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var scope = new AssertionScope();
                 // ignore auto enabled for simplicity
                 telemetry.AssertIntegrationDisabled(IntegrationId.HttpMessageHandler);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
                 telemetry.AssertIntegration(IntegrationId.HttpSocketsHandler, enabled: false, autoEnabled: null);
                 telemetry.AssertIntegration(IntegrationId.WinHttpHandler, enabled: false, autoEnabled: null);
                 telemetry.AssertIntegration(IntegrationId.CurlHandler, enabled: false, autoEnabled: null);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -158,6 +159,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             telemetry.AssertIntegrationEnabled(IntegrationId.Kafka);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         private void VerifyProducerSpanProperties(List<MockSpan> producerSpans, string serviceName, string resourceName, int expectedCount)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -95,6 +96,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 ValidateIntegrationSpans(allMongoSpans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.MongoDb);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
 
                 // do some basic verification on the "admin" spans
                 using var scope = new AssertionScope();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -117,6 +118,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             receiveCount.Should().Be(expectedReceiveCount);
             peekCount.Should().Be(expectedPeekCount);
             telemetry.AssertIntegrationEnabled(IntegrationId.Msmq);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -77,6 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .UseFileName(nameof(NetActivitySdkTests));
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -90,6 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .DisableRequireUniquePrefix();
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             }
         }
 
@@ -123,6 +125,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                   .DisableRequireUniquePrefix();
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.OpenTelemetry);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             }
         }
 
@@ -141,6 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var s = new AssertionScope();
                 spans.Should().BeEmpty();
                 telemetry.AssertIntegrationDisabled(IntegrationId.OpenTelemetry);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using VerifyXunit;
@@ -58,6 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Process);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
         }
 
         private async Task RunTest(string metadataSchemaVersion)
@@ -91,6 +93,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             VerifyInstrumentation(process.Process);
 
             telemetry.AssertIntegrationEnabled(IntegrationId.Process);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -11,6 +11,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions.Execution;
 using VerifyXunit;
@@ -89,6 +90,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             telemetry.AssertIntegrationEnabled(IntegrationId.RabbitMQ);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         private string GetPackageVersionSuffix(string packageVersion)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -91,6 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.ServiceStackRedis);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -110,6 +111,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             telemetry.AssertIntegrationEnabled(IntegrationId.StackExchangeRedis);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
         }
 
         private static PackageVersion GetPackageVersion(string packageVersionString)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -59,6 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var data = telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             AssertTelemetry(data);
             agent.Telemetry.Should().BeEmpty();
         }
@@ -85,6 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            agent.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
             AssertTelemetry(data);
         }
 
@@ -158,6 +160,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
                 agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+                agent.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
 
                 AssertTelemetry(data);
             }
@@ -183,6 +186,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             var data = agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
+            agent.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
 
             AssertTelemetry(data);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -144,7 +144,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 telemetry?.AssertIntegrationEnabled(IntegrationId.TraceAnnotations);
                 telemetry?.AssertConfiguration(ConfigTelemetryData.TraceMethods);
-                telemetry?.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
 
                 // Run snapshot verification
                 var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -144,6 +144,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 telemetry?.AssertIntegrationEnabled(IntegrationId.TraceAnnotations);
                 telemetry?.AssertConfiguration(ConfigTelemetryData.TraceMethods);
+                telemetry?.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
 
                 // Run snapshot verification
                 var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -61,6 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Null(parentSpanId);
                 Assert.Equal("false", tracingEnabled);
                 telemetry.AssertIntegrationDisabled(IntegrationId.WebRequest);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
                 VerifyInstrumentation(processResult.Process);
             }
         }
@@ -93,6 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Equal(firstSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
 
                 telemetry.AssertIntegrationEnabled(IntegrationId.WebRequest);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -64,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Null(parentSpanId);
                 Assert.Equal("false", tracingEnabled);
                 telemetry.AssertIntegrationDisabled(IntegrationId.WebRequest);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, "v0");
                 VerifyInstrumentation(processResult.Process);
             }
         }
@@ -97,6 +99,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Equal(firstSpan.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
                 Assert.Equal(firstSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
                 telemetry.AssertIntegrationEnabled(IntegrationId.WebRequest);
+                telemetry.AssertConfiguration(ConfigTelemetryData.MetadataSchemaVersion, metadataSchemaVersion);
                 VerifyInstrumentation(processResult.Process);
             }
         }


### PR DESCRIPTION
## Summary of changes
Adds the value of DD_TRACE_SPAN_ATTRIBUTE_SCHEMA to the configuration telemetry. Also adds the value to our startup logs.

Telemetry:
- Group: Configuration
  - Key: `DD_TRACE_SPAN_ATTRIBUTE_SCHEMA`
  - Value: One of [`v0`, `v1`]

## Reason for change

## Implementation details

## Test coverage
In the integration tests, I've added the assertion that the new telemetry name is present and has the correct value (`v0` or `v1`).

## Other details
N/A
