### PR TITLE
Fix potential recursion in managed loader by moving log message

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -56,7 +56,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         private static Assembly ResolveAssembly(string name)
         {
             var assemblyName = new AssemblyName(name);
-            StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
 
             // On .NET Framework, having a non-US locale can cause mscorlib
             // to enter the AssemblyResolve event when searching for resources
@@ -70,6 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 return null;
             }
 
+            StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
             var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("Looking for: {0}", path);
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -69,6 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 return null;
             }
 
+            // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
             var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("Looking for: {0}", path);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -41,6 +41,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 return null;
             }
 
+            // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
             StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
             var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("Looking for: {0}", path);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -30,7 +30,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         private static Assembly ResolveAssembly(string name)
         {
             var assemblyName = new AssemblyName(name);
-            StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
 
             // On .NET Framework, having a non-US locale can cause mscorlib
             // to enter the AssemblyResolve event when searching for resources
@@ -42,6 +41,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 return null;
             }
 
+            StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
             var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
             StartupLogger.Debug("Looking for: {0}", path);
 


### PR DESCRIPTION
## Summary of changes

Moves the location of startup log message to avoid potential recursion on .NET Framework in loader when using non-us locale.

## Reason for change

When `DD_TRACE_DEBUG=1` and we have a non-US locale, there's the possibility of recursion in the assembly loader. This was introduced over 1 year ago in https://github.com/DataDog/dd-trace-dotnet/pull/2673, and circumvented that was previously added to avoid this issue 😅

## Implementation details

Moves the log message to _after_ we check for satellite assembly probing

## Test coverage

This was causing the scheduled `DD_TRACE_DEBUG=1` test run to fail, so this should fix it.

## Other details
The `StartupLogger` looks pretty inefficient (creating a new `FileSink` with every log call for example), so we should potentially look into optimizations here
