### PR TITLE
Add unit tests for all settings

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
@@ -17,7 +17,12 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
 
         private static NativeCallTargetDefinition[] callTargetDefinitions = null;
 
-        internal static LambdaMetadata Metadata { get; } = LambdaMetadata.Create();
+        internal static LambdaMetadata Metadata { get; private set; } = LambdaMetadata.Create();
+
+        internal static void SetMetadataTestsOnly(LambdaMetadata metadata)
+        {
+            Metadata = metadata;
+        }
 
         internal static void InitIfNeeded()
         {
@@ -175,7 +180,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
             /// <summary>
             /// Gets the paths we don't want to trace when running in Lambda
             /// </summary>
-            internal string DefaultHttpClientExclusions { get; } = "/2018-06-01/runtime/invocation/".ToUpperInvariant();
+            internal string DefaultHttpClientExclusions { get; private set; } = "/2018-06-01/runtime/invocation/".ToUpperInvariant();
 
             public static LambdaMetadata Create(string extensionPath = ExtensionFullPath)
             {
@@ -202,6 +207,14 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
                 };
 
                 return new LambdaMetadata(isRunningInLambda: true, functionName, handlerName, serviceName);
+            }
+
+            internal static LambdaMetadata CreateForTests(bool isRunningInLambda, string functionName, string handlerName, string serviceName, string defaultHttpExclusions)
+            {
+                return new LambdaMetadata(isRunningInLambda, functionName, handlerName, serviceName)
+                {
+                    DefaultHttpClientExclusions = defaultHttpExclusions
+                };
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableAzureAppServiceSettings.cs
@@ -9,7 +9,6 @@ using System;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
-using MetricsTransportType = Datadog.Trace.Vendors.StatsdClient.Transport.TransportType;
 
 namespace Datadog.Trace.Configuration
 {

--- a/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/IAST/Settings/IastSettings.cs
@@ -11,11 +11,11 @@ namespace Datadog.Trace.Iast.Settings;
 
 internal class IastSettings
 {
-    public static readonly string WeakCipherAlgorithmsDefault = "DES,TRIPLEDES,RC2";
-    public static readonly string WeakHashAlgorithmsDefault = "HMACMD5,MD5,HMACSHA1,SHA1";
-    public static readonly int VulnerabilitiesPerRequestDefault = 2;
-    public static readonly int MaxConcurrentRequestDefault = 2;
-    public static readonly int RequestSamplingDefault = 30;
+    public const string WeakCipherAlgorithmsDefault = "DES,TRIPLEDES,RC2";
+    public const string WeakHashAlgorithmsDefault = "HMACMD5,MD5,HMACSHA1,SHA1";
+    public const int VulnerabilitiesPerRequestDefault = 2;
+    public const int MaxConcurrentRequestDefault = 2;
+    public const int RequestSamplingDefault = 30;
 
     public IastSettings(IConfigurationSource source)
     {

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DirectLogSubmissionSettings.cs" company="Datadog">
+// <copyright file="DirectLogSubmissionSettings.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -18,14 +18,14 @@ namespace Datadog.Trace.Logging.DirectSubmission
     /// </summary>
     internal class DirectLogSubmissionSettings
     {
-        private const string DefaultSource = "csharp";
+        internal const string DefaultSource = "csharp";
+        internal const DirectSubmissionLogLevel DefaultMinimumLevel = DirectSubmissionLogLevel.Information;
+        internal const int DefaultBatchSizeLimit = 1000;
+        internal const int DefaultQueueSizeLimit = 100_000;
+        internal const int DefaultBatchPeriodSeconds = 2;
         private const string IntakePrefix = "https://http-intake.logs.";
         private const string DefaultSite = "datadoghq.com";
         private const string IntakeSuffix = ":443";
-        private const DirectSubmissionLogLevel DefaultMinimumLevel = DirectSubmissionLogLevel.Information;
-        private const int DefaultBatchSizeLimit = 1000;
-        private const int DefaultQueueSizeLimit = 100_000;
-        private const int DefaultBatchPeriodSeconds = 2;
 
         public DirectLogSubmissionSettings()
             : this(source: null)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal class RemoteConfigurationSettings
     {
-        private const int DefaultPollIntervalMilliseconds = 5000;
+        internal const int DefaultPollIntervalMilliseconds = 5000;
 
         public RemoteConfigurationSettings()
             : this(configurationSource: null)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
@@ -6,11 +6,13 @@
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests.Iast;
 
-public class IastSettingsTests
+public class IastSettingsTests : SettingsTestsBase
 {
     [Fact]
     public void GivenIastSettings_WhenSetRequestSamplingTo50_RequestSamplingIs50()
@@ -87,5 +89,47 @@ public class IastSettingsTests
         });
         var iastSettings = new IastSettings(settings);
         Assert.Equal(IastSettings.VulnerabilitiesPerRequestDefault, iastSettings.VulnerabilitiesPerRequest);
+    }
+
+    [Theory]
+    [MemberData(nameof(StringTestCases), IastSettings.WeakCipherAlgorithmsDefault, Strings.AllowEmpty)]
+    public void WeakCipherAlgorithms(string value, string expected)
+    {
+        var source = CreateConfigurationSource((ConfigurationKeys.Iast.WeakCipherAlgorithms, value));
+        var settings = new IastSettings(source);
+
+        settings.WeakCipherAlgorithms.Should().Be(expected);
+        settings.WeakCipherAlgorithmsArray.Should().BeEquivalentTo(expected.Split(','));
+    }
+
+    [Theory]
+    [MemberData(nameof(StringTestCases), IastSettings.WeakHashAlgorithmsDefault, Strings.AllowEmpty)]
+    public void WeakHashAlgorithms(string value, string expected)
+    {
+        var source = CreateConfigurationSource((ConfigurationKeys.Iast.WeakHashAlgorithms, value));
+        var settings = new IastSettings(source);
+
+        settings.WeakHashAlgorithms.Should().Be(expected);
+        settings.WeakHashAlgorithmsArray.Should().BeEquivalentTo(expected.Split(','));
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanTestCases), false)]
+    public void Enabled(string value, bool expected)
+    {
+        var source = CreateConfigurationSource((ConfigurationKeys.Iast.Enabled, value));
+        var settings = new IastSettings(source);
+
+        settings.Enabled.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(BooleanTestCases), true)]
+    public void DeduplicationEnabled(string value, bool expected)
+    {
+        var source = CreateConfigurationSource((ConfigurationKeys.Iast.IsIastDeduplicationEnabled, value));
+        var settings = new IastSettings(source);
+
+        settings.DeduplicationEnabled.Should().Be(expected);
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/IastSettingsTests.cs
@@ -99,7 +99,7 @@ public class IastSettingsTests : SettingsTestsBase
         var settings = new IastSettings(source);
 
         settings.WeakCipherAlgorithms.Should().Be(expected);
-        settings.WeakCipherAlgorithmsArray.Should().BeEquivalentTo(expected.Split(','));
+        settings.WeakCipherAlgorithmsArray.Should().BeEquivalentTo(expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Theory]
@@ -110,7 +110,7 @@ public class IastSettingsTests : SettingsTestsBase
         var settings = new IastSettings(source);
 
         settings.WeakHashAlgorithms.Should().Be(expected);
-        settings.WeakHashAlgorithmsArray.Should().BeEquivalentTo(expected.Split(','));
+        settings.WeakHashAlgorithmsArray.Should().BeEquivalentTo(expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -3,10 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Specialized;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.HtmlBlockedTemplate, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.BlockedHtmlTemplate);
+            settings.BlockedHtmlTemplate.Should().Be(expected);
         }
 
         [Theory]
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.JsonBlockedTemplate, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.BlockedJsonTemplate);
+            settings.BlockedJsonTemplate.Should().Be(expected);
         }
 
         [Theory]
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.Enabled);
+            settings.Enabled.Should().Be(expected);
         }
 
         [Theory]
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.CanBeToggled);
+            settings.CanBeToggled.Should().Be(expected);
         }
 
         [Theory]
