### PR TITLE
Option to add Datadog Profiler to the BenchmarkDotNet tests

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using BenchmarkDotNet.Analysers;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Validators;
+using Datadog.Trace;
+
+#nullable enable
+
+namespace Benchmarks.Trace.DatadogProfiler;
+
+/// <summary>
+/// Datadog profiler diagnoser
+/// </summary>
+internal class DatadogProfilerDiagnoser : IDiagnoser
+{
+    public IEnumerable<string> Ids { get; } = new[] { "DatadogProfiler" };
+    public IEnumerable<IExporter> Exporters { get; } = Array.Empty<IExporter>();
+    public IEnumerable<IAnalyser> Analysers { get; } = Array.Empty<IAnalyser>();
+
+    public RunMode GetRunMode(BenchmarkCase benchmarkCase)
+    {
+        return RunMode.NoOverhead;
+    }
+
+    public bool RequiresBlockingAcknowledgments(BenchmarkCase benchmarkCase)
+    {
+        return false;
+    }
+
+    public void Handle(HostSignal signal, DiagnoserActionParameters parameters)
+    {
+        if (signal == HostSignal.BeforeProcessStart)
+        {
+            string? monitorHome, profiler32Path, profiler64Path, ldPreload, loaderConfig;
+            if (FrameworkDescription.Instance.IsWindows())
+            {
+                monitorHome = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "..\\..\\..\\..\\..\\..\\..\\shared\\bin\\monitoring-home");
+                monitorHome = Path.GetFullPath(monitorHome);
+                profiler32Path = Path.Combine(monitorHome, "win-x86\\Datadog.Trace.ClrProfiler.Native.dll");
+                profiler64Path = Path.Combine(monitorHome, "win-x64\\Datadog.Trace.ClrProfiler.Native.dll");
+                loaderConfig = Path.Combine(monitorHome, "win-x64\\loader.conf");
+                ldPreload = null;
+            }
+            else
+            {
+                monitorHome = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "../../../../../../../shared/bin/monitoring-home/");
+                monitorHome = Path.GetFullPath(monitorHome);
+                profiler32Path = null;
+                profiler64Path = Path.Combine(monitorHome, "linux-x64/Datadog.Trace.ClrProfiler.Native.so");
+                loaderConfig = Path.Combine(monitorHome, "linux-x64/loader.conf");
+                ldPreload = Path.Combine(monitorHome, "linux-x64/Datadog.Linux.ApiWrapper.x64.so");
+            }
+
+            var environment = parameters.Process.StartInfo.Environment;
+            environment["COR_ENABLE_PROFILING"] = "1";
+            environment["CORECLR_ENABLE_PROFILING"] = "1";
+            environment["COR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
+            environment["CORECLR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
+
+            if (profiler32Path != null)
+            {
+                environment["COR_PROFILER_PATH_32"] = profiler32Path;
+                environment["CORECLR_PROFILER_PATH_32"] = profiler32Path;
+            }
+
+            if (profiler64Path != null)
+            {
+                environment["COR_PROFILER_PATH_64"] = profiler64Path;
+                environment["CORECLR_PROFILER_PATH_64"] = profiler64Path;
+            }
+
+            if (ldPreload != null)
+            {
+                environment["LD_PRELOAD"] = ldPreload;
+            }
+
+            if (loaderConfig != null)
+            {
+                environment["DD_NATIVELOADER_CONFIGFILE"] = loaderConfig;
+            }
+
+            environment["DD_TRACE_ENABLED"] = "0";
+            environment["DD_PROFILING_ENABLED"] = "1";
+            environment["DD_PROFILING_WALLTIME_ENABLED"] = "1";
+            environment["DD_PROFILING_CPU_ENABLED"] = "1";
+            environment["DD_PROFILING_ALLOCATION_ENABLED"] = "1";
+        }
+    }
+
+    public IEnumerable<Metric> ProcessResults(DiagnoserResults results)
+    {
+        return Enumerable.Empty<Metric>();
+    }
+
+    public void DisplayResults(ILogger logger)
+    {
+    }
+
+    public IEnumerable<ValidationError> Validate(ValidationParameters validationParameters)
+    {
+        return Enumerable.Empty<ValidationError>();
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -96,6 +96,7 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             environment["DD_PROFILING_ALLOCATION_ENABLED"] = "1";
             environment["DD_PROFILING_CONTENTION_ENABLED"] = "1";
             environment["DD_PROFILING_EXCEPTION_ENABLED"] = "1";
+            environment["DD_PROFILING_HEAP_ENABLED"] = "1";
         }
     }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -61,11 +61,13 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             }
 
             var environment = parameters.Process.StartInfo.Environment;
