### PR TITLE
Allow enabling v2 telemetry

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -77,6 +77,7 @@ steps:
         --env DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID \
         --env DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH \
         --env DD_LOGGER_DD_TAGS \
+        --env DD_INTERNAL_TELEMETRY_V2_ENABLED \
         ${{ parameters.extraArgs }} \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -115,7 +115,8 @@ variables:
   isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   # Run code coverage on main branches only, on scheduled build only
-  runCodeCoverage: $[or(eq(variables['run_code_coverage'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))))] 
+  runCodeCoverage: $[or(eq(variables['run_code_coverage'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))))]
+  DD_INTERNAL_TELEMETRY_V2_ENABLED: $[eq(variables['enable_telemetry_v2'], 'true')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -365,6 +365,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
 
   ProfilerIntegrationTests:
     build:
@@ -411,6 +412,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
     hostname: integrationtests
 
   IntegrationTests:
@@ -484,6 +486,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
     hostname: integrationtests
     depends_on:
       - aerospike
@@ -553,6 +556,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
     hostname: integrationtests
 
   IntegrationTests.Serverless:
@@ -606,6 +610,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
     hostname: integrationtests
 
   ExplorationTests:
@@ -655,6 +660,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
 
   StartDependencies:
     image: andrewlock/wait-for-dependencies
@@ -745,6 +751,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
     depends_on:
       - servicestackredis_arm64
       - stackexchangeredis_arm64
@@ -823,6 +830,7 @@ services:
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCECOMMITID
       - DD_LOGGER_SYSTEM_PULLREQUEST_SOURCEBRANCH
       - DD_LOGGER_DD_TAGS
+      - DD_INTERNAL_TELEMETRY_V2_ENABLED
 
   start-test-agent:
     image: andrewlock/wait-for-dependencies

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -4,6 +4,7 @@ imports:
 
 variables:
   commit_hash: 0
+  telemetry_v2: 0
 
 jobs:
   server:

--- a/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
@@ -4,6 +4,7 @@
 
 variables:
   commit_hash: 0
+  telemetry_v2: 0
 
 jobs:
   server:

--- a/tracer/build/crank/os.profiles.yml
+++ b/tracer/build/crank/os.profiles.yml
@@ -19,6 +19,7 @@ profiles:
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_DEBUG: 0
+          DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
         options:
           requiredOperatingSystem: windows
           requiredArchitecture: x64
@@ -44,6 +45,7 @@ profiles:
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_DEBUG: 0
+          DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: x64
@@ -69,6 +71,7 @@ profiles:
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_DEBUG: 0
+          DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
           DD_ENV: throughput-adhoc
         options:
           requiredOperatingSystem: linux
@@ -96,6 +99,7 @@ profiles:
           LD_LIBRARY_PATH: "{{ linuxProfilerPath }}/tracer-home-linux/linux-x64"
           LD_PRELOAD: "{{ linuxProfilerPath }}/tracer-home-linux/linux-x64/Datadog.Linux.ApiWrapper.x64.so"
           DD_PROFILING_ENABLED: 1
+          DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: x64
@@ -121,6 +125,7 @@ profiles:
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_LOGGING_RATE: 6
           DD_TRACE_DEBUG: 0
+          DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: arm64

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -8,6 +8,7 @@ echo "BUILD_SOURCEVERSION=$BUILD_SOURCEVERSION"
 echo "SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI=$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"
 echo "BUILD_REPOSITORY_URI=$BUILD_REPOSITORY_URI"
 echo "DD_CIVISIBILITY_AGENTLESS_ENABLED=$DD_CIVISIBILITY_AGENTLESS_ENABLED"
+echo "DD_INTERNAL_TELEMETRY_V2_ENABLED=$DD_INTERNAL_TELEMETRY_V2_ENABLED"
 echo "Will run extended throughput tests: $2"
 
 repo="$SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI"
@@ -38,28 +39,28 @@ if [ "$1" = "windows" ]; then
     
     echo "Running windows throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="baseline_windows.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="calltarget_ngen_windows.json"
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile windows --json trace_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile windows --json trace_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="trace_stats_windows.json"
     fi
 
     echo "Running manual instrumentation throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile windows --json manual_only_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha 
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile windows --json manual_only_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED 
     dd-trace --crank-import="manual_only_windows.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="manual_and_automatic_windows.json"
 
     if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile windows --json version_conflict_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile windows --json version_conflict_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="version_conflict_windows.json"
     fi
 
@@ -74,28 +75,28 @@ elif [ "$1" = "linux" ]; then
 
     echo "Running Linux x64 throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="baseline_linux.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="calltarget_ngen_linux.json"
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux --json trace_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux --json trace_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="trace_stats_linux.json"
     fi
 
     echo "Running manual instrumentation throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux --json manual_only_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux --json manual_only_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="manual_only_linux.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="manual_and_automatic_linux.json"
 
     if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux --json version_conflict_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux --json version_conflict_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="version_conflict_linux.json"
     fi
 
@@ -110,28 +111,28 @@ elif [ "$1" = "linux_arm64" ]; then
 
     echo "Running Linux arm64 throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="baseline_linux_arm64.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux_arm64 --json calltarget_ngen_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux_arm64 --json calltarget_ngen_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="calltarget_ngen_linux_arm64.json"
 
     if [ "$2" = "True" ]; then
       echo "Running throughput tests with stats enabled"
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="trace_stats_linux_arm64.json"
     fi
 
     echo "Running manual instrumentation throughput tests"
     
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux_arm64 --json manual_only_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux_arm64 --json manual_only_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="manual_only_linux_arm64.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
     dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
     if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux_arm64 --json version_conflict_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux_arm64 --json version_conflict_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha --variable telemetry_v2=$DD_INTERNAL_TELEMETRY_V2_ENABLED
       dd-trace --crank-import="version_conflict_linux_arm64.json"
     fi
 else

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollectorV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollectorV2.cs
@@ -80,5 +80,18 @@ namespace Datadog.Trace.Configuration.Telemetry
                 };
             }
         }
