### PR TITLE
Fix NullReferenceException in GitMetadataTagsProvider

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
@@ -73,7 +73,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
         catch (Exception e)
         {
             Log.Error(e, "Error while extracting SourceLink information");
-            gitMetadata = GitMetadata.Empty;
+            gitMetadata = _cachedGitTags = GitMetadata.Empty;
             return true;
         }
     }

--- a/tracer/src/Datadog.Trace/PDBs/DatadogPdbReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogPdbReader.cs
@@ -76,12 +76,15 @@ namespace Datadog.Trace.Pdb
             // and the PDB may not be copied to this folder until later or never, as it is only copied on demand (usually when an exception is thrown).
             // In these cases, we'll try to find it in the application directory (e.g. C:\inetpub\wwwroot\MyApp\bin\MyApp.pdb).
             string fileName = Path.GetFileName(pdbInSameFolder);
-            var pdbInAppDirectory = Directory.EnumerateFiles(System.Web.Hosting.HostingEnvironment.ApplicationPhysicalPath, fileName, SearchOption.AllDirectories).FirstOrDefault();
-
-            if (pdbInAppDirectory != null)
+            string applicationDirectory = System.Web.Hosting.HostingEnvironment.ApplicationPhysicalPath;
+            if (applicationDirectory != null)
             {
-                pdbFullPath = pdbInAppDirectory;
-                return true;
+                var pdbInAppDirectory = Directory.EnumerateFiles(applicationDirectory, fileName, SearchOption.AllDirectories).FirstOrDefault();
+                if (pdbInAppDirectory != null)
+                {
+                    pdbFullPath = pdbInAppDirectory;
+                    return true;
+                }
             }
 #endif
 


### PR DESCRIPTION
## Reason for change
In logs that were shared with us by a customer, we found 78 occurrences of the following exception: 

2023-05-12 10:28:18.115 -07:00 [ERR] Error while extracting SourceLink information System.ArgumentNullException: Value cannot be null.
Parameter name: path
   at System.IO.Directory.EnumerateFiles(String path, String searchPattern, SearchOption searchOption)
   at Datadog.Trace.Pdb.DatadogPdbReader.TryFindPdbFile(Assembly assembly, String& pdbFullPath)
   at Datadog.Trace.Pdb.DatadogPdbReader.CreatePdbReader(Assembly assembly)
   at Datadog.Trace.Pdb.SourceLinkInformationExtractor.ExtractFromPdb(Assembly assembly, String& commitSha, String& repositoryUrl)
   at Datadog.Trace.Pdb.SourceLinkInformationExtractor.TryGetSourceLinkInfo(Assembly assembly, String& commitSha, String& repositoryUrl)
   at Datadog.Trace.Configuration.GitMetadataTagsProvider.TryGetGitTagsFromSourceLink(GitMetadata& result)
   at Datadog.Trace.Configuration.GitMetadataTagsProvider.TryExtractGitMetadata(GitMetadata& gitMetadata)

## Summary of changes
* Added a null check to avoid the above NullReferenceException
* Change the logic in `GitMetadataTagsProvider` so that we stop trying return an empty result in case of an unexpected error.

## Test coverage

Since this change is quite trivial, I did not add dedicated tests, but I did test it manually by changing the code to introduce an exception, and verifying that indeed the exception only gets logged once.