### PR TITLE
Fix TracerManager initialization when replaced

### DIFF
--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -63,8 +63,9 @@ namespace Datadog.Trace
                 + nameof(Tracer) + "." + nameof(Configure) + "() to replace the global Tracer settings for the application")]
         public Tracer(TracerSettings settings)
         {
-            // TODO: Switch to immutable settings
-            Configure(settings);
+            // Don't call Configure because it will call Start on the TracerManager
+            // before this new instance of Tracer is assigned to Tracer.Instance
+            TracerManager.ReplaceGlobalManager(settings?.Build(), TracerManagerFactory.Instance);
 
             // update the count of Tracer instances
             Interlocked.Increment(ref _liveTracerCount);
@@ -244,6 +245,7 @@ namespace Datadog.Trace
         public static void Configure(TracerSettings settings)
         {
             TracerManager.ReplaceGlobalManager(settings?.Build(), TracerManagerFactory.Instance);
+            Tracer.Instance.TracerManager.Start();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

When calling `Tracer.Configure`, we create a new TracerManager but we don't call `Start` on it. 

## Reason for change

Because we replace the RCM instance when reconfiguring the tracer, we must make sure it's properly started.

## Implementation details

The `Tracer(TracerSettings)` constructor was calling `Tracer.Configure`. But we shouldn't call `TracerManager.Start` in that case, because that instance of the tracer is not active yet. So instead it now directly calls `TracerManager.ReplaceGlobalManager`.
