### PR TITLE
Swap Samples.WebRequest to use Activity

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_HTTP_CLIENT_ERROR_STATUSES", "410-499");
             SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsWebRequest(metadataSchemaVersion);

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
@@ -12,6 +12,7 @@
           "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
   
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+          "DD_TRACE_OTEL_ENABLED": "true"
         },
         "nativeDebugging": true
       }

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using ActivitySampleHelper;
 
 namespace Samples.WebRequest
 {
@@ -13,6 +14,7 @@ namespace Samples.WebRequest
         private static readonly Encoding Utf8 = Encoding.UTF8;
         private static readonly AutoResetEvent _allDone = new(false);
         private const string TracingEnabled = "x-datadog-tracing-enabled";
+        private static readonly ActivitySourceHelper _sampleHelpers = new("Samples.WebRequest");
 
         public static async Task SendWebClientRequests(bool tracingDisabled, string url, string requestContent)
         {
@@ -27,9 +29,9 @@ namespace Samples.WebRequest
                     webClient.Headers.Add(TracingEnabled, "false");
                 }
 
-                using (SampleHelpers.CreateScope("WebClient"))
+                using (_sampleHelpers.CreateScope("WebClient"))
                 {
-                    using (SampleHelpers.CreateScope("DownloadData"))
+                    using (_sampleHelpers.CreateScope("DownloadData"))
                     {
                         webClient.DownloadData(GetUrlForTest("DownloadData", url));
                         Console.WriteLine("Received response for client.DownloadData(String)");
@@ -38,7 +40,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadData(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadDataAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadDataAsync"))
                     {
                         webClient.DownloadDataAsyncAndWait(new Uri(GetUrlForTest("DownloadDataAsync", url)));
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri)");
@@ -47,7 +49,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadDataTaskAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadDataTaskAsync"))
                     {
                         await webClient.DownloadDataTaskAsync(GetUrlForTest("DownloadDataTaskAsync", url));
                         Console.WriteLine("Received response for client.DownloadDataTaskAsync(String)");
@@ -56,7 +58,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadDataTaskAsync(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadFile"))
+                    using (_sampleHelpers.CreateScope("DownloadFile"))
                     {
                         webClient.DownloadFile(GetUrlForTest("DownloadFile", url), "DownloadFile.string.txt");
                         Console.WriteLine("Received response for client.DownloadFile(String, String)");
@@ -65,7 +67,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFile(Uri, String)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadFileAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadFileAsync"))
                     {
                         webClient.DownloadFileAsyncAndWait(new Uri(GetUrlForTest("DownloadFileAsync", url)), "DownloadFileAsync.uri.txt");
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String)");
@@ -74,7 +76,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadFileTaskAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadFileTaskAsync"))
                     {
                         await webClient.DownloadFileTaskAsync(GetUrlForTest("DownloadFileTaskAsync", url), "DownloadFileTaskAsync.string.txt");
                         Console.WriteLine("Received response for client.DownloadFileTaskAsync(String, String)");
@@ -83,7 +85,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadFileTaskAsync(Uri, String)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadString"))
+                    using (_sampleHelpers.CreateScope("DownloadString"))
                     {
                         webClient.DownloadString(GetUrlForTest("DownloadString", url));
                         Console.WriteLine("Received response for client.DownloadString(String)");
@@ -92,7 +94,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadString(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadStringAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadStringAsync"))
                     {
                         webClient.DownloadStringAsyncAndWait(new Uri(GetUrlForTest("DownloadStringAsync", url)));
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri)");
@@ -101,7 +103,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("DownloadStringTaskAsync"))
+                    using (_sampleHelpers.CreateScope("DownloadStringTaskAsync"))
                     {
                         await webClient.DownloadStringTaskAsync(GetUrlForTest("DownloadStringTaskAsync", url));
                         Console.WriteLine("Received response for client.DownloadStringTaskAsync(String)");
@@ -110,7 +112,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.DownloadStringTaskAsync(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("OpenRead"))
+                    using (_sampleHelpers.CreateScope("OpenRead"))
                     {
                         webClient.OpenRead(GetUrlForTest("OpenRead", url)).Close();
                         Console.WriteLine("Received response for client.OpenRead(String)");
@@ -119,7 +121,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenRead(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("OpenReadAsync"))
+                    using (_sampleHelpers.CreateScope("OpenReadAsync"))
                     {
                         webClient.OpenReadAsyncAndWait(new Uri(GetUrlForTest("OpenReadAsync", url)));
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri)");
@@ -128,7 +130,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("OpenReadTaskAsync"))
+                    using (_sampleHelpers.CreateScope("OpenReadTaskAsync"))
                     {
                         using Stream readStream1 = await webClient.OpenReadTaskAsync(GetUrlForTest("OpenReadTaskAsync", url));
                         Console.WriteLine("Received response for client.OpenReadTaskAsync(String)");
@@ -137,7 +139,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.OpenReadTaskAsync(Uri)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadData"))
+                    using (_sampleHelpers.CreateScope("UploadData"))
                     {
                         webClient.UploadData(GetUrlForTest("UploadData", url), new byte[0]);
                         Console.WriteLine("Received response for client.UploadData(String, Byte[])");
@@ -152,7 +154,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadData(Uri, String, Byte[])");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadDataAsync"))
+                    using (_sampleHelpers.CreateScope("UploadDataAsync"))
                     {
                         webClient.UploadDataAsyncAndWait(new Uri(GetUrlForTest("UploadDataAsync", url)), new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, Byte[])");
@@ -164,7 +166,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, String, Byte[], Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadDataTaskAsync"))
+                    using (_sampleHelpers.CreateScope("UploadDataTaskAsync"))
                     {
                         await webClient.UploadDataTaskAsync(GetUrlForTest("UploadDataTaskAsync", url), new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataTaskAsync(String, Byte[])");
@@ -181,7 +183,7 @@ namespace Samples.WebRequest
 
                     File.WriteAllText("UploadFile.txt", requestContent);
 
-                    using (SampleHelpers.CreateScope("UploadFile"))
+                    using (_sampleHelpers.CreateScope("UploadFile"))
                     {
                         webClient.UploadFile(GetUrlForTest("UploadFile", url), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFile(String, String)");
@@ -196,7 +198,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFile(Uri, String, String)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadFileAsync"))
+                    using (_sampleHelpers.CreateScope("UploadFileAsync"))
                     {
                         webClient.UploadFileAsyncAndWait(new Uri(GetUrlForTest("UploadFileAsync", url)), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String)");
@@ -208,7 +210,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String, String, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadFileTaskAsync"))
+                    using (_sampleHelpers.CreateScope("UploadFileTaskAsync"))
                     {
                         await webClient.UploadFileTaskAsync(GetUrlForTest("UploadFileTaskAsync", url), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileTaskAsync(String, String)");
@@ -223,7 +225,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadFileTaskAsync(Uri, String, String)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadString"))
+                    using (_sampleHelpers.CreateScope("UploadString"))
                     {
                         webClient.UploadString(GetUrlForTest("UploadString", url), requestContent);
                         Console.WriteLine("Received response for client.UploadString(String, String)");
@@ -238,7 +240,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadString(Uri, String, String)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadStringAsync"))
+                    using (_sampleHelpers.CreateScope("UploadStringAsync"))
                     {
                         webClient.UploadStringAsyncAndWait(new Uri(GetUrlForTest("UploadStringAsync", url)), requestContent);
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String)");
@@ -250,7 +252,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String, String, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadStringTaskAsync"))
+                    using (_sampleHelpers.CreateScope("UploadStringTaskAsync"))
                     {
                         await webClient.UploadStringTaskAsync(GetUrlForTest("UploadStringTaskAsync", url), requestContent);
                         Console.WriteLine("Received response for client.UploadStringTaskAsync(String, String)");
@@ -266,7 +268,7 @@ namespace Samples.WebRequest
                     }
 
                     var values = new NameValueCollection();
-                    using (SampleHelpers.CreateScope("UploadValues"))
+                    using (_sampleHelpers.CreateScope("UploadValues"))
                     {
                         webClient.UploadValues(GetUrlForTest("UploadValues", url), values);
                         Console.WriteLine("Received response for client.UploadValues(String, NameValueCollection)");
@@ -281,7 +283,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadValues(Uri, String, NameValueCollection)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadValuesAsync"))
+                    using (_sampleHelpers.CreateScope("UploadValuesAsync"))
                     {
                         webClient.UploadValuesAsyncAndWait(new Uri(GetUrlForTest("UploadValuesAsync", url)), values);
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, NameValueCollection)");
@@ -293,7 +295,7 @@ namespace Samples.WebRequest
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, String, NameValueCollection, Object)");
                     }
 
-                    using (SampleHelpers.CreateScope("UploadValuesTaskAsync"))
+                    using (_sampleHelpers.CreateScope("UploadValuesTaskAsync"))
                     {
                         await webClient.UploadValuesTaskAsync(GetUrlForTest("UploadValuesTaskAsync", url), values);
                         Console.WriteLine("Received response for client.UploadValuesTaskAsync(String, NameValueCollection)");
@@ -315,9 +317,9 @@ namespace Samples.WebRequest
         {
             Console.WriteLine($"[WebRequest] sending requests to {url}");
 
-            using (SampleHelpers.CreateScope("WebRequest"))
+            using (_sampleHelpers.CreateScope("WebRequest"))
             {
-                using (SampleHelpers.CreateScope("GetResponse"))
+                using (_sampleHelpers.CreateScope("GetResponse"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponse", url));
@@ -330,7 +332,7 @@ namespace Samples.WebRequest
                     Console.WriteLine("Received response for request.GetResponse()");
                 }
 
-                using (SampleHelpers.CreateScope("GetResponseNotFound"))
+                using (_sampleHelpers.CreateScope("GetResponseNotFound"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseNotFound", url));
@@ -353,7 +355,7 @@ namespace Samples.WebRequest
                     }
                 }
 
-                using (SampleHelpers.CreateScope("GetResponseTeapot"))
+                using (_sampleHelpers.CreateScope("GetResponseTeapot"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseTeapot", url));
@@ -376,7 +378,7 @@ namespace Samples.WebRequest
                     }
                 }
 
-                using (SampleHelpers.CreateScope("GetResponseAsync"))
+                using (_sampleHelpers.CreateScope("GetResponseAsync"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsync", url));
@@ -389,7 +391,7 @@ namespace Samples.WebRequest
                     Console.WriteLine("Received response for request.GetResponseAsync()");
                 }
 
-                using (SampleHelpers.CreateScope("GetResponseAsyncNotFound"))
+                using (_sampleHelpers.CreateScope("GetResponseAsyncNotFound"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsyncNotFound", url));
@@ -412,7 +414,7 @@ namespace Samples.WebRequest
                     }
                 }
 
-                using (SampleHelpers.CreateScope("GetResponseAsyncTeapot"))
+                using (_sampleHelpers.CreateScope("GetResponseAsyncTeapot"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsyncTeapot", url));
@@ -435,32 +437,32 @@ namespace Samples.WebRequest
                     }
                 }
 
-                using (SampleHelpers.CreateScope("GetRequestStream"))
+                using (_sampleHelpers.CreateScope("GetRequestStream"))
                 {
                     GetRequestStream(tracingDisabled, url);
                 }
 
-                using (SampleHelpers.CreateScope("BeginGetRequestStream"))
+                using (_sampleHelpers.CreateScope("BeginGetRequestStream"))
                 {
                     BeginGetRequestStream(tracingDisabled, url);
                 }
 
-                using (SampleHelpers.CreateScope("BeginGetResponse"))
+                using (_sampleHelpers.CreateScope("BeginGetResponse"))
                 {
                     BeginGetResponse(tracingDisabled, "BeginGetResponseAsync", url);
                 }
 
-                using (SampleHelpers.CreateScope("BeginGetResponseNotFound"))
+                using (_sampleHelpers.CreateScope("BeginGetResponseNotFound"))
                 {
                     BeginGetResponse(tracingDisabled, "BeginGetResponseNotFoundAsync", url);
                 }
 
-                using (SampleHelpers.CreateScope("BeginGetResponseTeapot"))
+                using (_sampleHelpers.CreateScope("BeginGetResponseTeapot"))
                 {
                     BeginGetResponse(tracingDisabled, "BeginGetResponseTeapotAsync", url);
                 }
 
-                using (SampleHelpers.CreateScope("BeginGetResponse TaskFactoryFromAsync"))
+                using (_sampleHelpers.CreateScope("BeginGetResponse TaskFactoryFromAsync"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
                     HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("TaskFactoryFromAsync", url));

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
@@ -1,3 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

Swaps `Samples.WebRequest` to use `Activity` instead of `SampleHelpers` for manual instrumentation.

## Reason for change

Want to move toward using `OTel`/`Activity` for manual instrumentation within integration tests instead of `SampleHelpers`.

## Implementation details

- Added reference to the `ActivitySampleHelper` project and swapped `SampleHelpers` to use that
- Enabled OTel

## Test coverage

- Ran tests and they passed

## Other details
<!-- Fixes #{issue} -->
