### PR TITLE
Properly handle a wrong setup where `DD_DOTNET_TRACER_HOME` isn't set

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             if (!Directory.Exists(fullPath))
             {
-                StartupLogger.Log($"The managed profiler directory cannot be found at {fullPath}. It seems that the tracer hasn't been properly setup. DD_DOTNET_TRACER_HOME value was: {tracerHomeDirectory} ");
+                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}'");
                 return null;
             }
 
@@ -109,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             return null;
         }
 
-        private static bool IsDatadogAssembly(string path, out Assembly? cachedAssembly)
+        private static bool IsDatadogAssembly(string path, [NotNullWhen(true)] out Assembly? cachedAssembly)
         {
             for (var i = 0; i < _assemblies!.Length; i++)
             {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -9,8 +9,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 
-#nullable enable
-
 namespace Datadog.Trace.ClrProfiler.Managed.Loader
 {
     /// <summary>
@@ -18,11 +16,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private static CachedAssembly[]? _assemblies;
+        private static CachedAssembly[] _assemblies;
 
         internal static System.Runtime.Loader.AssemblyLoadContext DependencyLoadContext { get; } = new ManagedProfilerAssemblyLoadContext();
 
-        private static string? ResolveManagedProfilerDirectory()
+        private static string ResolveManagedProfilerDirectory()
         {
             string tracerFrameworkDirectory = "netstandard2.0";
 
@@ -50,18 +48,18 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 assemblies.Add(new CachedAssembly(file, null));
             }
 
-            _assemblies = assemblies.ToArray()!;
-            StartupLogger.Debug("Total number of assemblies: {0}", _assemblies!.Length);
+            _assemblies = assemblies.ToArray();
+            StartupLogger.Debug("Total number of assemblies: {0}", _assemblies.Length);
 
             return fullPath;
         }
 
-        private static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
+        private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
             return ResolveAssembly(args.Name);
         }
 
-        private static Assembly? ResolveAssembly(string name)
+        private static Assembly ResolveAssembly(string name)
         {
             var assemblyName = new AssemblyName(name);
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
@@ -109,11 +107,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             return null;
         }
 
-        private static bool IsDatadogAssembly(string path, [NotNullWhen(true)] out Assembly? cachedAssembly)
+        private static bool IsDatadogAssembly(string path, out Assembly cachedAssembly)
         {
-            for (var i = 0; i < _assemblies!.Length; i++)
+            for (var i = 0; i < _assemblies.Length; i++)
             {
-                var assembly = _assemblies![i];
+                var assembly = _assemblies[i];
                 if (assembly.Path == path)
                 {
                     cachedAssembly = assembly.Assembly;
@@ -127,11 +125,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
         private static void SetDatadogAssembly(string path, Assembly cachedAssembly)
         {
-            for (var i = 0; i < _assemblies!.Length; i++)
+            for (var i = 0; i < _assemblies.Length; i++)
             {
-                if (_assemblies![i].Path == path)
+                if (_assemblies[i].Path == path)
                 {
-                    _assemblies![i] = new CachedAssembly(path, cachedAssembly);
+                    _assemblies[i] = new CachedAssembly(path, cachedAssembly);
                     break;
                 }
             }
@@ -140,9 +138,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         private readonly struct CachedAssembly
         {
             public readonly string Path;
-            public readonly Assembly? Assembly;
+            public readonly Assembly Assembly;
 
-            public CachedAssembly(string path, Assembly? assembly)
+            public CachedAssembly(string path, Assembly assembly)
             {
                 Path = path;
                 Assembly = assembly;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             var fullPath = Path.Combine(tracerHomeDirectory, "net461");
             if (!Directory.Exists(fullPath))
             {
-                StartupLogger.Log($"The managed profiler directory cannot be found at {fullPath}. It seems that the tracer hasn't been properly setup. DD_DOTNET_TRACER_HOME value was: {tracerHomeDirectory}. ");
+                StartupLogger.Log($"The tracer home directory cannot be found at '{fullPath}', based on the DD_DOTNET_TRACER_HOME value '{tracerHomeDirectory}'");
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -9,8 +9,6 @@ using System;
 using System.IO;
 using System.Reflection;
 
-#nullable enable
-
 namespace Datadog.Trace.ClrProfiler.Managed.Loader
 {
     /// <summary>
@@ -18,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private static string? ResolveManagedProfilerDirectory()
+        private static string ResolveManagedProfilerDirectory()
         {
             var tracerHomeDirectory = ReadEnvironmentVariable("DD_DOTNET_TRACER_HOME") ?? string.Empty;
             var fullPath = Path.Combine(tracerHomeDirectory, "net461");
@@ -31,12 +29,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             return fullPath;
         }
 
-        private static Assembly? AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
+        private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
             return ResolveAssembly(args.Name);
         }
 
-        private static Assembly? ResolveAssembly(string name)
+        private static Assembly ResolveAssembly(string name)
         {
             var assemblyName = new AssemblyName(name);
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -28,14 +28,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         /// </summary>
         static Startup()
         {
-            var managedProfilerDirectory = ResolveManagedProfilerDirectory();
-            if (managedProfilerDirectory is null)
+            ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
+            if (ManagedProfilerDirectory is null)
             {
-                StartupLogger.Log("Managed profiler directory doesn't exist. Bailing out.", ManagedProfilerDirectory);
+                StartupLogger.Log("Managed profiler directory doesn't exist. Automatic instrumentation will be disabled");
                 return;
             }
-
-            ManagedProfilerDirectory = managedProfilerDirectory;
             StartupLogger.Debug("Resolving managed profiler directory to: {0}", ManagedProfilerDirectory);
 
             try

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -28,7 +28,14 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         /// </summary>
         static Startup()
         {
-            ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
+            var managedProfilerDirectory = ResolveManagedProfilerDirectory();
+            if (managedProfilerDirectory is null)
+            {
+                StartupLogger.Log("Managed profiler directory doesn't exist. Bailing out.", ManagedProfilerDirectory);
+                return;
+            }
+
+            ManagedProfilerDirectory = managedProfilerDirectory;
             StartupLogger.Debug("Resolving managed profiler directory to: {0}", ManagedProfilerDirectory);
 
             try
@@ -67,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
         }
 
-        internal static string ManagedProfilerDirectory { get; }
+        internal static string? ManagedProfilerDirectory { get; }
 
         private static void TryInvokeManagedMethod(string typeName, string methodName, string? loaderHelperTypeName = null)
         {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 StartupLogger.Log("Managed profiler directory doesn't exist. Automatic instrumentation will be disabled");
                 return;
             }
+
             StartupLogger.Debug("Resolving managed profiler directory to: {0}", ManagedProfilerDirectory);
 
             try


### PR DESCRIPTION
## Summary of changes
Bail out of the tracer managed initialization when the managed directory cannot be found

## Reason for change
When not setup properly, we can crash an application in .NET Core at startup if the `DD_DOTNET_TRACER_HOME` variable isn't set. With this change, I handle that possibility and bailout instead.
It shouldn't happen in a correct setup but still it's good to bail out properly.

## Implementation details
Just check if the managed directory actually exists before going further.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