+
+        public void Clear()
+        {
+            // clears any data stored in the buffers
+            while (_backBuffer.TryDequeue(out _))
+            {
+            }
+
+            var config = Interlocked.Exchange(ref _entries, _backBuffer);
+            while (config.TryDequeue(out _))
+            {
+            }
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -14,13 +14,9 @@ namespace Datadog.Trace.Telemetry
 {
     internal class DependencyTelemetryCollector : IDependencyTelemetryCollector
     {
-        private static DependencyTelemetryCollector? _instance;
-
         // value is true when sent to the backend
         private readonly ConcurrentDictionary<DependencyTelemetryData, bool> _assemblies = new();
         private int _hasChangesFlag = 0;
-
-        internal static DependencyTelemetryCollector Instance => LazyInitializer.EnsureInitialized(ref _instance)!;
 
         /// <summary>
         /// Called when an assembly is loaded

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -110,6 +110,13 @@ internal class MetricsTelemetryCollector : IMetricsTelemetryCollector
         return new(metricData, distributionData);
     }
 
+    public void Clear()
+    {
+        _reserveBuffer.Clear();
+        var buffer = Interlocked.Exchange(ref _buffer, _reserveBuffer);
+        buffer.Clear();
+    }
+
     [Conditional("DEBUG")]
     private static void AssertTags(Count metric, int actualTags)
         => Debug.Assert(metric.ExpectedTags() == actualTags, $"Expected {metric} to have {metric.ExpectedTags()} tags, but found {actualTags}");

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -453,12 +453,12 @@ internal class MetricsTelemetryCollector : IMetricsTelemetryCollector
 
             for (var i = 0; i < DistributionExtensions.Length; i++)
             {
-                Distributions[i].Clear();
+                while (Distributions[i].TryDequeue(out _)) { }
             }
 
             foreach (var kvp in DistributionsWithTags)
             {
-                kvp.Value.Clear();
+                while (kvp.Value.TryDequeue(out _)) { }
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
@@ -69,7 +69,7 @@ internal class TelemetryDataBuilderV2
                 const int maxPerMessage = 2000;
                 // Only 2000 dependencies should be included per message, so need to split into separate requests
                 var depsToSend = dependencies.Count > maxPerMessage
-                                     ? dependencies.Skip(skip).Take(2000).ToList()
+                                     ? dependencies.Skip(skip).Take(maxPerMessage).ToList()
                                      : dependencies;
                 skip += depsToSend.Count;
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -5,37 +5,65 @@
 #nullable enable
 using System;
 using System.Threading;
-using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Telemetry.Metrics;
+using Datadog.Trace.Telemetry.Collectors;
 using Datadog.Trace.Telemetry.Transports;
 
 namespace Datadog.Trace.Telemetry
 {
     internal class TelemetryFactory
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
+        // need to start collecting these immediately
+        private static IMetricsTelemetryCollector _metrics = new MetricsTelemetryCollector();
+        private static IConfigurationTelemetry _configurationV2 = new ConfigurationTelemetry();
 
-        private static readonly ConfigurationTelemetryCollector Configuration = new();
-        private static readonly IntegrationTelemetryCollector Integrations = new();
+        // V1 integration only
+        private ConfigurationTelemetryCollector? _configuration;
+
+        // v2 integration only
+        private ProductsTelemetryCollector? _products;
+        private ApplicationTelemetryCollectorV2? _application;
+
+        // shared
+        private IntegrationTelemetryCollector? _integrations;
+        private IDependencyTelemetryCollector? _dependencies;
+
+        private TelemetryFactory()
+        {
+        }
+
+        public static TelemetryFactory Instance { get; } = new();
 
         /// <summary>
-        /// Gets the static metrics instance used to record telemetry
-        /// Once v2 is telemetry is supported, this will return a real instance
+        /// Gets the static metrics instance used to record telemetry.
         /// </summary>
-        public static IMetricsTelemetryCollector Metrics => NullMetricsTelemetryCollector.Instance;
+        public static IMetricsTelemetryCollector Metrics => Volatile.Read(ref _metrics);
 
         /// <summary>
         /// Gets the static configuration instance used to record telemetry
-        /// Once v2 is telemetry is supported, this will return a real instance
         /// </summary>
-        internal static IConfigurationTelemetry Config => NullConfigurationTelemetry.Instance;
+        internal static IConfigurationTelemetry Config => Volatile.Read(ref _configurationV2);
 
-        internal static ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings)
+        internal static IMetricsTelemetryCollector SetMetricsForTesting(IMetricsTelemetryCollector telemetry)
+            => Interlocked.Exchange(ref _metrics, telemetry);
+
+        internal static IConfigurationTelemetry SetConfigForTesting(IConfigurationTelemetry telemetry)
+            => Interlocked.Exchange(ref _configurationV2, telemetry);
+
+        /// <summary>
+        /// For testing purposes only. Use <see cref="Instance"/> in production
+        /// </summary>
+        public static TelemetryFactory CreateFactory() => new();
+
+        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings)
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config));
+
+        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, TelemetrySettings settings)
         {
-            var settings = TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config);
+            // Deliberately not s static field, because otherwise creates a circular dependency during startup
+            var log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
             if (settings.TelemetryEnabled)
             {
                 try
@@ -44,30 +72,86 @@ namespace Datadog.Trace.Telemetry
 
                     if (telemetryTransports.Length == 0)
                     {
+                        log.Debug("Telemetry collection disabled: no available transports");
                         return NullTelemetryController.Instance;
                     }
 
-                    var transportManager = new TelemetryTransportManager(telemetryTransports);
+                    _dependencies = settings.DependencyCollectionEnabled
+                                        ? new DependencyTelemetryCollector()
+                                        : NullDependencyTelemetryCollector.Instance;
 
-                    IDependencyTelemetryCollector dependencies = settings.DependencyCollectionEnabled
-                                                                     ? DependencyTelemetryCollector.Instance
-                                                                     : NullDependencyTelemetryCollector.Instance;
+                    if (!settings.V2Enabled)
+                    {
+                        // if we're not using V2, we don't need the config collector
+                        Interlocked.Exchange(ref _configurationV2, NullConfigurationTelemetry.Instance);
+                    }
 
-                    return new TelemetryController(
-                        Configuration,
-                        dependencies,
-                        Integrations,
-                        transportManager,
-                        TelemetryConstants.DefaultFlushInterval,
-                        settings.HeartbeatInterval);
+                    if (!settings.MetricsEnabled)
+                    {
+                        // if we're not using metrics, we don't need the metrics collector
+                        log.Debug("Telemetry metrics collection disabled");
+                        Interlocked.Exchange(ref _metrics, NullMetricsTelemetryCollector.Instance);
+                    }
+
+                    // Making assumptions that we never switch from one to two,
+                    // so we don't need to "clean up" the collectors.
+                    if (settings.V2Enabled)
+                    {
+                        log.Debug("Creating telemetry controller v2");
+                        return CreateV2Controller(telemetryTransports, settings);
+                    }
+                    else
+                    {
+                        log.Debug("Creating telemetry controller v1");
+                        return CreateV1Controller(telemetryTransports, settings);
+                    }
                 }
                 catch (Exception ex)
                 {
-                    Log.Warning(ex, "Error initializing telemetry. Telemetry collection disabled.");
+                    log.Warning(ex, "Telemetry collection disabled: error initializing telemetry");
+                    return NullTelemetryController.Instance;
                 }
             }
 
