### PR TITLE
[RCM] In the agent TargetsVersion is a uint64

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmClientState.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         public int RootVersion { get; }
 
         [JsonProperty("targets_version")]
-        public int TargetsVersion { get; }
+        public long TargetsVersion { get; }
 
         [JsonProperty("config_states")]
         public List<RcmConfigState> ConfigStates { get; }


### PR DESCRIPTION
## Summary of changes

As spotted by @kevingosse , in the agent it's a uint 64 that matches this field
https://github.com/DataDog/datadog-agent/blob/31be8f5117ebc058603bfd61d8ef83f5f8ed3375/pkg/config/remote/uptane/client_state.go#L60

compared with ours here 
https://github.com/DataDog/datadog-agent/blob/31be8f5117ebc058603bfd61d8ef83f5f8ed3375/pkg/config/remote/service/service.go#L444
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