@@ -95,7 +95,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Rules, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.Rules);
+            settings.Rules.Should().Be(expected);
         }
 
         [Theory]
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.CustomIpHeader, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.CustomIpHeader);
+            settings.CustomIpHeader.Should().Be(expected);
         }
 
         [Theory]
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ExtraHeaders, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.ExtraHeaders);
+            settings.ExtraHeaders.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -128,7 +128,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.KeepTraces, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.KeepTraces);
+            settings.KeepTraces.Should().Be(expected);
         }
 
         [Theory]
@@ -138,7 +138,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.TraceRateLimit, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.TraceRateLimit);
+            settings.TraceRateLimit.Should().Be(expected);
         }
 
         [Theory]
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.ObfuscationParameterKeyRegex);
+            settings.ObfuscationParameterKeyRegex.Should().Be(expected);
         }
 
         [Theory]
@@ -158,7 +158,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterValueRegex, value));
             var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, settings.ObfuscationParameterValueRegex);
+            settings.ObfuscationParameterValueRegex.Should().Be(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -6,11 +6,12 @@
 using System.Collections.Specialized;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests
 {
-    public class SecuritySettingsTests
+    public class SecuritySettingsTests : SettingsTestsBase
     {
         [Theory]
         [InlineData(null)]
@@ -19,11 +20,12 @@ namespace Datadog.Trace.Security.Unit.Tests
         [InlineData("gibberish")]
         [InlineData("5mins")] // unknown suffix ending in 's'
         [InlineData("500d")] // unknown suffix
-        public void InvalidValuesUseDefault(string value)
+        public void WafTimeoutInvalid(string value)
         {
-            var target = CreateTestTarget(value);
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.WafTimeout, value));
+            var settings = new SecuritySettings(source);
 
-            Assert.Equal(100_000ul, target.WafTimeoutMicroSeconds);
+            Assert.Equal(100_000ul, settings.WafTimeoutMicroSeconds);
         }
 
         [Theory]
@@ -35,11 +37,140 @@ namespace Datadog.Trace.Security.Unit.Tests
         [InlineData("  500us", 500ul)]
         [InlineData("  500us  ", 500ul)]
         [InlineData("  500 us  ", 500ul)]
-        public void ParsesValueCorrectly(string value, ulong expected)
+        public void WafTimeoutValid(string value, ulong expected)
         {
-            var target = CreateTestTarget(value);
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.WafTimeout, value));
+            var settings = new SecuritySettings(source);
 
-            Assert.Equal(expected, target.WafTimeoutMicroSeconds);
+            Assert.Equal(expected, settings.WafTimeoutMicroSeconds);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedHtmlTemplate, true)]
+        public void BlockedHtmlTemplate(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.HtmlBlockedTemplate, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.BlockedHtmlTemplate);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedJsonTemplate, true)]
+        public void BlockedJsonTemplate(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.JsonBlockedTemplate, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.BlockedJsonTemplate);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void Enabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.Enabled);
+        }
+
+        [Theory]
+        [InlineData("true", false)]
+        [InlineData("false", false)]
+        [InlineData(null, true)]
+        public void CanBeToggled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Enabled, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.CanBeToggled);
+        }
+
+        [Theory]
+        [InlineData("test", "test")]
+        [InlineData(null, null)]
+        public void Rules(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.Rules, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.Rules);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void CustomIpHeader(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.CustomIpHeader, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.CustomIpHeader);
+        }
+
+        [Theory]
+        [InlineData("test", new[] { "test" })]
+        [InlineData("test1,test2", new[] { "test1", "test2" })]
+        [InlineData(null, new string[0])]
+        [InlineData("", new string[0])]
+        public void ExtraHeaders(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ExtraHeaders, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.ExtraHeaders);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void KeepTraces(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.KeepTraces, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.KeepTraces);
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32TestCases), 100)]
+        public void TraceRateLimit(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.TraceRateLimit, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.TraceRateLimit);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterKeyRegexDefault, false)]
+        public void ObfuscationParameterKeyRegex(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.ObfuscationParameterKeyRegex);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterValueRegexDefault, false)]
+        public void ObfuscationParameterValueRegex(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterValueRegex, value));
+            var settings = new SecuritySettings(source);
+
+            Assert.Equal(expected, settings.ObfuscationParameterValueRegex);
+        }
+
+        private static IConfigurationSource CreateConfigurationSource(params (string Key, string Value)[] values)
+        {
+            var config = new NameValueCollection();
+
+            foreach (var (key, value) in values)
+            {
+                config.Add(key, value);
+            }
+
+            return new NameValueConfigurationSource(config);
         }
 
         private static SecuritySettings CreateTestTarget(string stringToBeParsed)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/SecuritySettingsTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedHtmlTemplate, true)]
+        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedHtmlTemplate, Strings.AllowEmpty)]
         public void BlockedHtmlTemplate(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.HtmlBlockedTemplate, value));
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedJsonTemplate, true)]
+        [MemberData(nameof(StringTestCases), SecurityConstants.BlockedJsonTemplate, Strings.AllowEmpty)]
         public void BlockedJsonTemplate(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.JsonBlockedTemplate, value));
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterKeyRegexDefault, false)]
+        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterKeyRegexDefault, Strings.DisallowEmpty)]
         public void ObfuscationParameterKeyRegex(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterKeyRegex, value));
@@ -152,33 +152,13 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterValueRegexDefault, false)]
+        [MemberData(nameof(StringTestCases), SecurityConstants.ObfuscationParameterValueRegexDefault, Strings.DisallowEmpty)]
         public void ObfuscationParameterValueRegex(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.AppSec.ObfuscationParameterValueRegex, value));
             var settings = new SecuritySettings(source);
 
             Assert.Equal(expected, settings.ObfuscationParameterValueRegex);
-        }
-
-        private static IConfigurationSource CreateConfigurationSource(params (string Key, string Value)[] values)
-        {
-            var config = new NameValueCollection();
-
-            foreach (var (key, value) in values)
-            {
-                config.Add(key, value);
-            }
-
-            return new NameValueConfigurationSource(config);
-        }
-
-        private static SecuritySettings CreateTestTarget(string stringToBeParsed)
-        {
-            var config = new NameValueCollection() { { ConfigurationKeys.AppSec.WafTimeout, stringToBeParsed } };
-
-            var target = new SecuritySettings(new NameValueConfigurationSource(config));
-            return target;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -45,6 +45,17 @@ namespace Datadog.Trace.TestHelpers
             yield return new object[] { string.Empty, defaultValue };
         }
 