+            log.Debug("Telemetry collection disabled");
             return NullTelemetryController.Instance;
+        }
+
+        private ITelemetryController CreateV1Controller(
+            ITelemetryTransport[] telemetryTransports,
+            TelemetrySettings settings)
+        {
+            var transportManager = new TelemetryTransportManager(telemetryTransports);
+            var configuration = LazyInitializer.EnsureInitialized(ref _configuration)!;
+            var integrations = LazyInitializer.EnsureInitialized(ref _integrations)!;
+
+            return new TelemetryController(
+                configuration,
+                _dependencies,
+                integrations,
+                transportManager,
+                TelemetryConstants.DefaultFlushInterval,
+                settings.HeartbeatInterval);
+        }
+
+        private ITelemetryController CreateV2Controller(
+            ITelemetryTransport[] telemetryTransports,
+            TelemetrySettings settings)
+        {
+            var transportManager = new TelemetryTransportManagerV2(telemetryTransports);
+            var integrations = LazyInitializer.EnsureInitialized(ref _integrations)!;
+            var products = LazyInitializer.EnsureInitialized(ref _products)!;
+            var application = LazyInitializer.EnsureInitialized(ref _application)!;
+
+            return new TelemetryControllerV2(
+                Config,
+                _dependencies!,
+                integrations,
+                Metrics,
+                products,
+                application,
+                transportManager,
+                settings.HeartbeatInterval);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -83,14 +83,23 @@ namespace Datadog.Trace.Telemetry
                     if (!settings.V2Enabled)
                     {
                         // if we're not using V2, we don't need the config collector
-                        Interlocked.Exchange(ref _configurationV2, NullConfigurationTelemetry.Instance);
+                        var oldConfig = Interlocked.Exchange(ref _configurationV2, NullConfigurationTelemetry.Instance);
+                        if (oldConfig is ConfigurationTelemetry config)
+                        {
+                            config.Clear();
+                        }
                     }
 
                     if (!settings.MetricsEnabled)
                     {
                         // if we're not using metrics, we don't need the metrics collector
                         log.Debug("Telemetry metrics collection disabled");
-                        Interlocked.Exchange(ref _metrics, NullMetricsTelemetryCollector.Instance);
+                        var oldMetrics = Interlocked.Exchange(ref _metrics, NullMetricsTelemetryCollector.Instance);
+                        if (oldMetrics is MetricsTelemetryCollector metrics)
+                        {
+                            // "clears" all the data stored so far
+                            metrics.Clear();
+                        }
                     }
 
                     // Making assumptions that we never switch from one to two,

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace
                 settings.ServiceVersion,
                 gitMetadataTagsProvider);
 
