### PR TITLE
[Tracing] clean up for 128-bit trace ids

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -264,8 +264,6 @@ namespace Datadog.Trace.MSBuild
                     int? endLineNumber = e.EndLineNumber > 0 ? e.EndLineNumber : null;
                     int? endColumnNumber = e.EndColumnNumber > 0 ? e.EndColumnNumber : null;
                     string projectFile = e.ProjectFile;
-                    string filePath;
-                    string stack;
                     string subCategory = e.Subcategory;
 
                     projectSpan.Error = true;
@@ -278,11 +276,12 @@ namespace Datadog.Trace.MSBuild
 
                     if (!string.IsNullOrEmpty(e.File))
                     {
-                        filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
+                        var filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
                         projectSpan.SetTag(BuildTags.ErrorFile, filePath);
+
                         if (lineNumber.HasValue && lineNumber != 0)
                         {
-                            stack = $" at Source code in {filePath}:line {e.LineNumber}";
+                            var stack = $" at Source code in {filePath}:line {e.LineNumber}";
                             projectSpan.SetTag(BuildTags.ErrorStack, stack);
                         }
                     }
@@ -323,6 +322,7 @@ namespace Datadog.Trace.MSBuild
                 Log.Debug("Warning Raised");
 
                 int context = e.BuildEventContext.ProjectContextId;
