### PR TITLE
Move RCM initialization in the TracerManager

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -390,18 +390,16 @@ namespace Datadog.Trace.AppSec
 
         private void SetRemoteConfigCapabilites()
         {
-            RemoteConfigurationManager.CallbackWithInitializedInstance(
-                rcm =>
-                {
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmActivation, _settings.CanBeToggled);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmDdRules, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmIpBlocking, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmExclusion, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmRequestBlocking, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmResponseBlocking, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomRules, _noLocalRules);
-                    rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomBlockingResponse, _noLocalRules);
-                });
+            var rcm = RcmSubscriptionManager.Instance;
+
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmActivation, _settings.CanBeToggled);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmDdRules, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmIpBlocking, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmExclusion, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRequestBlocking, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmResponseBlocking, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomRules, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomBlockingResponse, _noLocalRules);
         }
 
         private void InitWafAndInstrumentations(bool fromRemoteConfig = false)

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
@@ -24,8 +25,8 @@ namespace Datadog.Trace.Ci
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CITracerManager>();
 
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName, IGitMetadataTagsProvider gitMetadataTagsProvider)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, GetProcessors(settings.Exporter.PartialFlushEnabled, agentWriter is CIVisibilityProtocolWriter))
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName, IGitMetadataTagsProvider gitMetadataTagsProvider, IRemoteConfigurationManager remoteConfigurationManager)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager, GetProcessors(settings.Exporter.PartialFlushEnabled, agentWriter is CIVisibilityProtocolWriter))
         {
         }
 
