### PR TITLE
[ASM] Fix ip resolution: some local ips weren't seen as local

### DIFF
--- a/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
+++ b/tracer/src/Datadog.Trace/Headers/Ip/IpExtractor.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Headers.Ip
         {
             _ipv4LocalCidrs = new List<Tuple<int, int>>();
 
-            foreach (var currentCidrMask in new string[] { "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16" })
+            foreach (var currentCidrMask in new[] { "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16" })
             {
                 var parts = currentCidrMask.Split('/');
 

--- a/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Headers/Ip/IpExtractionTests.cs
@@ -15,6 +15,8 @@ namespace Datadog.Trace.Tests.Headers.Ip
         [InlineData("81.202.236.243", 5001,  "81.202.236.243:5001")]
         [InlineData("83.204.236.243", 443, "172.16.2.4, 172.31.255.255, 192.168.255.255, 10.145.255.255, 83.204.236.243:443")]
         [InlineData("192.168.1.1", 80, "192.168.1.1, 172.16.32.41, 172.16.32.43")]
+        [InlineData("83.204.236.243", 80, "127.0.0.1, 83.204.236.243")]
+        [InlineData("83.204.236.243", 80, "169.254.0.3, 83.204.236.243")]
         public void Ipv4PublicDetectedLocalIgnored(string expectedIp, int expectedPort, string headerValue)
         {
             var ip = IpExtractor.RealIpFromValue(headerValue, https: false);


### PR DESCRIPTION
## Summary of changes

Adding some subnets for detecting an ip is actually private and is not relevant. 
We were missing some subnets specified [here](https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2118779066/Client+IP+addresses+resolution)
This fixes this [bug](https://datadoghq.atlassian.net/browse/APPSEC-9194)

## Reason for change

## Implementation details

## Test coverage
Adding 2 unit tests with local ips that weren't detected

## Other details
<!-- Fixes #{issue} -->
