### PR TITLE
Swap Samples.MongoDB to use Activity

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -500,7 +500,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NetActivitySdk", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Owin.Iis.WebApi2", "tracer\test\test-applications\aspnet\Samples.Owin.Iis.WebApi2\Samples.Owin.Iis.WebApi2.csproj", "{B417E258-A21F-4546-B78F-8A7A4879472A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.Trace.BenchmarkDotNet.Tests", "tracer\test\Datadog.Trace.BenchmarkDotNet.Tests\Datadog.Trace.BenchmarkDotNet.Tests.csproj", "{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.BenchmarkDotNet.Tests", "tracer\test\Datadog.Trace.BenchmarkDotNet.Tests\Datadog.Trace.BenchmarkDotNet.Tests.csproj", "{CC549AFF-0EC0-4AD4-93E3-F05C8A74F4D9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.InstrumentedTests", "tracer\test\test-applications\integrations\Samples.InstrumentedTests\Samples.InstrumentedTests.csproj", "{64E32F7A-8989-480E-AFE7-3BD343424F6A}"
 EndProject
@@ -515,6 +515,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Security.AspNetCore5", "tracer\test\test-applications\security\Samples.Security.AspNetCore5\Samples.Security.AspNetCore5.csproj", "{87D57940-9A6E-473C-A4D6-777E3BAFD5F9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Security.AspNetCore2", "tracer\test\test-applications\security\Samples.Security.AspNetCore2\Samples.Security.AspNetCore2.csproj", "{C5E7978A-DE2A-4944-86DB-4721A110E720}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivitySampleHelper", "tracer\test\test-applications\integrations\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj", "{51AF3B29-D107-4E22-8A85-DF02A8A898E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1210,6 +1212,10 @@ Global
 		{C5E7978A-DE2A-4944-86DB-4721A110E720}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C5E7978A-DE2A-4944-86DB-4721A110E720}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C5E7978A-DE2A-4944-86DB-4721A110E720}.Release|Any CPU.Build.0 = Release|Any CPU
