### PR TITLE
Change the ownership of the RuntimeMetrics statsd instance

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -217,18 +217,18 @@ namespace Datadog.Trace
                     await oldManager.AgentWriter.FlushAndCloseAsync().ConfigureAwait(false);
                 }
 
-                var statsdReplaced = false;
-                if (oldManager.Statsd != newManager.Statsd)
-                {
-                    statsdReplaced = true;
-                    oldManager.Statsd?.Dispose();
-                }
-
                 var runtimeMetricsWriterReplaced = false;
                 if (oldManager.RuntimeMetrics != newManager.RuntimeMetrics)
                 {
                     runtimeMetricsWriterReplaced = true;
                     oldManager.RuntimeMetrics?.Dispose();
+                }
+
+                var statsdReplaced = false;
+                if (oldManager.Statsd != newManager.Statsd)
+                {
+                    statsdReplaced = true;
+                    oldManager.Statsd?.Dispose();
                 }
 
                 var telemetryReplaced = false;
@@ -607,7 +607,10 @@ namespace Datadog.Trace
             // use the count of Tracer instances as the heartbeat value
             // to estimate the number of "live" Tracers than can potentially
             // send traces to the Agent
-            _instance?.Statsd?.Gauge(TracerMetricNames.Health.Heartbeat, Tracer.LiveTracerCount);
+            if (_instance?.Settings.TracerMetricsEnabled == true)
+            {
+                _instance?.Statsd?.Gauge(TracerMetricNames.Health.Heartbeat, Tracer.LiveTracerCount);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -100,16 +100,18 @@ namespace Datadog.Trace
 
             discoveryService ??= GetDiscoveryService(settings);
 
-            statsd = settings.TracerMetricsEnabled
+            bool runtimeMetricsEnabled = settings.RuntimeMetricsEnabled && !DistributedTracer.Instance.IsChildTracer;
+
+            statsd = (settings.TracerMetricsEnabled || runtimeMetricsEnabled)
                          ? (statsd ?? CreateDogStatsdClient(settings, defaultServiceName))
                          : null;
             sampler ??= GetSampler(settings);
             agentWriter ??= GetAgentWriter(settings, statsd, sampler, discoveryService);
             scopeManager ??= new AsyncLocalScopeManager();
 
-            if (settings.RuntimeMetricsEnabled && !DistributedTracer.Instance.IsChildTracer)
+            if (runtimeMetricsEnabled)
             {
-                runtimeMetrics ??= new RuntimeMetricsWriter(statsd ?? CreateDogStatsdClient(settings, defaultServiceName), TimeSpan.FromSeconds(10), settings.IsRunningInAzureAppService);
+                runtimeMetrics ??= new RuntimeMetricsWriter(statsd, TimeSpan.FromSeconds(10), settings.IsRunningInAzureAppService);
             }
 
             var gitMetadataTagsProvider = GetGitMetadataTagsProvider(settings);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace
                          ? (statsd ?? CreateDogStatsdClient(settings, defaultServiceName))
                          : null;
             sampler ??= GetSampler(settings);
-            agentWriter ??= GetAgentWriter(settings, statsd, sampler, discoveryService);
+            agentWriter ??= GetAgentWriter(settings, settings.TracerMetricsEnabled ? statsd : null, sampler, discoveryService);
             scopeManager ??= new AsyncLocalScopeManager();
 
             if (runtimeMetricsEnabled)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public async Task NamedPipesSubmitsMetrics()
+        public void NamedPipesSubmitsMetrics()
         {
             if (!EnvironmentTools.IsWindows())
             {
@@ -75,21 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             EnvironmentHelper.EnableWindowsNamedPipes();
-            // The server implementation of named pipes is flaky so have 3 attempts
-            var attemptsRemaining = 3;
-            while (true)
-            {
-                try
-                {
-                    attemptsRemaining--;
-                    RunTest();
-                    return;
-                }
-                catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
-                {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
-                }
-            }
+            RunTest();
         }
 
         private void RunTest()


### PR DESCRIPTION
## Summary of changes

If tracer metrics are disabled, the runtime metrics get their own statsd instance. It is never disposed. Change that to always use the TracerManager statsd instance.

## Reason for change

I suspect this is causing some flakiness, as the statsd instance is not disposed, and therefore not properly flushed. Also, as RCM will allow to enable/disable runtime metrics on the fly, we must make sure this is not going to cause memory leaks.

## Implementation details

In the heartbeat we check if the statsd instance is null to know if tracer metrics are enabled. This assumption is not valid anymore as statsd can now be not null even if the tracer metrics are disabled, so I've added a specific check. I also made sure that the AgentWriter still receives a null statsd instance, but likewise we might want to change it to an explicit settings check.

## Test coverage

I've removed the retry on the named pipe runtime metrics tests because I like to live on the edge.
