### PR TITLE
Include signed dlls in windows-tracer-home artifact

### DIFF
--- a/tracer/build/_build/Build.Gitlab.cs
+++ b/tracer/build/_build/Build.Gitlab.cs
@@ -45,8 +45,12 @@ partial class Build
        .After(PackageTracerHome)
        .Executes(async () =>
         {
-            var files = ArtifactsDirectory.GlobFiles("**/*.msi")
-                                         .Concat(ArtifactsDirectory.GlobFiles("**/*.nupkg"));
+            // We don't currently sign the NuGet packages because that would mean
+            // _all_ NuGet packages uploaded under the datadog owner would need to be signed.
+            // While that would be the best option, it requires everyone to switch across at the same time
+
+            var files = ArtifactsDirectory.GlobFiles("**/*.msi");
+                                         // .Concat(ArtifactsDirectory.GlobFiles("**/*.nupkg"));
             await SignFiles(files);
         });
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -701,7 +701,7 @@ partial class Build
 
     Target ZipMonitoringHomeWindows => _ => _
         .Unlisted()
-        .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
+        .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader, SignDlls)
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {


### PR DESCRIPTION
## Summary of changes

Make sure we call `SignDlls` _before_ `ZipMonitoringHomeWindows`

## Reason for change

The artifact we upload currently contains unsigned dlls

## Implementation details

Fix Nuke order

## Test coverage

Will manually verify that it works as expected

## Other details
I removed the code signing from nupkg packages because, as previously discussed, uploading signed packages to NuGet has implications (you can no longer upload _unsigned_ packages after that). Removed the signing for now to avoid any risks of accidental upload.

Note that we currently sign the dlls _inside_ the Nuget packages, but as we only build a subset of the packages in gitlab (we don't build the bundle or dd-trace packages) there's probably little value in switching to uploading the packages we do build for now.