+
                 if (_projects.TryGetValue(context, out Span projectSpan))
                 {
                     _tracer.TracerManager.DirectLogSubmission.Sink.EnqueueLog(new MsBuildLogEvent(DirectSubmissionLogLevelExtensions.Warning, e.Message, projectSpan));

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -256,17 +256,17 @@ namespace Datadog.Trace.MSBuild
                 int context = e.BuildEventContext.ProjectContextId;
                 if (_projects.TryGetValue(context, out Span projectSpan))
                 {
-                    string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
+                    // string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
                     string message = e.Message;
                     string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Error";
                     string code = e.Code;
-                    int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
-                    int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
-                    int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
-                    int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
+                    int? lineNumber = e.LineNumber > 0 ? e.LineNumber : null;
+                    int? columnNumber = e.ColumnNumber > 0 ? e.ColumnNumber : null;
+                    int? endLineNumber = e.EndLineNumber > 0 ? e.EndLineNumber : null;
+                    int? endColumnNumber = e.EndColumnNumber > 0 ? e.EndColumnNumber : null;
                     string projectFile = e.ProjectFile;
-                    string filePath = null;
-                    string stack = null;
+                    string filePath;
+                    string stack;
                     string subCategory = e.Subcategory;
 
                     projectSpan.Error = true;
@@ -326,27 +326,28 @@ namespace Datadog.Trace.MSBuild
                 int context = e.BuildEventContext.ProjectContextId;
                 if (_projects.TryGetValue(context, out Span projectSpan))
                 {
-                    string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
-                    string message = e.Message;
-                    string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Warning";
-                    string code = e.Code;
-                    int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
-                    int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
-                    int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
-                    int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
-                    string projectFile = e.ProjectFile;
-                    string filePath = null;
-                    string stack = null;
-                    string subCategory = e.Subcategory;
+                    // string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
+                    // string message = e.Message;
+                    // string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Warning";
+                    // string code = e.Code;
+                    // int? lineNumber = e.LineNumber > 0 ? e.LineNumber : null;
+                    // int? columnNumber = e.ColumnNumber > 0 ? e.ColumnNumber : null;
+                    // int? endLineNumber = e.EndLineNumber > 0 ? e.EndLineNumber : null;
+                    // int? endColumnNumber = e.EndColumnNumber > 0 ? e.EndColumnNumber : null;
+                    // string projectFile = e.ProjectFile;
+                    // string filePath;
+                    // string stack = null;
+                    // string subCategory = e.Subcategory;
 
-                    if (!string.IsNullOrEmpty(e.File))
-                    {
-                        filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
-                        if (lineNumber.HasValue && lineNumber != 0)
-                        {
-                            stack = $" at Source code in {filePath}:line {e.LineNumber}";
-                        }
-                    }
+                    // if (!string.IsNullOrEmpty(e.File))
+                    // {
+                    //     filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
+                    //
+                    //     if (lineNumber.HasValue && lineNumber != 0)
+                    //     {
+                    //         stack = $" at Source code in {filePath}:line {e.LineNumber}";
+                    //     }
+                    // }
 
                     _tracer.TracerManager.DirectLogSubmission.Sink.EnqueueLog(new MsBuildLogEvent(DirectSubmissionLogLevelExtensions.Warning, e.Message, projectSpan));
                 }

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -256,7 +256,6 @@ namespace Datadog.Trace.MSBuild
                 int context = e.BuildEventContext.ProjectContextId;
                 if (_projects.TryGetValue(context, out Span projectSpan))
                 {
-                    // string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
                     string message = e.Message;
                     string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Error";
                     string code = e.Code;
@@ -326,29 +325,6 @@ namespace Datadog.Trace.MSBuild
                 int context = e.BuildEventContext.ProjectContextId;
                 if (_projects.TryGetValue(context, out Span projectSpan))
                 {
-                    // string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
-                    // string message = e.Message;
-                    // string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Warning";
-                    // string code = e.Code;
-                    // int? lineNumber = e.LineNumber > 0 ? e.LineNumber : null;
-                    // int? columnNumber = e.ColumnNumber > 0 ? e.ColumnNumber : null;
-                    // int? endLineNumber = e.EndLineNumber > 0 ? e.EndLineNumber : null;
-                    // int? endColumnNumber = e.EndColumnNumber > 0 ? e.EndColumnNumber : null;
-                    // string projectFile = e.ProjectFile;
-                    // string filePath;
-                    // string stack = null;
-                    // string subCategory = e.Subcategory;
-
-                    // if (!string.IsNullOrEmpty(e.File))
-                    // {
-                    //     filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
-                    //
-                    //     if (lineNumber.HasValue && lineNumber != 0)
-                    //     {
-                    //         stack = $" at Source code in {filePath}:line {e.LineNumber}";
-                    //     }
-                    // }
-
                     _tracer.TracerManager.DirectLogSubmission.Sink.EnqueueLog(new MsBuildLogEvent(DirectSubmissionLogLevelExtensions.Warning, e.Message, projectSpan));
                 }
             }

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -272,8 +272,8 @@ namespace Datadog.Trace.MSBuild
                     projectSpan.SetTag(BuildTags.ErrorMessage, message);
                     projectSpan.SetTag(BuildTags.ErrorType, type);
                     projectSpan.SetTag(BuildTags.ErrorCode, code);
-                    projectSpan.SetTag(BuildTags.ErrorStartLine, lineNumber.ToString());
-                    projectSpan.SetTag(BuildTags.ErrorStartColumn, columnNumber.ToString());
+                    projectSpan.SetTag(BuildTags.ErrorStartLine, lineNumber?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+                    projectSpan.SetTag(BuildTags.ErrorStartColumn, columnNumber?.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
                     projectSpan.SetTag(BuildTags.ErrorProjectFile, projectFile);
 
                     if (!string.IsNullOrEmpty(e.File))

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/AnalyticsEventsSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/AnalyticsEventsSampler.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
                 if (span.GetMetric(Tags.Analytics) is { } rate)
                 {
-                    return SamplingHelpers.SampleByRate(span.TraceId128.Lower, rate);
+                    return SamplingHelpers.SampleByRate(span.TraceId128, rate);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Globalization;
 using System.Net;
 
 using Datadog.Trace.Agent.Transports;
@@ -39,13 +40,14 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
             var request = WebRequest.Create(Uri + EndInvocationPath);
             request.Method = "POST";
             request.Headers.Set(HttpHeaderNames.TracingEnabled, "false");
-            if (scope != null)
-            {
-                // TODO: support 128-bit trace ids?
-                request.Headers.Set(HttpHeaderNames.TraceId, scope.Span.TraceId128.Lower.ToString());
-                request.Headers.Set(HttpHeaderNames.SpanId, scope.Span.SpanId.ToString());
 
-                if (scope.Span.Context.TraceContext?.SamplingPriority is { } samplingPriority)
+            if (scope is { Span: var span })
+            {
+                // TODO: add support for 128-bit trace ids in serverless
+                request.Headers.Set(HttpHeaderNames.TraceId, span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture));
+                request.Headers.Set(HttpHeaderNames.SpanId, span.SpanId.ToString(CultureInfo.InvariantCulture));
+
+                if (span.Context.TraceContext?.SamplingPriority is { } samplingPriority)
                 {
                     request.Headers.Set(HttpHeaderNames.SamplingPriority, samplingPriority.ToString());
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaRequestBuilder.cs
@@ -41,7 +41,8 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
             request.Headers.Set(HttpHeaderNames.TracingEnabled, "false");
             if (scope != null)
             {
-                request.Headers.Set(HttpHeaderNames.TraceId, scope.Span.TraceId.ToString());
+                // TODO: support 128-bit trace ids?
+                request.Headers.Set(HttpHeaderNames.TraceId, scope.Span.TraceId128.Lower.ToString());
                 request.Headers.Set(HttpHeaderNames.SpanId, scope.Span.SpanId.ToString());
 
                 if (scope.Span.Context.TraceContext?.SamplingPriority is { } samplingPriority)

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -689,8 +690,10 @@ namespace Datadog.Trace.Debugger.Snapshots
         internal void FinalizeSnapshot(string methodName, string typeFullName, string probeFilePath)
         {
             var activeScope = Tracer.Instance.InternalActiveScope;
-            var traceId = activeScope?.Span?.TraceId.ToString();
-            var spanId = activeScope?.Span?.SpanId.ToString();
+
+            // TODO: support 128-bit trace ids?
+            var traceId = activeScope?.Span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
+            var spanId = activeScope?.Span.SpanId.ToString(CultureInfo.InvariantCulture);
 
             AddStackInfo()
             .EndSnapshot()

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Sampling
                 return sampleRate;
             }
 
-            Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.TraceId, _defaultSamplingRate);
+            Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.Context.RawTraceId, _defaultSamplingRate);
 
             defaultRate = _defaultSamplingRate ?? 1;
             SetSamplingAgentDecision(span, defaultRate);

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Sampling
 {
@@ -61,7 +62,10 @@ namespace Datadog.Trace.Sampling
                 return sampleRate;
             }
 
-            Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.Context.RawTraceId, _defaultSamplingRate);
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("Could not establish sample rate for trace {TraceId}. Using default rate instead: {Rate}", span.Context.RawTraceId, _defaultSamplingRate);
+            }
 
             defaultRate = _defaultSamplingRate ?? 1;
             SetSamplingAgentDecision(span, defaultRate);

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -31,8 +31,6 @@ namespace Datadog.Trace.Sampling
 
         public SamplingDecision MakeSamplingDecision(Span span)
         {
-            var traceId = span.Context.RawTraceId;
-
             if (_rules.Count > 0)
             {
                 foreach (var rule in _rules)
@@ -41,18 +39,25 @@ namespace Datadog.Trace.Sampling
                     {
                         var sampleRate = rule.GetSamplingRate(span);
 
-                        Log.Debug(
-                            "Matched on rule {RuleName}. Applying rate of {Rate} to trace id {TraceId}",
-                            rule.RuleName,
-                            sampleRate,
-                            traceId);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug(
+                                "Matched on rule {RuleName}. Applying rate of {Rate} to trace id {TraceId}",
+                                rule.RuleName,
+                                sampleRate,
+                                span.Context.RawTraceId);
+                        }
 
                         return MakeSamplingDecision(span, sampleRate, rule.SamplingMechanism);
                     }
                 }
             }
 
-            Log.Debug("No rules matched for trace {TraceId}", traceId);
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("No rules matched for trace {TraceId}", span.Context.RawTraceId);
+            }
+
             return SamplingDecision.Default;
         }
 

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Sampling
 
         public SamplingDecision MakeSamplingDecision(Span span)
         {
-            var traceId = span.TraceId;
+            var traceId = span.Context.RawTraceId;
 
             if (_rules.Count > 0)
             {

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Sampling
 {
@@ -78,7 +79,7 @@ namespace Datadog.Trace.Sampling
         private SamplingDecision MakeSamplingDecision(Span span, float rate, int mechanism)
         {
             // make a sampling decision as a function of traceId and sampling rate.
-            var sample = SamplingHelpers.SampleByRate(span.TraceId, rate);
+            var sample = SamplingHelpers.SampleByRate(span.TraceId128, rate);
 
             var priority = mechanism switch
                            {

--- a/tracer/src/Datadog.Trace/Span.ISpan.cs
+++ b/tracer/src/Datadog.Trace/Span.ISpan.cs
@@ -51,8 +51,8 @@ namespace Datadog.Trace
         }
 
         /// <inheritdoc />
-        // this public API always returns the lower 64-bits, truncate using TraceId.Lower
-        ulong ISpan.TraceId => Context.TraceId128.Lower;
+        // this public API always returns the lower 64-bits, truncate using TraceId128.Lower
+        ulong ISpan.TraceId => TraceId128.Lower;
 
         /// <inheritdoc />
         ulong ISpan.SpanId => SpanId;

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -137,10 +137,12 @@ namespace Datadog.Trace
         public override string ToString()
         {
             var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-            sb.AppendLine($"TraceId64: {Context.TraceId}");
+            sb.AppendLine($"TraceId64: {Context.TraceId128.Lower}");
             sb.AppendLine($"TraceId128: {Context.TraceId128}");
+            sb.AppendLine($"RawTraceId: {Context.RawTraceId}");
             sb.AppendLine($"ParentId: {Context.ParentId}");
             sb.AppendLine($"SpanId: {Context.SpanId}");
+            sb.AppendLine($"RawSpanId: {Context.RawSpanId}");
             sb.AppendLine($"Origin: {Context.Origin}");
             sb.AppendLine($"ServiceName: {ServiceName}");
             sb.AppendLine($"OperationName: {OperationName}");

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace
 
                 Log.Debug(
                     "Span started: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] with Tags: [{Tags}], Tags Type: [{TagsType}])",
-                    new object[] { SpanId, Context.ParentId, TraceId, Tags, tagsType });
+                    new object[] { Context.RawSpanId, Context.ParentId, Context.RawTraceId, Tags, tagsType });
             }
         }
 
@@ -435,7 +435,7 @@ namespace Datadog.Trace
                 {
                     Log.Debug(
                         "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
-                        new object[] { SpanId, Context.ParentId, TraceId, ServiceName, ResourceName, OperationName, Tags });
+                        new object[] { Context.RawSpanId, Context.ParentId, Context.RawTraceId, ServiceName, ResourceName, OperationName, Tags });
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -175,6 +175,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the 64-bit trace id, or the lower 64 bits of a 128-bit trace id.
         /// </summary>
+        [PublicApi]
         public ulong TraceId => TraceId128.Lower;
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Util
 
         internal static bool SampleByRate(TraceId traceId, double rate) =>
             // use the lower 64 bits of the trace id which are the only random part
-            ((traceId.Lower * KnuthFactor) % MaxInt64) <= (rate * MaxInt64);
+            SampleByRate(traceId.Lower, rate);
 
         internal static bool SampleByRate(ulong spanId, double rate) =>
             ((spanId * KnuthFactor) % MaxInt64) <= (rate * MaxInt64);

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -11,14 +11,28 @@ namespace Datadog.Trace.Util
     {
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 
+        // This is intentionally not ulong.MaxValue.
         private const ulong MaxInt64 = long.MaxValue;
 
+        /// <summary>
+        /// Determines if a trace should be kept based on its trace id and the given sampling rate.
+        /// </summary>
+        /// <param name="traceId">The 128-bit id of the trace.</param>
+        /// <param name="rate">The sampling rate to apply.</param>
+        /// <returns><c>true</c> if the trace should be sampled (kept), <c>false</c> otherwise.</returns>
         internal static bool SampleByRate(TraceId traceId, double rate) =>
             // use the lower 64 bits of the trace id which are the only random part
             SampleByRate(traceId.Lower, rate);
 
-        internal static bool SampleByRate(ulong spanId, double rate) =>
-            ((spanId * KnuthFactor) % MaxInt64) <= (rate * MaxInt64);
+        /// <summary>
+        /// Determines if an object (such as a span) should be kept based on
+        /// the object's 64-bit id and the given sampling rate.
+        /// </summary>
+        /// <param name="id">The 64-bit id of the object. For example, a span id.</param>
+        /// <param name="rate">The sampling rate to apply.</param>
+        /// <returns><c>true</c> if the object should be sampled (kept), <c>false</c> otherwise.</returns>
+        internal static bool SampleByRate(ulong id, double rate) =>
+            ((id * KnuthFactor) % MaxInt64) <= (rate * MaxInt64);
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace) =>
             trace.Array![trace.Offset].Context.TraceContext?.SamplingPriority > 0;

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             distributedTracer.Verify(t => t.GetSpanContext(), Times.Exactly(2));
             scope.Span.TraceId128.Should().Be(spanContext.TraceId128);
-            scope.Span.TraceId.Should().Be(spanContext.TraceId);
+            ((ISpan)scope.Span).TraceId.Should().Be(spanContext.TraceId);
             scope.Span.Context.TraceContext.SamplingPriority.Should().Be(spanContext.SamplingPriority);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tests
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
-            scope.Span.TraceId.Should().Be(1234);
+            ((ISpan)scope.Span).TraceId.Should().Be(1234);
             scope.Span.SpanId.Should().BeGreaterThan(0);
         }
 
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().BeGreaterThan(TraceId.Zero);
-            scope.Span.TraceId.Should().BeGreaterThan(0);
+            ((ISpan)scope.Span).TraceId.Should().BeGreaterThan(0);
             scope.Span.SpanId.Should().BeGreaterThan(0);
             scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
         }
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Tests
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().Be((TraceId)1234);
-            scope.Span.TraceId.Should().Be(1234);
+            ((ISpan)scope.Span).TraceId.Should().Be(1234);
             scope.Span.SpanId.Should().BeGreaterThan(0);
             scope.Span.Context.TraceContext.SamplingPriority.Should().Be(-1);
         }
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
 
             scope.Should().NotBeNull();
             scope.Span.TraceId128.Should().BeGreaterThan((TraceId.Zero));
