### PR TITLE
[Profiler/Windows] Release HANDLE when Managed thread dies

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <memory>
+#include <utility>
 
 
 static constexpr int32_t MinFieldAlignRequirement = 8;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -109,7 +109,7 @@ private:
         ScopedHandle(ScopedHandle&& other) noexcept
         {
             // set the other handle to NULL and store its value in _handle
-            _handle = std::exchange(other._handle, NULL);
+            _handle = std::exchange(other._handle, static_cast<HANDLE>(NULL));
         }
 
         ScopedHandle& operator=(ScopedHandle&& other) noexcept
@@ -117,7 +117,7 @@ private:
             if (this != &other)
             {
                 // set the other handle to NULL and store its value in _handle
-                _handle = std::exchange(other._handle, NULL);
+                _handle = std::exchange(other._handle, static_cast<HANDLE>(NULL));
             }
             return *this;
         }


### PR DESCRIPTION
## Summary of changes

Release `HANDLE` when managed thread dies.

## Reason for change

We duplicate thread handles when a managed thread is created but we do not release it. This leaks handles.

## Implementation details

Create a `ScopedHandle` class to use RAII to managed `HANDLE` lifecycle.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