+        public static IEnumerable<object[]> DoubleTestCases()
+        {
+            yield return new object[] { "1.5", 1.5d };
+            yield return new object[] { "1", 1.0d };
+            yield return new object[] { "0", 0.0d };
+            yield return new object[] { "-1", -1.0d };
+            yield return new object[] { "A", null };
+            yield return new object[] { null, null };
+            yield return new object[] { string.Empty, null };
+        }
+
         public static IEnumerable<object[]> StringTestCases()
         {
             yield return new object[] { "test", "test" };

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -4,12 +4,27 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
 
 namespace Datadog.Trace.TestHelpers
 {
     public abstract class SettingsTestsBase
     {
-        public static IEnumerable<object[]> BooleanTestCases(bool defaultValue)
+        public enum Strings
+        {
+            /// <summary>
+            /// Empty string values are accepted
+            /// </summary>
+            AllowEmpty,
+
+            /// <summary>
+            /// Empty string values are replaced by the default value
+            /// </summary>
+            DisallowEmpty
+        }
+
+        public static IEnumerable<object[]> BooleanTestCases(bool? defaultValue)
         {
             yield return new object[] { "true", true };
             yield return new object[] { "1", true };
@@ -37,11 +52,23 @@ namespace Datadog.Trace.TestHelpers
             yield return new object[] { string.Empty, string.Empty };
         }
 
-        public static IEnumerable<object[]> StringTestCases(string defaultValue, bool allowEmpty)
+        public static IEnumerable<object[]> StringTestCases(string defaultValue, Strings emptyStringBehavior)
         {
             yield return new object[] { "test", "test" };
             yield return new object[] { null, defaultValue };
-            yield return new object[] { string.Empty, allowEmpty ? string.Empty : defaultValue };
+            yield return new object[] { string.Empty, emptyStringBehavior == Strings.AllowEmpty ? string.Empty : defaultValue };
+        }
+
+        protected static IConfigurationSource CreateConfigurationSource(params (string Key, string Value)[] values)
+        {
+            var config = new NameValueCollection();
+
+            foreach (var (key, value) in values)
+            {
+                config.Add(key, value);
+            }
+
+            return new NameValueConfigurationSource(config);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -24,16 +24,17 @@ namespace Datadog.Trace.TestHelpers
             DisallowEmpty
         }
 
-        public static IEnumerable<object[]> BooleanTestCases(bool? defaultValue)
-        {
-            yield return new object[] { "true", true };
-            yield return new object[] { "1", true };
-            yield return new object[] { "false", false };
-            yield return new object[] { "0", false };
-            yield return new object[] { "A", defaultValue };
-            yield return new object[] { null, defaultValue };
-            yield return new object[] { string.Empty, defaultValue };
-        }
+        public static TheoryData<string, bool?> BooleanTestCases(bool? defaultValue) 
+            => new TheoryData<string, bool?>
+            {
+                { "true", true },
+                { "1", true },
+                { "false", false },
+                { "0", false },
+                { "A", defaultValue },
+                { null, defaultValue },
+                { string.Empty, defaultValue },
+            };
 
         public static IEnumerable<object[]> Int32TestCases(int defaultValue)
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -1,0 +1,47 @@
+// <copyright file="SettingsTestsBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public abstract class SettingsTestsBase
+    {
+        public static IEnumerable<object[]> BooleanTestCases(bool defaultValue)
+        {
+            yield return new object[] { "true", true };
+            yield return new object[] { "1", true };
+            yield return new object[] { "false", false };
+            yield return new object[] { "0", false };
+            yield return new object[] { "A", defaultValue };
+            yield return new object[] { null, defaultValue };
+            yield return new object[] { string.Empty, defaultValue };
+        }
+
+        public static IEnumerable<object[]> Int32TestCases(int defaultValue)
+        {
+            yield return new object[] { "1", 1 };
+            yield return new object[] { "0", 0 };
+            yield return new object[] { "-1", -1 };
+            yield return new object[] { "A", defaultValue };
+            yield return new object[] { null, defaultValue };
+            yield return new object[] { string.Empty, defaultValue };
+        }
+
+        public static IEnumerable<object[]> StringTestCases()
+        {
+            yield return new object[] { "test", "test" };
+            yield return new object[] { null, null };
+            yield return new object[] { string.Empty, string.Empty };
+        }
+
+        public static IEnumerable<object[]> StringTestCases(string defaultValue, bool allowEmpty)
+        {
+            yield return new object[] { "test", "test" };
+            yield return new object[] { null, defaultValue };
+            yield return new object[] { string.Empty, allowEmpty ? string.Empty : defaultValue };
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SettingsTestsBase.cs
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using Xunit;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -24,7 +24,7 @@ namespace Datadog.Trace.TestHelpers
             DisallowEmpty
         }
 
-        public static TheoryData<string, bool?> BooleanTestCases(bool? defaultValue) 
+        public static TheoryData<string, bool?> BooleanTestCases(bool? defaultValue)
             => new TheoryData<string, bool?>
             {
                 { "true", true },
@@ -36,40 +36,44 @@ namespace Datadog.Trace.TestHelpers
                 { string.Empty, defaultValue },
             };
 
-        public static IEnumerable<object[]> Int32TestCases(int defaultValue)
-        {
-            yield return new object[] { "1", 1 };
-            yield return new object[] { "0", 0 };
-            yield return new object[] { "-1", -1 };
-            yield return new object[] { "A", defaultValue };
-            yield return new object[] { null, defaultValue };
-            yield return new object[] { string.Empty, defaultValue };
-        }
+        public static TheoryData<string, int?> Int32TestCases(int defaultValue)
+            => new TheoryData<string, int?>
+            {
+                { "1", 1 },
+                { "0", 0 },
+                { "-1", -1 },
+                { "A", defaultValue },
+                { null, defaultValue },
+                { string.Empty, defaultValue }
+            };
 
-        public static IEnumerable<object[]> DoubleTestCases()
-        {
-            yield return new object[] { "1.5", 1.5d };
-            yield return new object[] { "1", 1.0d };
-            yield return new object[] { "0", 0.0d };
-            yield return new object[] { "-1", -1.0d };
-            yield return new object[] { "A", null };
-            yield return new object[] { null, null };
-            yield return new object[] { string.Empty, null };
-        }
+        public static TheoryData<string, double?> DoubleTestCases()
+            => new TheoryData<string, double?>
+            {
+                { "1.5", 1.5d },
+                { "1", 1.0d },
+                { "0", 0.0d },
+                { "-1", -1.0d },
+                { "A", null },
+                { null, null },
+                { string.Empty, null }
+            };
 
-        public static IEnumerable<object[]> StringTestCases()
-        {
-            yield return new object[] { "test", "test" };
-            yield return new object[] { null, null };
-            yield return new object[] { string.Empty, string.Empty };
-        }
+        public static TheoryData<string, string> StringTestCases()
+            => new TheoryData<string, string>
+            {
+                { "test", "test" },
+                { null, null },
+                { string.Empty, string.Empty }
+            };
 
-        public static IEnumerable<object[]> StringTestCases(string defaultValue, Strings emptyStringBehavior)
-        {
-            yield return new object[] { "test", "test" };
-            yield return new object[] { null, defaultValue };
-            yield return new object[] { string.Empty, emptyStringBehavior == Strings.AllowEmpty ? string.Empty : defaultValue };
-        }
+        public static TheoryData<string, string> StringTestCases(string defaultValue, Strings emptyStringBehavior)
+            => new TheoryData<string, string>
+            {
+                { "test", "test" },
+                { null, defaultValue },
+                { string.Empty, emptyStringBehavior == Strings.AllowEmpty ? string.Empty : defaultValue }
+            };
 
         protected static IConfigurationSource CreateConfigurationSource(params (string Key, string Value)[] values)
         {

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -6,6 +6,7 @@
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
@@ -19,7 +20,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Enabled, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.Enabled);
+            settings.Enabled.Should().Be(expected);
         }
 
         [Theory]
@@ -29,7 +30,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessEnabled, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.Agentless);
+            settings.Agentless.Should().Be(expected);
         }
 
         [Theory]
@@ -39,7 +40,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Logs, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.Logs);
+            settings.Logs.Should().Be(expected);
         }
 
         [Theory]
