### PR TITLE
Refactor cache classes to avoid emitting new methods

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CachedMessageHeadersHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         private const string StringDataType = "String";
 
         private static readonly Func<string, object> _createMessageAttributeValue;
-        private static readonly Func<IDictionary> _createDict;
+        private static readonly Type _dictionaryType;
 
         static CachedMessageHeadersHelper()
         {
@@ -48,27 +48,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             _createMessageAttributeValue = (Func<string, object>)createMessageAttributeValueMethod.CreateDelegate(typeof(Func<string, object>));
 
             // Initialize delegate for creating a Dictionary<string, MessageAttributeValue> object
-            var genericDictType = typeof(Dictionary<,>);
-            var constructedDictType = genericDictType.MakeGenericType(new Type[] { typeof(string), messageAttributeValueType });
-            ConstructorInfo dictionaryCtor = constructedDictType.GetConstructor(System.Type.EmptyTypes);
-
-            DynamicMethod createDictMethod = new DynamicMethod(
-                $"KafkaCachedMessageHeadersHelpers",
-                constructedDictType,
-                null,
-                typeof(DuckType).Module,
-                true);
-
-            ILGenerator dictIL = createDictMethod.GetILGenerator();
-            dictIL.Emit(OpCodes.Newobj, dictionaryCtor);
-            dictIL.Emit(OpCodes.Ret);
-
-            _createDict = (Func<IDictionary>)createDictMethod.CreateDelegate(typeof(Func<IDictionary>));
+            _dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), messageAttributeValueType);
         }
 
         public static IDictionary CreateMessageAttributes()
         {
-            return _createDict();
+            return (IDictionary)Activator.CreateInstance(_dictionaryType);
         }
 
         public static object CreateMessageAttributeValue(string value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CachedMessageHeadersHelper.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
 {
@@ -17,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         private const string StringDataType = "String";
 
         private static readonly Func<string, object> _createMessageAttributeValue;
-        private static readonly Type _dictionaryType;
+        private static readonly ActivatorHelper DictionaryActivator;
 
         static CachedMessageHeadersHelper()
         {
@@ -48,12 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             _createMessageAttributeValue = (Func<string, object>)createMessageAttributeValueMethod.CreateDelegate(typeof(Func<string, object>));
 
             // Initialize delegate for creating a Dictionary<string, MessageAttributeValue> object
-            _dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), messageAttributeValueType);
+            DictionaryActivator = new ActivatorHelper(typeof(Dictionary<,>).MakeGenericType(typeof(string), messageAttributeValueType));
         }
 
         public static IDictionary CreateMessageAttributes()
         {
-            return (IDictionary)Activator.CreateInstance(_dictionaryType);
+            return (IDictionary)DictionaryActivator.CreateInstance();
         }
 
         public static object CreateMessageAttributeValue(string value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 
         static NullableStringHelper()
         {
-            NullableActivator = new ActivatorHelper(typeof(TMarkerType).Assembly.GetType("NullableString"));
+            NullableActivator = new ActivatorHelper(typeof(TMarkerType).Assembly.GetType("NullableString")!);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
@@ -6,34 +6,17 @@
 #if !NETFRAMEWORK
 #nullable enable
 using System;
-using System.Reflection;
-using System.Reflection.Emit;
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 {
     internal static class NullableStringHelper<TMarkerType>
     {
-        private static readonly Func<object> Activator;
+        private static readonly Type NullableStringType;
 
         static NullableStringHelper()
         {
-            var nullableStringType = typeof(TMarkerType).Assembly.GetType("NullableString")!;
-
-            ConstructorInfo ctor = nullableStringType.GetConstructor(System.Type.EmptyTypes)!;
-
-            DynamicMethod createHeadersMethod = new DynamicMethod(
-                $"NullableStringHelper",
-                nullableStringType,
-                null,
-                typeof(DuckType).Module,
-                true);
-
-            ILGenerator il = createHeadersMethod.GetILGenerator();
-            il.Emit(OpCodes.Newobj, ctor);
-            il.Emit(OpCodes.Ret);
-
-            Activator = (Func<object>)createHeadersMethod.CreateDelegate(typeof(Func<object>));
+            NullableStringType = typeof(TMarkerType).Assembly.GetType("NullableString")!;
         }
 
         /// <summary>
@@ -41,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         /// </summary>
         public static object CreateNullableString(string value)
         {
-            var nullableString = Activator();
+            var nullableString = Activator.CreateInstance(NullableStringType)!;
             nullableString.DuckCast<INullableString>().Value = value;
             return nullableString;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/NullableStringHelper.cs
@@ -7,16 +7,17 @@
 #nullable enable
 using System;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 {
     internal static class NullableStringHelper<TMarkerType>
     {
-        private static readonly Type NullableStringType;
+        private static readonly ActivatorHelper NullableActivator;
 
         static NullableStringHelper()
         {
-            NullableStringType = typeof(TMarkerType).Assembly.GetType("NullableString")!;
+            NullableActivator = new ActivatorHelper(typeof(TMarkerType).Assembly.GetType("NullableString"));
         }
 
         /// <summary>
@@ -24,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         /// </summary>
         public static object CreateNullableString(string value)
         {
-            var nullableString = Activator.CreateInstance(NullableStringType)!;
+            var nullableString = NullableActivator.CreateInstance();
             nullableString.DuckCast<INullableString>().Value = value;
             return nullableString;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/CachedMetadataHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/CachedMetadataHelper.cs
@@ -4,21 +4,22 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
 {
     internal static class CachedMetadataHelper<TMarkerType>
     {
-        private static readonly Type MetadataType;
+        private static readonly ActivatorHelper MetadataActivator;
 
         static CachedMetadataHelper()
         {
-            MetadataType = typeof(TMarkerType).Assembly.GetType("Grpc.Core.Metadata");
+            MetadataActivator = new ActivatorHelper(typeof(TMarkerType).Assembly.GetType("Grpc.Core.Metadata"));
         }
 
         /// <summary>
         /// Creates a Grpc.Core.Metadata object
         /// </summary>
-        public static object CreateMetadata() => Activator.CreateInstance(MetadataType);
+        public static object CreateMetadata() => MetadataActivator.CreateInstance();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/CachedMetadataHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/CachedMetadataHelper.cs
@@ -4,44 +4,21 @@
 // </copyright>
 
 using System;
-using System.Reflection;
-using System.Reflection.Emit;
-using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
 {
     internal static class CachedMetadataHelper<TMarkerType>
     {
-        private static Func<object> _activator;
+        private static readonly Type MetadataType;
 
         static CachedMetadataHelper()
         {
-            CreateActivator(typeof(TMarkerType));
-        }
-
-        private static void CreateActivator(Type markerType)
-        {
-            var metadataType = markerType.Assembly.GetType("Grpc.Core.Metadata");
-
-            ConstructorInfo ctor = metadataType.GetConstructor(System.Type.EmptyTypes);
-
-            DynamicMethod createHeadersMethod = new DynamicMethod(
-                $"GrpcCoreCachedMetadataHelper",
-                metadataType,
-                null,
-                typeof(DuckType).Module,
-                true);
-
-            ILGenerator il = createHeadersMethod.GetILGenerator();
-            il.Emit(OpCodes.Newobj, ctor);
-            il.Emit(OpCodes.Ret);
-
-            _activator = (Func<object>)createHeadersMethod.CreateDelegate(typeof(Func<object>));
+            MetadataType = typeof(TMarkerType).Assembly.GetType("Grpc.Core.Metadata");
         }
 
         /// <summary>
         /// Creates a Grpc.Core.Metadata object
         /// </summary>
-        public static object CreateMetadata() => _activator();
+        public static object CreateMetadata() => Activator.CreateInstance(MetadataType);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/CachedMessageHeadersHelper.cs
@@ -5,16 +5,17 @@
 
 using System;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
     internal static class CachedMessageHeadersHelper<TMarkerType>
     {
-        private static readonly Type _headersType;
+        private static readonly ActivatorHelper HeadersActivator;
 
         static CachedMessageHeadersHelper()
         {
-            _headersType = typeof(TMarkerType).Assembly.GetType("Confluent.Kafka.Headers");
+            HeadersActivator = new ActivatorHelper(typeof(TMarkerType).Assembly.GetType("Confluent.Kafka.Headers"));
         }
 
         /// <summary>
@@ -23,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <returns>A proxy for the new Headers object</returns>
         public static IHeaders CreateHeaders()
         {
-            var headers = Activator.CreateInstance(_headersType);
+            var headers = HeadersActivator.CreateInstance();
             return headers.DuckCast<IHeaders>();
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -383,7 +383,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
         // internal for testing
         internal static Func<object> CreateLoggingRuleActivator(Assembly nlogAssembly)
         {
-            var activator = new ActivatorHelper(nlogAssembly.GetType("NLog.Config.LoggingRule"));
+            var activator = new ActivatorHelper(nlogAssembly.GetType("NLog.Config.LoggingRule")!);
             return () => activator.CreateInstance()!;
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -383,8 +383,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
         // internal for testing
         internal static Func<object> CreateLoggingRuleActivator(Assembly nlogAssembly)
         {
-            var loggingRuleType = nlogAssembly.GetType("NLog.Config.LoggingRule")!;
-            return () => Activator.CreateInstance(loggingRuleType)!;
+            var activator = new ActivatorHelper(nlogAssembly.GetType("NLog.Config.LoggingRule"));
+            return () => activator.CreateInstance()!;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Emit;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43;
 using Datadog.Trace.DuckTyping;
@@ -384,21 +383,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
         // internal for testing
         internal static Func<object> CreateLoggingRuleActivator(Assembly nlogAssembly)
         {
-            var loggingRuleType = nlogAssembly.GetType("NLog.Config.LoggingRule");
-            var ctor = loggingRuleType!.GetConstructor(Type.EmptyTypes)!; // Nullable YOLO
-
-            DynamicMethod createLoggingRuleMethod = new DynamicMethod(
-                $"NLogCommon_CreateLoggingRuleActivator",
-                loggingRuleType,
-                null,
-                typeof(DuckType).Module,
-                true);
-
-            ILGenerator il = createLoggingRuleMethod.GetILGenerator();
-            il.Emit(OpCodes.Newobj, ctor);
-            il.Emit(OpCodes.Ret);
-
-            return (Func<object>)createLoggingRuleMethod.CreateDelegate(typeof(Func<object>));
+            var loggingRuleType = nlogAssembly.GetType("NLog.Config.LoggingRule")!;
+            return () => Activator.CreateInstance(loggingRuleType)!;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Util/ActivatorHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ActivatorHelper.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="ActivatorHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Util;
+
+internal class ActivatorHelper
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<ActivatorHelper>();
+
+    private readonly Type _type;
+    private Func<object> _activator;
+
+    public ActivatorHelper(Type type)
+    {
+        _type = type;
+        _activator = DefaultActivator;
+        Task.Run(CreateCustomActivator);
+    }
+
+    public object CreateInstance() => _activator();
+
+    private object DefaultActivator()
+    {
+        return Activator.CreateInstance(_type);
+    }
+
+    private void CreateCustomActivator()
+    {
+        try
+        {
+            var ctor = _type.GetConstructor(Type.EmptyTypes)!;
+
+            var createHeadersMethod = new DynamicMethod(
+                $"TypeActivator" + _type.Name,
+                _type,
+                new[] { typeof(object) },
+                typeof(DuckType).Module,
+                true);
+
+            var il = createHeadersMethod.GetILGenerator();
+            il.Emit(OpCodes.Newobj, ctor);
+            il.Emit(OpCodes.Ret);
+
+            _activator = (Func<object>)createHeadersMethod.CreateDelegate(typeof(Func<object>), _type);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error Creating the custom activator for: {Type}", _type.FullName);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Util/ActivatorHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ActivatorHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
@@ -29,7 +31,7 @@ internal class ActivatorHelper
 
     private object DefaultActivator()
     {
-        return Activator.CreateInstance(_type);
+        return Activator.CreateInstance(_type)!;
     }
 
     private void CreateCustomActivator()


### PR DESCRIPTION
## Summary of changes

This PR replaces the custom activator in a couple of integrations with the default `Activator.CreateInstance`. 

## Reason for change

~After chatting with @andrewlock, there isn't a good reason to have a custom activator for these classes. So this PR remove those with the standard Activator.~

There's a thing to discuss by the team before acepting this PR and is related to Andrew's blog post: https://andrewlock.net/benchmarking-4-reflection-methods-for-calling-a-constructor-in-dotnet/#the-results

And is the compromise between a faster Allocator for hotpaths but with a slow setup time, and a slower allocator but with a faster setup time.

In the long run we have these numbers for the Allocator call:
Method | Mean | Error | StdDev | Ratio | RatioSD
-- | -- | -- | -- | -- | --
Direct | 9.851 ns | 0.1219 ns | 0.1081 ns | 1.00 | 0.00
Reflection | 97.489 ns | 0.7870 ns | 0.6977 ns | 9.90 | 0.12
**ActivatorCreateInstance** | 38.092 ns | 0.3416 ns | 0.2853 ns | 3.87 | 0.06
CompiledExpression | 11.579 ns | 0.1674 ns | 0.1398 ns | 1.18 | 0.02
**ReflectionEmit** | 12.464 ns | 0.2388 ns | 0.2117 ns | 1.27 | 0.02

But for the first request we have these penalties:

Method | Mean | Error | StdDev | Median
-- | -- | -- | -- | --
Reflection | 310.29 ns | 10.195 ns | 218.95 ns | 288.30 ns
**ActivatorCreateInstance** | 146.38 ns | 9.178 ns | 197.10 ns | 119.70 ns
CompiledExpression | 90,413.14 ns | 437.343 ns | 9,221.75 ns | 88,071.55 ns
**ReflectionEmit** | 86,897.24 ns | 820.281 ns | 16,968.07 ns | 79,778.60 ns
