### PR TITLE
[Profiler] Try to avoid a race condition in named pipe tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
@@ -218,7 +218,7 @@ namespace Datadog.Profiler.IntegrationTests
                     x => Output.WriteLine(x),
                     _readinessNotifier);
 
-                _profilesListenerTask = Task.Run(_namedPipeServer.Start);
+                _profilesListenerTask = _namedPipeServer.Start();
             }
 
             public string ProfilesPipeName { get; }


### PR DESCRIPTION
## Summary of changes
Ensure that named pipe server is created synchronously

## Reason for change
Should avoid flacky test due to race condition between the named pipe server and the tested application

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