-            telemetry ??= TelemetryFactory.CreateTelemetryController(settings);
+            telemetry ??= TelemetryFactory.Instance.CreateTelemetryController(settings);
             telemetry.RecordTracerSettings(settings, defaultServiceName);
 
             var security = Security.Instance;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -40,15 +40,15 @@ public class DataStreamsMonitoringTests : TestHelper
     ///
     /// In mermaid (view at https://mermaid.live/), this looks like:
     /// sequenceDiagram
-    ///    participant A as Root Service<br>(12926600137239154356)
-    ///    participant T1 as Topic 1<br>(2704081292861755358)
-    ///    participant C1 as Consumer 1<br>(5289074475783863123)
-    ///    participant T2a as Topic 2<br>(2821413369272395429)
-    ///    participant C2a as Consumer 2<br>(9753735904472423641)
-    ///    participant T3a as Topic 3<br>(5363062531028060751)
-    ///    participant T2 as Topic 2<br>(246622801349204431)
-    ///    participant C2 as Consumer 2<br>(3398817358352474903)
-    ///    participant T3 as Topic 3<br>(16689539899325095461 )
+    ///    participant A as Root Service (12926600137239154356)
+    ///    participant T1 as Topic 1 (2704081292861755358)
+    ///    participant C1 as Consumer 1 (5289074475783863123)
+    ///    participant T2a as Topic 2 (2821413369272395429)
+    ///    participant C2a as Consumer 2 (9753735904472423641)
+    ///    participant T3a as Topic 3 (5363062531028060751)
+    ///    participant T2 as Topic 2 (246622801349204431)
+    ///    participant C2 as Consumer 2 (3398817358352474903)
+    ///    participant T3 as Topic 3 (16689539899325095461 )
     ///
     ///    A->>+T1: Produce
     ///    T1-->>-C1: Consume
