### PR TITLE
Add an additional scheduled run in which we explicitly enable debug mode

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -84,6 +84,13 @@ schedules:
         - release/1.x
     always: true
 
+  - cron: "0 4 * * *"
+    displayName: Daily Debug Run
+    branches:
+      include:
+        - master
+    always: true
+
   - cron: "*/6 1 * * Sat"
     displayName: Saturday CI, every 6 minutes from 1am
     branches:

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -92,8 +92,9 @@ partial class Build
         .After(BuildDebuggerIntegrationTests)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             EnsureResultsDirectory(DebuggerIntegrationTests);
 
@@ -109,6 +110,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFilter(GetTestFilter())
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1145,8 +1145,9 @@ partial class Build
         .Requires(() => IsWin)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -1163,6 +1164,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(!string.IsNullOrEmpty(Filter), c => c.SetFilter(Filter))
@@ -1185,6 +1187,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "RunOnWindows=True&LoadFromGAC!=True&IIS!=True&Category!=AzureFunctions")
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1233,8 +1236,9 @@ partial class Build
         .Requires(() => IsWin)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             var project = Solution.GetProject(Projects.ClrProfilerIntegrationTests);
             EnsureExistingDirectory(TestLogsDirectory);
             EnsureResultsDirectory(project);
@@ -1251,6 +1255,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "RunOnWindows=True&Category=AzureFunctions")
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1273,8 +1278,9 @@ partial class Build
         .After(BuildNativeLoader)
         .Requires(() => IsWin)
         .Requires(() => Framework)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