@@ -49,7 +50,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.ApiKey);
+            settings.ApiKey.Should().Be(expected);
         }
 
         [Theory]
@@ -59,7 +60,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.ApplicationKey, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.ApplicationKey);
+            settings.ApplicationKey.Should().Be(expected);
         }
 
         [Theory]
@@ -69,7 +70,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.Site, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.Site);
+            settings.Site.Should().Be(expected);
         }
 
         [Theory]
@@ -79,7 +80,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessUrl, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.AgentlessUrl);
+            settings.AgentlessUrl.Should().Be(expected);
         }
 
         [Fact]
@@ -88,7 +89,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource();
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(5 * 1024 * 1024, settings.MaximumAgentlessPayloadSize);
+            settings.MaximumAgentlessPayloadSize.Should().Be(5 * 1024 * 1024);
         }
 
         [Theory]
@@ -98,7 +99,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyHttps, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.ProxyHttps);
+            settings.ProxyHttps.Should().Be(expected);
         }
 
         [Theory]
@@ -111,7 +112,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyNoProxy, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.ProxyNoProxy);
+            settings.ProxyNoProxy.Should().BeEquivalentTo(expected);
         }
 
         [Theory]
@@ -121,7 +122,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.IntelligentTestRunnerEnabled);
+            settings.IntelligentTestRunnerEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -131,7 +132,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.TestsSkippingEnabled, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.TestsSkippingEnabled);
+            settings.TestsSkippingEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -141,7 +142,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverage, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.CodeCoverageEnabled);
+            settings.CodeCoverageEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -151,7 +152,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageSnkFile, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.CodeCoverageSnkFilePath);
+            settings.CodeCoverageSnkFilePath.Should().Be(expected);
         }
 
         [Theory]
@@ -161,7 +162,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoveragePath, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.CodeCoveragePath);
+            settings.CodeCoveragePath.Should().Be(expected);
         }
 
         [Theory]
@@ -171,7 +172,7 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.CodeCoverageEnableJitOptimizations);
+            settings.CodeCoverageEnableJitOptimizations.Should().Be(expected);
         }
 
         [Theory]
@@ -181,17 +182,17 @@ namespace Datadog.Trace.Tests.Configuration
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.GitUploadEnabled, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.GitUploadEnabled);
+            settings.GitUploadEnabled.Should().Be(expected);
         }
 
         [Theory]
         [MemberData(nameof(BooleanTestCases), false)]
-        public void ForceAgentsEvpProxy(string value, bool? expected)
+        public void ForceAgentsEvpProxy(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, value));
             var settings = new CIVisibilitySettings(source);
 