+		{51AF3B29-D107-4E22-8A85-DF02A8A898E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{51AF3B29-D107-4E22-8A85-DF02A8A898E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{51AF3B29-D107-4E22-8A85-DF02A8A898E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{51AF3B29-D107-4E22-8A85-DF02A8A898E5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1407,12 +1413,15 @@ Global
 		{E774F1F8-B87C-4082-BD15-04B880B4C016} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{87D57940-9A6E-473C-A4D6-777E3BAFD5F9} = {0972AD57-B16B-494F-AE0A-091DD6F3B42B}
 		{C5E7978A-DE2A-4944-86DB-4721A110E720} = {0972AD57-B16B-494F-AE0A-091DD6F3B42B}
+		{51AF3B29-D107-4E22-8A85-DF02A8A898E5} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
 	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{3c6dd42e-9214-4747-92ba-78de29aace59}*SharedItemsImports = 4
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{472dba92-4fea-4b9a-ba70-0e97b942e12d}*SharedItemsImports = 5
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{65492dd4-ccd9-437a-b383-e7eb7ab872d2}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{6d86109f-b7c9-477d-86d7-45735a3a0818}*SharedItemsImports = 4
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{7b0822f6-80de-4b49-8125-93975678d0d5}*SharedItemsImports = 4
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{99a62ccf-8e7f-4d57-8383-d38c371c8087}*SharedItemsImports = 4

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -44,6 +44,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
+
             var isExternalSpan = metadataSchemaVersion == "v0";
             var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-mongodb" : EnvironmentHelper.FullSampleName;
 

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV0.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,26 +29,36 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
@@ -62,7 +78,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -85,7 +101,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -108,7 +124,7 @@
       mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -131,7 +147,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -154,7 +170,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -177,7 +193,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -200,7 +216,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -223,7 +239,7 @@
       mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -246,7 +262,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV1.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,26 +29,36 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV0.verified.txt
@@ -2,15 +2,21 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
@@ -87,7 +113,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -109,7 +135,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -132,7 +158,7 @@
       mongodb.query: { "count" : "employees", "query" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -155,7 +181,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -175,7 +201,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -197,7 +223,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -219,7 +245,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -242,7 +268,7 @@
       mongodb.query: { "count" : "employees", "query" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -265,7 +291,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -285,7 +311,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -305,7 +331,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
@@ -2,15 +2,21 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV0.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
@@ -88,7 +114,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true, "deletes" : [{ "q" : { }, "limit" : 0 }] },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -111,7 +137,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true, "documents" : [{ "_id" : ObjectId("ABC123"), "name" : "MongoDB", "type" : "Database", "count" : 1, "info" : { "x" : 203, "y" : 102 } }] },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -134,7 +160,7 @@
       mongodb.query: { "count" : "employees", "query" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -157,7 +183,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -177,7 +203,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -200,7 +226,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true, "deletes" : [{ "q" : { }, "limit" : 0 }] },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -223,7 +249,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true, "documents" : [{ "_id" : ObjectId("ABC123"), "name" : "MongoDB", "type" : "Database", "count" : 1, "info" : { "x" : 203, "y" : 102 } }] },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -246,7 +272,7 @@
       mongodb.query: { "count" : "employees", "query" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -269,7 +295,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -289,7 +315,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -309,7 +335,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV0.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
@@ -88,7 +114,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -111,7 +137,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -134,7 +160,7 @@
       mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -157,7 +183,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -177,7 +203,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -200,7 +226,7 @@
       mongodb.query: { "delete" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -223,7 +249,7 @@
       mongodb.query: { "insert" : "employees", "ordered" : true },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -246,7 +272,7 @@
       mongodb.query: { "aggregate" : "employees", "pipeline" : [{ "$match" : { } }, { "$group" : { "_id" : 1, "n" : { "$sum" : 1 } } }], "cursor" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -269,7 +295,7 @@
       mongodb.query: { "find" : "employees", "filter" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -289,7 +315,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -309,7 +335,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV1.verified.txt
@@ -1,16 +1,22 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,52 +29,72 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: sync-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: async-calls-execute,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls-execute,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV0.verified.txt
@@ -2,15 +2,21 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,26 +29,36 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
@@ -61,7 +77,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -83,7 +99,7 @@
       mongodb.collection: employees,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -106,7 +122,7 @@
       mongodb.query: { "count" : "employees", "query" : { } },
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {
@@ -126,7 +142,7 @@
       env: integration_tests,
       out.host: mongo,
       out.port: 27017,
-      runtime-id: Guid_1,
+      runtime-id: Guid_2,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
@@ -2,15 +2,21 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: Main(),
+    Name: Samples.MongoDB.internal,
     Resource: Main(),
     Service: Samples.MongoDB,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,
@@ -23,26 +29,36 @@
   {
     TraceId: Id_1,
     SpanId: Id_3,
-    Name: sync-calls,
+    Name: Samples.MongoDB.internal,
     Resource: sync-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: async-calls,
+    Name: Samples.MongoDB.internal,
     Resource: async-calls,
     Service: Samples.MongoDB,
+    Type: custom,
     ParentId: Id_2,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: Samples.MongoDB,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      span.kind: internal,
       version: 1.0.0
     }
   },

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ActivitySampleHelper;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
@@ -12,6 +13,7 @@ namespace Samples.MongoDB
 {
     public static class Program
     {
+        private static readonly ActivitySourceHelper _sampleHelpers = new("Samples.MongoDB");
         private static string Host()
         {
             return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
@@ -37,7 +39,7 @@ namespace Samples.MongoDB
             };
 
 
-            using (var mainScope = SampleHelpers.CreateScope("Main()"))
+            using (var mainScope = _sampleHelpers.CreateScope("Main()"))
             {
                 var connectionString = $"mongodb://{Host()}:27017";
                 var client = new MongoClient(connectionString);
@@ -58,7 +60,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var syncScope = SampleHelpers.CreateScope("sync-calls"))
+            using (var syncScope = _sampleHelpers.CreateScope("sync-calls"))
             {
 #if MONGODB_2_2
                 collection.DeleteMany(allFilter);
@@ -101,7 +103,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var asyncScope = SampleHelpers.CreateScope("async-calls"))
+            using (var asyncScope = _sampleHelpers.CreateScope("async-calls"))
             {
                 await collection.DeleteManyAsync(allFilter);
                 await collection.InsertOneAsync(newDocument);
@@ -123,14 +125,14 @@ namespace Samples.MongoDB
 
         public static void WireProtocolExecuteIntegrationTest(MongoClient client)
         {
-            using (var syncScope = SampleHelpers.CreateScope("sync-calls-execute"))
+            using (var syncScope = _sampleHelpers.CreateScope("sync-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);
                 channel.KillCursors(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None);
             }
 
-            using (var asyncScope = SampleHelpers.CreateScope("async-calls-execute"))
+            using (var asyncScope = _sampleHelpers.CreateScope("async-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Properties/launchSettings.json
@@ -3,6 +3,9 @@
     "Samples.MongoDB": {
       "commandName": "Project",
       "environmentVariables": {
+        "DD_VERSION": "",
+        "DD_SERVICE": "Samples.MongoDB",
+
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
@@ -12,9 +15,18 @@
         "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
-        "DD_VERSION": "1.0.0"
+        "DD_TRACE_OTEL_ENABLED": "true"
       },
       "nativeDebugging": true
+    },
+    "NoDatadog": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DD_ENV": "",
+        "DD_SERVICE": "",
+        "DD_VERSION": ""
+      },
+      "nativeDebugging": false
     }
   }
 }

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.8.0</ApiVersion>
-    <DefineConstants Condition="'$(ApiVersion)'>='2.15.0'">$(DefineConstants);MONGODB_2_15</DefineConstants>
-    <DefineConstants Condition="'$(ApiVersion)'>='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
-    <DefineConstants Condition="'$(ApiVersion)'>='2.2.0'">$(DefineConstants);MONGODB_2_2</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.15.0'">$(DefineConstants);MONGODB_2_15</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
+    <DefineConstants Condition="'$(ApiVersion)'&gt;='2.2.0'">$(DefineConstants);MONGODB_2_2</DefineConstants>
     <RequiresDockerDependency>true</RequiresDockerDependency>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
@@ -15,4 +15,13 @@
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySampleHelper.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySampleHelper.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>11.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+
+
+</Project>

--- a/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics;
+
+namespace ActivitySampleHelper
+{
+    public class ActivitySourceHelper
+    {
+        public ActivitySourceHelper(string sampleName)
+        {
+            ActivitySource = new ActivitySource(sampleName);
+            var activityListener = new ActivityListener
+            {
+                ActivityStarted = activity => Console.WriteLine($"{activity.DisplayName}:{activity.Id} - Started"),
+                ActivityStopped = activity => Console.WriteLine($"{activity.DisplayName}:{activity.Id} - Stopped"),
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
+            };
+
+            ActivitySource.AddActivityListener(activityListener);
+        }
+
+        public ActivitySource ActivitySource { get; }
+
+        public IDisposable CreateScope(string operationName)
+        {
+            var activity = ActivitySource.StartActivity(operationName);
+            if (activity == null)
+            {
+                throw new Exception($"Failed to start Activity for {operationName}");
+            }
+            return activity;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

This changes Samples.MongoDB to use `Activity` objects for manual instrumentation instead of `SampleHelpers`
I've also added a helper library for this to better match the existing API of `SampleHelpers` as I think it might be beneficial, but up to changing/removing it if it doesn't seem to be worthwhile.

## Reason for change

We want to move away from using SampeHelpers for instrumentation in integration tests

## Implementation details

- Created new class library `ActivitySampleHelper` to be similar to `SampleHelpers` API (not a shared project though)
- Samples.MongoDB uses new `ActivitySampleHelper` to swap from `SampleHelpers` to `Activity.

## Test coverage

- Snapshots updated

## Other details
<!-- Fixes #{issue} -->