@@ -94,8 +95,8 @@ namespace Datadog.Trace.Ci
 
         internal class LockedManager : CITracerManager, ILockedTracer
         {
-            public LockedManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName, IGitMetadataTagsProvider gitMetadataTagsProvider)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider)
+            public LockedManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, ITelemetryController telemetry, IDiscoveryService discoveryService, DataStreamsManager dataStreamsManager, string defaultServiceName, IGitMetadataTagsProvider gitMetadataTagsProvider, IRemoteConfigurationManager remoteConfigurationManager)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager)
             {
             }
         }

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
@@ -46,15 +47,16 @@ namespace Datadog.Trace.Ci
             IDiscoveryService discoveryService,
             DataStreamsManager dataStreamsManager,
             string defaultServiceName,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            IRemoteConfigurationManager remoteConfigurationManager)
         {
             if (_useLockedManager)
             {
-                return new CITracerManager.LockedManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider);
+                return new CITracerManager.LockedManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager);
             }
             else
             {
-                return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider);
+                return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager);
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -445,7 +445,6 @@ namespace Datadog.Trace.ClrProfiler
         {
             // Service Name must be lowercase, otherwise the agent will not be able to find the service
             var serviceName = TraceUtil.NormalizeTag(tracer.Settings.ServiceName ?? tracer.DefaultServiceName);
-            var configurationManager = tracer.TracerManager.RemoteConfigurationManager;
             var discoveryService = tracer.TracerManager.DiscoveryService;
 
             Task.Run(

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
 
@@ -21,4 +22,8 @@ internal interface IRcmSubscriptionManager
     void Unsubscribe(ISubscription subscription);
 
     List<ApplyDetails> Update(Dictionary<string, List<RemoteConfiguration>> configByProducts, Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct);
+
+    void SetCapability(BigInteger index, bool available);
+
+    byte[] GetCapabilities();
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
@@ -3,18 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Numerics;
-using System.Threading.Tasks;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
-    internal interface IRemoteConfigurationManager
+    internal interface IRemoteConfigurationManager : IDisposable
     {
-        /// <summary>
-        /// Start polling configurations asynchronously in an endless loop.
-        /// </summary>
-        Task StartPollingAsync();
-
         void SetCapability(BigInteger index, bool available);
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
@@ -4,14 +4,11 @@
 // </copyright>
 
 using System;
-using System.Numerics;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal interface IRemoteConfigurationManager : IDisposable
     {
         void Start();
-
-        void SetCapability(BigInteger index, bool available);
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRemoteConfigurationManager.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal interface IRemoteConfigurationManager : IDisposable
     {
+        void Start();
+
         void SetCapability(BigInteger index, bool available);
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
@@ -15,6 +16,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     public static readonly IRcmSubscriptionManager Instance = new RcmSubscriptionManager();
     private readonly List<ISubscription> _subscriptions = new();
     private readonly object _syncRoot = new();
+    private BigInteger _capabilities;
 
     public bool HasAnySubscription => _subscriptions.Count > 0;
 
@@ -92,6 +94,31 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
         }
 
         return results;
+    }
+
+    public void SetCapability(BigInteger index, bool available)
+    {
+        if (available)
+        {
+            _capabilities |= index;
+        }
+        else
+        {
+            _capabilities &= ~index;
+        }
+    }
+
+    public byte[] GetCapabilities()
+    {
+        // capabilitiesArray needs to be big endian
+#if NETCOREAPP
+        var capabilitiesArray = _capabilities.ToByteArray(true, true);
+#else
+        var capabilitiesArray = _capabilities.ToByteArray();
+        Array.Reverse(capabilitiesArray);
+#endif
+
+        return capabilitiesArray;
     }
 
     private void RefreshProductKeys() => ProductKeys = _subscriptions.SelectMany(s => s.ProductKeys).Distinct().ToList();

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -76,9 +76,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             _subscriptionManager = subscriptionManager;
             _cancellationSource = new CancellationTokenSource();
             discoveryService.SubscribeToChanges(SetRcmEnabled);
-
-            _ = StartPollingAsync()
-               .ContinueWith(t => { Log.Error(t.Exception, "Remote Configuration management polling failed"); }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         public static RemoteConfigurationManager? Instance { get; private set; }
@@ -151,6 +148,12 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             }
 
             action(inst);
+        }
+
+        public void Start()
+        {
+            _ = Task.Run(StartPollingAsync)
+               .ContinueWith(t => { Log.Error(t.Exception, "Remote Configuration management polling failed"); }, TaskContinuationOptions.OnlyOnFaulted);
         }
 
         public void Dispose()

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -6,10 +6,8 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -27,8 +25,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
     internal class RemoteConfigurationManager : IRemoteConfigurationManager
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RemoteConfigurationManager));
-        private static readonly object LockObject = new object();
-        private static readonly ConcurrentQueue<Action<RemoteConfigurationManager>> _initializationQueue = new();
 
         private readonly string _id;
         private readonly RcmClientTracer _rcmTracer;
@@ -46,10 +42,9 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         private readonly Dictionary<string, RemoteConfigurationCache> _appliedConfigurations = new();
 
         private readonly int _rootVersion;
-        private BigInteger _capabilities;
         private int _targetsVersion;
         private string? _lastPollError;
-        private bool _isPollingStarted;
+        private int _isPollingStarted;
         private bool _isRcmEnabled;
         private string? _backendClientState;
         private bool _gitMetadataAddedToRequestTags;
@@ -78,14 +73,11 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             discoveryService.SubscribeToChanges(SetRcmEnabled);
         }
 
-        public static RemoteConfigurationManager? Instance { get; private set; }
-
         public static RemoteConfigurationManager Create(IDiscoveryService discoveryService, IRemoteConfigurationApi remoteConfigurationApi, RemoteConfigurationSettings settings, string serviceName, ImmutableTracerSettings tracerSettings, IGitMetadataTagsProvider gitMetadataTagsProvider, IRcmSubscriptionManager subscriptionManager)
         {
             var tags = GetTags(settings, tracerSettings);
-            lock (LockObject)
-            {
-                Instance ??= new RemoteConfigurationManager(
+
+            return new RemoteConfigurationManager(
                     discoveryService,
                     remoteConfigurationApi,
                     id: settings.Id,
@@ -93,14 +85,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                     pollInterval: settings.PollInterval,
                     gitMetadataTagsProvider,
                     subscriptionManager);
-            }
-
-            while (_initializationQueue.TryDequeue(out var action))
-            {
-                action(Instance);
-            }
-
-            return Instance;
         }
 
         private static List<string> GetTags(RemoteConfigurationSettings rcmSettings, ImmutableTracerSettings tracerSettings)
@@ -134,22 +118,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             return tags;
         }
 