@@ -77,7 +77,6 @@ public class DataStreamsMonitoringTests : TestHelper
 
         using var assertionScope = new AssertionScope();
         var payload = NormalizeDataStreams(agent.DataStreams);
-        agent.AssertConfiguration(ConfigTelemetryData.DataStreamsMonitoringEnabled, true);
         // using span verifier to add all the default scrubbers
         var settings = VerifyHelper.GetSpanVerifierSettings();
         settings.AddSimpleScrubber(TracerConstants.AssemblyVersion, "2.x.x.x");
@@ -137,8 +136,6 @@ public class DataStreamsMonitoringTests : TestHelper
         using var assertionScope = new AssertionScope();
 
         var payload = NormalizeDataStreams(agent.DataStreams);
-
-        agent.AssertConfiguration(ConfigTelemetryData.DataStreamsMonitoringEnabled, true);
 
         // using span verifier to add all the default scrubbers
         var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelper.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     internal static class TelemetryHelper
     {
-        public static MockTelemetryAgent ConfigureTelemetry(this TestHelper helper)
+        public static MockTelemetryAgent ConfigureTelemetry(this TestHelper helper, bool? enableV2 = null)
         {
             int telemetryPort = TcpPortProvider.GetOpenPort();
             var telemetry = new MockTelemetryAgent(telemetryPort);
@@ -29,6 +29,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             helper.SetEnvironmentVariable("DD_TRACE_TELEMETRY_URL", $"http://localhost:{telemetry.Port}");
             // API key is required when using the custom url
             helper.SetEnvironmentVariable("DD_API_KEY", "INVALID_KEY_FOR_TESTS");
+
+            switch (enableV2)
+            {
+                case true:
+                    helper.SetEnvironmentVariable("DD_INTERNAL_TELEMETRY_V2_ENABLED", "1");
+                    break;
+                case false:
+                    helper.SetEnvironmentVariable("DD_INTERNAL_TELEMETRY_V2_ENABLED", "0");
+                    break;
+            }
+
             return telemetry;
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/TelemetryRestorerAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TelemetryRestorerAttribute.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="TelemetryRestorerAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = true)]
+public class TelemetryRestorerAttribute : BeforeAfterTestAttribute
+{
+    private IMetricsTelemetryCollector _metrics;
+    private IConfigurationTelemetry _config;
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        _metrics = TelemetryFactory.Metrics;
+        _config = TelemetryFactory.Config;
+        base.Before(methodUnderTest);
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        TelemetryFactory.SetMetricsForTesting(_metrics);
+        TelemetryFactory.SetConfigForTesting(_config);
+        base.After(methodUnderTest);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorV2Tests.cs
@@ -7,6 +7,7 @@ using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Collectors;
 using FluentAssertions;
 using Xunit;
@@ -39,17 +40,22 @@ public class ApplicationTelemetryCollectorV2Tests
 
         collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName);
 
-        var data = collector.GetApplicationData();
+        // calling twice should give same results
+        AssertData(collector.GetApplicationData());
+        AssertData(collector.GetApplicationData());
 
-        data.Should().NotBeNull();
-        data.ServiceName.Should().Be(ServiceName);
-        data.Env.Should().Be(env);
-        data.TracerVersion.Should().Be(TracerConstants.AssemblyVersion);
-        data.LanguageName.Should().Be("dotnet");
-        data.ServiceVersion.Should().Be(serviceVersion);
-        data.LanguageVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
-        data.RuntimeName.Should().NotBeNullOrEmpty().And.Be(FrameworkDescription.Instance.Name);
-        data.RuntimeVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
+        void AssertData(ApplicationTelemetryDataV2 data)
+        {
+            data.Should().NotBeNull();
+            data.ServiceName.Should().Be(ServiceName);
+            data.Env.Should().Be(env);
+            data.TracerVersion.Should().Be(TracerConstants.AssemblyVersion);
+            data.LanguageName.Should().Be("dotnet");
+            data.ServiceVersion.Should().Be(serviceVersion);
+            data.LanguageVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
+            data.RuntimeName.Should().NotBeNullOrEmpty().And.Be(FrameworkDescription.Instance.Name);
+            data.RuntimeVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
+        }
     }
 
     [Fact]
@@ -74,8 +80,14 @@ public class ApplicationTelemetryCollectorV2Tests
 
         collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName);
 
