### PR TITLE
OSX Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,12 +353,15 @@ shared/src/Datadog.Trace.ClrProfiler.Native/CMakeCache.txt
 shared/src/Datadog.Trace.ClrProfiler.Native/cmake_install.cmake
 shared/src/Datadog.Trace.ClrProfiler.Native/cmake-build-debug/
 !shared/src/Datadog.Trace.ClrProfiler.Native/lib/**
+cmake-build-debug/*
 
 #profiler build files
 profiler/_build/
 
 # global build folder
 obj/*
+obj_arm64/*
+obj_x86_64/*
 
 # cmake build files
 .ionide/

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -412,13 +412,11 @@ partial class Build : NukeBuild
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                 );
 
-                var framework = TargetFramework.NETCOREAPP3_1;
-                var runtimes = "net472 netcoreapp3.1";
-                if (IsOsx)
-                {
-                    framework = TargetFramework.NET6_0;
-                    runtimes = "net6.0";
-                }
+            var (framework, runtimes) = IsOsx switch
+            {
+                true => (TargetFramework.NETCOREAPP3_1, "net6.0"),
+                false => (TargetFramework.NET6_0, "net472 netcoreapp3.1.0"),
+            };
                 
                 DotNetRun(s => s
                     .SetProjectFile(benchmarksProject)

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -412,13 +412,21 @@ partial class Build : NukeBuild
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                 );
 
+                var framework = TargetFramework.NETCOREAPP3_1;
+                var runtimes = "net472 netcoreapp3.1";
+                if (IsOsx)
+                {
+                    framework = TargetFramework.NET6_0;
+                    runtimes = "net6.0";
+                }
+                
                 DotNetRun(s => s
                     .SetProjectFile(benchmarksProject)
                     .SetConfiguration(BuildConfiguration)
-                    .SetFramework(TargetFramework.NETCOREAPP3_1)
+                    .SetFramework(framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetApplicationArguments($"-r net472 netcoreapp3.1 -m -f {Filter ?? "*"} --iterationTime 2000")
+                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --iterationTime 2000")
                     .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                     .SetProcessEnvironmentVariable("DD_ENV", "CI")
                     .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)


### PR DESCRIPTION
## Summary of changes

This PR:

1. Fixes the `RunBenchmarks` nuke command when running in OSX.
2. Reduces the incremental build times.

### Cold Build (first one)

<img width="741" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/80ad8e4c-8e81-461a-bc0f-ab4b7a3fc035">

### Incremental build (second one)

<img width="742" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/5cb4b8a2-b93e-4bbb-b823-ccd5f7599fdb">

## Reason for change

`RunBenchmarks` command doesn't work in OSX because it requires net472 toolchain that is not available for macos.