-        public static void CallbackWithInitializedInstance(Action<RemoteConfigurationManager> action)
-        {
-            RemoteConfigurationManager? inst = null;
-            lock (LockObject)
-            {
-                inst = Instance;
-                if (inst == null)
-                {
-                    _initializationQueue.Enqueue(action);
-                    return;
-                }
-            }
-
-            action(inst);
-        }
-
         public void Start()
         {
             _ = Task.Run(StartPollingAsync)
@@ -162,33 +130,13 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             _cancellationSource.Cancel();
         }
 
-        public void SetCapability(BigInteger index, bool available)
-        {
-            if (available)
-            {
-                _capabilities |= index;
-            }
-            else
-            {
-                _capabilities &= ~index;
-            }
-        }
-
         private async Task StartPollingAsync()
         {
-            lock (LockObject)
+            if (Interlocked.Exchange(ref _isPollingStarted, 1) != 0)
             {
-                if (_isPollingStarted)
-                {
-                    Log.Warning("Remote Configuration management polling is already started.");
-                    return;
-                }
-
-                _isPollingStarted = true;
+                Log.Warning("Remote Configuration management polling is already started.");
+                return;
             }
-
-            // Make sure not to block the caller
-            await Task.Yield();
 
             while (!_cancellationSource.IsCancellationRequested)
             {
@@ -242,16 +190,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
                 configStates.Add(new RcmConfigState(cache.Path.Id, cache.Version, cache.Path.Product, cache.ApplyState, cache.Error));
             }
 
-            // capabilitiesArray needs to be big endian
-            // a first for me, until now I had never worked on a code base with an endian issue ...
-#if NETCOREAPP
-            var capabilitiesArray = _capabilities.ToByteArray(true, true);
-#else
-            var capabilitiesArray = _capabilities.ToByteArray();
-            Array.Reverse(capabilitiesArray);
-#endif
             var rcmState = new RcmClientState(_rootVersion, _targetsVersion, configStates, _lastPollError != null, _lastPollError, _backendClientState);
-            var rcmClient = new RcmClient(_id, _subscriptionManager.ProductKeys, _rcmTracer, rcmState, capabilitiesArray);
+            var rcmClient = new RcmClient(_id, _subscriptionManager.ProductKeys, _rcmTracer, rcmState, _subscriptionManager.GetCapabilities());
             EnrichTagsWithGitMetadata(rcmClient.ClientTracer.Tags);
             var rcmRequest = new GetRcmRequest(rcmClient, cachedTargetFiles);
             return rcmRequest;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null, remoteConfigurationManager: null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -207,6 +207,7 @@ namespace Datadog.Trace
             // Must be idempotent and thread safe
             DirectLogSubmission?.Sink.Start();
             Telemetry?.Start();
+            RemoteConfigurationManager.Start();
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -22,6 +22,7 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Processors;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
@@ -64,6 +65,7 @@ namespace Datadog.Trace
             DataStreamsManager dataStreamsManager,
             string defaultServiceName,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
+            IRemoteConfigurationManager remoteConfigurationManager,
             ITraceProcessor[] traceProcessors = null)
         {
             Settings = settings;
@@ -91,6 +93,8 @@ namespace Datadog.Trace
             }
 
             TagProcessors = lstTagProcessors.ToArray();
+
+            RemoteConfigurationManager = remoteConfigurationManager;
         }
 
         /// <summary>
@@ -150,6 +154,8 @@ namespace Datadog.Trace
         public IDiscoveryService DiscoveryService { get; }
 
         public DataStreamsManager DataStreamsManager { get; }