-        var data = collector.GetHostData();
-        data.Should().NotBeNull();
-        data.Hostname.Should().Be(HostMetadata.Instance.Hostname ?? string.Empty);
+        // calling twice should give same results
+        AssertData(collector.GetHostData());
+        AssertData(collector.GetHostData());
+
+        static void AssertData(HostTelemetryDataV2 data)
+        {
+            data.Should().NotBeNull();
+            data.Hostname.Should().Be(HostMetadata.Instance.Hostname ?? string.Empty);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorV2Tests.cs
@@ -120,6 +120,17 @@ public class ConfigurationTelemetryCollectorV2Tests
     }
 
     [Fact]
+    public void HasNoDataAfterCallingClear()
+    {
+        var collector = new ConfigurationTelemetry();
+
+        _ = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }), collector);
+
+        collector.Clear();
+        collector.GetData().Should().BeNull();
+    }
+
+    [Fact]
     public void ConfigurationDataShouldMarkAsManagedOnlyWhenProfilerNotAttached()
     {
         var collector = new ConfigurationTelemetry();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataAggregatorTests.cs
@@ -31,11 +31,14 @@ public class TelemetryDataAggregatorTests
         result.Products.Should().BeSameAs(previous.Products);
     }
 
-    [Fact]
-    public void GetCombinedConfiguration_WhenHaveCurrent_AndNoPrevious_ReturnsCurrent()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void GetCombinedConfiguration_WhenHaveCurrent_AndNoPrevious_ReturnsCurrent(bool previousIsNull)
     {
+        TelemetryInput? previous = previousIsNull ? null : new TelemetryInput();
         var next = GetPopulatedTelemetryInput();
-        var aggregator = new TelemetryDataAggregator(null);
+        var aggregator = new TelemetryDataAggregator(previous);
 
         var result = aggregator.Combine(next);
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -1,0 +1,166 @@
+﻿// <copyright file="TelemetryFactoryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.Tests.Telemetry;
+
+[CollectionDefinition(nameof(TelemetryFactoryTests), DisableParallelization = true)]
+[Collection(nameof(TelemetryFactoryTests))]
+[TelemetryRestorer]
+public class TelemetryFactoryTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TelemetryFactory_DisabledIfTelemetryIsDisabled(bool v2Enabled)
+    {
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: false, // explicitly disabled
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: v2Enabled,
+            metricsEnabled: false);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        controller.Should().Be(NullTelemetryController.Instance);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TelemetryFactory_DisabledIfNoTransports(bool v2Enabled)
+    {
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null, // no agentless
+            agentProxyEnabled: false, // disable proxy
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: v2Enabled,
+            metricsEnabled: false);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        controller.Should().Be(NullTelemetryController.Instance);
+    }
+
+    [Fact]
+    public void TelemetryFactory_UsesV1ControllerIfV2Disabled()
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: false,
+            metricsEnabled: false);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        controller.Should().BeOfType<TelemetryController>();
+        TelemetryFactory.Config.Should().BeOfType<NullConfigurationTelemetry>();
+        TelemetryFactory.Metrics.Should().BeOfType<NullMetricsTelemetryCollector>();
+    }
+
+    [Fact]
+    public void TelemetryFactory_UsesV2ControllerIfV2Enabled()
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: true,
+            metricsEnabled: false);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        controller.Should().BeOfType<TelemetryControllerV2>();
+        TelemetryFactory.Config.Should().BeOfType<ConfigurationTelemetry>();
+    }
+
+    [Fact]
+    public void TelemetryFactory_V2Telemetry_DisablesMetricsIfMetricsDisabled()
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: true,
+            metricsEnabled: false);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        TelemetryFactory.Metrics.Should().BeOfType<NullMetricsTelemetryCollector>();
+    }
+
+    [Fact]
+    public void TelemetryFactory_V2Telemetry_EnablesMetricsIfMetricsEnabled()
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: true,
+            metricsEnabled: true);
+
+        var controller = factory.CreateTelemetryController(tracerSettings, settings);
+
+        TelemetryFactory.Metrics.Should().BeOfType<MetricsTelemetryCollector>();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Util/ModuleInitializer.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/ModuleInitializer.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Tests.Util
 {
@@ -16,6 +18,12 @@ namespace Datadog.Trace.Tests.Util
         {
             // disable telemetry for any tests which create a "real" telemetry instance
             Environment.SetEnvironmentVariable(ConfigurationKeys.Telemetry.Enabled, "false");
+
+            // disable config by default
+            TelemetryFactory.SetConfigForTesting(NullConfigurationTelemetry.Instance);
+
+            // disable metrics by default
+            TelemetryFactory.SetMetricsForTesting(NullMetricsTelemetryCollector.Instance);
         }
     }
 }

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -60,6 +60,9 @@ namespace Samples.AspNetCoreSimpleController
             }
 #endif
 
