### PR TITLE
[IAST] Update evidence redaction suite . yml and fixes accordingly

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/CommandTokenizer.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/CommandTokenizer.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Iast.SensitiveData;
 /// </summary>
 internal class CommandTokenizer : ITokenizer
 {
-    private static Regex _pattern = new Regex(@"^(?:\s*(?:sudo|doas|cmd|cmd.exe)\s+)?\b\S+\b(.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static Regex _pattern = new(@"^(?:\s*(?:sudo|doas|cmd|cmd.exe)\s+)?\b\S+\b\s+(.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     public List<Range> GetTokens(string value, IntegrationId? integrationId = null)
     {

--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
@@ -30,6 +30,7 @@ internal class EvidenceRedactor
         { VulnerabilityTypeName.LdapInjection, new LdapTokenizer() },
         { VulnerabilityTypeName.CommandInjection, new CommandTokenizer() },
         { VulnerabilityTypeName.Ssrf, new UrlTokenizer() },
+        { VulnerabilityTypeName.UnvalidatedRedirect, new UrlTokenizer() },
     };
 
     public EvidenceRedactor(string keysPattern, string valuesPattern, TimeSpan timeout, IDatadogLogger? logger = null)

--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/SqlInjectionTokenizer.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/SqlInjectionTokenizer.cs
@@ -42,6 +42,7 @@ internal class SqlInjectionTokenizer : ITokenizer
         { IntegrationId.Oracle, _oracleDialectPattern },
         { IntegrationId.Npgsql, _postgresqlDialectPattern },
         { IntegrationId.MySql, _mySqlDialectPattern },
+        { IntegrationId.Sqlite, _mySqlDialectPattern }
     };
 
     public List<Range> GetTokens(string value, IntegrationId? integrationId = null)

--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/SqlInjectionTokenizer.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/SqlInjectionTokenizer.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Iast.SensitiveData;
 internal class SqlInjectionTokenizer : ITokenizer
 {
     private const string StringLiteral = "'(?:''|[^'])*'";
-    private const string OracleEscapedLiteral = "q'\\S.*\\S'";
+    private const string OracleEscapedLiteral = "q'<.*?>'|q'\\(.*?\\)'|q'\\{.*?\\}'|q'\\[.*?\\]'|q'(?<ESCAPE>.).*?\\k<ESCAPE>'";
     private const string PostgresqlEscapedLiteral = "\\$([^$]*)\\$.*?\\$\\1\\$";
     private const string MysqlStringLiteral = "\"(?:\\\"|[^\"])*\"|'(?:(?:'')|[^'])*'";
     private const string LineComment = "--.*$";

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityTypeName.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityTypeName.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+
 #nullable enable
 using System.ComponentModel;
 
@@ -30,6 +31,8 @@ internal static class VulnerabilityTypeName
     public const string LdapInjection = "LDAP_INJECTION";
 
     public const string Ssrf = "SSRF";
+
+    public const string UnvalidatedRedirect = "UNVALIDATED_REDIRECT";
 
     public static string GetName(VulnerabilityType vulnerability)
     {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.Bundle.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.Bundle.cs
@@ -243,6 +243,7 @@ public partial class VulnerabilityBatchTests
             "POSTGRESQL" => IntegrationId.Npgsql,
             "MYSQL" => IntegrationId.MySql,
             "MARIADB" => IntegrationId.MySql,
+            "SQLITE" => IntegrationId.Sqlite,
             _ => null
         };
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/evidence-redaction-suite.yml
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/evidence-redaction-suite.yml
@@ -4,44 +4,44 @@ suite:
     description: 'Source with sensitive name "$1"'
     parameters:
       $1:
-        - password
-        - passwd
-        - pwd
-        - pass
-        - pass_phrase
-        - passPhrase
-        - secret
-        - api_key
-        - apikey
-        - secret_key
-        - secretKey
         - access_key_id
         - accessKeyId
-        - secret_access_key
-        - secretAccessKey
+        - apikey
+        - api_key
+        - apiToken
+        - api_token
+        - auth
+        - authentication
+        - authorization
+        - consumerId
+        - consumer_id
+        - consumerKey
+        - consumer_key
+        - consumerSecret
+        - consumer_secret
+        - expirationToken
+        - expiration_token
+        - pass
+        - passwd
+        - password
+        - passPhrase
+        - pass_phrase
         - private_key
         - privateKey
-        - public_key
         - publicKey
-        - token
-        - api_token
-        - apiToken
-        - expiration_token
-        - expirationToken
-        - refresh_token
+        - public_key
+        - pwd
         - refreshToken
-        - consumer_id
-        - consumerId
-        - consumer_key
-        - consumerKey
-        - consumer_secret
-        - consumerSecret
+        - refresh_token
+        - secret
+        - secretAccessKey
+        - secret_access_key
+        - secretKey
+        - secret_key
         - sign
         - signature
         - signed
-        - auth
-        - authorization
-        - authentication
+        - token
     input: >
       [
         { "origin": "http.request.parameter", "name": "$1", "value": "table" }
@@ -208,7 +208,7 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'Query with string literal $1'
+    description: 'Query with single quoted string literal $1'
     parameters:
       $1:
         - john
@@ -248,11 +248,12 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: '$1 query with string literal $2'
+    description: '$1 query with double quoted string literal $2'
     parameters:
       $1:
         - MYSQL
         - MARIADB
+        - SQLITE
       $2:
         - john
         - username with 🌉 surrogate
@@ -332,6 +333,7 @@ suite:
       $1:
         - MYSQL
         - MARIADB
+        - SQLITE
     context: >
       { "DATABASE": "$1" }
     input: >
@@ -367,7 +369,54 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: '$1 query with escaped string literal'
+    description: '$1 query with arbitrary escaped string literal'
+    parameters:
+      $1:
+        - ORACLE
+      $2:
+        - '%'
+        - '$'
+        - 'Z'
+    context: >
+      { "DATABASE": "$1" }
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = q'$2I'm an escaped string$2' and common_name = 'doe' or last_name = q'$2I'm another escaped string$2'",
+            "ranges": [
+              { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "table", "value": "users" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from " },
+                { "source": 0, "value": "users" },
+                { "value": " where username = q'$2" },
+                { "redacted": true },
+                { "value": "$2' and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = q'$2" },
+                { "redacted": true },
+                { "value": "$2'" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: '$1 query with matched escaped string literal (< and >)'
     parameters:
       $1:
         - ORACLE
@@ -378,7 +427,7 @@ suite:
         {
           "type": "SQL_INJECTION",
           "evidence": {
-            "value": "select * from users where username = q'<I'm an escaped string>'",
+            "value": "select * from users where username = q'<I'm an escaped string>' and common_name = 'doe' or last_name = q'!I'm another escaped string!'",
             "ranges": [
               { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
             ]
@@ -399,7 +448,11 @@ suite:
                 { "source": 0, "value": "users" },
                 { "value": " where username = q'<" },
                 { "redacted": true },
-                { "value": ">'" }
+                { "value": ">' and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = q'!" },
+                { "redacted": true },
+                { "value": "!'" }
               ]
             }
           }
@@ -420,7 +473,7 @@ suite:
         {
           "type": "SQL_INJECTION",
           "evidence": {
-            "value": "select * from users where username = $2I'm an escaped string$2",
+            "value": "select * from users where username = $2I'm an escaped string$2 and common_name = 'doe' or last_name = $TEST$I'm another escaped string$$$TEST$",
             "ranges": [
               { "start" : 14, "length" : 5, "source": { "origin": "http.request.parameter", "name": "table", "value": "users" } }
             ]
@@ -441,7 +494,11 @@ suite:
                 { "source": 0, "value": "users" },
                 { "value": " where username = $2" },
                 { "redacted": true },
-                { "value": "$2" }
+                { "value": "$2 and common_name = '" },
+                { "redacted": true },
+                { "value": "' or last_name = $TEST$" },
+                { "redacted": true },
+                { "value": "$TEST$" }
               ]
             }
           }
@@ -725,6 +782,40 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
+    description: 'Query with string literal containing tainted range'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'john:doe:ADMIN'",
+            "ranges": [
+              { "start" : 43, "length" : 3, "source": { "origin": "http.request.parameter", "name": "last_name", "value": "doe" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "last_name", "redacted": true }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from users where username = '" },
+                { "redacted": true },
+                { "source": 0, "redacted": true },
+                { "redacted": true },
+                { "value": "'" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
     description: 'Query with string literal and tainted range crossing boundaries'
     input: >
       [
@@ -830,6 +921,50 @@ suite:
           }
         ]
       }
+
+  - type: 'VULNERABILITIES'
+    description: 'Query with tainted range in two LIKEs with not tainted % char'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from table where name LIKE '%searchparam%' OR description LIKE '%searchparam%'",
+            "ranges": [
+              {
+                "start": 38, "length": 11, "source": { "origin": "http.request.parameter", "name": "query", "value": "searchparam" }
+              },
+              {
+                "start": 74, "length": 11, "source": { "origin": "http.request.parameter", "name": "query", "value": "searchparam" }
+              }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "query", "redacted": true }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from table where name LIKE '" },
+                { "redacted": true },
+                { "source": 0, "redacted": true },
+                { "redacted": true },
+                { "value": "' OR description LIKE '" },
+                { "redacted": true },
+                { "source": 0, "redacted": true },
+                { "redacted": true },
+                { "value": "'" }
+              ]
+            }
+          }
+        ]
+      }
   - type: 'VULNERABILITIES'
     description: 'Ldap with literal and filter $1'
     parameters:
@@ -887,7 +1022,7 @@ suite:
     expected: >
       {
         "sources": [
-         { "origin": "http.request.parameter", "name": "oid", "value": "2.4.6.8.10" }
+          { "origin": "http.request.parameter", "name": "oid", "value": "2.4.6.8.10" }
         ],
         "vulnerabilities": [
           {
@@ -1046,7 +1181,7 @@ suite:
             "type": "COMMAND_INJECTION",
             "evidence": {
               "valueParts": [
-                { "value": "cat" },
+                { "value": "cat " },
                 { "redacted": true },
                 { "source": 0, "redacted": true}
               ]
@@ -1082,7 +1217,7 @@ suite:
             "type": "COMMAND_INJECTION",
             "evidence": {
               "valueParts": [
-                { "value": "$1 cat" },
+                { "value": "$1 cat " },
                 { "redacted": true },
                 { "source": 0, "redacted": true}
               ]
@@ -1091,11 +1226,49 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'SSRF without authority or query params'
+    description: 'Command injection does not redact ranges with only whitespaces'
     input: >
       [
         {
-          "type": "SSRF",
+          "type": "COMMAND_INJECTION",
+          "evidence": {
+            "value": "ls -lah",
+            "ranges": [
+              { "start" : 0, "length" : 2, "source": { "origin": "http.request.parameter", "name": "command", "value": "ls" } },
+              { "start" : 3, "length" : 4, "source": { "origin": "http.request.parameter", "name": "argument", "value": "-lah" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "command", "value": "ls" },
+          { "origin": "http.request.parameter", "name": "argument", "redacted": true }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "COMMAND_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "value": "ls" },
+                { "value": " " },
+                { "source": 1, "redacted": true}
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: '$1 without authority or query params'
+    parameters:
+      $1:
+        - SSRF
+        - UNVALIDATED_REDIRECT
+    input: >
+      [
+        {
+          "type": "$1",
           "evidence": {
             "value": "http://datadoghq.com",
             "ranges": [
@@ -1111,7 +1284,7 @@ suite:
         ],
         "vulnerabilities": [
           {
-            "type": "SSRF",
+            "type": "$1",
             "evidence": {
               "valueParts": [
                 { "value": "http://" },
@@ -1122,9 +1295,12 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'SSRF with authority $1'
+    description: '$1 with authority $2'
     parameters:
       $1:
+        - SSRF
+        - UNVALIDATED_REDIRECT
+      $2:
         - 'user'
         - ':'
         - 'user:'
@@ -1133,9 +1309,9 @@ suite:
     input: >
       [
         {
-          "type": "SSRF",
+          "type": "$1",
           "evidence": {
-            "value": "http://$1@datadoghq.com",
+            "value": "http://$2@datadoghq.com",
             "ranges": [
               { "start" : 0, "length" : 4, "source": { "origin": "http.request.parameter", "name": "protocol", "value": "http" } }
             ]
@@ -1149,7 +1325,7 @@ suite:
         ],
         "vulnerabilities": [
           {
-            "type": "SSRF",
+            "type": "$1",
             "evidence": {
               "valueParts": [
                 { "source": 0, "value": "http" },
@@ -1162,17 +1338,20 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'SSRF with query parameters or fragment'
+    description: '$1 with query parameters or fragment'
     parameters:
       $1:
+        - SSRF
+        - UNVALIDATED_REDIRECT
+      $2:
         - '?'
         - '#'
     input: >
       [
         {
-          "type": "SSRF",
+          "type": "$1",
           "evidence": {
-            "value": "http://datadoghq.com$1first_name=john&last_name=doe",
+            "value": "http://datadoghq.com$2first_name=john&last_name=doe",
             "ranges": [
               { "start" : 7, "length" : 13, "source": { "origin": "http.request.parameter", "name": "host", "value": "datadoghq.com" } },
               { "start" : 32, "length" : 4, "source": { "origin": "http.request.parameter", "name": "fist_name", "value": "john" } }
@@ -1188,12 +1367,12 @@ suite:
         ],
         "vulnerabilities": [
           {
-            "type": "SSRF",
+            "type": "$1",
             "evidence": {
               "valueParts": [
                 { "value": "http://" },
                 { "source": 0, "value": "datadoghq.com" },
-                { "value": "$1first_name=" },
+                { "value": "$2first_name=" },
                 { "source": 1, "redacted": true },
                 { "value": "&last_name=" },
                 { "redacted": true }
@@ -1203,11 +1382,15 @@ suite:
         ]
       }
   - type: 'VULNERABILITIES'
-    description: 'SSRF authority query and fragment'
+    description: '$1 authority query and fragment'
+    parameters:
+      $1:
+        - SSRF
+        - UNVALIDATED_REDIRECT
     input: >
       [
         {
-          "type": "SSRF",
+          "type": "$1",
           "evidence": {
             "value": "https://user:password@datadoghq.com:443/api/v1/test/123/?param1=pone&param2=ptwo#fragment1=fone&fragment2=ftwo",
             "ranges": [
@@ -1223,7 +1406,7 @@ suite:
         ],
         "vulnerabilities": [
           {
-            "type": "SSRF",
+            "type": "$1",
             "evidence": {
               "valueParts": [
                 { "value": "https://" },
@@ -1241,5 +1424,17 @@ suite:
               ]
             }
           }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Weak randomness should not be redacted'
+    input: >
+      [
+        { "type": "WEAK_RANDOMNESS", "evidence": { "value": "java.util.Math" } }
+      ]
+    expected: >
+      {
+        "vulnerabilities": [
+          { "type": "WEAK_RANDOMNESS", "evidence": { "value": "java.util.Math" } }
         ]
       }

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -33,7 +33,7 @@
             "source": 0
           },
           {
-            "redacted": true
+            "value": " "
           },
           {
             "redacted": true,

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -34,7 +34,7 @@
             "source": 0
           },
           {
-            "redacted": true
+            "value": " "
           },
           {
             "redacted": true,

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -33,7 +33,7 @@
             "source": 0
           },
           {
-            "redacted": true
+            "value": " "
           },
           {
             "redacted": true,

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -34,7 +34,7 @@
             "source": 0
           },
           {
-            "redacted": true
+            "value": " "
           },
           {
             "redacted": true,

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -29,7 +29,7 @@
       "evidence": {
         "valueParts": [
           {
-            "redacted": true,
+            "value": "nonexisting.exe",
             "source": 0
           }
         ]
@@ -40,7 +40,7 @@
     {
       "origin": "http.request.body",
       "name": "Property2",
-      "redacted": true
+      "value": "nonexisting.exe"
     }
   ]
 },

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -30,7 +30,7 @@
       "evidence": {
         "valueParts": [
           {
-            "redacted": true,
+            "value": "nonexisting.exe",
             "source": 0
           }
         ]
@@ -41,7 +41,7 @@
     {
       "origin": "http.request.body",
       "name": "Property2",
-      "redacted": true
+      "value": "nonexisting.exe"
     }
   ]
 },


### PR DESCRIPTION
## Summary of changes

Update to the new test file: https://github.com/DataDog/experimental/blob/malvarez/iast-redaction-test-suite/teams/asm/iast/redaction/suite/evidence-redaction-suite.yml

Adapt regex for Oracle, Command tokenizer.
Map Unvalidated redirect vulnerability to Url tokenizer

## Reason for change

New tests and file and [RFC](https://docs.google.com/document/d/1eHfZuCQJbPb1VvERdbhRXZhH7PHVlGoAP2-LNKfFNFI/edit#heading=h.lq3n19z70wbp)

## Implementation details

## Test coverage

Same tests should now pass

## Other details
<!-- Fixes #{issue} -->
