### PR TITLE
Allow forcing code coverage in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -108,7 +108,7 @@ variables:
   isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   # Run code coverage on main branches only, on scheduled build only
-  runCodeCoverage: $[and(eq(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/')))] 
+  runCodeCoverage: $[or(eq(variables['run_code_coverage'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))))] 
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages


### PR DESCRIPTION
## Summary of changes

Allow forcing a code coverage run in CI

## Reason for change

By default, we only run code coverage on master, as it is a source of flakiness. This PR means we can force enable code coverage for a manual run (I wanted to do this for #4033 but realized I couldn't)

## Implementation details

Add a variable check to the condition. Set `run_code_coverage=true` when starting a run in AzDo

## Test coverage

Tested it out [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=136761&view=results)
