### PR TITLE
Disable parallelization for LargePayloadTests integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/DefaultTransportLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/DefaultTransportLargePayloadTests.cs
@@ -8,6 +8,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [Collection("LargePayloadTests")]
     public class DefaultTransportLargePayloadTests : LargePayloadTestBase
     {
         public DefaultTransportLargePayloadTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
@@ -13,6 +13,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [CollectionDefinition("LargePayloadTests", DisableParallelization = true)]
     public class LargePayloadTestBase : TestHelper
     {
         public LargePayloadTestBase(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/UnixDomainSocketLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/UnixDomainSocketLargePayloadTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [Collection("LargePayloadTests")]
     public class UnixDomainSocketLargePayloadTests : LargePayloadTestBase
     {
         public UnixDomainSocketLargePayloadTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/WindowsNamedPipeLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/WindowsNamedPipeLargePayloadTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [Collection("LargePayloadTests")]
     public class WindowsNamedPipeLargePayloadTests : LargePayloadTestBase
     {
         public WindowsNamedPipeLargePayloadTests(ITestOutputHelper output)


### PR DESCRIPTION
## Reason for change
Attempt to fix flakiness of LargePayloadTests, which only fail when they reach the 60 second timeout. We'll disable parallelization to make sure the LargePayloadTests do not occur simultaneously
