### PR TITLE
Fix ducktype over non public struct fields

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.DuckTyping
             Type returnType = targetField.FieldType;
 
             // Load the field value to the stack
-            if (UseDirectAccessTo(proxyTypeBuilder, targetType) && targetField.IsPublic)
+            if (UseDirectAccessTo(proxyTypeBuilder, targetType))
             {
                 // Load the instance
                 if (!targetField.IsStatic)
@@ -179,7 +179,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
             // We set the field value
-            if (UseDirectAccessTo(proxyTypeBuilder, targetType) && targetField.IsPublic)
+            if (UseDirectAccessTo(proxyTypeBuilder, targetType))
             {
                 // If the instance and the field are public then is easy to set.
                 il.WriteTypeConversion(currentValueType, targetField.FieldType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -137,8 +137,10 @@ namespace Datadog.Trace.DuckTyping.Tests
         [Fact]
         public void NonPublicStructCopyFieldTest()
         {
-            InternalFieldStruct instance = default;
-            CopyFieldStruct copy = instance.DuckCast<CopyFieldStruct>(); // crashes test process
+            InternalFieldStruct instance = new InternalFieldStruct("InstanceValue");
+            CopyFieldStruct copy = instance.DuckCast<CopyFieldStruct>();
+            Assert.Equal(instance.Value, copy.Value);
+            Assert.Equal(InternalFieldStruct.StaticValue, copy.StaticValue);
         }
 
         [DuckCopy]
@@ -146,6 +148,9 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             [DuckField]
             public string Value;
+
+            [DuckField]
+            public string StaticValue;
         }
 
         public readonly struct InternalFieldStruct
@@ -155,6 +160,7 @@ namespace Datadog.Trace.DuckTyping.Tests
                 Value = value;
             }
 
+            internal static readonly string StaticValue = "MyValue";
             internal readonly string Value;
         }
     }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -133,5 +133,29 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             public string Name;
         }
+
+        [Fact]
+        public void NonPublicStructCopyFieldTest()
+        {
+            InternalFieldStruct instance = default;
+            CopyFieldStruct copy = instance.DuckCast<CopyFieldStruct>(); // crashes test process
+        }
+
+        [DuckCopy]
+        public struct CopyFieldStruct
+        {
+            [DuckField]
+            public string Value;
+        }
+
+        public readonly struct InternalFieldStruct
+        {
+            public InternalFieldStruct(string value)
+            {
+                Value = value;
+            }
+
+            internal readonly string Value;
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes ducktype when the target instance is a struct with non public fields.

## Reason for change

Without the fix, the app crashes due to bad IL.
