### PR TITLE
Add jetbrains diagnoser to Benchmark tests

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
+    <PackageReference Include="Tony.BenchmarkDotnet.Jetbrains" Version="0.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -35,12 +35,12 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.3.0" />
+    <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.4.2" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
-    <PackageReference Include="Tony.BenchmarkDotnet.Jetbrains" Version="0.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -34,7 +34,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="JetBrains.Profiler.Api" Version="1.3.0" />
     <PackageReference Include="JetBrains.Profiler.SelfApi" Version="2.4.2" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="NLog" Version="4.7.9" />

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using JetBrains.Profiler.SelfApi;
+
+namespace Benchmarks.Trace.Jetbrains;
+
+/// <summary>
+/// Jetbrains diagnoser
+/// </summary>
+internal class JetbrainsDiagnoser : IDiagnoser
+{
+    public IEnumerable<string> Ids { get; } = new[] { "Jetbrains" };
+    public IEnumerable<IExporter> Exporters { get; } = Array.Empty<IExporter>();
+    public IEnumerable<IAnalyser> Analysers { get; } = Array.Empty<IAnalyser>();
+
+    private readonly JetbrainsProduct _product;
+    private List<string> _filePaths;
+    private string? _outputFolder;
+
+    public JetbrainsDiagnoser(JetbrainsProduct product, string? outputFolder = null)
+    {
+        _product = product;
+        _filePaths = new List<string>();
+        _outputFolder = outputFolder;
+        switch (_product)
+        {
+            case JetbrainsProduct.Memory:
+                DotMemory.EnsurePrerequisite();
+                break;
+            case JetbrainsProduct.Trace:
+                DotTrace.EnsurePrerequisite();
+                break;
+        }
+    }
+
+    public RunMode GetRunMode(BenchmarkCase benchmarkCase)
+    {
+        return RunMode.ExtraRun;
+    }
+
+    public bool RequiresBlockingAcknowledgments(BenchmarkCase benchmarkCase)
+    {
+        return false;
+    }
+
+    public void Handle(HostSignal signal, DiagnoserActionParameters parameters)
+    {
+        if (signal == HostSignal.BeforeActualRun)
+        {
+            var outputFolder = _outputFolder ?? parameters.Config.ArtifactsPath;
+            var filePath = Path.Combine(outputFolder, parameters.BenchmarkCase.Descriptor.FolderInfo.Replace(".", "_") + $"_{DateTime.UtcNow.ToBinary()}");
+            switch (_product)
+            {
+                case JetbrainsProduct.Memory:
+                    DotMemory.Attach(new DotMemory.Config().SaveToFile(filePath));
+                    DotMemory.GetSnapshot("Start");
+                    break;
+                case JetbrainsProduct.Trace:
+                    DotTrace.Attach(new DotTrace.Config().SaveToFile(filePath));
+                    DotTrace.StartCollectingData();
+                    break;
+            }
+        }
+        else if (signal == HostSignal.AfterActualRun)
+        {
+            switch (_product)
+            {
+                case JetbrainsProduct.Memory:
+                    DotMemory.GetSnapshot("End");
+                    _filePaths.Add(DotMemory.Detach());
+                    break;
+                case JetbrainsProduct.Trace:
+                    DotTrace.SaveData();
+                    _filePaths.AddRange(DotTrace.GetCollectedSnapshotFiles());
+                    DotTrace.Detach();
+                    break;
+            }
+        }
+    }
+
+    public IEnumerable<Metric> ProcessResults(DiagnoserResults results)
+    {
+        return Enumerable.Empty<Metric>();
+    }
+
+    public void DisplayResults(ILogger logger)
+    {
+        logger.WriteLine(LogKind.Statistic, "Jetbrains files:");
+        foreach (var filePath in _filePaths)
+        {
+            logger.WriteLine(LogKind.Statistic, filePath);
+        }
+    }
+
+    public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+    {
+        return Enumerable.Empty<ValidationError>();
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
@@ -12,6 +12,8 @@ using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
 using JetBrains.Profiler.SelfApi;
 
+#nullable enable
+
 namespace Benchmarks.Trace.Jetbrains;
 
 /// <summary>
@@ -62,11 +64,11 @@ internal class JetbrainsDiagnoser : IDiagnoser
             switch (_product)
             {
                 case JetbrainsProduct.Memory:
-                    DotMemory.Attach(new DotMemory.Config().SaveToFile(filePath));
+                    DotMemory.Attach(new DotMemory.Config().SaveToFile(filePath + ".dmw"));
                     DotMemory.GetSnapshot("Start");
                     break;
                 case JetbrainsProduct.Trace:
-                    DotTrace.Attach(new DotTrace.Config().SaveToFile(filePath));
+                    DotTrace.Attach(new DotTrace.Config().SaveToFile(filePath + ".dtp"));
                     DotTrace.StartCollectingData();
                     break;
             }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsDiagnoser.cs
@@ -58,7 +58,7 @@ internal class JetbrainsDiagnoser : IDiagnoser
         if (signal == HostSignal.BeforeActualRun)
         {
             var outputFolder = _outputFolder ?? parameters.Config.ArtifactsPath;
-            var filePath = Path.Combine(outputFolder, parameters.BenchmarkCase.Descriptor.FolderInfo.Replace(".", "_") + $"_{DateTime.UtcNow.ToBinary()}");
+            var filePath = Path.Combine(outputFolder, parameters.BenchmarkCase.Descriptor.FolderInfo.Replace(".", "_") + $"_{DateTime.UtcNow:yyyy_MM_dd_HH_mm_ss}");
             switch (_product)
             {
                 case JetbrainsProduct.Memory:

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsExtensions.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsExtensions.cs
@@ -1,0 +1,24 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Benchmarks.Trace.Jetbrains;
+
+/// <summary>
+/// Jetbrains extensions
+/// </summary>
+public static class JetbrainsExtensions
+{
+    /// <summary>
+    /// Configure the Jetbrains diagnoser
+    /// </summary>
+    /// <param name="config">Configuration instance</param>
+    /// <param name="product">Jetbrains product</param>
+    /// <param name="outputFolder">Output folder</param>
+    /// <returns>Same configuration instance</returns>
+    public static IConfig WithJetbrains(this IConfig config, JetbrainsProduct product, string? outputFolder = null)
+    {
+        return config
+              .AddDiagnoser(new JetbrainsDiagnoser(product, outputFolder))
+              .AddJob(Job.InProcess);
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsExtensions.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsExtensions.cs
@@ -1,6 +1,8 @@
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 
+#nullable enable
+
 namespace Benchmarks.Trace.Jetbrains;
 
 /// <summary>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsProduct.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Jetbrains/JetbrainsProduct.cs
@@ -1,0 +1,17 @@
+namespace Benchmarks.Trace.Jetbrains;
+
+/// <summary>
+/// Jetbrains product
+/// </summary>
+public enum JetbrainsProduct
+{
+    /// <summary>
+    /// DotMemory file
+    /// </summary>
+    Memory,
+
+    /// <summary>
+    /// DotTrace file
+    /// </summary>
+    Trace
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
-using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Datadog.Trace.BenchmarkDotNet;
@@ -22,11 +18,6 @@ namespace Benchmarks.Trace
             Console.WriteLine("CurrentCulture is {0}.", CultureInfo.CurrentCulture.Name);
 
             var config = DefaultConfig.Instance;
-            if (args?.Any(a => a == "-jetbrains") == true)
-            {
-                ExecuteWithJetbrainsTools(args);
-                return;
-            }
 
             const string jetBrainsDotTrace = "-jetbrains:dottrace";
             const string jetBrainsDotMemory = "-jetbrains:dotmemory";
@@ -58,82 +49,6 @@ namespace Benchmarks.Trace
             }
 
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
-        }
-
-        private static void ExecuteWithJetbrainsTools(string[] args)
-        {
-            var numIter = 100_000;
-            var numArg = args.FirstOrDefault(a => a.StartsWith("-n:", StringComparison.OrdinalIgnoreCase))?.Substring(3);
-            if (int.TryParse(numArg, out var numArgInt))
-            {
-                numIter = numArgInt;
-            }
-
-            if ((JetBrains.Profiler.Api.MeasureProfiler.GetFeatures() &
-                 JetBrains.Profiler.Api.MeasureFeatures.Ready) == 0 &&
-                (JetBrains.Profiler.Api.MemoryProfiler.GetFeatures() &
-                 JetBrains.Profiler.Api.MemoryFeatures.Ready) == 0)
-            {
-                Console.WriteLine("Waiting for jetbrains dotTrace/dotMemory to attach...");
-                var currentProcess = Process.GetCurrentProcess();
-                Console.WriteLine("Process Id: {0}, Name: {1}", currentProcess.Id, currentProcess.ProcessName);
-                while ((JetBrains.Profiler.Api.MeasureProfiler.GetFeatures() &
-                        JetBrains.Profiler.Api.MeasureFeatures.Ready) == 0 &&
-                       (JetBrains.Profiler.Api.MemoryProfiler.GetFeatures() &
-                        JetBrains.Profiler.Api.MemoryFeatures.Ready) == 0)
-                {
-                    Thread.Sleep(1000);
-                }
-            }
-            Console.WriteLine("Connected. Running benchmarks (N: {0})", numIter);
-            HashSet<string> hashSet = new HashSet<string>(args.Where(a => a != "-jetbrains" && !a.StartsWith("-n:", StringComparison.OrdinalIgnoreCase)).Select(a => a.ToLowerInvariant()));
-            var benchmarkTypes = typeof(Program).Assembly.GetTypes().Where(t => hashSet.Contains(t.Name.ToLowerInvariant()));
-            foreach (var benchmarkType in benchmarkTypes)
-            {
-                foreach (var method in benchmarkType.GetMethods())
-                {
-                    if (method.GetCustomAttributes(false).Any(att => att is BenchmarkAttribute))
-                    {
-                        var benchmarkInstance = Activator.CreateInstance(benchmarkType);
-                        var groupName = string.Format("{0}.{1}", benchmarkType.FullName, method.Name);
-                        Console.WriteLine("Running: " + groupName);
-                        for (var i = 0; i < 1000; i++)
-                        {
-                            method.Invoke(benchmarkInstance, null);
-                        }
-                        GC.Collect();
-                        GC.WaitForPendingFinalizers();
-
-                        if ((JetBrains.Profiler.Api.MeasureProfiler.GetFeatures() & JetBrains.Profiler.Api.MeasureFeatures.Ready) != 0)
-                        {
-                            Console.WriteLine("  Collecting Data...");
-                            JetBrains.Profiler.Api.MeasureProfiler.StartCollectingData(groupName);
-                            for (var i = 0; i < numIter; i++)
-                            {
-                                method.Invoke(benchmarkInstance, null);
-                            }
-                            JetBrains.Profiler.Api.MeasureProfiler.StopCollectingData();
-                            JetBrains.Profiler.Api.MeasureProfiler.SaveData(groupName);
-                            GC.Collect();
-                            GC.WaitForPendingFinalizers();
-                        }
-
-                        if ((JetBrains.Profiler.Api.MemoryProfiler.GetFeatures() & JetBrains.Profiler.Api.MemoryFeatures.Ready) != 0)
-                        {
-                            Console.WriteLine("  Getting memory snapshot...");
-                            JetBrains.Profiler.Api.MemoryProfiler.ForceGc();
-                            JetBrains.Profiler.Api.MemoryProfiler.CollectAllocations(true);
-                            for (var i = 0; i < numIter; i++)
-                            {
-                                method.Invoke(benchmarkInstance, null);
-                            }
-                            JetBrains.Profiler.Api.MemoryProfiler.GetSnapshot(groupName);
-                            JetBrains.Profiler.Api.MemoryProfiler.CollectAllocations(false);
-                        }
-                    }
-                }
-                Console.WriteLine("Done.");
-            }
         }
     }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Running;
 using Datadog.Trace.BenchmarkDotNet;
 using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Filters;
-using Tony.BenchmarkDotnet.Jetbrains;
+using Benchmarks.Trace.Jetbrains;
 
 namespace Benchmarks.Trace
 {


### PR DESCRIPTION
## Summary of changes

This PR replaces the old way to collect trace and memory data using jetbrains dotTrace and dotMemory with a new Benchmark diagnoser and the Jetbrains SelfApi.

With this change now you can collect traces and memory snapshot from Benchmark.Trace by using one of the following arguments:

- `-jetbrains:dottrace`
- `-jetbrains:dotmemory`

This will enable (and download if is required) and execute the benchmark in `InProc` mode and attacha dottracer or dotmemory. 

**Note**: This solution doesn't require you have any jetbrains product previously installed, and works from CI.

### After executing tests, you will have the path of the jetbrains artifacts, for example:

```

// * Diagnostic Output - Jetbrains *
Jetbrains files:
/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/test/benchmarks/Benchmarks.Trace/BenchmarkDotNet.Artifacts/Benchmarks_Trace_AgentWriterBenchmark_WriteAndFlushEnrichedTraces_2023_04_21_16_48_58.dtp.0000
/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/test/benchmarks/Benchmarks.Trace/BenchmarkDotNet.Artifacts/Benchmarks_Trace_AgentWriterBenchmark_WriteAndFlushEnrichedTraces_2023_04_21_16_48_58.dtp
/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/test/benchmarks/Benchmarks.Trace/BenchmarkDotNet.Artifacts/Benchmarks_Trace_AgentWriterBenchmark_WriteAndFlushEnrichedTraces_2023_04_21_16_48_58.dtp.0001
/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/test/benchmarks/Benchmarks.Trace/BenchmarkDotNet.Artifacts/Benchmarks_Trace_AgentWriterBenchmark_WriteAndFlushEnrichedTraces_2023_04_21_16_48_58.dtp.0003
/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/test/benchmarks/Benchmarks.Trace/BenchmarkDotNet.Artifacts/Benchmarks_Trace_AgentWriterBenchmark_WriteAndFlushEnrichedTraces_2023_04_21_16_48_58.dtp.0002

```

Artifact can be opened with dotTrace / dotMemory.

For non windows os, you can use the Rider integration:

<img width="1754" alt="image" src="https://user-images.githubusercontent.com/69803/233692564-2898c197-a862-4a7b-b801-68d06a8dd7af.png">
