### PR TITLE
[CIVisibility] Change the code coverage EVP subdomain to `citestcov-intake`

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Ci.Agent.Payloads
             Reset();
         }
 
-        public override string EventPlatformSubdomain => "event-platform-intake";
+        public override string EventPlatformSubdomain => "citestcov-intake";
 
         public override string EventPlatformPath => "api/v2/citestcov";
 


### PR DESCRIPTION
## Summary of changes

This PR changes the code coverage evp intake subdomain from `event-platform-intake` to `citestcov-intake` to fulfill the petition from the event platform.