-            Assert.Equal(expected, settings.ForceAgentsEvpProxy);
+            settings.ForceAgentsEvpProxy.Should().Be(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="CIVisibilitySettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Ci.Configuration;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class CIVisibilitySettingsTests : SettingsTestsBase
+    {
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void Enabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Enabled, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.Enabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void Agentless(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessEnabled, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.Agentless);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void Logs(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Logs, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.Logs);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ApiKey(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.ApiKey);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ApplicationKey(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ApplicationKey, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.ApplicationKey);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "datadoghq.com", Strings.AllowEmpty)]
+        public void Site(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Site, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.Site);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void AgentlessUrl(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.AgentlessUrl, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.AgentlessUrl);
+        }
+
+        [Fact]
+        public void MaximumAgentlessPayloadSize()
+        {
+            var source = CreateConfigurationSource();
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(5 * 1024 * 1024, settings.MaximumAgentlessPayloadSize);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ProxyHttps(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyHttps, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.ProxyHttps);
+        }
+
+        [Theory]
+        [InlineData("", new string[0])]
+        [InlineData(null, new string[0])]
+        [InlineData("value", new[] { "value" })]
+        [InlineData("value1 value2", new[] { "value1", "value2" })]
+        public void ProxyNoProxy(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Proxy.ProxyNoProxy, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.ProxyNoProxy);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void IntelligentTestRunnerEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.IntelligentTestRunnerEnabled, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.IntelligentTestRunnerEnabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        public void TestsSkippingEnabled(string value, bool? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.TestsSkippingEnabled, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.TestsSkippingEnabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        public void CodeCoverageEnabled(string value, bool? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverage, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.CodeCoverageEnabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void CodeCoverageSnkFilePath(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageSnkFile, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.CodeCoverageSnkFilePath);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void CodeCoveragePath(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoveragePath, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.CodeCoveragePath);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void CodeCoverageEnableJitOptimizations(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.CodeCoverageEnableJitOptimizations);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), parameters: new object[] { null })]
+        public void GitUploadEnabled(string value, bool? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.GitUploadEnabled, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.GitUploadEnabled);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void ForceAgentsEvpProxy(string value, bool? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, value));
+            var settings = new CIVisibilitySettings(source);
+
+            Assert.Equal(expected, settings.ForceAgentsEvpProxy);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
@@ -1,0 +1,35 @@
+// <copyright file="GlobalSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class GlobalSettingsTests : SettingsTestsBase
+    {
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void DebugEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DebugEnabled, value));
+            var settings = new GlobalSettings(source);
+
+            settings.DebugEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void DiagnosticSourceEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DiagnosticSourceEnabled, value));
+            var settings = new GlobalSettings(source);
+
+            settings.DiagnosticSourceEnabled.Should().Be(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
@@ -1,0 +1,193 @@
+// <copyright file="ImmutableAzureAppServiceSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class ImmutableAzureAppServiceSettingsTests : SettingsTestsBase
+    {
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("any value", false)]
+        public void IsUnsafeToTrace(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.IsUnsafeToTrace.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("test", "test")]
+        [InlineData("+", null)]
+        [InlineData("test1+test2", "test1")]
+        public void SubscriptionId(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.SubscriptionId.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ResourceGroup(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.ResourceGroupKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.ResourceGroup.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void SiteName(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteNameKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.SiteName.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("Subscription", "Sitename", "Resourcegroup", "/subscriptions/subscription/resourcegroups/resourcegroup/providers/microsoft.web/sites/sitename")]
+        [InlineData(null, "Sitename", "Resourcegroup", null)]
+        [InlineData("Subscription", null, "Resourcegroup", null)]
+        [InlineData("Subscription", "Sitename", null, null)]
+        [InlineData("", "", "", null)]
+        public void ResourceId(string subscriptionId, string siteName, string resourceGroup, string expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.AzureAppService.SiteNameKey, siteName),
+                (ConfigurationKeys.AzureAppService.ResourceGroupKey, resourceGroup),
+                (ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey, subscriptionId));
+
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.ResourceId.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "unknown", Strings.AllowEmpty)]
+        public void InstanceId(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.InstanceIdKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.InstanceId.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "unknown", Strings.AllowEmpty)]
+        public void InstanceName(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.InstanceNameKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.InstanceName.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "unknown", Strings.AllowEmpty)]
+        public void OperatingSystem(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.OperatingSystemKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.OperatingSystem.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "unknown", Strings.AllowEmpty)]
+        public void SiteExtensionVersion(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.SiteExtensionVersionKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.SiteExtensionVersion.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void FunctionsWorkerRuntime(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.FunctionsWorkerRuntime.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void FunctionsExtensionVersion(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.FunctionsExtensionVersion.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("value", null, Trace.PlatformHelpers.AzureContext.AzureFunctions)]
+        [InlineData(null, "value", Trace.PlatformHelpers.AzureContext.AzureFunctions)]
+        [InlineData(null, null, Trace.PlatformHelpers.AzureContext.AzureAppService)]
+        public void AzureContext(string functionsWorkerRuntime, string functionsExtensionVersion, object expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.AzureAppService.FunctionsWorkerRuntimeKey, functionsWorkerRuntime),
+                (ConfigurationKeys.AzureAppService.FunctionsExtensionVersionKey, functionsExtensionVersion));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.AzureContext.Should().Be((AzureContext)expected);
+        }
+
+        [Fact]
+        public void Runtime()
+        {
+            var source = CreateConfigurationSource();
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.Runtime.Should().Be(FrameworkDescription.Instance.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void DebugModeEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DebugEnabled, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.DebugModeEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void CustomTracingEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AasEnableCustomTracing, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.CustomTracingEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void NeedsDogStatsD(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AasEnableCustomMetrics, value));
+            var settings = new ImmutableAzureAppServiceSettings(source);
+
+            settings.NeedsDogStatsD.Should().Be(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableAzureAppServiceSettingsTests.cs
@@ -28,7 +28,9 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [InlineData(null, null)]
         [InlineData("", null)]
+        [InlineData("  ", null)]
         [InlineData("test", "test")]
+        [InlineData("+test", null)]
         [InlineData("+", null)]
         [InlineData("test1+test2", "test1")]
         public void SubscriptionId(string value, string expected)
@@ -61,6 +63,7 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("Subscription", "Sitename", "Resourcegroup", "/subscriptions/subscription/resourcegroups/resourcegroup/providers/microsoft.web/sites/sitename")]
+        [InlineData("Subscription", "", "", "/subscriptions/subscription/resourcegroups//providers/microsoft.web/sites/")]
         [InlineData(null, "Sitename", "Resourcegroup", null)]
         [InlineData("Subscription", null, "Resourcegroup", null)]
         [InlineData("Subscription", "Sitename", null, null)]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
@@ -1,0 +1,63 @@
+// <copyright file="RemoteConfigurationSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class RemoteConfigurationSettingsTests : SettingsTestsBase
+    {
+        [Fact]
+        public void RuntimeId()
+        {
+            var source = CreateConfigurationSource();
+            var settings = new RemoteConfigurationSettings(source);
+
+            settings.RuntimeId.Should().Be(Datadog.Trace.Util.RuntimeId.Get());
+        }
+
+        [Fact]
+        public void TracerVersion()
+        {
+            var source = CreateConfigurationSource();
+            var settings = new RemoteConfigurationSettings(source);
+
+            settings.TracerVersion.Should().Be(TracerConstants.ThreePartVersion);
+        }
+
+        [Theory]
+        [InlineData(null, null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        [InlineData("", null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        [InlineData("invalid", null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        [InlineData("50", "100", 50)]
+        [InlineData(null, "100", 100)]
+        [InlineData("invalid", "100", 100)]
+        [InlineData("0", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        [InlineData("-1", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        [InlineData("5000", "100", 5000)]
+        [InlineData("5001", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
+        public void PollInterval(string value, string fallbackValue, int expected)
+        {
+#pragma warning disable CS0618
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.Rcm.PollInterval, value),
+                (ConfigurationKeys.Rcm.PollIntervalInternal, fallbackValue));
+#pragma warning restore CS0618
+
+            var settings = new RemoteConfigurationSettings(source);
+
+            settings.PollInterval.Should().Be(TimeSpan.FromMilliseconds(expected));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -213,6 +213,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("test", "error", "test")]
         [InlineData(null, "test", "test")]
         [InlineData("", "test", "")]
+        [InlineData(null, null, null)]
         public void ServiceName(string value, string legacyValue, string expected)
         {
             const string legacyServiceName = "DD_SERVICE_NAME";
@@ -518,7 +519,7 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [MemberData(nameof(BooleanTestCases), true)]
-        public void RouteTemplateResKafkaCreateConsumerScopeEnabledourceNamesEnabled(string value, bool expected)
+        public void KafkaCreateConsumerScopeEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.KafkaCreateConsumerScopeEnabled, value));
             var settings = new TracerSettings(source);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -748,10 +748,10 @@ namespace Datadog.Trace.Tests.Configuration
         [MemberData(nameof(BooleanTestCases), false)]
         public void IsRunningInAzureAppService(string value, bool expected)
         {
-            var source = CreateConfigurationSource((ConfigurationKeys.RareSamplerEnabled, value));
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, value));
             var settings = new TracerSettings(source);
 
-            settings.IsRareSamplerEnabled.Should().Be(expected);
+            settings.IsRunningInAzureAppService.Should().Be(expected);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -8,15 +8,19 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Agent;
+using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Tagging;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
 {
-    public class TracerSettingsTests
+    public class TracerSettingsTests : SettingsTestsBase
     {
         private readonly Mock<IAgentWriter> _writerMock;
         private readonly Mock<ITraceSampler> _samplerMock;
@@ -192,6 +196,648 @@ namespace Datadog.Trace.Tests.Configuration
         public void SetServerHttpCodes()
         {
             SetAndValidateStatusCodes((s, c) => s.SetHttpServerErrorStatusCodes(c), s => s.HttpServerErrorStatusCodes);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void Environment(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Environment, value));
+            var settings = new TracerSettings(source);
+
+            settings.Environment.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("test", null, "test")]
+        [InlineData("test", "error", "test")]
+        [InlineData(null, "test", "test")]
+        [InlineData("", "test", "")]
+        public void ServiceName(string value, string legacyValue, string expected)
+        {
+            const string legacyServiceName = "DD_SERVICE_NAME";
+
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceName, value), (legacyServiceName, legacyValue));
+            var settings = new TracerSettings(source);
+
+            settings.ServiceName.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ServiceVersion(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceVersion, value));
+            var settings = new TracerSettings(source);
+
+            settings.ServiceVersion.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void GitCommitSha(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GitCommitSha, value));
+            var settings = new TracerSettings(source);
+
+            settings.GitCommitSha.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void GitRepositoryUrl(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GitRepositoryUrl, value));
+            var settings = new TracerSettings(source);
+
+            settings.GitRepositoryUrl.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void GitMetadataEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GitMetadataEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.GitMetadataEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, true, new string[0])]
+        [InlineData(null, false, new[] { "OpenTelemetry" })]
+        [InlineData("", true, new string[0])]
+        [InlineData("test", false, new[] { "test", "OpenTelemetry" })]
+        [InlineData("test1;TEST1;test2", true, new[] { "test1", "test2" })]
+        public void DisabledIntegrationNames(string value, bool isOpenTelemetryEnabled, string[] expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.DisabledIntegrations, value),
+                (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isOpenTelemetryEnabled ? "1" : "0"));
+            var settings = new TracerSettings(source);
+
+            settings.DisabledIntegrationNames.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void AnalyticsEnabled(string value, bool expected)
+        {
+#pragma warning disable 618 // App analytics is deprecated, but still used
+            var source = CreateConfigurationSource((ConfigurationKeys.GlobalAnalyticsEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.AnalyticsEnabled.Should().Be(expected);
+#pragma warning restore 618
+        }
+
+        [Fact]
+        public void Integrations()
+        {
+            // Further testing is done in IntegrationSettingsTests
+            var source = CreateConfigurationSource(
+                ($"DD_{IntegrationRegistry.Names[1]}_ENABLED", "0"),
+                ($"DD_{IntegrationRegistry.Names[2]}_ENABLED", "1"));
+
+            var settings = new TracerSettings(source);
+
+            settings.Integrations[IntegrationRegistry.Names[0]].Enabled.Should().BeNull();
+            settings.Integrations[IntegrationRegistry.Names[1]].Enabled.Should().BeFalse();
+            settings.Integrations[IntegrationRegistry.Names[2]].Enabled.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("10", null, 10)]
+        [InlineData("10", "50", 10)]
+        [InlineData(null, "10", 10)]
+        [InlineData("", "10", 10)]
+        [InlineData("", "", 100)]
+        [InlineData("A", "A", 100)]
+        public void MaxTracesSubmittedPerSecond(string value, string legacyValue, int expected)
+        {
+#pragma warning disable 618 // this parameter has been replaced but may still be used
+            var source = CreateConfigurationSource((ConfigurationKeys.TraceRateLimit, value), (ConfigurationKeys.MaxTracesSubmittedPerSecond, legacyValue));
+            var settings = new TracerSettings(source);
+
+            settings.MaxTracesSubmittedPerSecond.Should().Be(expected);
+#pragma warning restore 618
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", "key3:value3", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,invalid,key2: value2", "key3:value3", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("invalid", "key1:value1,key2:value2", new string[0])]
+        [InlineData(null, "key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("", "key1:value1,key2:value2", new string[0])]
+        [InlineData("", "", new string[0])]
+        [InlineData("invalid", "invalid", new string[0])]
+        public void GlobalTags(string value, string legacyValue, string[] expected)
+        {
+            const string legacyGlobalTagsKey = "DD_TRACE_GLOBAL_TAGS";
+
+            var source = CreateConfigurationSource((ConfigurationKeys.GlobalTags, value), (legacyGlobalTagsKey, legacyValue));
+            var settings = new TracerSettings(source);
+
+            settings.GlobalTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", true, new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,empty,key2: value2", true, new[] { "key1:value1", "empty:", "key2:value2" })]
+        [InlineData(null, true, new string[0])]
+        [InlineData("", true, new string[0])]
+        [InlineData("key1 :val.ue1?", false, new[] { "key1:val_ue1_" })]
+        [InlineData("key1 :val.ue1?", true, new[] { "key1:val.ue1_" })]
+        public void HeaderTags(string value, bool normalizationFixEnabled, string[] expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.HeaderTags, value),
+                (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
+            var settings = new TracerSettings(source);
+
+            settings.HeaderTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [InlineData("v1", SchemaVersion.V1)]
+        [InlineData("V1", SchemaVersion.V1)]
+        [InlineData("", SchemaVersion.V0)]
+        [InlineData(null, SchemaVersion.V0)]
+        [InlineData("v1 ", SchemaVersion.V0)]
+        public void MetadataSchemaVersion(string value, object expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.MetadataSchemaVersion, value));
+            var settings = new TracerSettings(source);
+
+            settings.MetadataSchemaVersion.Should().Be((SchemaVersion)expected);
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,invalid,key2: value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("invalid", new string[0])]
+        [InlineData(null, null)]
+        [InlineData("", new string[0])]
+        public void ServiceNameMappings(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ServiceNameMappings, value));
+            var settings = new TracerSettings(source);
+
+            settings.ServiceNameMappings.Should().BeEquivalentTo(expected?.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void TracerMetricsEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.TracerMetricsEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.TracerMetricsEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void StatsComputationEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StatsComputationEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.StatsComputationEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32TestCases), 10)]
+        public void StatsComputationInterval(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StatsComputationInterval, value));
+            var settings = new TracerSettings(source);
+
+            settings.StatsComputationInterval.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void RuntimeMetricsEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.RuntimeMetricsEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.RuntimeMetricsEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void CustomSamplingRules(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.CustomSamplingRules, value));
+            var settings = new TracerSettings(source);
+
+            settings.CustomSamplingRules.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void SpanSamplingRules(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.SpanSamplingRules, value));
+            var settings = new TracerSettings(source);
+
+            settings.SpanSamplingRules.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(DoubleTestCases))]
+        public void GlobalSamplingRate(string value, double? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GlobalSamplingRate, value));
+            var settings = new TracerSettings(source);
+
+            settings.GlobalSamplingRate.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void StartupDiagnosticLogEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.StartupDiagnosticLogEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.StartupDiagnosticLogEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32TestCases), 1024 * 1024 * 10)]
+        public void TraceBufferSize(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.BufferSize, value));
+            var settings = new TracerSettings(source);
+
+            settings.TraceBufferSize.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32TestCases), 100)]
+        public void TraceBatchInterval(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.SerializationBatchInterval, value));
+            var settings = new TracerSettings(source);
+
+            settings.TraceBatchInterval.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void RouteTemplateResourceNamesEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.RouteTemplateResourceNamesEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("1", "1", true)]
+        [InlineData("true", "1", true)]
+        [InlineData("0", "1", false)]
+        [InlineData("false", "1", false)]
+        [InlineData("invalid", "1", false)]
+        [InlineData("invalid", "0", true)]
+        [InlineData("", "0", true)]
+        [InlineData(null, "0", true)]
+        [InlineData(null, null, false)]
+        public void ExpandRouteTemplatesEnabled(string value, string fallbackValue, bool expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.ExpandRouteTemplatesEnabled, value),
+                (ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, fallbackValue));
+            var settings = new TracerSettings(source);
+
+            settings.ExpandRouteTemplatesEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void RouteTemplateResKafkaCreateConsumerScopeEnabledourceNamesEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.KafkaCreateConsumerScopeEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.KafkaCreateConsumerScopeEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void DelayWcfInstrumentationEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.DelayWcfInstrumentationEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void WcfObfuscationEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.WcfObfuscationEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.WcfObfuscationEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), TracerSettings.DefaultObfuscationQueryStringRegex, Strings.AllowEmpty)]
+        public void ObfuscationQueryStringRegex(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ObfuscationQueryStringRegex, value));
+            var settings = new TracerSettings(source);
+
+            settings.ObfuscationQueryStringRegex.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), true)]
+        public void QueryStringReportingEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.QueryStringReportingEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.QueryStringReportingEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(Int32TestCases), 5000)]
+        public void QueryStringReportingSize(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.QueryStringReportingSize, value));
+            var settings = new TracerSettings(source);
+
+            settings.QueryStringReportingSize.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("1.5", 1.5d)]
+        [InlineData("-1", 200)]
+        [InlineData("", 200)]
+        [InlineData(null, 200)]
+        [InlineData("invalid", 200)]
+        public void ObfuscationQueryStringRegexTimeout(string value, double expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ObfuscationQueryStringRegexTimeout, value));
+            var settings = new TracerSettings(source);
+
+            settings.ObfuscationQueryStringRegexTimeout.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("1", "0", true)]
+        [InlineData("0", "0", false)]
+        [InlineData("true", "1", true)]
+        [InlineData("false", "1", false)]
+        [InlineData(null, "1", true)]
+        [InlineData(null, "true", true)]
+        [InlineData(null, "0", false)]
+        [InlineData(null, "false", false)]
+        [InlineData(null, null, false)]
+        [InlineData("", "", false)]
+        public void IsActivityListenerEnabled(string value, string fallbackValue, bool expected)
+        {
+            const string fallbackKey = "DD_TRACE_ACTIVITY_LISTENER_ENABLED";
+
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, value), (fallbackKey, fallbackValue));
+            var settings = new TracerSettings(source);
+
+            settings.IsActivityListenerEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
+        [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
+        [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
+        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
+        public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string[] expected)
+        {
+            const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
+
+            foreach (var isActivityListenerEnabled in new[] { true, false })
+            {
+                var source = CreateConfigurationSource(
+                    (ConfigurationKeys.PropagationStyleInject, value),
+                    (legacyKey, legacyValue),
+                    (ConfigurationKeys.PropagationStyle, fallbackValue),
+                    (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
+
+                var settings = new TracerSettings(source);
+
+                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
+            }
+        }
+
+        [Theory]
+        [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
+        [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
+        [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
+        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
+        public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string[] expected)
+        {
+            const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";
+
+            foreach (var isActivityListenerEnabled in new[] { true, false })
+            {
+                var source = CreateConfigurationSource(
+                    (ConfigurationKeys.PropagationStyleExtract, value),
+                    (legacyKey, legacyValue),
+                    (ConfigurationKeys.PropagationStyle, fallbackValue),
+                    (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
+
+                var settings = new TracerSettings(source);
+
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
+            }
+        }
+
+        // TODO: DirectLogSubmissionSettings
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "")]
+        public void TraceMethods(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.TraceMethods, value));
+            var settings = new TracerSettings(source);
+
+            settings.TraceMethods.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("key1:value1,key2:value2", new[] { "key1:value1", "key2:value2" })]
+        [InlineData("key1 :value1,empty,key2: value2", new[] { "key1:value1", "empty:", "key2:value2" })]
+        [InlineData(null, new string[0])]
+        [InlineData("", new string[0])]
+        [InlineData("key1 :val.ue1?", new[] { "key1:val.ue1_" })]
+        public void GrpcTags(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.GrpcTags, value));
+            var settings = new TracerSettings(source);
+
+            settings.GrpcTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+        }
+
+        [Theory]
+        [InlineData("", TagPropagation.OutgoingTagPropagationHeaderMaxLength)]
+        [InlineData(null, TagPropagation.OutgoingTagPropagationHeaderMaxLength)]
+        [InlineData("invalid", TagPropagation.OutgoingTagPropagationHeaderMaxLength)]
+        [InlineData("512", 512)]
+        [InlineData("513", TagPropagation.OutgoingTagPropagationHeaderMaxLength)]
+        [InlineData("0", 0)]
+        [InlineData("-1", TagPropagation.OutgoingTagPropagationHeaderMaxLength)]
+        public void OutgoingTagPropagationHeaderMaxLength(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.TagPropagation.HeaderMaxLength, value));
+            var settings = new TracerSettings(source);
+
+            settings.OutgoingTagPropagationHeaderMaxLength.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("test1", "test2", "test1")]
+        [InlineData(null, "test2", "test2")]
+        [InlineData("", "test2", "")]
+        [InlineData(null, null, null)]
+        public void IpHeader(string value, string fallbackValue, string expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.IpHeader, value),
+                (ConfigurationKeys.AppSec.CustomIpHeader, fallbackValue));
+            var settings = new TracerSettings(source);
+
+            settings.IpHeader.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void IpHeaderEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.IpHeaderEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.IpHeaderEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void IsDataStreamsMonitoringEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DataStreamsMonitoring.Enabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.IsDataStreamsMonitoringEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void IsRareSamplerEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.RareSamplerEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.IsRareSamplerEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void IsRunningInAzureAppService(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.RareSamplerEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.IsRareSamplerEnabled.Should().Be(expected);
+        }
+
+        // TODO: ImmutableAzureAppServiceSettings
+
+        [Fact]
+        public void DisableTracerIfNoApiKeyInAas()
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1"));
+            var settings = new TracerSettings(source);
+
+            settings.TraceEnabled.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("test1,, ,test2", false, false, new[] { "TEST1", "TEST2" })]
+        [InlineData("test1,, ,test2", true, true, new[] { "TEST1", "TEST2" })]
+        [InlineData(null, true, true, new[] { "azuredefault" })]
+        [InlineData(null, false, true, new[] { "SERVERLESS" })]
+        [InlineData(null, false, false, new string[0])]
+        [InlineData("", true, true, new string[0])]
+        public void HttpClientExcludedUrlSubstrings(string value, bool isRunningInAppService, bool isRunningInLambda, string[] expected)
+        {
+            if (expected.Length == 1 && expected[0] == "azuredefault")
+            {
+                expected = ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions.Split(',').Select(s => s.Trim()).ToArray();
+            }
+
+            var oldMetadata = Serverless.Metadata;
+
+            try
+            {
+                var source = CreateConfigurationSource(
+                    (ConfigurationKeys.HttpClientExcludedUrlSubstrings, value),
+                    (ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, isRunningInAppService ? "1" : "0"));
+
+                if (isRunningInLambda)
+                {
+                    var metadata = Serverless.LambdaMetadata.CreateForTests(true, "functionName", "handlerName", "serviceName", "serverless");
+                    Serverless.SetMetadataTestsOnly(metadata);
+                }
+
+                var settings = new TracerSettings(source);
+
+                settings.HttpClientExcludedUrlSubstrings.Should().BeEquivalentTo(expected);
+            }
+            finally
+            {
+                Serverless.SetMetadataTestsOnly(oldMetadata);
+            }
+        }
+
+        [Theory]
+        [InlineData("", DbmPropagationLevel.Disabled)]
+        [InlineData(null, DbmPropagationLevel.Disabled)]
+        [InlineData("invalid", DbmPropagationLevel.Disabled)]
+        [InlineData("Disabled", DbmPropagationLevel.Disabled)]
+        [InlineData("full", DbmPropagationLevel.Full)]
+        [InlineData("SERVICE", DbmPropagationLevel.Service)]
+        public void DbmPropagationMode(string value, object expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DbmPropagationMode, value));
+            var settings = new TracerSettings(source);
+
+            settings.DbmPropagationMode.Should().Be((DbmPropagationLevel)expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void TraceId128BitGenerationEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.TraceId128BitGenerationEnabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), false)]
+        public void TraceId128BitLoggingEnabled(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.TraceId128BitLoggingEnabled, value));
+            var settings = new TracerSettings(source);
+
+            settings.TraceId128BitLoggingEnabled.Should().Be(expected);
         }
 
         private void SetAndValidateStatusCodes(Action<TracerSettings, IEnumerable<int>> setStatusCodes, Func<TracerSettings, bool[]> getStatusCodes)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -662,7 +662,7 @@ namespace Datadog.Trace.Tests.Configuration
         // TODO: DirectLogSubmissionSettings
 
         [Theory]