-            scope.Span.TraceId.Should().BeGreaterThan(0);
+            ((ISpan)scope.Span).TraceId.Should().BeGreaterThan(0);
             scope.Span.SpanId.Should().BeGreaterThan(0);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -232,14 +232,11 @@ namespace Datadog.Trace.Tests.Propagators
             const ulong expectedSpanId = 0x00f067aa0ba902b7UL;
 
             var result = B3Propagator.Extract(headers.Object);
+
             result.Should().NotBeNull();
             result!.TraceId128.Should().Be(expectedTraceId);
             result.TraceId.Should().Be(expectedTraceId.Lower);
             result.SpanId.Should().Be(expectedSpanId);
-
-            // Check truncation
-            var truncatedTraceId64 = expectedTraceId.Lower.ToString("x16");
-            traceId.Substring(16).Should().Be(truncatedTraceId64);
 
             // Check the injection restoring the 128 bits traceId.
             var headersForInjection = new Mock<IHeadersCollection>(MockBehavior.Strict);

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -226,17 +226,17 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void StartActive_SetParentManuallyFromExternalContext_ParentIsSet()
         {
-            const ulong traceId = 11;
+            var traceId = (TraceId)11;
             const ulong parentId = 7;
             const int samplingPriority = SamplingPriorityValues.UserKeep;
 
-            var parent = new SpanContext(traceId, parentId, (SamplingPriority)samplingPriority);
+            var parent = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin: null);
             var spanCreationSettings = new SpanCreationSettings() { Parent = parent };
             var child = (Scope)_tracer.StartActive("Child", spanCreationSettings);
             var childSpan = child.Span;
 
             Assert.True(childSpan.IsRootSpan);
