### PR TITLE
Add `Debug` build stage and fix warnings

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -676,6 +676,93 @@ stages:
         displayName: Publish NuGet packages
         artifact: nuget-packages
 
+- stage: debug_builds
+  dependsOn: [merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux, macos, windows, linux_arm64]
+
+  - job: linux
+    timeoutInMinutes: 60 #default value
+    dependsOn: []
+    strategy:
+      matrix:
+        centos7:
+          baseImage: centos7
+        alpine:
+          baseImage: alpine
+    pool:
+      name: azure-linux-scale-set
+
+    steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - template: steps/run-in-docker.yml
+        parameters:
+          build: true
+          target: builder
+          baseImage: $(baseImage)
+          command: "Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug"
+          retryCountForRunCommand: 1
+
+  - job: windows
+    timeoutInMinutes: 60 #default value
+    dependsOn: []
+    pool:
+      name: azure-windows-scale-set-3
+    steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - template: steps/install-latest-dotnet-sdk.yml
+
+      - script: tracer\build.cmd Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug
+        displayName: Build tracer home in debug
+        retryCountOnTaskFailure: 1
+
+  - job: linux_arm64
+    timeoutInMinutes: 60 #default value
+    dependsOn: []
+    pool:
+      name: aws-arm64-auto-scaling
+    workspace:
+      clean: all
+    steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - template: steps/run-in-docker.yml
+        parameters:
+          build: true
+          target: builder
+          baseImage: debian
+          command: "Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug"
+          retryCountForRunCommand: 1
+
+  - job: macos
+    timeoutInMinutes: 60 #default value
+    dependsOn: [ ]
+    pool:
+      vmImage: macos-11
+    steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - template: steps/install-latest-dotnet-sdk.yml
+
+      - script: ./tracer/build.sh Clean Restore CreateRequiredDirectories CompileManagedSrc BuildRunnerTool -buildConfiguration Debug
+        displayName: Build tracer home
+        retryCountOnTaskFailure: 1
+
 - stage: unit_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [build_windows_tracer, merge_commit_id]

--- a/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.OpenTracing
             // Keep supporting this older public method by creating a TracerConfiguration
             // from default sources, overwriting the specified settings, and passing that to the constructor.
             var configuration = TracerSettings.FromDefaultSources();