-        [MemberData(nameof(StringTestCases), "")]
+        [MemberData(nameof(StringTestCases), "", Strings.AllowEmpty)]
         public void TraceMethods(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.TraceMethods, value));

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -659,8 +659,6 @@ namespace Datadog.Trace.Tests.Configuration
             }
         }
 
-        // TODO: DirectLogSubmissionSettings
-
         [Theory]
         [MemberData(nameof(StringTestCases), "", Strings.AllowEmpty)]
         public void TraceMethods(string value, string expected)
@@ -755,8 +753,6 @@ namespace Datadog.Trace.Tests.Configuration
 
             settings.IsRareSamplerEnabled.Should().Be(expected);
         }
-
-        // TODO: ImmutableAzureAppServiceSettings
 
         [Fact]
         public void DisableTracerIfNoApiKeyInAas()

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -1,16 +1,20 @@
-﻿// <copyright file="DirectLogSubmissionSettingsTests.cs" company="Datadog">
+// <copyright file="DirectLogSubmissionSettingsTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Logging.DirectSubmission
 {
-    public class DirectLogSubmissionSettingsTests
+    public class DirectLogSubmissionSettingsTests : SettingsTestsBase
     {
         [Theory]
         [InlineData(null)]
@@ -69,6 +73,21 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         }
 
         [Fact]
+        public void LogSpecificGlobalTagsFallBackToLegacyGlobalTags()
+        {
+            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
+            {
+                { "DD_TRACE_GLOBAL_TAGS", "test1:value1, test2:value2" },
+            }));
+
+            tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags
+               .Should()
+               .BeEquivalentTo(expected);
+        }
+
+        [Fact]
         public void LogSpecificGlobalTagsOverrideTracerGlobalTags()
         {
             var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
@@ -77,6 +96,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             {
                 { ConfigurationKeys.DirectLogSubmission.GlobalTags, "test1:value1, test2:value2" },
                 { ConfigurationKeys.GlobalTags, "test3:value3, test4:value4" },
+                { "DD_TRACE_GLOBAL_TAGS", "test5:value5, test6:value6" },
             }));
 
             tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags
