### PR TITLE
[Profiler] Fix reading from named pipe

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpHeaders.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpHeaders.cs
@@ -1,0 +1,98 @@
+// <copyright file="HttpHeaders.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal class HttpHeaders : IEnumerable<HttpHeaders.HttpHeader>
+    {
+        private readonly List<HttpHeader> _headers;
+
+        public HttpHeaders()
+        {
+            _headers = new List<HttpHeader>();
+        }
+
+        public HttpHeaders(int initialCapacity)
+        {
+            _headers = new List<HttpHeader>(initialCapacity);
+        }
+
+        public int Count => _headers.Count;
+
+        public bool IsReadOnly { get; }
+
+        public void Add(string name, string value)
+        {
+            _headers.Add(new HttpHeader(name, value));
+        }
+
+        public void Remove(string name)
+        {
+            _headers.RemoveAll(h => string.Equals(h.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public string GetValue(string name)
+        {
+            foreach (var header in _headers)
+            {
+                if (string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return header.Value;
+                }
+            }
+
+            return null;
+        }
+
+        public IEnumerable<string> GetValues(string name)
+        {
+            foreach (var header in _headers)
+            {
+                if (string.Equals(header.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return header.Value;
+                }
+            }
+        }
+
+        IEnumerator<HttpHeader> IEnumerable<HttpHeader>.GetEnumerator()
+        {
+            return _headers.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _headers.GetEnumerator();
+        }
+
+        public override string ToString()
+        {
+            return string.Join(", ", _headers.Select(h => $"{h.Name}: {h.Value}"));
+        }
+
+        public readonly struct HttpHeader
+        {
+            public readonly string Name;
+
+            public readonly string Value;
+
+            public HttpHeader(string name, string value)
+            {
+                Name = name;
+                Value = value;
+            }
+
+            public override string ToString()
+            {
+                return $"{Name}: {Value}";
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpMessage.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpMessage.cs
@@ -1,0 +1,67 @@
+// <copyright file="HttpMessage.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Text;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal abstract class HttpMessage
+    {
+        private static readonly UTF8Encoding Utf8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        public HttpMessage(HttpHeaders headers, IHttpContent content)
+        {
+            Headers = headers;
+            Content = content;
+        }
+
+        public HttpHeaders Headers { get; }
+
+        public IHttpContent Content { get; }
+
+        public int? ContentLength => int.TryParse(Headers.GetValue("Content-Length"), out int length) ? length : (int?)null;
+
+        public string ContentType => Headers.GetValue("Content-Type");
+
+        public Encoding GetContentEncoding()
+        {
+            // reduce getter calls
+            var contentType = ContentType;
+
+            if (contentType == null)
+            {
+                return null;
+            }
+
+            if (string.Equals("application/json", contentType, StringComparison.OrdinalIgnoreCase))
+            {
+                // Default
+                return Utf8Encoding;
+            }
+
+            // text/plain; charset=utf-8
+            string[] pairs = contentType.Split(';');
+
+            foreach (string pair in pairs)
+            {
+                string[] parts = pair.Split('=');
+
+                if (parts.Length == 2 && string.Equals(parts[0].Trim(), "charset", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    switch (parts[1].Trim())
+                    {
+                        case "utf-8":
+                            return Utf8Encoding;
+                        case "us-ascii":
+                            return Encoding.ASCII;
+                    }
+                }
+            }
+
+            return Utf8Encoding;
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpRequest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpRequest.cs
@@ -1,0 +1,24 @@
+// <copyright file="HttpRequest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal class HttpRequest : HttpMessage
+    {
+        public HttpRequest(string verb, string host, string path, HttpHeaders headers, IHttpContent content)
+            : base(headers, content)
+        {
+            Verb = verb;
+            Host = host;
+            Path = path;
+        }
+
+        public string Verb { get; }
+
+        public string Host { get; }
+
+        public string Path { get; }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpResponse.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/HttpResponse.cs
@@ -1,0 +1,21 @@
+// <copyright file="HttpResponse.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal class HttpResponse : HttpMessage
+    {
+        public HttpResponse(int statusCode, string responseMessage, HttpHeaders headers, IHttpContent content)
+            : base(headers, content)
+        {
+            StatusCode = statusCode;
+            ResponseMessage = responseMessage;
+        }
+
+        public int StatusCode { get; }
+
+        public string ResponseMessage { get; }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/IHttpContent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/IHttpContent.cs
@@ -1,0 +1,19 @@
+// <copyright file="IHttpContent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal interface IHttpContent
+    {
+        long? Length { get; }
+
+        Task CopyToAsync(Stream destination);
+
+        Task CopyToAsync(byte[] buffer);
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/StreamContent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/HttpOverStreams/StreamContent.cs
@@ -1,0 +1,58 @@
+// <copyright file="StreamContent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams
+{
+    internal class StreamContent : IHttpContent
+    {
+        public StreamContent(Stream stream, long? length)
+        {
+            Stream = stream;
+            Length = length;
+        }
+
+        public Stream Stream { get; }
+
+        public long? Length { get; }
+
+        public Task CopyToAsync(Stream destination)
+        {
+            return Stream.CopyToAsync(destination);
+        }
+
+        public async Task CopyToAsync(byte[] buffer)
+        {
+            if (!Length.HasValue)
+            {
+                throw new InvalidOperationException("Unable to CopyToAsync with buffer when content Length is unknown");
+            }
+
+            if (Length > buffer.Length)
+            {
+                throw new ArgumentException($"Provided buffer was smaller {buffer.Length} than the content length {Length}");
+            }
+
+            var length = 0;
+            long remaining = Length.Value;
+            while (true)
+            {
+                var bytesToRead = (int)Math.Min(remaining, int.MaxValue);
+                var bytesRead = await Stream.ReadAsync(buffer, offset: length, count: bytesToRead).ConfigureAwait(false);
+
+                length += bytesRead;
+                remaining -= bytesRead;
+
+                if (bytesRead == 0 || remaining <= 0)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
@@ -234,11 +234,12 @@ namespace Datadog.Profiler.IntegrationTests
             {
                 Interlocked.Increment(ref _nbTime);
 
-                var stream = new MemoryStream();
-                await ss.CopyToAsync(stream, cancellationToken);
-
-                await ss.WriteAsync(_responseBytes, cancellationToken);
-                NbCallsOnProfilingEndpoint++;
+                while (ss.IsConnected)
+                {
+                    _ = MockHttpParser.ReadRequest(ss);
+                    await ss.WriteAsync(_responseBytes, cancellationToken);
+                    NbCallsOnProfilingEndpoint++;
+                }
             }
         }
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
@@ -234,9 +234,9 @@ namespace Datadog.Profiler.IntegrationTests
             {
                 Interlocked.Increment(ref _nbTime);
 
-                var buffer = new byte[1 << 32];
+                var stream = new MemoryStream();
+                await ss.CopyToAsync(stream, cancellationToken);
 
-                await ss.ReadAsync(buffer, cancellationToken);
                 await ss.WriteAsync(_responseBytes, cancellationToken);
                 NbCallsOnProfilingEndpoint++;
             }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockHttpParser.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockHttpParser.cs
@@ -1,0 +1,179 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Profiler.IntegrationTests.Helpers.HttpOverStreams;
+
+namespace Datadog.Profiler.IntegrationTests.Helpers
+{
+    internal class MockHttpParser
+    {
+        private const string ContentLengthHeaderKey = "Content-Length";
+
+        public static async Task<MockHttpRequest> ReadRequest(Stream stream)
+        {
+            var headers = new HttpHeaders();
+            char currentChar = char.MinValue;
+            int streamPosition = 0;
+
+            // https://tools.ietf.org/html/rfc2616#section-4.2
+            const int bufferSize = 10;
+
+            var stringBuilder = new StringBuilder();
+
+            var chArray = new byte[bufferSize];
+
+            async Task GoNextChar()
+            {
+                var bytesRead = await stream.ReadAsync(chArray, offset: 0, count: 1).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    throw new InvalidOperationException($"Unexpected end of stream at position {streamPosition}");
+                }
+
+                currentChar = Encoding.ASCII.GetChars(chArray)[0];
+                streamPosition++;
+            }
+
+            async Task ReadUntil(StringBuilder builder, char stopChar)
+            {
+                while (!currentChar.Equals(stopChar))
+                {
+                    builder.Append(currentChar);
+                    await GoNextChar().ConfigureAwait(false);
+                }
+            }
+
+            async Task ReadUntilNewLine(StringBuilder builder)
+            {
+                do
+                {
+                    if (await IsNewLine().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    await ReadUntil(builder, MockDatadogAgent.DatadogHttpValues.CarriageReturn).ConfigureAwait(false);
+                }
+                while (true);
+            }
+
+            async Task<bool> IsNewLine()
+            {
+                if (currentChar.Equals(MockDatadogAgent.DatadogHttpValues.CarriageReturn))
+                {
+                    // end of headers
+                    // Next character should be a LineFeed, regardless of Linux/Windows
+                    // Skip the newline indicator
+                    await GoNextChar().ConfigureAwait(false);
+
+                    if (!currentChar.Equals(MockDatadogAgent.DatadogHttpValues.LineFeed))
+                    {
+                        throw new Exception($"Unexpected character {currentChar} in headers: CR must be followed by LF");
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+
+            stringBuilder.Clear();
+
+            // Read POST
+            await ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
+
+            var method = stringBuilder.ToString();
+            stringBuilder.Clear();
+
+            // Read /path?request
+            await GoNextChar().ConfigureAwait(false);
+            await ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
+
+            var pathAndQuery = stringBuilder.ToString().Trim();
+            stringBuilder.Clear();
+
+            // Skip to end of line
+            await ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
+            stringBuilder.Clear();
+
+            // Read headers
+            do
+            {
+                await GoNextChar().ConfigureAwait(false);
+
+                // Check for end of headers
+                if (await IsNewLine().ConfigureAwait(false))
+                {
+                    // Empty line, content starts next
+                    break;
+                }
+
+                // Read key
+                await ReadUntil(stringBuilder, stopChar: ':').ConfigureAwait(false);
+
+                var name = stringBuilder.ToString().Trim();
+                stringBuilder.Clear();
+
+                // skip separator
+                await GoNextChar().ConfigureAwait(false);
+
+                // Read value
+                await ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
+
+                var value = stringBuilder.ToString().Trim();
+                stringBuilder.Clear();
+
+                headers.Add(name, value);
+            }
+            while (true);
+
+            var length = long.TryParse(headers.GetValue(ContentLengthHeaderKey), out var headerValue) ? headerValue : (long?)null;
+
+            return new MockHttpRequest()
+            {
+                Headers = headers,
+                Method = method,
+                PathAndQuery = pathAndQuery,
+                ContentLength = length,
+                Body = new StreamContent(stream, length)
+            };
+        }
+
+        internal class MockHttpRequest
+        {
+            public HttpHeaders Headers { get; set; } = new HttpHeaders();
+
+            public string Method { get; set; }
+
+            public string PathAndQuery { get; set; }
+
+            public long? ContentLength { get; set; }
+
+            public StreamContent Body { get; set; }
+
+            public static MockHttpRequest Create(HttpListenerRequest request)
+            {
+                var headers = new HttpHeaders(request.Headers.Count);
+
+                foreach (var key in request.Headers.AllKeys)
+                {
+                    foreach (var value in request.Headers.GetValues(key))
+                    {
+                        headers.Add(key, value);
+                    }
+                }
+
+                return new MockHttpRequest
+                {
+                    Headers = headers,
+                    Method = request.HttpMethod,
+                    PathAndQuery = request.Url?.PathAndQuery,
+                    ContentLength = request.ContentLength64,
+                    Body = new StreamContent(request.InputStream, request.ContentLength64),
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

To drain the pipe, the test was calling `stream.Read` a single time. However, this will return only the available data at a given time, so more data might arrive later.

This PR replaces the whole logic with a `CopyTo` to a MemoryStream. This way we also get rid of the 4GB (🙀 ) buffer.

## Reason for change

Flaky tests
