### PR TITLE
Add `nullable` and more tests for configuration

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -387,7 +387,7 @@ namespace Datadog.Trace.Ci
                 case OSPlatformName.Linux:
                     if (!string.IsNullOrEmpty(HostMetadata.Instance.KernelRelease))
                     {
-                        return HostMetadata.Instance.KernelRelease;
+                        return HostMetadata.Instance.KernelRelease!;
                     }
 
                     break;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
@@ -28,6 +28,4 @@ internal readonly record struct ConfigurationResult<T>
     public static ConfigurationResult<T> Valid(T result) => new(result, isValid: true);
 
     public static ConfigurationResult<T> Invalid(T result) => new(result, isValid: false);
-
-    public static ConfigurationResult<T>? NotFound() => null;
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             DirectLogSubmissionHost = config
                                      .WithKeys(ConfigurationKeys.DirectLogSubmission.Host)
-                                     .AsString(HostMetadata.Instance.Hostname);
+                                     .AsString(HostMetadata.Instance.Hostname ?? string.Empty);
             DirectLogSubmissionSource = config
                                        .WithKeys(ConfigurationKeys.DirectLogSubmission.Source)
                                        .AsString(DefaultSource);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.IO;
 using Datadog.Trace.Util;
@@ -25,7 +27,7 @@ namespace Datadog.Trace.PlatformHelpers
                 kernelVersion: version);
         }
 