+
+        public IRemoteConfigurationManager RemoteConfigurationManager { get; }
 
         private RuntimeMetricsWriter RuntimeMetrics { get; }
 
@@ -256,10 +262,17 @@ namespace Datadog.Trace
                     await oldManager.DataStreamsManager.DisposeAsync().ConfigureAwait(false);
                 }
 
+                var configurationManagerReplaced = false;
+                if (oldManager.RemoteConfigurationManager != newManager.RemoteConfigurationManager && oldManager.RemoteConfigurationManager is not null)
+                {
+                    configurationManagerReplaced = true;
+                    oldManager.RemoteConfigurationManager.Dispose();
+                }
+
                 Log.Information(
                     exception: null,
-                    "Replaced global instances. AgentWriter: {AgentWriterReplaced}, StatsD: {StatsDReplaced}, RuntimeMetricsWriter: {RuntimeMetricsWriterReplaced}, Telemetry: {TelemetryReplaced}, Discovery: {DiscoveryReplaced}, DataStreamsManager: {DataStreamsManagerReplaced}",
-                    new object[] { agentWriterReplaced, statsdReplaced, runtimeMetricsWriterReplaced, telemetryReplaced, discoveryReplaced, dataStreamsReplaced });
+                    "Replaced global instances. AgentWriter: {AgentWriterReplaced}, StatsD: {StatsDReplaced}, RuntimeMetricsWriter: {RuntimeMetricsWriterReplaced}, Telemetry: {TelemetryReplaced}, Discovery: {DiscoveryReplaced}, DataStreamsManager: {DataStreamsManagerReplaced}, RemoteConfigurationManager: {ConfigurationManagerReplaced}",
+                    new object[] { agentWriterReplaced, statsdReplaced, runtimeMetricsWriterReplaced, telemetryReplaced, discoveryReplaced, dataStreamsReplaced, configurationManagerReplaced });
             }
             catch (Exception ex)
             {
@@ -591,10 +604,13 @@ namespace Datadog.Trace
                     var discoveryService = instance.DiscoveryService?.DisposeAsync() ?? Task.CompletedTask;
                     Log.Debug("Disposing Data streams.");
                     var dataStreamsTask = instance.DataStreamsManager?.DisposeAsync() ?? Task.CompletedTask;
+                    Log.Debug("Disposing RemoteConfigurationManager");
+                    instance.RemoteConfigurationManager?.Dispose();
 
                     Log.Debug("Waiting for disposals.");
                     await Task.WhenAll(flushTracesTask, logSubmissionTask, telemetryTask, discoveryService, dataStreamsTask).ConfigureAwait(false);
 
+                    Log.Debug("Disposing Runtime Metrics");
                     instance.RuntimeMetrics?.Dispose();
 
                     Log.Debug("Finished waiting for disposals.");

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace
                 telemetry: null,
                 discoveryService: null,
                 dataStreamsManager: null,
-                remoteConfigurationManager: previous?.RemoteConfigurationManager);
+                remoteConfigurationManager: null);
 
             try
             {

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -22,13 +22,17 @@ using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Propagators;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RemoteConfigurationManagement.Transport;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 using ConfigurationKeys = Datadog.Trace.Configuration.ConfigurationKeys;
 using MetricsTransportType = Datadog.Trace.Vendors.StatsdClient.Transport.TransportType;
+using Stopwatch = System.Diagnostics.Stopwatch;
 
 namespace Datadog.Trace
 {
@@ -56,7 +60,8 @@ namespace Datadog.Trace
                 logSubmissionManager: previous?.DirectLogSubmission,
                 telemetry: null,
                 discoveryService: null,
-                dataStreamsManager: null);
+                dataStreamsManager: null,
+                remoteConfigurationManager: previous?.RemoteConfigurationManager);
 
             try
             {
@@ -90,7 +95,8 @@ namespace Datadog.Trace
             DirectLogSubmissionManager logSubmissionManager,
             ITelemetryController telemetry,
             IDiscoveryService discoveryService,
-            DataStreamsManager dataStreamsManager)
+            DataStreamsManager dataStreamsManager,
+            IRemoteConfigurationManager remoteConfigurationManager)
         {
             settings ??= ImmutableTracerSettings.FromDefaultSources();
 
@@ -143,7 +149,22 @@ namespace Datadog.Trace
 
             dataStreamsManager ??= DataStreamsManager.Create(settings, discoveryService, defaultServiceName);
 
-            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider);
+            if (remoteConfigurationManager == null)
+            {
+                var sw = Stopwatch.StartNew();
+
+                var rcmSettings = RemoteConfigurationSettings.FromDefaultSource();
+                var rcmApi = RemoteConfigurationApiFactory.Create(settings.Exporter, rcmSettings, discoveryService);
+
+                // Service Name must be lowercase, otherwise the agent will not be able to find the service
+                var serviceName = TraceUtil.NormalizeTag(settings.ServiceName ?? defaultServiceName);
+
+                remoteConfigurationManager = RemoteConfigurationManager.Create(discoveryService, rcmApi, rcmSettings, serviceName, settings, gitMetadataTagsProvider, RcmSubscriptionManager.Instance);
+
+                TelemetryFactory.Metrics.Record(Distribution.InitTime, MetricTags.Component_RCM, sw.ElapsedMilliseconds);
+            }
+
+            var tracerManager = CreateTracerManagerFrom(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager);
             return tracerManager;
         }
 
