### PR TITLE
[Tracer] v1 Schema: Update operation name for gRPC server integration

### DIFF
--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -226,7 +226,7 @@ span.kind | `server`
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `grpc.request`
+Name | `grpc.request`; `grpc.server.request`
 Type | `grpc`
 ### Tags
 Name | Required |

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
@@ -44,8 +44,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
                 }
 
                 var serviceName = tracer.DefaultServiceName ?? "grpc-server";
-
-                scope = tracer.StartActiveInternal(GrpcCommon.OperationName, parent: spanContext, tags: tags, serviceName: serviceName);
+                string operationName = tracer.Schema.Server.GetOperationNameForProtocol("grpc");
+                scope = tracer.StartActiveInternal(operationName, parent: spanContext, tags: tags, serviceName: serviceName);
 
                 var span = scope.Span;
                 span.Type = SpanTypes.Grpc;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/GrpcLegacyServerCommon.cs
@@ -38,8 +38,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
                 }
 
                 var serviceName = tracer.DefaultServiceName ?? "grpc-server";
-
-                scope = tracer.StartActiveInternal(GrpcCommon.OperationName, parent: spanContext, tags: tags, serviceName: serviceName);
+                string operationName = tracer.Schema.Server.GetOperationNameForProtocol("grpc");
+                scope = tracer.StartActiveInternal(operationName, parent: spanContext, tags: tags, serviceName: serviceName);
 
                 var span = scope.Span;
                 span.Type = SpanTypes.Grpc;

--- a/tracer/src/Datadog.Trace/Configuration/Schema/ServerSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/ServerSchema.cs
@@ -19,6 +19,13 @@ namespace Datadog.Trace.Configuration.Schema
             _version = version;
         }
 
+        public string GetOperationNameForProtocol(string protocol) =>
+            _version switch
+            {
+                SchemaVersion.V0 => $"{protocol}.request",
+                _ => $"{protocol}.server.request",
+            };
+
         public string GetOperationNameForComponent(string component) =>
             _version switch
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -349,7 +349,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         // These _may_ not get the expected values (though the _client_ spans always will)
                         // Depending on how the server handles them
                         var verySlowGrpcServerSpans = spans