-            Assert.Equal(traceId, parent.TraceId);
+            Assert.Equal(traceId, parent.TraceId128);
             Assert.Equal(parentId, parent.SpanId);
             Assert.Null(parent.TraceContext);
             Assert.Equal(parent, childSpan.Context.Parent);


### PR DESCRIPTION
 ## Summary of changes

Some low-priority code cleanup after merging #3744, mostly removing usages of `Span.TraceId` and `SpanContext.TraceId`, and adding the 128-bit trace id to `CorrelationIdentifier`.

## Reason for change

- We should stop using `Span.TraceId` and `SpanContext.TraceId` because they can lead to unintentionally truncating a 128-bit trace id down to its lower 64 bits. Unfortunately, `SpanContext.TraceId` is public and removing `Span.TraceId` causes other issues (which I make look into in a separate PR), so we can't remove them.
- ~We should expose the full 128-bit trace id to users in `CorrelationIdentifier`~ edit: removed from this PR, maybe later

## Implementation details

Stop using the 64-bit `TraceId` properties:
- Replace all remaining uses of `Span.TraceId` with one of:
  - `Span.TraceId128` where a 128-bit `TraceId` is accepted
  - `Span.TraceId128.Lower` where a truncated 64-bit `ulong` is needed
  - `Span.Context.RawTraceId` where a 32-char hex string is needed
- ~Remove `Span.TraceId` (no uses left) to prevent accidental truncation~ edit: maybe later
- Add `[PublicApi]` to `SpanContext.TraceId` to prevent accidental truncation

Other clean-up:
- Replace `TraceId128.Lower` with `TraceId128` where a 128-bit `TraceId` is accepted (stop truncating)
- Bonus: comment out unused code in `Datadog.Trace.MSBuild.DatadogLogger`

New feature:
- ~add `CorrelationIdentifier.TraceId128`, returns a W3C-compatible 32-char hex string~ edit: removed from this PR, maybe later

## Test coverage

~Added tests for the new `CorrelationIdentifier.TraceId128` property.~

## Other details

Follows #3744.