@@ -91,11 +111,126 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             {
                 { ConfigurationKeys.DirectLogSubmission.GlobalTags, string.Empty },
                 { ConfigurationKeys.GlobalTags, "test3:value3, test4:value4" },
+                { "DD_TRACE_GLOBAL_TAGS", "test5:value5, test6:value6" },
             }));
 
             tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags
                           .Should()
                           .BeEmpty();
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), "default", Strings.AllowEmpty)]
+        public void DirectLogSubmissionHost(string value, string expected)
+        {
+            if (expected == "default")
+            {
+                expected = HostMetadata.Instance.Hostname;
+            }
+
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.Host, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionHost.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases), DirectLogSubmissionSettings.DefaultSource, Strings.AllowEmpty)]
+        public void DirectLogSubmissionSource(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.Source, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionSource.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", DirectLogSubmissionSettings.DefaultMinimumLevel)]
+        [InlineData(null, DirectLogSubmissionSettings.DefaultMinimumLevel)]
+        [InlineData("trace", DirectSubmissionLogLevel.Verbose)] // Further tested in DirectSubmissionLogLevelExtensionsTests
+        public void DirectLogSubmissionMinimumLevel(string value, object expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.MinimumLevel, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionMinimumLevel.Should().Be((DirectSubmissionLogLevel)expected);
+        }
+
+        [Theory]
+        [InlineData("", new string[0])]
+        [InlineData(null, new string[0])]
+        [InlineData("test1;TEST1;;test2", new[] { "test1", "test2" })]
+        public void DirectLogSubmissionEnabledIntegrations(string value, string[] expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionEnabledIntegrations.Should().BeEquivalentTo(expected);
+        }
+
+        [Theory]
+        [InlineData("", DirectLogSubmissionSettings.DefaultBatchSizeLimit)]
+        [InlineData(null, DirectLogSubmissionSettings.DefaultBatchSizeLimit)]
+        [InlineData("invalid", DirectLogSubmissionSettings.DefaultBatchSizeLimit)]
+        [InlineData("0", DirectLogSubmissionSettings.DefaultBatchSizeLimit)]
+        [InlineData("-1", DirectLogSubmissionSettings.DefaultBatchSizeLimit)]
+        [InlineData("256", 256)]
+        public void DirectLogSubmissionBatchSizeLimit(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.BatchSizeLimit, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionBatchSizeLimit.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", DirectLogSubmissionSettings.DefaultQueueSizeLimit)]
+        [InlineData(null, DirectLogSubmissionSettings.DefaultQueueSizeLimit)]
+        [InlineData("invalid", DirectLogSubmissionSettings.DefaultQueueSizeLimit)]
+        [InlineData("0", DirectLogSubmissionSettings.DefaultQueueSizeLimit)]
+        [InlineData("-1", DirectLogSubmissionSettings.DefaultQueueSizeLimit)]
+        [InlineData("256", 256)]
+        public void DirectLogSubmissionQueueSizeLimit(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.QueueSizeLimit, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionQueueSizeLimit.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("", DirectLogSubmissionSettings.DefaultBatchPeriodSeconds)]
+        [InlineData(null, DirectLogSubmissionSettings.DefaultBatchPeriodSeconds)]
+        [InlineData("invalid", DirectLogSubmissionSettings.DefaultBatchPeriodSeconds)]
+        [InlineData("0", DirectLogSubmissionSettings.DefaultBatchPeriodSeconds)]
+        [InlineData("-1", DirectLogSubmissionSettings.DefaultBatchPeriodSeconds)]
+        [InlineData("256", 256)]
+        public void DirectLogSubmissionBatchPeriod(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.DirectLogSubmissionBatchPeriod.Should().Be(TimeSpan.FromSeconds(expected));
+        }
+
+        [Theory]
+        [MemberData(nameof(StringTestCases))]
+        public void ApiKey(string value, string expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.ApiKey, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.ApiKey.Should().Be(expected);
+        }
+
+        [Theory]
+        [MemberData(nameof(BooleanTestCases), null)]
+        public void LogsInjectionEnabled(string value, bool? expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.LogsInjectionEnabled, value));
+            var settings = new DirectLogSubmissionSettings(source);
+
+            settings.LogsInjectionEnabled.Should().Be(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -1,18 +1,20 @@
-﻿// <copyright file="TelemetrySettingsTests.cs" company="Datadog">
+// <copyright file="TelemetrySettingsTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Telemetry
 {
-    public class TelemetrySettingsTests
+    public class TelemetrySettingsTests : SettingsTestsBase
     {
         private const string DefaultIntakeUrl = "https://instrumentation-telemetry-intake.datadoghq.com/";
 
@@ -273,6 +275,21 @@ namespace Datadog.Trace.Tests.Telemetry
             {
                 settings.Agentless.Should().BeNull();
             }
+        }
+
+        [Theory]
+        [InlineData("0", 60)]
+        [InlineData(null, 60)]
+        [InlineData("", 60)]
+        [InlineData("invalid", 60)]
+        [InlineData("3600", 3600)]
+        [InlineData("3601", 60)]
+        public void HeartbeatInterval(string value, int expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds, value));
+            var settings = TelemetrySettings.FromSource(source, () => true);
+
+            settings.HeartbeatInterval.Should().Be(TimeSpan.FromSeconds(expected));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -282,6 +282,7 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData(null, 60)]
         [InlineData("", 60)]
         [InlineData("invalid", 60)]
+        [InlineData("523", 523)]
         [InlineData("3600", 3600)]
         [InlineData("3601", 60)]
         public void HeartbeatInterval(string value, int expected)


### PR DESCRIPTION
## Summary of changes

Add a set of unit test for every settings.

## Reason for change

As we're about to introduce significant changes to our configuration system, we must make sure not to break any mapping or validation rule.

## Implementation details

Tried to group all the common test cases in the shared `SettingsTestsBase` class.

