### PR TITLE
[ASM] Add custom rules support

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rcm/AsmProduct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/AsmProduct.cs
@@ -38,6 +38,12 @@ internal class AsmProduct : IAsmConfigUpdater
                 configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafExclusionsKey);
             }
 
+            if (asmConfig.CustomRules != null)
+            {
+                configurationStatus.CustomRulesByFile[asmConfigName] = asmConfig.CustomRules;
+                configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafCustomRulesKey);
+            }
+
             if (asmConfig.Actions != null)
             {
                 foreach (var action in asmConfig.Actions)
@@ -58,15 +64,17 @@ internal class AsmProduct : IAsmConfigUpdater
 
     public void ProcessRemovals(ConfigurationStatus configurationStatus, List<RemoteConfigurationPath> removedConfigsForThisProduct)
     {
-        var removedRulesOveride = false;
+        var removedRulesOverride = false;
         var removedExclusions = false;
+        var removedCustomRules = false;
         foreach (var configurationPath in removedConfigsForThisProduct)
         {
-            removedRulesOveride |= configurationStatus.RulesOverridesByFile.Remove(configurationPath.Path);
+            removedRulesOverride |= configurationStatus.RulesOverridesByFile.Remove(configurationPath.Path);
             removedExclusions |= configurationStatus.ExclusionsByFile.Remove(configurationPath.Path);
+            removedCustomRules |= configurationStatus.CustomRulesByFile.Remove(configurationPath.Path);
         }
 
-        if (removedRulesOveride)
+        if (removedRulesOverride)
         {
             configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesOverridesKey);
         }
@@ -74,6 +82,11 @@ internal class AsmProduct : IAsmConfigUpdater
         if (removedExclusions)
         {
             configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafExclusionsKey);
+        }
+
+        if (removedCustomRules)
+        {
+            configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafCustomRulesKey);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/Models/Asm/Payload.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/Models/Asm/Payload.cs
@@ -18,4 +18,7 @@ internal class Payload
 
     [JsonProperty("exclusions")]
     public JArray? Exclusions { get; set; }
+
+    [JsonProperty("custom_rules")]
+    public JArray? CustomRules { get; set; }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmCustomRules.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmCustomRules.cs
@@ -1,0 +1,95 @@
+// <copyright file="AspNetCore5AsmCustomRules.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Datadog.Trace.AppSec.Rcm.Models.Asm;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Security.IntegrationTests.Rcm
+{
+    /// <summary>
+    /// Product rcm named ASM, actions object being tested cf https://docs.google.com/document/d/1a_-isT9v_LiiGshzQZtzPzCK_CxMtMIil_2fOq9Z1RE
+    /// </summary>
+    public class AspNetCore5AsmCustomRules : RcmBase
+    {
+        private const string AsmProduct = "ASM";
+        private const string CustomRuleExample = """
+[
+    {
+      "id": "test_custom_rule",
+      "name": "Test custom rule",
+      "tags": {
+        "type": "custom_rule",
+        "category": "attack_attempt"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "list": [
+              "customrule"
+            ]
+          },
+          "operator": "phrase_match"
+        }
+      ],
+      "transformers": [
+        "lowercase"
+      ]
+    },
+]
+""";
+
+        public AspNetCore5AsmCustomRules(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+            : base(fixture, outputHelper, enableSecurity: true, testName: nameof(AspNetCore5AsmActionsConfiguration))
+        {
+            SetEnvironmentVariable(ConfigurationKeys.DebugEnabled, "0");
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestCustomRules()
+        {
+            var url = $"/Health/?arg=customrule_trigger";
+            await TryStartApp();
+            var agent = Fixture.Agent;
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+
+            var spans1 = await SendRequestsAsync(agent, url);
+            await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload { CustomRules = (JArray)JToken.Parse(CustomRuleExample) }, AsmProduct, nameof(TestCustomRules)) });
+
+            var spans2 = await SendRequestsAsync(agent, url);
+            var spans = new List<MockSpan>();
+            spans.AddRange(spans1);
+            spans.AddRange(spans2);
+            await VerifySpans(spans.ToImmutableList(), settings);
+            // need to reset if the process is going to be reused
+            await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload { CustomRules = new JArray() }, AsmProduct, nameof(TestCustomRules)) });
+        }
+
+        protected override string GetTestName() => Prefix + nameof(AspNetCore5AsmCustomRules);
+    }
+}
+#endif

--- a/tracer/test/snapshots/Security.AspNetCore5AsmCustomRules._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5AsmCustomRules._.verified.txt
@@ -1,0 +1,83 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /health,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.HealthController.Index (Samples.Security.AspNetCore5),
+      aspnet_core.route: health,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: health,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Health/?arg=customrule_trigger,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_3,
+    SpanId: Id_4,
+    Name: aspnet_core.request,
+    Resource: GET /health,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.event: true,
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.HealthController.Index (Samples.Security.AspNetCore5),
+      aspnet_core.route: health,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.endpoint: health,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-length: 3,
+      http.response.headers.content-type: text/plain; charset=utf-8,
+      http.route: health,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Health/?arg=customrule_trigger,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"test_custom_rule","name":"Test custom rule","tags":{"category":"attack_attempt","type":"custom_rule"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"server.request.query","highlight":["customrule"],"key_path":["arg","0"],"value":"customrule_trigger"}]}]}]},
+      _dd.origin: appsec,
+      _dd.p.dm: -0,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

The Datadog dashboard will propose options to allow clients to build there own rules. These will be send to the library via remote config. 

## Implementation details

The implementation is straight forward after the RCM refactoring. It just adds another key to the ASM products, which contains the rule data.

## Test coverage

New integration test.

