### PR TITLE
Investigate failing test on alpine

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Models/DataLayer.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Models/DataLayer.cs
@@ -109,6 +109,10 @@ namespace BuggyBits.Models
 
                     continue;
                 }
+                catch (Exception e)
+                {
+                    Console.WriteLine("[Error] Ooops we did not catch this one " + e.GetType().ToString());
+                }
             }
 
             return allProducts;


### PR DESCRIPTION
## Summary of changes

Investigate failing test on alpine.

## Reason for change

We have a profiler integration test that fails randomly with the error code 134 (SIGABRT - abort). After digging in the memory dump, all hypothesis I had are invalidated :
- Profiler thread(s) is doing something wrong: they all are sleeping. The thread calling `abort` is a managed thread actually throwing an exception (which is caught)
- The test throws an Overflow exception: no still a FormatException nested in a PriceException

The rest I have is hard to check: 
- profiler and/or tracer wrote something in memory 🤷 and it fails

By doing this change, we can check that the Exception thrown is not the one expected (maybe a bug in the CLR ??? 🤷 ...not really convinced but...)

## Implementation details

Add a try catch + Log the string `[Error]` to still fail the test

## Test coverage

## Other details
<!-- Fixes #{issue} -->
