### PR TITLE
[Profiler] Log information about secure-execution mode

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -390,8 +390,11 @@ bool OpSysTools::IsSafeToStartProfiler(double coresThreshold)
         // Check if process is running is a secure-execution mode
         auto at_secure = getauxval(AT_SECURE);
         Log::Info("Is process running in a secure execution mode ? ", std::boolalpha, at_secure);
-        Log::Info("Process User ID: ", getuid(), ", process effective User ID: ", geteuid());
-        Log::Info("Process Group ID: ", getgid(), ", process effective Group ID: ", getegid());
+        // Reasons for which AT_SECURE is true:
+        //   User ID != Effective User ID
+        Log::Info("Process User ID differs from Effective User ID ? ", std::boolalpha, getuid() != geteuid());
+        //   Group ID != Effective Group ID
+        Log::Info("Process Group ID differs from Effective Group ID ? ", std::boolalpha, getgid() != getegid());
         // TODO check capabilities (for now checking capabilities requires additional packages/libraries)
         // if at_secure is true, we know that it due to the capabilities
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.cpp
@@ -22,6 +22,7 @@
 #define _GNU_SOURCE
 #include <errno.h>
 #include "cgroup.h"
+#include <sys/auxv.h>
 #endif
 
 #include <chrono>
@@ -385,6 +386,14 @@ bool OpSysTools::IsSafeToStartProfiler(double coresThreshold)
                 Log::Info("Unable to get information about shared library containing '", customFnName, "'");
             }
         }
+
+        // Check if process is running is a secure-execution mode
+        auto at_secure = getauxval(AT_SECURE);
+        Log::Info("Is process running in a secure execution mode ? ", std::boolalpha, at_secure);
+        Log::Info("Process User ID: ", getuid(), ", process effective User ID: ", geteuid());
+        Log::Info("Process Group ID: ", getgid(), ", process effective Group ID: ", getegid());
+        // TODO check capabilities (for now checking capabilities requires additional packages/libraries)
+        // if at_secure is true, we know that it due to the capabilities
 
         return false;
     }


### PR DESCRIPTION
## Summary of changes

Log information if the process is running in a secure-execution mode.

## Reason for change

`LD_PRELOAD` is discarded when the process is  `secure-execution mode`. 

## Implementation details

Get `AT_SECURE` value and print uid/eid and gid and egid.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