-        private HostMetadata(string hostname, string kernelName, string kernelRelease, string kernelVersion)
+        private HostMetadata(string? hostname, string? kernelName, string? kernelRelease, string? kernelVersion)
         {
             Hostname = hostname;
             KernelName = kernelName;
@@ -39,28 +41,28 @@ namespace Datadog.Trace.PlatformHelpers
         /// Gets the name of the host on which the code is running
         /// Returns <c>null</c> if the host name can not be determined
         /// </summary>
-        public string Hostname { get; }
+        public string? Hostname { get; }
 
         /// <summary>
         /// Gets the name of the kernel, e.g. Linux
         /// Returns <c>null</c> if it can not be determined
         /// </summary>
-        public string KernelName { get; }
+        public string? KernelName { get; }
 
         /// <summary>
         /// Gets the release name of the kernel, e.g. 3.2.0-4-686-pae
         /// Returns <c>null</c> if it can not be determined
         /// </summary>
-        public string KernelRelease { get; }
+        public string? KernelRelease { get; }
 
         /// <summary>
         /// Gets the version number of the kernel, e.g. #1 SMP Debian 3.2.63-2+deb7u2
         /// Returns <c>null</c> if it can not be determined
         /// </summary>
-        public string KernelVersion { get; }
+        public string? KernelVersion { get; }
 
         // internal for testing
-        internal static void ParseKernel(string fullVersion, out string kernel, out string kernelRelease, out string kernelVersion)
+        internal static void ParseKernel(string fullVersion, out string? kernel, out string? kernelRelease, out string? kernelVersion)
         {
             kernel = null;
             kernelRelease = null;
@@ -104,7 +106,7 @@ namespace Datadog.Trace.PlatformHelpers
             kernelVersion = fullVersion.Substring(versionIndex);
         }
 
-        private static void TryGetKernelInformation(out string kernel, out string kernelRelease, out string kernelVersion)
+        private static void TryGetKernelInformation(out string? kernel, out string? kernelRelease, out string? kernelVersion)
         {
             try
             {
@@ -127,7 +129,7 @@ namespace Datadog.Trace.PlatformHelpers
             kernelVersion = null;
         }
 
-        private static string GetHostInternal()
+        private static string? GetHostInternal()
         {
             try
             {

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationTelemetryTests.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
 using FluentAssertions;
@@ -19,37 +18,36 @@ public class ConfigurationTelemetryTests
     [Fact]
     public void Record_RecordsTelemetryValues()
     {
-        var i = 0;
         var stringValues = new List<ConfigDto>
         {
-            new("string1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
-            new("string2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i)),
-            new("string3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), error: TelemetryErrorCode.FailedValidation),
-            new("string4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i)),
-            new("string4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
-            new("redacted1", null, ConfigurationOrigins.Code, Interlocked.Increment(ref i), recordValue: false),
-            new("redacted2", "value", ConfigurationOrigins.AppConfig, Interlocked.Increment(ref i), recordValue: false),
-            new("redacted3", "value", ConfigurationOrigins.DdConfig, Interlocked.Increment(ref i), recordValue: false, TelemetryErrorCode.FailedValidation),
-            new("redacted4", "overridden", ConfigurationOrigins.RemoteConfig, Interlocked.Increment(ref i), recordValue: false),
-            new("redacted4", "newvalue", ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i), recordValue: false),
+            new("string1", null, ConfigurationOrigins.Code),
+            new("string2", "value", ConfigurationOrigins.AppConfig),
+            new("string3", "value", ConfigurationOrigins.DdConfig, error: TelemetryErrorCode.FailedValidation),
+            new("string4", "overridden", ConfigurationOrigins.RemoteConfig),
+            new("string4", "newvalue", ConfigurationOrigins.EnvVars),
+            new("redacted1", null, ConfigurationOrigins.Code, recordValue: false),
+            new("redacted2", "value", ConfigurationOrigins.AppConfig, recordValue: false),
+            new("redacted3", "value", ConfigurationOrigins.DdConfig, recordValue: false, TelemetryErrorCode.FailedValidation),
+            new("redacted4", "overridden", ConfigurationOrigins.RemoteConfig, recordValue: false),
+            new("redacted4", "newvalue", ConfigurationOrigins.EnvVars, recordValue: false),
         };
 
         var boolValues = new List<ConfigDto>
         {
-            new("bool", false, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
-            new("bool", true, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+            new("bool", false, ConfigurationOrigins.EnvVars),
+            new("bool", true, ConfigurationOrigins.Code),
         };
 
         var intValues = new List<ConfigDto>
         {
-            new("int", 123, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
-            new("int", 42, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+            new("int", 123, ConfigurationOrigins.EnvVars),
+            new("int", 42, ConfigurationOrigins.Code),
         };
 
         var doubleValues = new List<ConfigDto>
         {
-            new("double", 123.0, ConfigurationOrigins.EnvVars, Interlocked.Increment(ref i)),
-            new("double", 42.0, ConfigurationOrigins.Code, Interlocked.Increment(ref i)),
+            new("double", 123.0, ConfigurationOrigins.EnvVars),
+            new("double", 42.0, ConfigurationOrigins.Code),
         };
 
         var telemetry = new ConfigurationTelemetry();
@@ -87,12 +85,11 @@ public class ConfigurationTelemetryTests
                       .Concat(boolValues)
                       .Concat(intValues)
                       .Concat(doubleValues)
-                      .OrderBy(x => x.SeqId)
                       .ToList();
 
         var actual = telemetry.GetLatest()
-                              .Select(x => new ConfigDto(x))
                               .OrderBy(x => x.SeqId)
+                              .Select(x => new ConfigDto(x))
                               .ToList();
 
         actual.Should().BeEquivalentTo(expected);
@@ -115,17 +112,15 @@ public class ConfigurationTelemetryTests
             RecordValue = entry.Type != ConfigurationTelemetry.ConfigurationTelemetryEntryType.Redacted;
             Origin = entry.Origin;
             Error = entry.Error;
-            SeqId = entry.SeqId;
         }
 
-        public ConfigDto(string name, object value, ConfigurationOrigins origin, long seqId, bool recordValue = true, TelemetryErrorCode? error = null)
+        public ConfigDto(string name, object value, ConfigurationOrigins origin, bool recordValue = true, TelemetryErrorCode? error = null)
         {
             Name = name;
             Value = value;
             RecordValue = recordValue;
             Origin = origin;
             Error = error;
-            SeqId = seqId;
         }
 
         public string Name { get; set; }
@@ -137,7 +132,5 @@ public class ConfigurationTelemetryTests
         public ConfigurationOrigins Origin { get; set; }
 
         public TelemetryErrorCode? Error { get; set; }
-
-        public long SeqId { get; set; }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Some cleanup after #4033
- Added a bunch of unit tests for missing code coverage

## Reason for change

Checking the code coverage for #4033 there were a bunch of untested paths, particularly in `ConfigurationBuilder`, `JsonConfigurationSource` and `CustomTelemeteredConfigurationSource`.

Also fixed some nullability (which will become important in subsequent PRs)

## Implementation details

`#nullable enable` and unit tests

## Test coverage

More than there was
