### PR TITLE
[Profiler] Introduce IThreadInfo interface

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -15,11 +15,13 @@
 
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>
+
 #include "OsSpecificApi.h"
 #include "OpSysTools.h"
 #include "ScopeFinalizer.h"
 
 #include "IConfiguration.h"
+#include "IThreadInfo.h"
 #include "Log.h"
 #include "LinuxStackFramesCollector.h"
 #include "ProfilerSignalManager.h"
@@ -143,7 +145,7 @@ bool GetCpuInfo(pid_t tid, bool& isRunning, uint64_t& cpuTime)
     return true;
 }
 
-uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
+uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo)
 {
     bool isRunning = false;
     uint64_t cpuTime = 0;
@@ -155,7 +157,7 @@ uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
     return cpuTime;
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
+bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
     bool isRunning = false;
     if (!GetCpuInfo(pThreadInfo->GetOsThreadId(), isRunning, cpuTime))

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/OsSpecificApi.cpp
@@ -9,6 +9,7 @@
 #include "OsSpecificApi.h"
 
 #include "IConfiguration.h"
+#include "IThreadInfo.h"
 #include "StackFramesCollectorBase.h"
 #include "SystemTime.h"
 #include "Windows32BitStackFramesCollector.h"
@@ -30,7 +31,7 @@ std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
 #endif
 }
 
-uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo)
+uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo)
 {
     FILETIME creationTime, exitTime = {}; // not used here
     FILETIME kernelTime = {};
@@ -156,7 +157,7 @@ bool IsRunning(ULONG threadState)
     // If some callstacks show non cpu-bound frames at the top, return true only for Running state
 }
 
-bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
+bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed)
 {
     failed = true;
     cpuTime = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -246,6 +246,7 @@
     <ClInclude Include="IExceptionsRecorder.h" />
     <ClInclude Include="IGarbageCollectionsListener.h" />
     <ClInclude Include="ISampledAllocationsListener.h" />
+    <ClInclude Include="IThreadInfo.h" />
     <ClInclude Include="IUpscaleProvider.h" />
     <ClInclude Include="LiveObjectInfo.h" />
     <ClInclude Include="LiveObjectsProvider.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -328,6 +328,7 @@
     <ClInclude Include="DebugInfoStore.h" />
     <ClInclude Include="IDebugInfoStore.h" />
     <ClInclude Include="IExceptionsRecorder.h" />
+    <ClInclude Include="IThreadInfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IThreadInfo.h
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "cor.h"
+#include "corprof.h"
+
+#include "shared/src/native-src/string.h"
+
+class IThreadInfo
+{
+public:
+    virtual ~IThreadInfo() = default;
+    virtual DWORD GetOsThreadId() const = 0;
+    virtual shared::WSTRING const& GetThreadName() const = 0;
+    virtual HANDLE GetOsThreadHandle() const = 0;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -8,6 +8,7 @@
 #include "cor.h"
 #include "corprof.h"
 
+#include "IThreadInfo.h"
 #include "Semaphore.h"
 #include "shared/src/native-src/string.h"
 
@@ -27,7 +28,7 @@ public:
     std::uint64_t _currentSpanId;
 };
 
-struct ManagedThreadInfo
+struct ManagedThreadInfo : public IThreadInfo
 {
 private:
     ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle, shared::WSTRING pThreadName);
@@ -41,11 +42,11 @@ public:
 
     inline ThreadID GetClrThreadId() const;
 
-    inline DWORD GetOsThreadId() const;
-    inline HANDLE GetOsThreadHandle() const;
+    inline DWORD GetOsThreadId() const override;
+    inline HANDLE GetOsThreadHandle() const override;
     inline void SetOsInfo(DWORD osThreadId, HANDLE osThreadHandle);
 
-    inline const shared::WSTRING& GetThreadName() const;
+    inline const shared::WSTRING& GetThreadName() const override;
     inline void SetThreadName(shared::WSTRING pThreadName);
 
     inline std::uint64_t GetLastSampleHighPrecisionTimestampNanoseconds() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OsSpecificApi.h
@@ -12,13 +12,14 @@ namespace shared {
 struct LoaderResourceMonikerIDs;
 }
 class IConfiguration;
+class IThreadInfo;
 
 // Those functions must be defined in the main projects (Linux and Windows)
 // Here are forward declarations to avoid hard coupling
 namespace OsSpecificApi
 {
    std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration const* pConfiguration);
-   uint64_t GetThreadCpuTime(ManagedThreadInfo* pThreadInfo);
-   bool IsRunning(ManagedThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
+   uint64_t GetThreadCpuTime(IThreadInfo* pThreadInfo);
+   bool IsRunning(IThreadInfo* pThreadInfo, uint64_t& cpuTime, bool& failed);
    int32_t GetProcessorCount();
 } // namespace OsSpecificApi


### PR DESCRIPTION
## Summary of changes

Introduce a new interface `IThreadInfo`.
## Reason for change

This interface is a first step toward reporting native thread Cpu time.

## Implementation details

- Add `IThreadInfo` interface
- Replace `ManagedThreadInfo` in `OsSpecificApi` namespace.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