+            environment["DD_ENV"] = "benchnmark";
             environment["COR_ENABLE_PROFILING"] = "1";
             environment["CORECLR_ENABLE_PROFILING"] = "1";
             environment["COR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
             environment["CORECLR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
-
+            environment["DD_DOTNET_TRACER_HOME"] = monitorHome;
+            
             if (profiler32Path != null)
             {
                 environment["COR_PROFILER_PATH_32"] = profiler32Path;
@@ -89,6 +91,7 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             }
 
             environment["DD_TRACE_ENABLED"] = "0";
+            environment["DD_TRACE_DEBUG"] = "1";
             environment["DD_PROFILING_ENABLED"] = "1";
             environment["DD_PROFILING_WALLTIME_ENABLED"] = "1";
             environment["DD_PROFILING_CPU_ENABLED"] = "1";

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -43,6 +43,11 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
         if (signal == HostSignal.BeforeProcessStart)
         {
             var monitorHome = EnvironmentHelpers.GetEnvironmentVariable("DD_DOTNET_TRACER_HOME");
+            if (monitorHome is not null && !Directory.Exists(monitorHome))
+            {
+                monitorHome = null;
+            }
+
             string? profiler32Path, profiler64Path, ldPreload, loaderConfig;
             if (FrameworkDescription.Instance.IsWindows())
             {

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -61,7 +61,6 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             }
 
             var environment = parameters.Process.StartInfo.Environment;
-            environment["DD_ENV"] = "benchnmark";
             environment["COR_ENABLE_PROFILING"] = "1";
             environment["CORECLR_ENABLE_PROFILING"] = "1";
             environment["COR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
@@ -91,7 +90,6 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             }
 
             environment["DD_TRACE_ENABLED"] = "0";
-            environment["DD_TRACE_DEBUG"] = "1";
             environment["DD_PROFILING_ENABLED"] = "1";
             environment["DD_PROFILING_WALLTIME_ENABLED"] = "1";
             environment["DD_PROFILING_CPU_ENABLED"] = "1";

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -12,6 +12,7 @@ using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Validators;
 using Datadog.Trace;
+using Datadog.Trace.Ci;
 
 #nullable enable
 
@@ -61,6 +62,21 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             }
 
             var environment = parameters.Process.StartInfo.Environment;
+            if (!environment.TryGetValue("DD_SERVICE", out _))
+            {
+                environment["DD_SERVICE"] = parameters.BenchmarkCase.Descriptor.FolderInfo;
+            }
+
+            if (!environment.TryGetValue("DD_ENV", out _))
+            {
+                environment["DD_ENV"] = "benchmarks";
+            }
+
+            if (!environment.TryGetValue("DD_VERSION", out _))
+            {
+                environment["DD_VERSION"] = CIEnvironmentValues.Instance.Branch;
+            }
+
             environment["COR_ENABLE_PROFILING"] = "1";
             environment["CORECLR_ENABLE_PROFILING"] = "1";
             environment["COR_PROFILER"] = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerDiagnoser.cs
@@ -94,6 +94,8 @@ internal class DatadogProfilerDiagnoser : IDiagnoser
             environment["DD_PROFILING_WALLTIME_ENABLED"] = "1";
             environment["DD_PROFILING_CPU_ENABLED"] = "1";
             environment["DD_PROFILING_ALLOCATION_ENABLED"] = "1";
+            environment["DD_PROFILING_CONTENTION_ENABLED"] = "1";
+            environment["DD_PROFILING_EXCEPTION_ENABLED"] = "1";
         }
     }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerExtensions.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DatadogProfiler/DatadogProfilerExtensions.cs
@@ -1,0 +1,22 @@
+﻿using BenchmarkDotNet.Configs;
+
+#nullable enable
+
+namespace Benchmarks.Trace.DatadogProfiler;
+
+/// <summary>
+/// Datadog profiler extensions
+/// </summary>
+public static class DatadogProfilerExtensions
+{
+    /// <summary>
+    /// Configure the Datadog profiler diagnoser
+    /// </summary>
+    /// <param name="config">Configuration instance</param>
+    /// <returns>Same configuration instance</returns>
+    public static IConfig WithDatadogProfiler(this IConfig config)
+    {
+        return config
+              .AddDiagnoser(new DatadogProfilerDiagnoser());
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Running;
 using Datadog.Trace.BenchmarkDotNet;
 using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Filters;
+using Benchmarks.Trace.DatadogProfiler;
 using Benchmarks.Trace.Jetbrains;
 
 namespace Benchmarks.Trace
@@ -22,6 +23,7 @@ namespace Benchmarks.Trace
             const string jetBrainsDotTrace = "-jetbrains:dottrace";
             const string jetBrainsDotTraceTimeline = "-jetbrains:dottrace:timeline";
             const string jetBrainsDotMemory = "-jetbrains:dotmemory";
+            const string datadogProfiler = "-datadog:profiler";
 
             if (args?.Any(a => a == jetBrainsDotTrace) == true)
             {
@@ -40,6 +42,12 @@ namespace Benchmarks.Trace
                 Console.WriteLine("Setting Jetbrains memory collection... (could take time downloading collector binaries)");
                 args = args.Where(a => a != jetBrainsDotMemory).ToArray();
                 config = config.WithJetbrains(JetbrainsProduct.Memory);
+            }
+            else if (args?.Any(a => a == datadogProfiler) == true)
+            {
+                Console.WriteLine("Setting Datadog Profiler...");
+                args = args.Where(a => a != datadogProfiler).ToArray();
+                config = config.WithDatadogProfiler();
             }
             
             config = config.WithDatadog()


### PR DESCRIPTION
## Summary of changes

This PR adds the option to execute our BenchmarkDotNet tests with the Datadog Profiler, so we can analyse and optimize our code.

## Reason for change

We already have the option to attach, Jetbrains dotTracer and dotMemory products in our BenchmarkDotNet, only our own Datadog profiler product was missing. This PR solves this.

## Implementation details

A new diagnoser was created to inject the required environment variables to the target process running the benchmarks.

## Example

![image](https://user-images.githubusercontent.com/69803/235206498-94d2b3c0-fbf4-4af2-bab9-729c0e618d93.png)

