### PR TITLE
[Version Bump] 2.31.0

### DIFF
--- a/.github/scripts/package_and_deploy.sh
+++ b/.github/scripts/package_and_deploy.sh
@@ -6,7 +6,7 @@ ddprof_deploy_folder=$1
 commit_sha=$2
 commit_author=$3
 
-current_profiler_version="2.30.0"
+current_profiler_version="2.31.0"
 profiler_version=v${current_profiler_version}_$(date -u +%G%m%d%H%M%S)
 
 ## Create master.index.txt file

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,25 +1,86 @@
 # Datadog .NET Tracer (`dd-trace-dotnet`) Release Notes
 
+## [Release 2.30.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.30.0)
 
+## Summary
 
+- [Tracer] Adds support for 128-bit Trace IDs
+- [ASM] Adds custom rules support
+- [Continuous Profiler] Enables timestamps and GC events by default for timeline view
 
+> **Note**
+> The Datadog .NET Tracer does not support application running in partial trust.
 
+## Changes
 
+### Tracer
+* [Tracing] add support for 128-bit trace ids (#3744)
+* Change the ownership of the RuntimeMetrics statsd instance (#4060)
+* Make ModuleMetadata thread-safe (#4061)
+* Update `MessagePack` to 1.9.11 (#4078)
+* Reduce allocations in sampling mechanism tagging (#4085)
+* [Tracer] Add interfaces to standardize operation name and service name calculations across schema versions (#4088)
+* Add support for MySql.Data 8.0.33 (#4109)
 
+### CI Visibility
+* [CI Visibility] Rename Intelligent Test Runner tag names (#3909)
+* [CI Visibility] Update ci specs and add codefresh support (#4049)
+* [CI Visibility] Add support for importing code coverage from cobertura and opencover format to the test session. (#4069)
 
+### ASM
+* [ASM] Update waf and custom rules (#4053)
+* [ASM] Add methods to location json (#4063)
+* [ASM] Fix ip resolution: some local ips weren't seen as local (#4067)
+* [ASM] Add custom rules support (#4077)
+* [ASM] Add IAST instrumented tests ownership to ASM (#4087)
+* [ASM] Update WAF (#4112)
 
+### Continuous Profiler
+* [Profiler] Enable timestamps and GC events by default for timeline view (#3982)
+* [Profiler] Make sure the memory dump is copied when a profiler test failed (#4047)
+* Fix rare and random crash on linux (#4055)
+* Investigate failing test on alpine (#4073)
+* [Profiler] Fix race for endpoint profiling (#4079)
+* [Profiler/Windows] Release HANDLE when Managed thread dies (#4089)
 
+### Fixes
+* Remove support for partial trust environment (#4083)
+* Add `EditorBrowsableState.Never` to types that should never be invoked (#4091)
 
+### Build / Test
+* [IAST] Enable deduplication tests on net7  (#3973)
+* Enable crash dumps on Windows (#3975)
+* [Tracer] Update samples for log collection, agentless logging, and logs trace ID correlation (#3994)
+* Update Nuke build to latest (#4000)
+* [Test Package Versions Bump] Updating package versions (#4013)
+* [Tracer] Attribute Schema configuration: Create distinct v0 and v1 span metadata rules (#4031)
+* Update dockerfile to build native code with clang-16 (#4036)
+* Add checksums for release artifacts (#4041)
+* Replace Datadog.Trace.OSX.sln with a solution filter (#4048)
+* [Tracer] Comprehensive package version testing fixes (#4057)
+* Fix CI Visibility source root in Docker based test (#4059)
+* InstrumentationVerification should override the log folder only if enabled (#4066)
+* Setup python3.9 for system tests (#4070)
+* Add `obj` as a folder exception in the static analysis workflow. (#4071)
+* Add debuglink to linux native lib to ease debugging experience (#4072)
+* Add jetbrains diagnoser to Benchmark tests (#4074)
+* Reduce the pressure on threadpool in the tests (#4086)
+* Option to add Datadog Profiler to the BenchmarkDotNet tests (#4094)
+* [Test Package Versions Bump] Updating package versions (#4096)
+* Fix BenchmarkDotNet tests build warnings (#4110)
+* Allow forcing code coverage in CI (#4113)
+* Stop the flake (#4114)
 
+### Miscellaneous
+* RCM refactoring from event model to subscriptions (#3983)
+* [Tracer] Improvement: Make the ServiceNames immutable (#4043)
+* Bump spdlog version (#4044)
+* Exclude more high-cardinality dependencies from telemetry (#4050)
+* Update Minimum required SDK version in Readme (#4092)
+* Skip injecting loader on partial trust (#4108)
+* Add `trace::profiler` null check (#4116)
 
-
-
-
-
-
-
-
-
+[Changes since 2.29.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.29.0...v2.30.0)
 
 
 ## [Release 2.29.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.29.0)
@@ -58,7 +119,8 @@ Fixes the following issues:
 * Fix BadImageFormatException that occurred when trace annotations were used in conjunction with DD_TRACE_DEBUG (#4045)
 
 
-[Changes since 2.28.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.28.0...v2.29.0)
+[Changes since 2.28.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.28.0...v2.29.0)
+
 
 ## [Release 2.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.28.0)
 
@@ -154,7 +216,8 @@ Also the tracer now supports
 * Fix the log level and remove redundant info (#3991)
 
 
-[Changes since 2.27.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.27.0...v2.28.0)
+[Changes since 2.27.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.27.0...v2.28.0)
+
 
 ## [Release 2.27.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.27.0)
 
@@ -228,7 +291,8 @@ Tracer
 * Fix native compilation warning (#3932)
 
 
-[Changes since 2.26.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.26.0...v2.27.0)
+[Changes since 2.26.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.26.0...v2.27.0)
+
 
 ## [Release 2.26.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.26.0)
 

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Linux.ApiWrapper" VERSION 2.30.0)
+project("Datadog.Linux.ApiWrapper" VERSION 2.31.0)
 
 # ******************************************************
 # Compiler options

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Profiler.Native.Linux" VERSION 2.30.0)
+project("Datadog.Profiler.Native.Linux" VERSION 2.31.0)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
 option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
@@ -62,8 +62,8 @@ END
 
 // ------- version info -------------------------------------------------------
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION             2,30,0,0
-PRODUCTVERSION          2,30,0,0
+FILEVERSION             2,31,0,0
+PRODUCTVERSION          2,31,0,0
 FILEFLAGSMASK           VS_FF_PRERELEASE
 FILEOS                  VOS_NT
 FILETYPE                VFT_DLL
@@ -74,12 +74,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Continuous Profiler for .NET Applications"
-            VALUE "FileVersion", "2.30.0.0"
+            VALUE "FileVersion", "2.31.0.0"
             VALUE "InternalName", "Native Profiler Engine"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Profiler.Native.dll"
             VALUE "ProductName", "Continuous Profiler for .NET Applications"
-            VALUE "ProductVersion", "2.30.0.0"
+            VALUE "ProductVersion", "2.31.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.30.0";
+constexpr auto PROFILER_VERSION = "2.31.0";

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -5,7 +5,7 @@
 
   <!-- * * * * * * * * * * * INPUTS. Update this section EVERY time the component is shipped/released! * * * * * * * * * * *                -->
   <PropertyGroup>
-    <ProductVersion>2.30.0</ProductVersion>
+    <ProductVersion>2.31.0</ProductVersion>
   </PropertyGroup>
   <!-- * * * * * * * * * * * END OF INPUTS.  * * * * * * * * * * *                                                                          -->
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 2.30.0)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 2.31.0)
 
 # ******************************************************
 # Environment detection

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -57,8 +57,8 @@ VS_VERSION_INFO VERSIONINFO
 #else
  FILEFLAGS 0x0L
 #endif
- FILEVERSION             2,30,0,0
- PRODUCTVERSION          2,30,0,0
+ FILEVERSION             2,31,0,0
+ PRODUCTVERSION          2,31,0,0
  FILEOS                  VOS_NT
  FILETYPE                VFT_DLL
 BEGIN
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Native loader for Datadog .NET APM"
-            VALUE "FileVersion", "2.30.0.0"
+            VALUE "FileVersion", "2.31.0.0"
             VALUE "InternalName", "Native loader"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Trace.ClrProfiler.Native.dll"
             VALUE "ProductName", "Native loader for Datadog .NET APM"
-            VALUE "ProductVersion", "2.30.0.0"
+            VALUE "ProductVersion", "2.31.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,9 +17,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-2.30.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-2.31.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
-    <DefineConstants>InstallerVersion=2.30.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
+    <DefineConstants>InstallerVersion=2.31.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>$(DefineConstants);Debug</DefineConstants>

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -55,7 +55,7 @@ partial class Build : NukeBuild
     readonly bool IsAlpine = false;
 
     [Parameter("The current version of the source and build")]
-    readonly string Version = "2.30.0";
+    readonly string Version = "2.31.0";
 
     [Parameter("Whether the current build version is a prerelease(for packaging purposes)")]
     readonly bool IsPrerelease = false;

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -73,6 +73,11 @@ namespace PrepareRelease
             return Regex.Replace(text, $"<PackageReference Include=\"Datadog.Trace\" Version=\"{VersionPattern(withPrereleasePostfix: true)}\" />", $"<PackageReference Include=\"Datadog.Trace\" Version=\"{VersionString(withPrereleasePostfix: true)}\" />", RegexOptions.Singleline);
         }
 
+        private string DatadogTraceBundleNugetDependencyVersionReplace(string text)
+        {
+            return Regex.Replace(text, $"<PackageReference Include=\"Datadog.Trace.Bundle\" Version=\"{VersionPattern(withPrereleasePostfix: true)}\" />", $"<PackageReference Include=\"Datadog.Trace.Bundle\" Version=\"{VersionString(withPrereleasePostfix: true)}\" />", RegexOptions.Singleline);
+        }
+
         private string NugetVersionReplace(string text)
         {
             return Regex.Replace(text, $"<Version>{VersionPattern(withPrereleasePostfix: true)}</Version>", $"<Version>{VersionString(withPrereleasePostfix: true)}</Version>", RegexOptions.Singleline);
@@ -179,22 +184,22 @@ namespace PrepareRelease
                 // Sample application package updates
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
                 SynchronizeVersion(
                     "samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj",
-                    DatadogTraceNugetDependencyVersionReplace);
+                    DatadogTraceBundleNugetDependencyVersionReplace);
 
                 // Dockerfile updates
                 SynchronizeVersion(

--- a/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" />
   </ItemGroup>

--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="NLog" Version="4.0.0" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.29.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.30.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.29.0
+ARG TRACER_VERSION=2.30.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.29.0
+ARG TRACER_VERSION=2.30.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Debian.dockerfile
+++ b/tracer/samples/ConsoleApp/Debian.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=2.29.0
+ARG TRACER_VERSION=2.30.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/tracer/samples/WindowsContainer/Dockerfile
+++ b/tracer/samples/WindowsContainer/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2019 AS base
 WORKDIR /app
 
-ARG TRACER_VERSION=2.29.0
+ARG TRACER_VERSION=2.30.0
 ENV DD_TRACER_VERSION=$TRACER_VERSION
 ENV ASPNETCORE_URLS=http://*.80
 

--- a/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <Title>Datadog CI Visibility - BenchmarkDotNet</Title>
     <Description>BenchmarkDotNet exporter for Datadog CI Visibility</Description>
     <Nullable>enable</Nullable>

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -6,7 +6,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private const string AssemblyName = "Datadog.Trace, Version=2.30.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
+        private const string AssemblyName = "Datadog.Trace, Version=2.31.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
         private const string AzureAppServicesKey = "DD_AZURE_APP_SERVICES";
         private const string AasCustomTracingKey = "DD_AAS_ENABLE_CUSTOM_TRACING";
         private const string AasCustomMetricsKey = "DD_AAS_ENABLE_CUSTOM_METRICS";

--- a/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
+++ b/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
   </PropertyGroup>
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the

--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <Title>Datadog APM - OpenTracing</Title>
     <Description>Provides OpenTracing support for Datadog APM</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <Description>Auto-instrumentation dotnet global tool for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.30.0</Version>
+    <Version>2.31.0</Version>
     <Title>Datadog APM</Title>
     <Description>Instrumentation library for Datadog APM.</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace
     internal static class TracerConstants
     {
         public const string Language = "dotnet";
-        public const string AssemblyVersion = "2.30.0.0";
-        public const string ThreePartVersion = "2.30.0";
+        public const string AssemblyVersion = "2.31.0.0";
+        public const string ThreePartVersion = "2.31.0";
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 # Project definition
 # ******************************************************
 
-project("Datadog.Tracer.Native" VERSION 2.30.0)
+project("Datadog.Tracer.Native" VERSION 2.31.0)
 
 # ******************************************************
 # Environment detection

--- a/tracer/src/Datadog.Tracer.Native/Resource.rc
+++ b/tracer/src/Datadog.Tracer.Native/Resource.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,30,0,0
- PRODUCTVERSION 2,30,0,0
+ FILEVERSION 2,31,0,0
+ PRODUCTVERSION 2,31,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog, Inc."
             VALUE "FileDescription", "Datadog CLR Profiler"
-            VALUE "FileVersion", "2.30.0.0"
+            VALUE "FileVersion", "2.31.0.0"
             VALUE "InternalName", "Datadog.Tracer.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2017 Datadog, Inc."
             VALUE "OriginalFilename", "Datadog.Tracer.Native.DLL"
             VALUE "ProductName", "Datadog .NET Tracer"
-            VALUE "ProductVersion", "2.30.0"
+            VALUE "ProductVersion", "2.31.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -84,7 +84,7 @@ const shared::WSTRING system_private_corelib_assemblyName = WStr("System.Private
 const shared::WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("Datadog.Trace.ClrProfiler.Managed.Loader");
 
 const shared::WSTRING managed_profiler_full_assembly_version =
-    WStr("Datadog.Trace, Version=2.30.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+    WStr("Datadog.Trace, Version=2.31.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
 const shared::WSTRING managed_profiler_name = WStr("Datadog.Trace");
 
@@ -127,7 +127,7 @@ const AssemblyProperty managed_profiler_assembly_property = AssemblyProperty(
                   49,  105, 236, 40,  21,  176, 12, 238, 238, 204, 141, 90,  27,  244, 61,  182, 125, 41,  97,  163,
                   233, 190, 161, 57,  127, 4,   62, 192, 116, 145, 112, 150, 73,  37,  47,  85,  101, 183, 86,  197},
     160, 32772, 1)
-        .WithVersion(2, 30, 0, 0);
+        .WithVersion(2, 31, 0, 0);
 
 } // namespace trace
 

--- a/tracer/src/Datadog.Tracer.Native/version.h
+++ b/tracer/src/Datadog.Tracer.Native/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.30.0";
+constexpr auto PROFILER_VERSION = "2.31.0";

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Datadog.Trace" Version="2.29.0" />
+      <PackageReference Include="Datadog.Trace" Version="2.30.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
> **Note**
> This PR also updates the `SetAllVersions` script because the changes in #3994 broke the [Auto version bump on release completed](https://github.com/DataDog/dd-trace-dotnet/actions/workflows/auto_create_version_bump_pr.yml) action 🙄 So I ran all the steps locally instead

The following files were found to be modified (as expected)

- [x] docs/CHANGELOG.md
- [x] .github/scripts/package_and_deploy.sh
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
- [x] profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
- [x] profiler/src/ProfilerEngine/ProductVersion.props
- [x] shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
- [x] shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
- [x] shared/src/msi-installer/WindowsInstaller.wixproj
- [x] tracer/build/_build/Build.cs
- [x] tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
- [x] tracer/samples/ConsoleApp/Alpine3.10.dockerfile
- [x] tracer/samples/ConsoleApp/Alpine3.9.dockerfile
- [x] tracer/samples/ConsoleApp/Debian.dockerfile
- [x] tracer/samples/WindowsContainer/Dockerfile
- [x] tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
- [x] tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
- [x] tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
- [x] tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
- [x] tracer/src/Datadog.Tracer.Native/CMakeLists.txt
- [x] tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
- [x] tracer/src/Datadog.Tracer.Native/Resource.rc
- [x] tracer/src/Datadog.Tracer.Native/version.h
- [x] tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
- [x] tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
- [x] tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
- [x] tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
- [x] tracer/src/Datadog.Trace/Datadog.Trace.csproj
- [x] tracer/src/Datadog.Trace/TracerConstants.cs
- [x] tracer/tools/PipelineMonitor/PipelineMonitor.csproj

@DataDog/apm-dotnet