@@ -167,8 +188,9 @@ namespace Datadog.Trace
             IDiscoveryService discoveryService,
             DataStreamsManager dataStreamsManager,
             string defaultServiceName,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
-            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider);
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            IRemoteConfigurationManager remoteConfigurationManager)
+            => new TracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, remoteConfigurationManager);
 
         protected virtual ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tests.Configuration
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager(TracerSettings tracerSettings)
-                : base(new ImmutableTracerSettings(tracerSettings), null, null, null, null, null, null, null, null, null, null, null)
+                : base(new ImmutableTracerSettings(tracerSettings), null, null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -133,21 +132,6 @@ public class LiveDebuggerTests
         public List<ApplyDetails> Update(Dictionary<string, List<RemoteConfiguration>> configByProducts, Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct)
         {
             throw new NotImplementedException();
-        }
-    }
-
-    private class RemoteConfigurationManagerMock : IRemoteConfigurationManager
-    {
-        internal bool Called { get; private set; }
-
-        public Task StartPollingAsync()
-        {
-            Called = true;
-            return Task.CompletedTask;
-        }
-
-        public void SetCapability(BigInteger index, bool available)
-        {
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
@@ -130,6 +131,16 @@ public class LiveDebuggerTests
         }
 
         public List<ApplyDetails> Update(Dictionary<string, List<RemoteConfiguration>> configByProducts, Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetCapability(BigInteger index, bool available)
+        {
+            throw new NotImplementedException();
+        }
+
+        public byte[] GetCapabilities()
         {
             throw new NotImplementedException();
         }

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -8,8 +8,10 @@ using System.Collections.Generic;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests
@@ -118,7 +120,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null, null)
+                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null, Mock.Of<IRemoteConfigurationManager>())
             {
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null)
+                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }


### PR DESCRIPTION
## Summary of changes

Initialize the RCM in the TracerManager instead of `Instrumentation.Initialize`.

## Reason for change

Until now, RCM was only used in automatic instrumentation scenarios, so initializing it in `Instrumentation` was fine. For dynamic configuration however, we need to also support manual instrumentation.

## Implementation details

 - Removed the `StartPollingAsync` method from the interface. Now we automatically start polling as soon as the class is created, which is more consistent with the other services.

 - Previously the RemoteConfigurationManager relied on the LifeTimeManager for cleanup. That responsibility has been moved to the TracerManager.

## Test coverage

There are already tests covering RCM... probably? I hope?