-            GlobalSettings.SetDebugEnabled(isDebugEnabled);
+            GlobalSettings.SetDebugEnabledInternal(isDebugEnabled);
 
             if (agentEndpoint != null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckAgentCommand.cs
@@ -8,6 +8,7 @@ using System;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Tools.Runner.Checks;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -23,13 +24,13 @@ namespace Datadog.Trace.Tools.Runner
             if (settings.Url == null)
             {
                 // Try to autodetect the agent settings
-                configuration = new ExporterSettings(new EnvironmentConfigurationSource());
+                configuration = new ExporterSettings(new EnvironmentConfigurationSource(), NullConfigurationTelemetry.Instance);
 
                 AnsiConsole.WriteLine("No Agent URL provided, using environment variables");
             }
             else
             {
-                configuration = new ExporterSettings { AgentUri = new Uri(settings.Url) };
+                configuration = new ExporterSettings(source: null, NullConfigurationTelemetry.Instance) { AgentUri = new Uri(settings.Url) };
             }
 
             var result = await AgentConnectivityCheck.RunAsync(new ImmutableExporterSettings(configuration)).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Spectre.Console;
 
 using static Datadog.Trace.Tools.Runner.Checks.Resources;
@@ -21,7 +22,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         public static Task<bool> RunAsync(ProcessInfo process)
         {
-            var settings = new ExporterSettings(process.Configuration);
+            var settings = new ExporterSettings(process.Configuration, NullConfigurationTelemetry.Instance);
 
             var url = settings.AgentUri.ToString();
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessInfo.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessInfo.cs
@@ -13,6 +13,7 @@ using System.Management;
 using System.Runtime.InteropServices;
 using System.Xml.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 
 namespace Datadog.Trace.Tools.Runner.Checks
 {
@@ -107,11 +108,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         internal string? GetProcessLogDirectory()
         {
-            var logDirectory = Configuration?.GetString(ConfigurationKeys.LogDirectory);
+            var config = new ConfigurationBuilder(Configuration ?? NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
+
+            var logDirectory = config.WithKeys(ConfigurationKeys.LogDirectory).AsString();
             if (logDirectory == null)
             {
 #pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
-                var nativeLogFile = Configuration?.GetString(ConfigurationKeys.ProfilerLogPath);
+                var nativeLogFile = config.WithKeys(ConfigurationKeys.ProfilerLogPath).AsString();
 #pragma warning restore 618
                 if (!string.IsNullOrEmpty(nativeLogFile))
                 {

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -882,11 +882,13 @@ internal class IntelligentTestRunnerClient
 
     public readonly struct SettingsResponse
     {
+#pragma warning disable CS0649 // Readonly field is never assigned to - this is created using JSON deserialization
         [JsonProperty("code_coverage")]
         public readonly bool? CodeCoverage;
 
         [JsonProperty("tests_skipping")]
         public readonly bool? TestsSkipping;
+#pragma warning restore CS0649
     }
 
     private class ObjectPackFilesResult

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -64,6 +64,11 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public static void SetDebugEnabled(bool enabled)
         {
+            SetDebugEnabledInternal(enabled);
+        }
+
+        internal static void SetDebugEnabledInternal(bool enabled)
+        {
             Instance.DebugEnabled = enabled;
 
             if (enabled)

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncLineDebuggerInvoker.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
 
                     if (!MethodMetadataCollection.Instance.TryCreateAsyncMethodMetadataIfNotExists(instance, methodMetadataIndex, in methodHandle, in typeHandle, kickoffInfo))
                     {
-                        Log.Warning("([Async]BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId);
+                        Log.Warning("([Async]BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId });
                         return CreateInvalidatedAsyncLineDebuggerState();
                     }
                 }
@@ -153,7 +153,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
                 ref var probeData = ref ProbeDataCollection.Instance.TryCreateProbeDataIfNotExists(probeMetadataIndex, probeId);
                 if (probeData.IsEmpty())
                 {
-                    Log.Warning("[Async]BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
+                    Log.Warning("[Async]BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId });
                     return CreateInvalidatedAsyncLineDebuggerState();
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
 
             if (!MethodMetadataCollection.Instance.TryCreateAsyncMethodMetadataIfNotExists(instance, methodMetadataIndex, in methodHandle, in typeHandle, kickoffInfo))
             {
-                Log.Warning("BeginMethod: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId);
+                Log.Warning("BeginMethod: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance.GetType().Name, methodMetadataIndex, probeId });
                 isReEntryToMoveNext.LogState = AsyncMethodDebuggerState.CreateInvalidatedDebuggerState();
                 return;
             }
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             ref var probeData = ref ProbeDataCollection.Instance.TryCreateProbeDataIfNotExists(probeMetadataIndex, probeId);
             if (probeData.IsEmpty())
             {
-                Log.Warning("BeginMethod: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
+                Log.Warning("BeginMethod: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId });
                 isReEntryToMoveNext.LogState = AsyncMethodDebuggerState.CreateInvalidatedDebuggerState();
                 return;
             }

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/LineDebuggerInvoker.cs
@@ -158,14 +158,14 @@ namespace Datadog.Trace.Debugger.Instrumentation
             {
                 if (!MethodMetadataCollection.Instance.TryCreateNonAsyncMethodMetadataIfNotExists(methodMetadataIndex, in methodHandle, in typeHandle))
                 {
-                    Log.Warning("BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId);
+                    Log.Warning("BeginLine: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadataId = {MethodMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId });
                     return CreateInvalidatedLineDebuggerState();
                 }
 
                 ref var probeData = ref ProbeDataCollection.Instance.TryCreateProbeDataIfNotExists(probeMetadataIndex, probeId);
                 if (probeData.IsEmpty())
                 {
-                    Log.Warning("BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
+                    Log.Warning("BeginLine: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId });
                     return CreateInvalidatedLineDebuggerState();
                 }
 

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/MethodDebuggerInvoker.cs
@@ -39,14 +39,14 @@ namespace Datadog.Trace.Debugger.Instrumentation
         {
             if (!MethodMetadataCollection.Instance.TryCreateNonAsyncMethodMetadataIfNotExists(methodMetadataIndex, in methodHandle, in typeHandle))
             {
-                Log.Warning("BeginMethod_StartMarker: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadaId = {MethodMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId);
+                Log.Warning("BeginMethod_StartMarker: Failed to receive the InstrumentedMethodInfo associated with the executing method. type = {Type}, instance type name = {Name}, methodMetadaId = {MethodMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, methodMetadataIndex, probeId });
                 return CreateInvalidatedDebuggerState();
             }
 
             ref var probeData = ref ProbeDataCollection.Instance.TryCreateProbeDataIfNotExists(probeMetadataIndex, probeId);
             if (probeData.IsEmpty())
             {
-                Log.Warning("BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId);
+                Log.Warning("BeginMethod_StartMarker: Failed to receive the ProbeData associated with the executing probe. type = {Type}, instance type name = {Name}, probeMetadataIndex = {ProbeMetadataIndex}, probeId = {ProbeId}", new object[] { typeof(TTarget), instance?.GetType().Name, probeMetadataIndex, probeId });
                 return CreateInvalidatedDebuggerState();
             }
 

--- a/tracer/src/Datadog.Trace/IAST/IastModule.cs
+++ b/tracer/src/Datadog.Trace/IAST/IastModule.cs
@@ -188,7 +188,7 @@ internal static class IastModule
         {
             if (isRequest)
             {
-                traceContext?.IastRequestContext.AddVulnerability(vulnerability);
+                traceContext?.IastRequestContext?.AddVulnerability(vulnerability);
                 return null;
             }
             else

--- a/tracer/src/Datadog.Trace/Processors/TruncatorTagsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/TruncatorTagsProcessor.cs
@@ -26,13 +26,13 @@ namespace Datadog.Trace.Processors
             if (TraceUtil.TruncateUTF8(ref key, MaxMetaKeyLen))
             {
                 key += "...";
-                Log.Debug("span.truncate: truncating `Meta` key (max {MaxMetaKeyLen} chars): {Key}", MaxMetaKeyLen, key);
+                Log.Debug<int, string>("span.truncate: truncating `Meta` key (max {MaxMetaKeyLen} chars): {Key}", MaxMetaKeyLen, key);
             }
 
             if (TraceUtil.TruncateUTF8(ref value, MaxMetaValLen))
             {
                 value += "...";
-                Log.Debug("span.truncate: truncating `Meta` value (max {MaxMetaValLen} chars): {Value}", MaxMetaValLen, value);
+                Log.Debug<int, string>("span.truncate: truncating `Meta` value (max {MaxMetaValLen} chars): {Value}", MaxMetaValLen, value);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Processors
             if (TraceUtil.TruncateUTF8(ref key, MaxMetricsKeyLen))
             {
                 key += "...";
-                Log.Debug("span.truncate: truncating `Metrics` key (max {MaxMetricsKeyLen} chars): {Key}", MaxMetricsKeyLen, key);
+                Log.Debug<int, string>("span.truncate: truncating `Metrics` key (max {MaxMetricsKeyLen} chars): {Key}", MaxMetricsKeyLen, key);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Processors/TruncatorTraceProcessor.cs
+++ b/tracer/src/Datadog.Trace/Processors/TruncatorTraceProcessor.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Processors
         {
             if (TraceUtil.TruncateUTF8(ref r, MaxResourceLen))
             {
-                Log.Debug("span.truncate: truncated `Resource` (max {MaxResourceLen} chars): {Resource}", MaxResourceLen, r);
+                Log.Debug<int, string>("span.truncate: truncated `Resource` (max {MaxResourceLen} chars): {Resource}", MaxResourceLen, r);
             }
 
             return r;


### PR DESCRIPTION
## Summary of changes

- Add a standalone build stage to build the tracer + runner in debug mode
- Fix use of APIs marked with `[PublicApi]`
- Fix incorrect use of log overloads
- Ignore red-herring warning

## Reason for change

#4033 marked some methods with `[PublicApi]`, which is a debug-conditional attribute. There were some usages of `[PublicApi]` methods that were missed in #4033 because we don't build in `Debug` mode in CI. This caused local builds to fail.

While I was cleaning up, fixed some warnings from Rider (highlighting real issues)

## Implementation details

We could have made the `[PublicApi]` attribute non-conditional, but rather than include that as extra metadata/update snapshots, consensus was to add a build that sets `-buildConfiguration Debug`.

Individual fixes
- Created "internal" `SetDebugEnabled` method, which is used by the OpenTracing library
- Use null telemetry logger in `dd-trace` (I'm actually not sure how we should handle this in dd-trace, but I think ignoring it is fine for now)
- Fixed potential null reference in IAST
- Fixed use of incorrect logging overloads, which were accidentally using `CallerLineNumber` arguments
- Fixed complaining about "read only field is never set" in CI app for type that is deserialized from JSON (so fields are set using reflection)

## Test coverage

Ran the debug build in CI prior to these changes and confirmed it failed. Ran again and confirmed it passes.

## Other details
N/A
