### PR TITLE
[Tracer] v0 Schema: Add opt-in configuration for peer.service and client service name removal

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -413,6 +413,22 @@ namespace Datadog.Trace.Configuration
         public const string MetadataSchemaVersion = "DD_TRACE_SPAN_ATTRIBUTE_SCHEMA";
 
         /// <summary>
+        /// Configuration key for automatically populating the peer.service tag
+        /// from predefined precursor attributes when the span attribute schema is v0.
+        /// This is ignored when the span attribute schema is v1 or later.
+        /// Default value is false
+        /// </summary>
+        public const string PeerServiceDefaultsEnabled = "DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED";
+
+        /// <summary>
+        /// Configuration key for unifying client service names when the span
+        /// attribute schema is v0. This is ignored when the span attribute
+        /// schema is v1 or later.
+        /// Default value is false
+        /// </summary>
+        public const string RemoveClientServiceNamesEnabled = "DD_TRACE_REMOVE_CLIENT_SERVICE_NAMES_ENABLED";
+
+        /// <summary>
         /// String constants for CI Visibility configuration keys.
         /// </summary>
         public static class CIVisibility

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -426,7 +426,7 @@ namespace Datadog.Trace.Configuration
         /// schema is v1 or later.
         /// Default value is false
         /// </summary>
-        public const string RemoveClientServiceNamesEnabled = "DD_TRACE_REMOVE_CLIENT_SERVICE_NAMES_ENABLED";
+        public const string RemoveClientServiceNamesEnabled = "DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED";
 
         /// <summary>
         /// String constants for CI Visibility configuration keys.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -88,6 +88,8 @@ namespace Datadog.Trace.Configuration
             HttpClientExcludedUrlSubstrings = settings.HttpClientExcludedUrlSubstrings;
             HttpServerErrorStatusCodes = settings.HttpServerErrorStatusCodes;
             HttpClientErrorStatusCodes = settings.HttpClientErrorStatusCodes;
+            PeerServiceTagsEnabled = settings.PeerServiceTagsEnabled;
+            RemoveClientServiceNamesEnabled = settings.RemoveClientServiceNamesEnabled;
             MetadataSchemaVersion = settings.MetadataSchemaVersion;
             ServiceNameMappings = settings.ServiceNameMappings;
             TraceBufferSize = settings.TraceBufferSize;
@@ -454,6 +456,16 @@ namespace Datadog.Trace.Configuration
         internal ImmutableAzureAppServiceSettings? AzureAppServiceMetadata { get; }
 
         /// <summary>
+        /// Gets a value indicating whether to calculate the peer.service tag from predefined precursor attributes when using the v0 schema.
+        /// </summary>
+        internal bool PeerServiceTagsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether to remove the service names when using the v0 schema.
+        /// </summary>
+        internal bool RemoveClientServiceNamesEnabled { get; }
+
+        /// <summary>
         /// Gets the metadata schema version
         /// </summary>
         internal SchemaVersion MetadataSchemaVersion { get; }
@@ -510,7 +522,7 @@ namespace Datadog.Trace.Configuration
                 return name;
             }
 
-            if (MetadataSchemaVersion != SchemaVersion.V0)
+            if (MetadataSchemaVersion != SchemaVersion.V0 || RemoveClientServiceNamesEnabled)
             {
                 return tracer.DefaultServiceName;
             }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/ClientSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/ClientSchema.cs
@@ -13,12 +13,16 @@ namespace Datadog.Trace.Configuration.Schema
     internal class ClientSchema
     {
         private readonly SchemaVersion _version;
+        private readonly bool _peerServiceTagsEnabled;
+        private readonly bool _removeClientServiceNamesEnabled;
         private readonly string _defaultServiceName;
         private readonly IDictionary<string, string>? _serviceNameMappings;
 
-        public ClientSchema(SchemaVersion version, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
+        public ClientSchema(SchemaVersion version, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
         {
             _version = version;
+            _peerServiceTagsEnabled = peerServiceTagsEnabled;
+            _removeClientServiceNamesEnabled = removeClientServiceNamesEnabled;
             _defaultServiceName = defaultServiceName;
             _serviceNameMappings = serviceNameMappings;
         }
@@ -39,7 +43,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 => $"{_defaultServiceName}-{component}",
+                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{component}",
                 _ => _defaultServiceName,
             };
         }
@@ -47,7 +51,7 @@ namespace Datadog.Trace.Configuration.Schema
         public HttpTags CreateHttpTags()
             => _version switch
             {
-                SchemaVersion.V0 => new HttpTags(),
+                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new HttpTags(),
                 _ => new HttpV1Tags(),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/ClientSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/ClientSchema.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{component}",
+                SchemaVersion.V0 when !_removeClientServiceNamesEnabled => $"{_defaultServiceName}-{component}",
                 _ => _defaultServiceName,
             };
         }
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Configuration.Schema
         public HttpTags CreateHttpTags()
             => _version switch
             {
-                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new HttpTags(),
+                SchemaVersion.V0 when !_peerServiceTagsEnabled => new HttpTags(),
                 _ => new HttpV1Tags(),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/DatabaseSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/DatabaseSchema.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{databaseType}",
+                SchemaVersion.V0 when !_removeClientServiceNamesEnabled => $"{_defaultServiceName}-{databaseType}",
                 _ => _defaultServiceName,
             };
         }