@@ -1290,6 +1296,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "Category=Smoke&LoadFromGAC!=True&Category!=AzureFunctions")
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1312,7 +1319,7 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(() => RunWindowsIisIntegrationTests(
+        .Executes(async () => await RunWindowsIisIntegrationTests(
                       Solution.GetProject(Projects.ClrProfilerIntegrationTests)));
 
     Target RunWindowsSecurityIisIntegrationTests => _ => _
@@ -1322,11 +1329,12 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(() => RunWindowsIisIntegrationTests(
+        .Executes(async () => await RunWindowsIisIntegrationTests(
                       Solution.GetProject(Projects.AppSecIntegrationTests)));
 
-    void RunWindowsIisIntegrationTests(Project project)
+    async Task RunWindowsIisIntegrationTests(Project project)
     {
+        var isDebugRun = await IsDebugRun();
         EnsureResultsDirectory(project);
         try
         {
@@ -1340,6 +1348,7 @@ partial class Build
                                 .EnableNoBuild()
                                 .SetFilter(Filter ?? "(RunOnWindows=True)&LoadFromGAC=True&Category!=AzureFunctions")
                                 .SetTestTargetPlatform(TargetPlatform)
+                                .SetIsDebugRun(isDebugRun)
                                 .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                                 .SetLogsDirectory(TestLogsDirectory)
                                 .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1360,8 +1369,9 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             var project = Solution.GetProject(Projects.ClrProfilerIntegrationTests);
             var resultsDirectory = GetResultsDirectory(project);
             EnsureCleanDirectory(resultsDirectory);
@@ -1377,6 +1387,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "(RunOnWindows=True)&MSI=True&Category!=AzureFunctions")
                     .SetTestTargetPlatform(TargetPlatform)
+                    .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1585,8 +1596,9 @@ partial class Build
         .Requires(() => Framework)
         .Requires(() => !IsWin)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -1617,6 +1629,7 @@ partial class Build
                         //.WithMemoryDumpAfter(timeoutInMinutes: 30)
                         .EnableCrashDumps()
                         .SetFilter(filter)
+                        .SetIsDebugRun(isDebugRun)
                         .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                         .SetTestTargetPlatform(TargetPlatform)
                         .SetLogsDirectory(TestLogsDirectory)
@@ -1664,8 +1677,9 @@ partial class Build
         .Requires(() => Framework)
         .Requires(() => IsOsx)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(() =>
+        .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -1698,6 +1712,7 @@ partial class Build
                         //.WithMemoryDumpAfter(timeoutInMinutes: 30)
                         .EnableCrashDumps()
                         .SetFilter(filter)
+                        .SetIsDebugRun(isDebugRun)
                         .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                         .SetLocalOsxEnvironmentVariables()
                         .SetTestTargetPlatform(targetPlatform)
@@ -1778,8 +1793,9 @@ partial class Build
     Target RunToolArtifactTests => _ => _
        .Description("Runs the tool artifacts tests")
        .After(BuildToolArtifactTests)
-       .Executes(() =>
+       .Executes(async () =>
         {
+            var isDebugRun = await IsDebugRun();
             var project = Solution.GetProject(Projects.ToolArtifactsTests);
 
             DotNetTest(config => config
@@ -1787,6 +1803,7 @@ partial class Build
                 .SetConfiguration(BuildConfiguration)
                 .EnableNoRestore()
                 .EnableNoBuild()
+                .SetIsDebugRun(isDebugRun)
                 .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                 .SetProcessEnvironmentVariable("ToolInstallDirectory", ToolInstallDirectory)
                 .SetLogsDirectory(TestLogsDirectory)

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -378,7 +378,7 @@ partial class Build
         {
             var azDoApi = $"https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/{buildId}";
             using var client = new HttpClient();
-            using var stream = await client.GetStreamAsync(azDoApi + buildId);
+            using var stream = await client.GetStreamAsync(azDoApi);
             using var json = await JsonDocument.ParseAsync(stream);
             var triggerInfo = json.RootElement.GetProperty("triggerInfo");
             if (triggerInfo.TryGetProperty("scheduleName", out var scheduleNameElement))

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -388,7 +388,7 @@ partial class Build
             }
             else
             {
-                Logger.Warning("Error calling Azdo API to check for debug run - triggerInfo.scheduleName not found");
+                // scheduleName not found - this will happen on PRs etc
                 return false;
             }
         }

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -46,6 +46,9 @@ internal static partial class DotNetSettingsExtensions
             : settings.SetProperty("Platform", GetTargetPlatform(platform));
     }
 
+    public static DotNetTestSettings SetIsDebugRun(this DotNetTestSettings settings, bool isDebugRun)
+        => settings.When(isDebugRun, c => c.SetProcessEnvironmentVariable("DD_TRACE_DEBUG", "1"));
+
     private static string GetTargetPlatform(MSBuildTargetPlatform platform) =>
         platform == MSBuildTargetPlatform.MSIL ? "AnyCPU" : platform.ToString();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -24,7 +24,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             _inProcess = inProcess;
             _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
-            EnableDebugMode();
 
             SetServiceVersion("1.0.0");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -47,7 +47,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1UpperWithMapping}:{HeaderTagName1WithMapping},{HeaderName2},{HeaderName3}");
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
-            EnableDebugMode();
 
             SetServiceVersion("1.0.0");
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcWrongMethodTestBase.cs
@@ -27,7 +27,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             this.fixture = fixture;
             _testName = testName;
-            EnableDebugMode();
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -27,7 +27,6 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
         : base("DataStreams.RabbitMQ", output)
     {
         SetServiceVersion("1.0.0");
-        EnableDebugMode();
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -29,7 +29,6 @@ public class DataStreamsMonitoringTests : TestHelper
         : base("DataStreams.Kafka", output)
     {
         SetServiceVersion("1.0.0");
-        EnableDebugMode();
     }
 
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -39,7 +39,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("Kafka", output)
         {
             SetServiceVersion("1.0.0");
-            EnableDebugMode();
         }
 
         public static IEnumerable<object[]> GetEnabledConfig()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
@@ -17,7 +17,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(new EnvironmentHelper("Datadog.Tracer.Native.Checks", typeof(TestHelper), output, samplesDirectory: Path.Combine("test", "test-applications", "instrumentation"), prependSamplesToAppName: false), output)
         {
             SetServiceVersion("1.0.0");
-            EnableDebugMode();
         }
 
         [SkippableFact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -30,7 +30,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "true");
             SetServiceVersion(ServiceVersion);
-            EnableDebugMode();
             _output = output;
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -86,7 +86,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ddTraceMethodsString += ";Samples.TraceAnnotations.ExtensionMethods[ExtensionMethodForTestType,ExtensionMethodForTestTypeGeneric,ExtensionMethodForTestTypeTypeStruct];System.Net.Http.HttpRequestMessage[set_Method]";
 
             SetEnvironmentVariable("DD_TRACE_METHODS", ddTraceMethodsString);
-            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
             // Don't bother with telemetry when two assemblies are loaded because we could get unreliable results
             MockTelemetryAgent<TelemetryData> telemetry = _twoAssembliesLoaded ? null : this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -68,7 +68,6 @@ public class ProbesTests : TestHelper
         : base("Probes", Path.Combine("test", "test-applications", "debugger"), output)
     {
         SetServiceVersion("1.0.0");
-        EnableDebugMode();
     }
 
     public static IEnumerable<object[]> UdsMemberData =>

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -69,7 +69,6 @@ namespace Datadog.Trace.Security.IntegrationTests.Iast
             SetEnvironmentVariable("DD_IAST_REQUEST_SAMPLING", "100");
             SetEnvironmentVariable("DD_IAST_MAX_CONCURRENT_REQUESTS", "100");
             SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
-            SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
             DisableObfuscationQueryString();
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -45,7 +45,6 @@ public class DeduplicationTests : TestHelper
             instrumented = false;
         }
 
-        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
         SetEnvironmentVariable("DD_IAST_ENABLED", "1");
         SetEnvironmentVariable("DD_IAST_DEDUPLICATION_ENABLED", deduplicationEnabled.ToString());
         SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory));

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -185,7 +185,6 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
         public AspNetCore5AsmDataBlockingUser(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableSecurity, string testName)
             : base(fixture, outputHelper, enableSecurity, testName: testName)
         {
-            this.EnableDebugMode();
             SetEnvironmentVariable(ConfigurationKeys.DebugEnabled, "0");
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -403,6 +403,12 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
+        /// <summary>
+        /// NOTE: Only use this for local debugging, don't set permanently in tests
+        /// We have a dedicated run that tests with debug mode enabled, so want to make
+        /// sure that "normal" runs don't set this flag.
+        /// </summary>
+        [Obsolete("Setting this forces debug mode, whereas we want to automatically test in both modes")]
         protected void EnableDebugMode()
         {
             EnvironmentHelper.DebugModeEnabled = true;


### PR DESCRIPTION
## Summary of changes

Add an additional scheduled run that runs all the integration tests with `DD_TRACE_DEBUG=1`

## Reason for change

We recently had a bug that only affected code that was using trace annotations, and only when `DD_TRACE_DEBUG=1` was set. We currently sporadically set this value in some tests (which obviously means we're currently _not_ testing in non-Debug mode for some tests).

## Implementation details

- Added a Nuke method to call the REST api and retrieve the `triggerInfo.scheduleName` [as described here](https://developercommunity.visualstudio.com/t/no-buildschedulename-predefined-variable-in-azure-1/1440676), to know whether we're doing a "debug run". Also allowed forcing with an environment variable (`ForceDebugRun`)
- If nuke detects that we're in a "debug run" it sets `DD_TRACE_DEBUG=1` for the test host process (which _should_ be propagated to the test sample I believe)
- Removed the cases where we're currently explicitly setting `DD_TRACE_DEBUG` so that it is set/not-set as appropriate.
- Added an additional nightly scheduled run with the name `"Daily Debug Run"`

## Test coverage

Doing [a forced debug run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=136701&view=results) to make sure it behaves as expected. If that works, and the main run here _doesn't_ use debug mode, then probably easiest to merge and see what happens on the scheadule

## Other details

There's still _some_ places that seem to set `DD_TRACE_DEBUG` but don't know if we want to change that/it's worth the effort:

- [ ] Installer smoke tests run with DD_TRACE_DEBUG enabled, but we maybe don't want to change that, so we always get more logs?
- [ ] GitHub profiler pipeline runs with DD_TRACE_DEBUG enabled
- [ ] IAST instrumented tests _maybe_ run with DD_TRACE_DEBUG enabled (the runsettings.sh files sets it, but I'm not sure what they use in CI?)
