### PR TITLE
Reduce the pressure on threadpool in the tests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -294,28 +294,32 @@ namespace Datadog.Trace.TestHelpers
 
             var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
-            Task.Run(() =>
-            {
-                string line;
-                while ((line = process.StandardOutput.ReadLine()) != null)
+            Task.Factory.StartNew(
+                () =>
                 {
-                    Output.WriteLine($"[webserver][stdout] {line}");
-
-                    if (line.Contains("IIS Express is running"))
+                    string line;
+                    while ((line = process.StandardOutput.ReadLine()) != null)
                     {
-                        wh.Set();
-                    }
-                }
-            });
+                        Output.WriteLine($"[webserver][stdout] {line}");
 
-            Task.Run(() =>
-            {
-                string line;
-                while ((line = process.StandardError.ReadLine()) != null)
+                        if (line.Contains("IIS Express is running"))
+                        {
+                            wh.Set();
+                        }
+                    }
+                },
+                TaskCreationOptions.LongRunning);
+
+            Task.Factory.StartNew(
+                () =>
                 {
-                    Output.WriteLine($"[webserver][stderr] {line}");
-                }
-            });
+                    string line;
+                    while ((line = process.StandardError.ReadLine()) != null)
+                    {
+                        Output.WriteLine($"[webserver][stderr] {line}");
+                    }
+                },
+                TaskCreationOptions.LongRunning);
 
             wh.WaitOne(5000);
 

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -247,7 +247,8 @@ namespace Datadog.Trace.TestHelpers
 
                 for (int i = 0; i < Environment.ProcessorCount; i++)
                 {
-                    Task.Run(DoWork);
+                    var thread = new Thread(DoWork) { IsBackground = true };
+                    thread.Start();
                 }
             }
 
@@ -275,11 +276,11 @@ namespace Datadog.Trace.TestHelpers
                 return tcs.Task;
             }
 
-            private async Task DoWork()
+            private void DoWork()
             {
                 foreach (var item in _queue.GetConsumingEnumerable())
                 {
-                    await item();
+                    item().GetAwaiter().GetResult();
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -970,7 +970,7 @@ namespace Datadog.Trace.TestHelpers
                         }
                     }
 
-                    _statsdTask = Task.Run(HandleStatsdRequests);
+                    _statsdTask = Task.Factory.StartNew(HandleStatsdRequests, TaskCreationOptions.LongRunning);
 
                     listeners.Add($"Stats at port {StatsdPort}");
                 }
@@ -999,7 +999,7 @@ namespace Datadog.Trace.TestHelpers
                         _listener = listener;
 
                         listeners.Add($"Traces at port {Port}");
-                        _tracesListenerTask = Task.Run(HandleHttpRequests);
+                        _tracesListenerTask = Task.Factory.StartNew(HandleHttpRequests, TaskCreationOptions.LongRunning);
 
                         return;
                     }
@@ -1348,7 +1348,7 @@ namespace Datadog.Trace.TestHelpers
 
                     _udsStatsSocket.Bind(_statsEndpoint);
                     // NOTE: Connectionless protocols don't use Listen()
-                    _statsdTask = Task.Run(HandleUdsStats);
+                    _statsdTask = Task.Factory.StartNew(HandleUdsStats, TaskCreationOptions.LongRunning);
                 }
 
                 _tracesEndpoint = new UnixDomainSocketEndPoint(config.Traces);
@@ -1362,7 +1362,7 @@ namespace Datadog.Trace.TestHelpers
                 _udsTracesSocket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP);
                 _udsTracesSocket.Bind(_tracesEndpoint);
                 _udsTracesSocket.Listen(1000);
-                _tracesListenerTask = Task.Run(HandleUdsTraces);
+                _tracesListenerTask = Task.Factory.StartNew(HandleUdsTraces, TaskCreationOptions.LongRunning);
             }
 
             public string TracesUdsPath { get; }


### PR DESCRIPTION
## Summary of changes

In a lot of integration tests, we use threads to synchronously wait on I/Os (HTTP requests, console output, ...). The threadpool is not good at handling long running tasks (500+ ms), so move them to dedicated threads.

If that's not enough, we might want to also make `TestHelper.RunSampleAndWaitForExit` asynchronous, but that's a much bigger change.

## Reason for change

I've seen evidence of threadpool starvation when running the tests on my machine. I have good hope that it can explain some of the timeouts we're seeing in the CI.

## Implementation details

Switch to long-running tasks wherever appropriate. Also, stopped relying on the `Process` events to read the output of the sample apps, as it apparently use synchronous I/O on the threadpool under the cover.