+            Console.WriteLine(" * DD_INTERNAL_TELEMETRY_V2_ENABLED: '{0}'",
+                              Environment.GetEnvironmentVariable("DD_INTERNAL_TELEMETRY_V2_ENABLED"));
+
             Console.WriteLine(" * Using managed tracer version '{0}' and native tracer version '{1}'",
                               managedTracerVersion, nativeTracerVersion);
             Console.WriteLine();


### PR DESCRIPTION
## Summary of changes

- Update `TelemetryFactory` to allow enabling v2 telemetry by setting `DD_INTERNAL_TELEMETRY_V2_ENABLED`
- Allow enabling v2 telemetry in CI

## Reason for change

This allows _actually_ enabling telemetry v2.

## Implementation details

Checks if V2 setting is enabled, if so, it creates a V2 Telemetry Controller. If not, 

- Creates a V1 controller instead
- Disables v2 config telemetry collection
- Disables metric collection
- Clears any stored config or metrics from the static instances

## Test coverage

- Unit tests for the telemetry factory (requires quite a lot of faffing unfortunately, because this is fundamentally a static API)
- [Doing a run with v2 telemetry enabled in CI](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=137860&view=results) 

## Other details

Requires:
- https://github.com/DataDog/dd-trace-dotnet/pull/4180
- https://github.com/DataDog/dd-trace-dotnet/pull/4187
- https://github.com/DataDog/dd-trace-dotnet/pull/4188

In subsequent PRs (in rough order):
- Enable collection of configuration-in-code config telemetry (requires source-generation)
- Add/enable telemetry v2 system tests
- Enable by default in AAS
- Enable by default globally
- Enable sending metrics
- Add additional required metrics (inc. public API metrics)
- Enable double submission metrics