-                                                    .Where(x => x.Name == "grpc.request" && x.Resource.EndsWith("VerySlow") && x.Tags["span.kind"] == "server")
+                                                    .Where(x => x.Type == SpanTypes.Grpc && x.Resource.EndsWith("VerySlow") && x.Tags["span.kind"] == "server")
                                                     .ToList();
                         foreach (var span in verySlowGrpcServerSpans)
                         {

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -215,7 +215,7 @@ namespace Datadog.Trace.TestHelpers
 
         public static Result IsGrpcV1(this MockSpan span, ISet<string> excludeTags) => Result.FromSpan(span, excludeTags)
             .Properties(s => s
-                .Matches(Name, "grpc.request")
+                .MatchesOneOf(Name, "grpc.request", "grpc.server.request")
                 .Matches(Type, "grpc"))
             .Tags(s => s
                 .IsPresent("grpc.method.kind")

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Schema/ServerSchemaTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Schema/ServerSchemaTests.cs
@@ -25,6 +25,22 @@ namespace Datadog.Trace.Tests.Configuration.Schema
 
         [Theory]
         [MemberData(nameof(GetAllConfigs))]
+        public void GetOperationNameForProtocolIsCorrect(object schemaVersionObject, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled)
+        {
+            var schemaVersion = (SchemaVersion)schemaVersionObject; // Unbox SchemaVersion, which is only defined internally
+            var protocol = "some-rpc";
+            var expectedValue = schemaVersion switch
+            {
+                SchemaVersion.V0 => $"{protocol}.request",
+                _ => $"{protocol}.server.request",
+            };
+
+            var namingSchema = new NamingSchema(schemaVersion, peerServiceTagsEnabled, removeClientServiceNamesEnabled, DefaultServiceName, new Dictionary<string, string>());
+            namingSchema.Server.GetOperationNameForProtocol(protocol).Should().Be(expectedValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllConfigs))]
         public void GetOperationNameForComponentIsCorrect(object schemaVersionObject, bool peerServiceTagsEnabled, bool removeClientServiceNamesEnabled)
         {
             var schemaVersion = (SchemaVersion)schemaVersionObject; // Unbox SchemaVersion, which is only defined internally

--- a/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=False.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=False.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -77,7 +77,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_5,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingBothWays,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -177,7 +177,7 @@
   {
     TraceId: Id_6,
     SpanId: Id_10,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromClient,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -279,7 +279,7 @@
   {
     TraceId: Id_11,
     SpanId: Id_15,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -383,7 +383,7 @@
   {
     TraceId: Id_16,
     SpanId: Id_20,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -487,7 +487,7 @@
   {
     TraceId: Id_21,
     SpanId: Id_25,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -591,7 +591,7 @@
   {
     TraceId: Id_26,
     SpanId: Id_30,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -699,7 +699,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_31,
     SpanId: Id_35,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -803,7 +803,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_36,
     SpanId: Id_40,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -907,7 +907,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_41,
     SpanId: Id_45,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1011,7 +1011,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_46,
     SpanId: Id_50,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1117,7 +1117,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_51,
     SpanId: Id_55,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromServer,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1217,7 +1217,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_56,
     SpanId: Id_60,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1317,7 +1317,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_61,
     SpanId: Id_65,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1417,7 +1417,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_66,
     SpanId: Id_70,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1519,7 +1519,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_71,
     SpanId: Id_75,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcDotNet,
     Type: grpc,

--- a/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -97,7 +97,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_6,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingBothWays,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -217,7 +217,7 @@
   {
     TraceId: Id_7,
     SpanId: Id_12,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromClient,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -339,7 +339,7 @@
   {
     TraceId: Id_13,
     SpanId: Id_18,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -463,7 +463,7 @@
   {
     TraceId: Id_19,
     SpanId: Id_24,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -587,7 +587,7 @@
   {
     TraceId: Id_25,
     SpanId: Id_30,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -711,7 +711,7 @@
   {
     TraceId: Id_31,
     SpanId: Id_36,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -839,7 +839,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_37,
     SpanId: Id_42,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -963,7 +963,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_43,
     SpanId: Id_48,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1087,7 +1087,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_49,
     SpanId: Id_54,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1211,7 +1211,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_55,
     SpanId: Id_60,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1337,7 +1337,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_61,
     SpanId: Id_66,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromServer,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1457,7 +1457,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_67,
     SpanId: Id_72,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1577,7 +1577,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_73,
     SpanId: Id_78,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1697,7 +1697,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_79,
     SpanId: Id_84,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcDotNet,
     Type: grpc,
@@ -1819,7 +1819,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
   {
     TraceId: Id_85,
     SpanId: Id_90,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcDotNet,
     Type: grpc,

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
@@ -59,7 +59,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_4,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingBothWays,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -150,7 +150,7 @@
   {
     TraceId: Id_5,
     SpanId: Id_8,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromClient,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -247,7 +247,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_9,
     SpanId: Id_12,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -346,7 +346,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_13,
     SpanId: Id_16,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -445,7 +445,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_17,
     SpanId: Id_20,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -544,7 +544,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_21,
     SpanId: Id_24,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -643,7 +643,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_25,
     SpanId: Id_28,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -742,7 +742,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_29,
     SpanId: Id_32,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -841,7 +841,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_33,
     SpanId: Id_36,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -940,7 +940,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_37,
     SpanId: Id_40,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/ErroringMethod,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -1033,7 +1033,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_41,
     SpanId: Id_44,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/StreamingFromServer,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -1124,7 +1124,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_45,
     SpanId: Id_48,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -1215,7 +1215,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_49,
     SpanId: Id_52,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/Unary,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -1307,7 +1307,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_53,
     SpanId: Id_56,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcLegacy,
     Type: grpc,
@@ -1401,7 +1401,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
   {
     TraceId: Id_57,
     SpanId: Id_60,
-    Name: grpc.request,
+    Name: grpc.server.request,
     Resource: /greet.tester.Greeter/VerySlow,
     Service: Samples.GrpcLegacy,
     Type: grpc,


### PR DESCRIPTION
## Summary of changes
In accordance with the v1 schema, this PR updates the operation name of the gRPC server implementation from `grpc.request` to `grpc.server.request`.

## Reason for change
The v1 schema consolidates operation names to reduce cardinality and library-specific names in the operation names. Thus, the gRPC server should have an operation name of `http.server.request`.

## Implementation details
- Updates the ServerSchema object to add an API that returns the correct operation name according to the selected schema version and the specified protocol

## Test coverage
- Updates the unit tests for the `ServerSchema` class
- All of the v1 schema snapshots for the gRPC integration test have been updated, where the diff is that the operation name of the server spans has been updated from `grpc.request` to `grpc.server.request`

## Other details
Note: This PR is stacked on top of https://github.com/DataDog/dd-trace-dotnet/pull/4216 where the `ServerSchema` class is added