### PR TITLE
Add `obj` as a folder exception in the static analysis workflow.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,6 +57,7 @@ jobs:
           -**/test/test-applications/**
           -**/test/samples/**
           -**/Web.config
+          -**/obj/**
         input: ../results/cpp.sarif
         output: ../results/cpp.sarif
 
@@ -68,6 +69,7 @@ jobs:
           -**/test/test-applications/**
           -**/test/samples/**
           -**/Web.config
+          -**/obj/**
         input: ../results/csharp.sarif
         output: ../results/csharp.sarif
 
@@ -124,6 +126,7 @@ jobs:
           -**/test/test-applications/**
           -**/test/samples/**
           -**/Web.config
+          -**/obj/**
         input: ../results/cpp.sarif
         output: ../results/cpp.sarif
 
@@ -135,6 +138,7 @@ jobs:
           -**/test/test-applications/**
           -**/test/samples/**
           -**/Web.config
+          -**/obj/**
         input: ../results/csharp.sarif
         output: ../results/csharp.sarif
 


### PR DESCRIPTION
## Summary of changes

This PR adds `obj` as a folder exception in the static analysis workflow.