### PR TITLE
[ASM] Include ASM code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@
 /tracer/test/Datadog.Trace.Security.IntegrationTests/ @DataDog/asm-dotnet
 /tracer/test/Datadog.Trace.Security.Unit.Tests/       @DataDog/asm-dotnet
 /tracer/test/snapshots/Security*          @DataDog/asm-dotnet
+/tracer/test/snapshots/IAST*          	@DataDog/asm-dotnet
+AspectsDefinitions.g.cs 				@DataDog/asm-dotnet
 /tracer/test/test-applications/integrations/Samples.InstrumentedTests/ @DataDog/asm-dotnet
 
 # Profiler


### PR DESCRIPTION
## Summary of changes

This PR contains some changes in the code ownership. It gives the ownership of the IAST snapshots and the automatically generated IAST aspect files to ASM.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