@@ -47,14 +47,14 @@ namespace Datadog.Trace.Configuration.Schema
         public MongoDbTags CreateMongoDbTags()
             => _version switch
             {
-                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new MongoDbTags(),
+                SchemaVersion.V0 when !_peerServiceTagsEnabled => new MongoDbTags(),
                 _ => new MongoDbV1Tags(),
             };
 
         public SqlTags CreateSqlTags()
             => _version switch
             {
-                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new SqlTags(),
+                SchemaVersion.V0 when !_peerServiceTagsEnabled => new SqlTags(),
                 _ => new SqlV1Tags(),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/DatabaseSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/DatabaseSchema.cs
@@ -14,12 +14,16 @@ namespace Datadog.Trace.Configuration.Schema
     internal class DatabaseSchema
     {
         private readonly SchemaVersion _version;
+        private readonly bool _peerServiceTagsEnabled;
+        private readonly bool _removeClientServiceNamesEnabled;
         private readonly string _defaultServiceName;
         private readonly IDictionary<string, string>? _serviceNameMappings;
 
-        public DatabaseSchema(SchemaVersion version, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
+        public DatabaseSchema(SchemaVersion version, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
         {
             _version = version;
+            _peerServiceTagsEnabled = peerServiceTagsEnabled;
+            _removeClientServiceNamesEnabled = removeClientServiceNamesEnabled;
             _defaultServiceName = defaultServiceName;
             _serviceNameMappings = serviceNameMappings;
         }
@@ -35,7 +39,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 => $"{_defaultServiceName}-{databaseType}",
+                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{databaseType}",
                 _ => _defaultServiceName,
             };
         }
@@ -43,14 +47,14 @@ namespace Datadog.Trace.Configuration.Schema
         public MongoDbTags CreateMongoDbTags()
             => _version switch
             {
-                SchemaVersion.V0 => new MongoDbTags(),
+                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new MongoDbTags(),
                 _ => new MongoDbV1Tags(),
             };
 
         public SqlTags CreateSqlTags()
             => _version switch
             {
-                SchemaVersion.V0 => new SqlTags(),
+                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new SqlTags(),
                 _ => new SqlV1Tags(),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
@@ -13,12 +13,16 @@ namespace Datadog.Trace.Configuration.Schema
     internal class MessagingSchema
     {
         private readonly SchemaVersion _version;
+        private readonly bool _peerServiceTagsEnabled;
+        private readonly bool _removeClientServiceNamesEnabled;
         private readonly string _defaultServiceName;
         private readonly IDictionary<string, string>? _serviceNameMappings;
 
-        public MessagingSchema(SchemaVersion version, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
+        public MessagingSchema(SchemaVersion version, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
         {
             _version = version;
+            _peerServiceTagsEnabled = peerServiceTagsEnabled;
+            _removeClientServiceNamesEnabled = removeClientServiceNamesEnabled;
             _defaultServiceName = defaultServiceName;
             _serviceNameMappings = serviceNameMappings;
         }
@@ -39,7 +43,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 => $"{_defaultServiceName}-{messagingSystem}",
+                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{messagingSystem}",
                 _ => _defaultServiceName,
             };
         }
@@ -60,7 +64,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 => $"{_defaultServiceName}-{messagingSystem}",
+                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{messagingSystem}",
                 _ => _defaultServiceName,
             };
         }
@@ -68,7 +72,7 @@ namespace Datadog.Trace.Configuration.Schema
         public KafkaTags CreateKafkaTags(string spanKind)
             => _version switch
             {
-                SchemaVersion.V0 => new KafkaTags(SpanKinds.Consumer),
+                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new KafkaTags(SpanKinds.Consumer),
                 _ => new KafkaV1Tags(SpanKinds.Consumer),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{messagingSystem}",
+                SchemaVersion.V0 when !_removeClientServiceNamesEnabled => $"{_defaultServiceName}-{messagingSystem}",
                 _ => _defaultServiceName,
             };
         }
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Configuration.Schema
 
             return _version switch
             {
-                SchemaVersion.V0 when _removeClientServiceNamesEnabled == false => $"{_defaultServiceName}-{messagingSystem}",
+                SchemaVersion.V0 when !_removeClientServiceNamesEnabled => $"{_defaultServiceName}-{messagingSystem}",
                 _ => _defaultServiceName,
             };
         }
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Configuration.Schema
         public KafkaTags CreateKafkaTags(string spanKind)
             => _version switch
             {
-                SchemaVersion.V0 when _peerServiceTagsEnabled == false => new KafkaTags(SpanKinds.Consumer),
+                SchemaVersion.V0 when !_peerServiceTagsEnabled => new KafkaTags(SpanKinds.Consumer),
                 _ => new KafkaV1Tags(SpanKinds.Consumer),
             };
     }

