### PR TITLE
Upgrade Mono.Cecil to 0.11.5

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/Datadog.Trace.Coverage.collector.csproj
+++ b/tracer/src/Datadog.Trace.Coverage.collector/Datadog.Trace.Coverage.collector.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.4.0" />
-      <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+      <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -119,7 +119,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <PackageReference Include="Spectre.Console" Version="0.43.0" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="Microsoft.Web.Administration" Version="11.1.0" />


### PR DESCRIPTION
## Summary of changes

Upgrade Mono.Cecil to 0.11.5

## Reason for change

The new version contains a fix for https://github.com/dotnet/runtime/issues/79477#issuecomment-1354917614