--- a/tracer/src/Datadog.Trace/Configuration/Schema/NamingSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/NamingSchema.cs
@@ -11,12 +11,12 @@ namespace Datadog.Trace.Configuration.Schema
 {
     internal class NamingSchema
     {
-        public NamingSchema(SchemaVersion version, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
+        public NamingSchema(SchemaVersion version, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled, string defaultServiceName, IDictionary<string, string>? serviceNameMappings)
         {
             Version = version;
-            Client = new ClientSchema(version, defaultServiceName, serviceNameMappings);
-            Database = new DatabaseSchema(version, defaultServiceName, serviceNameMappings);
-            Messaging = new MessagingSchema(version, defaultServiceName, serviceNameMappings);
+            Client = new ClientSchema(version, peerServiceTagsEnabled, removeClientServiceNamesEnabled, defaultServiceName, serviceNameMappings);
+            Database = new DatabaseSchema(version, peerServiceTagsEnabled, removeClientServiceNamesEnabled, defaultServiceName, serviceNameMappings);
+            Messaging = new MessagingSchema(version, peerServiceTagsEnabled, removeClientServiceNamesEnabled, defaultServiceName, serviceNameMappings);
         }
 
         // TODO: Temporary, we can probably delete this once we migrate all the code off MetadataSchemaVersion

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -710,14 +710,14 @@ namespace Datadog.Trace.Configuration
         internal ImmutableAzureAppServiceSettings? AzureAppServiceMetadata { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to calculate the peer.service tag from predefined precursor attributes when using the v0 schema.
+        /// Gets a value indicating whether to calculate the peer.service tag from predefined precursor attributes when using the v0 schema.
         /// </summary>
-        internal bool PeerServiceTagsEnabled { get; set; }
+        internal bool PeerServiceTagsEnabled { get; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to remove the service names when using the v0 schema.
+        /// Gets a value indicating whether to remove the service names when using the v0 schema.
         /// </summary>
-        internal bool RemoveClientServiceNamesEnabled { get; set; }
+        internal bool RemoveClientServiceNamesEnabled { get; }
 
         /// <summary>
         /// Gets or sets the metadata schema version

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -144,6 +144,13 @@ namespace Datadog.Trace.Configuration
 
             // Filter out tags with empty keys or empty values, and trim whitespaces
             HeaderTags = InitializeHeaderTags(inputHeaderTags, headerTagsNormalizationFixEnabled);
+            PeerServiceTagsEnabled = config
+                                    .WithKeys(ConfigurationKeys.PeerServiceDefaultsEnabled)
+                                    .AsBool(defaultValue: false);
+            RemoveClientServiceNamesEnabled = config
+                                             .WithKeys(ConfigurationKeys.RemoveClientServiceNamesEnabled)
+                                             .AsBool(defaultValue: false);
+
             MetadataSchemaVersion = config
                                    .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
                                    .GetAs(
@@ -701,6 +708,16 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the AAS settings
         /// </summary>
         internal ImmutableAzureAppServiceSettings? AzureAppServiceMetadata { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to calculate the peer.service tag from predefined precursor attributes when using the v0 schema.
+        /// </summary>
+        internal bool PeerServiceTagsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to remove the service names when using the v0 schema.
+        /// </summary>
+        internal bool RemoveClientServiceNamesEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets the metadata schema version

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace
             Telemetry = telemetry;
             DiscoveryService = discoveryService;
             TraceProcessors = traceProcessors ?? Array.Empty<ITraceProcessor>();
-            Schema = new NamingSchema(settings.MetadataSchemaVersion, defaultServiceName, settings.ServiceNameMappings);
+            Schema = new NamingSchema(settings.MetadataSchemaVersion, settings.PeerServiceTagsEnabled, settings.RemoveClientServiceNamesEnabled, defaultServiceName, settings.ServiceNameMappings);
             QueryStringManager = new(settings.QueryStringReportingEnabled, settings.ObfuscationQueryStringRegexTimeout, settings.QueryStringReportingSize, settings.ObfuscationQueryStringRegex);
             var lstTagProcessors = new List<ITagProcessor>(TraceProcessors.Length);
             foreach (var traceProcessor in TraceProcessors)


### PR DESCRIPTION
## Summary of changes
Adds support for the following configuration keys when the selected schema is v0:
- `DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED`: Enables the peer.service calculation that is enabled by default in schema v1
- `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED`: Enables the client service renaming that is enabled by default in schema v1

## Reason for change
For a better migration path, it's been decided to allow configuration to opt-in to the v1 behaviors individually.

## Implementation details
This adds the configuration keys to the `TracerSettings`/`ImmutableTracerSettings` and propagates the bool variables down to the Schema objects. Now when the schema is v0, these settings will also be considered when returning the client service names and ITags implementations. These settings have no effect on future schema versions.

## Test coverage
The schema tests and the stop-gap ServiceName tests have been updated with the new settings. Additionally, to test all permutations of SchemaVersion/PeerServiceTagsEnabled/RemoveClientServiceNamesEnabled, the XUnit test methods have been updated to `Theory` tests.

## Other details
Note: This PR is stacked on top of the AdoNet changes, which itself is stacked on the HttpClient changes, so that all existing peer.service and service name implementations are updated.
