### PR TITLE
Swap more Sample projects to use Activity

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -63,6 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
             SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, enableRouteTemplateResourceNames.ToString());
             SetEnvironmentVariable(ConfigurationKeys.ExpandRouteTemplatesEnabled, enableRouteTemplateExpansion.ToString());
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
 
             _fixture = fixture;
             _output = output;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -37,6 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(output, "LogsInjection.Log4Net")
         {
             SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         public static System.Collections.Generic.IEnumerable<object[]> GetTestData()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -40,6 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(output, "LogsInjection.NLog")
         {
             SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         public static IEnumerable<object[]> GetTestData()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -32,6 +32,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(output, "LogsInjection.Serilog")
         {
             SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         // exclude loadFromConfig from v1.x as it's not available

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public LargePayloadTestBase(ITestOutputHelper output)
             : base("LargePayload", output)
         {
+            SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
         }
 
         public int FillerTagLength => 100;

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,7 +41,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,18 +41,23 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,7 +39,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,18 +39,23 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,7 +41,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,18 +41,23 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,7 +39,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,18 +39,23 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithExpansion.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,7 +41,7 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -41,18 +41,23 @@ at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String 
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,7 +39,7 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -39,18 +39,23 @@ at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
   {
     TraceId: Id_3,
     SpanId: Id_4,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_2,
       runtime-id: Guid_1,
-      span.kind: server,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,18 +2,23 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.handle-async,
+    Name: CustomTracingExceptionHandler.internal,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
+    Type: custom,
     Tags: {
       env: integration_tests,
       language: dotnet,
-      runtime-id: Guid_1,
-      span.kind: server,
+      otel.library.name: CustomTracingExceptionHandler,
+      otel.status_code: STATUS_CODE_UNSET,
+      otel.trace_id: Guid_1,
+      runtime-id: Guid_2,
+      span.kind: internal,
       version: 1.0.0,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
-      _dd.p.dm: -0
+      _dd.p.dm: -0,
+      _dd.p.tid: 1234567890abcdef
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/OwinWebApi2Tests.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -2,7 +2,7 @@
   {
     TraceId: Id_1,
     SpanId: Id_2,
-    Name: CustomTracingExceptionHandler.internal,
+    Name: CustomTracingExceptionHandler.handle-async,
     Resource: CustomTracingExceptionHandler.handle-async,
     Service: Samples.Owin.WebApi2,
     Type: custom,

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -16,7 +16,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
   </ItemGroup>
-  
+
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -21,4 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/Startup.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/Startup.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using ActivitySampleHelper;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
@@ -13,6 +14,7 @@ namespace LogsInjection.ILogger
     {
         public static volatile bool AppListening = false;
         public static volatile string ServerAddress = null;
+        private static readonly ActivitySourceHelper _sampleHelpers = new("LogsInjection.ILogger.Startup");
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddHostedService<Worker>();
@@ -25,7 +27,7 @@ namespace LogsInjection.ILogger
         {
             // Not injected as we won't have a traceId
             logger.UninjectedLog("Building pipeline");
-            using (var scope = SampleHelpers.CreateScope("pipeline build"))
+            using (var scope = _sampleHelpers.CreateScope("pipeline build"))
             {
                 logger.LogInformation("Still building pipeline...");
             }
@@ -47,7 +49,7 @@ namespace LogsInjection.ILogger
             {
                 logger.ConditionalLog("Received request, echoing");
 
-                using var scope = SampleHelpers.CreateScope("middleware execution");
+                using var scope = _sampleHelpers.CreateScope("middleware execution");
                 logger.LogInformation("Sending response");
                 return context.Response.WriteAsync("PONG");
             });

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/Worker.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/Worker.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using ActivitySampleHelper;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -17,7 +18,7 @@ namespace LogsInjection.ILogger
         private readonly IServiceProvider _serviceProvider;
 #pragma warning disable 618 // ignore obsolete IApplicationLifetime
         private readonly IApplicationLifetime _lifetime;
-
+        private static readonly ActivitySourceHelper _sampleHelpers = new("LogsInjection.ILogger.Worker");
         public Worker(ILogger<Worker> logger, IApplicationLifetime lifetime, IServiceProvider serviceProvider)
 #pragma warning restore 618
         {
@@ -40,7 +41,7 @@ namespace LogsInjection.ILogger
                 return;
             }
 
-            using (var scope = SampleHelpers.CreateScope("worker request"))
+            using (var scope = _sampleHelpers.CreateScope("worker request"))
             {
                 try
                 {

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
@@ -17,6 +17,12 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(ApiVersion)' &gt;= '2.0.8'">
     <PackageReference Include="log4net.Ext.Json" Version="2.0.8.1" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
@@ -12,6 +12,12 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="NLog" Version="$(ApiVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
@@ -15,6 +15,12 @@
 
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Serilog" Version="$(ApiVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />

--- a/tracer/test/test-applications/integrations/Samples.LargePayload/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.LargePayload/Program.cs
@@ -51,7 +51,7 @@ namespace Samples.LargePayload
 
                                                   while (spansRemaining-- > 0)
                                                   {
-                                                      using (var spanScope = SampleHelpers.CreateScope("nest"))
+                                                      using (var spanScope = _sampleHelpers.CreateScope("nest"))
                                                       {
                                                           _sampleHelpers.TrySetTag(spanScope, "fill", Guid.NewGuid().ToString());
                                                           _sampleHelpers.TrySetTag(spanScope, "stuff", traceFiller);

--- a/tracer/test/test-applications/integrations/Samples.LargePayload/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.LargePayload/Program.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using ActivitySampleHelper;
 using CommandLine;
 
 namespace Samples.LargePayload
 {
     public static class Program
     {
+        private static readonly ActivitySourceHelper _sampleHelpers = new(nameof(Program));
+
         public static int Main(string[] args)
         {
             ExitCode exitCode = 0;
@@ -39,10 +42,10 @@ namespace Samples.LargePayload
                            var traceTask = Task.Run(
                                           () =>
                                           {
-                                              using (var traceScope = SampleHelpers.CreateScope("very-big-trace"))
+                                              using (var traceScope = _sampleHelpers.CreateScope("very-big-trace"))
                                               {
-                                                  SampleHelpers.TrySetTag(traceScope, "fill", Guid.NewGuid().ToString());
-                                                  SampleHelpers.TrySetTag(traceScope, "stuff", traceFiller);
+                                                  _sampleHelpers.TrySetTag(traceScope, "fill", Guid.NewGuid().ToString());
+                                                  _sampleHelpers.TrySetTag(traceScope, "stuff", traceFiller);
 
                                                   var spansRemaining = spansPerTrace;
 
@@ -50,8 +53,8 @@ namespace Samples.LargePayload
                                                   {
                                                       using (var spanScope = SampleHelpers.CreateScope("nest"))
                                                       {
-                                                          SampleHelpers.TrySetTag(spanScope, "fill", Guid.NewGuid().ToString());
-                                                          SampleHelpers.TrySetTag(spanScope, "stuff", traceFiller);
+                                                          _sampleHelpers.TrySetTag(spanScope, "fill", Guid.NewGuid().ToString());
+                                                          _sampleHelpers.TrySetTag(spanScope, "stuff", traceFiller);
                                                       }
                                                   }
                                               }

--- a/tracer/test/test-applications/integrations/Samples.LargePayload/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.LargePayload/Properties/launchSettings.json
@@ -10,7 +10,17 @@
         "DD_SERVICE": "LargePayload",
         "DD_VERSION": "1.1.1",
         "DD_TAGS": "",
-        "DD_HOST": "PayloadHost"
+        "DD_HOST": "PayloadHost",
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_TRACE_OTEL_ENABLED": "true"
       }
     },
     "UnixDomainSocket": {
@@ -23,7 +33,17 @@
         "DD_SERVICE": "LargePayload",
         "DD_VERSION": "1.1.1",
         "DD_TAGS": "",
-        "DD_HOST": "PayloadHost"
+        "DD_HOST": "PayloadHost",
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_TRACE_OTEL_ENABLED": "true"
       }
     },
     "WindowsNamedPipe": {
@@ -36,7 +56,17 @@
         "DD_SERVICE": "LargePayload",
         "DD_VERSION": "1.1.1",
         "DD_TAGS": "",
-        "DD_HOST": "PayloadHost"
+        "DD_HOST": "PayloadHost",
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_TRACE_OTEL_ENABLED": "true"
       }
     }
   }

--- a/tracer/test/test-applications/integrations/Samples.LargePayload/Samples.LargePayload.csproj
+++ b/tracer/test/test-applications/integrations/Samples.LargePayload/Samples.LargePayload.csproj
@@ -2,5 +2,14 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Handlers/CustomTracingExceptionHandler.cs
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Handlers/CustomTracingExceptionHandler.cs
@@ -1,17 +1,20 @@
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http.ExceptionHandling;
+using ActivitySampleHelper;
 
 namespace Samples.Owin.WebApi2.Handlers
 {
     public class CustomTracingExceptionHandler : ExceptionHandler
     {
+        private static readonly ActivitySourceHelper _sampleHelpers = new(nameof(CustomTracingExceptionHandler));
+
         public override async Task HandleAsync(ExceptionHandlerContext context, CancellationToken cancellationToken)
         {
-            using (var scope = SampleHelpers.CreateScope("CustomTracingExceptionHandler.handle-async"))
+            using (var scope = _sampleHelpers.CreateScope("CustomTracingExceptionHandler.handle-async"))
             {
                 // Set span kind of span to server to pass through server span filtering
-                SampleHelpers.TrySetTag(scope, "span.kind", "server");
+                _sampleHelpers.TrySetTag(scope, "span.kind", "server");
 
                 await base.HandleAsync(context, cancellationToken);
             }

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
@@ -15,5 +15,8 @@
     <Compile Include="..\..\aspnet\Samples.AspNetMvc5\Controllers\ApiController.cs" Link="Controllers\ApiController.cs" />
     <Compile Include="..\..\aspnet\Samples.AspNetMvc5\Controllers\ConventionsController.cs" Link="Controllers\ConventionsController.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
@@ -29,5 +29,13 @@ namespace ActivitySampleHelper
             }
             return activity;
         }
+
+        public void TrySetTag(IDisposable scope, string key, string value)
+        {
+            if(scope is Activity activity)
+            {
+                activity.SetTag(key, value);
+            }
+        }
     }
 }

--- a/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/ActivitySampleHelper/ActivitySourceHelper.cs
@@ -37,5 +37,25 @@ namespace ActivitySampleHelper
                 activity.SetTag(key, value);
             }
         }
+
+        public ActivityTraceId GetTraceId(IDisposable scope)
+        {
+            if (scope is Activity activity)
+            {
+                return activity.TraceId;
+            }
+
+            throw new Exception("scope wasn't an Activity, can't get TraceId");
+        }
+
+        public ActivitySpanId GetSpanId(IDisposable scope)
+        {
+            if (scope is Activity activity)
+            {
+                return activity.SpanId;
+            }
+
+            throw new Exception("scope wasn't an Activity, can't get SpanId");
+        }
     }
 }

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Reflection;
+using ActivitySampleHelper;
 
 namespace PluginApplication
 {
@@ -11,6 +12,8 @@ namespace PluginApplication
         /// In other words, they're not written within a Datadog scope 
         /// </summary>
         private static readonly string ExcludeMessagePrefix = "[ExcludeMessage]";
+        private static readonly ActivitySourceHelper _sampleHelpers = new("LogsInjectionHelper");
+
 
         public static void DeleteExistingLogs()
         {
@@ -46,7 +49,7 @@ namespace PluginApplication
             try
             {
                 logAction($"{ExcludeMessagePrefix}Entering Datadog scope.");
-                using (var scope = Samples.SampleHelpers.CreateScope("transaction"))
+                using (var scope = _sampleHelpers.CreateScope("transaction"))
                 {
                     // In the middle of the trace, make a call across AppDomains
                     // Unless handled properly, this can cause the following error due

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LogsInjectionHelper.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LogsInjectionHelper.csproj
@@ -5,6 +5,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
+  <ItemGroup>
+    <ProjectReference Include="..\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
@@ -13,4 +13,14 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\integrations\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
@@ -1,11 +1,12 @@
 using log4net;
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using log4net.Core;
 using Samples;
-using System.Reflection;
+using ActivitySampleHelper;
 
 namespace DataDogThreadTest
 {
@@ -14,6 +15,7 @@ namespace DataDogThreadTest
         internal static readonly string TraceIdKey = "dd.trace_id";
         internal static readonly string SpanIdKey = "dd.span_id";
         internal static readonly string NonTraceMessage = "TraceId: 0, SpanId: 0";
+        private static readonly ActivitySourceHelper _sampleHelpers = new(nameof(Program));
 
         static int Main(string[] args)
         {
@@ -49,17 +51,17 @@ namespace DataDogThreadTest
                                         var i = 0;
                                         while (i++ < totalIterations)
                                         {
-                                            using (var outerScope = SampleHelpers.CreateScope("thread-test"))
+                                            using (var outerScope = _sampleHelpers.CreateScope("thread-test"))
                                             {
-                                                var outerTraceId = SampleHelpers.GetTraceId(outerScope);
-                                                var outerSpanId = SampleHelpers.GetSpanId(outerScope);
+                                                var outerTraceId = _sampleHelpers.GetTraceId(outerScope);
+                                                var outerSpanId = _sampleHelpers.GetSpanId(outerScope);
 
                                                 logger.Info($"TraceId: {outerTraceId}, SpanId: {outerSpanId}");
 
-                                                using (var innerScope = SampleHelpers.CreateScope("nest-thread-test"))
+                                                using (var innerScope = _sampleHelpers.CreateScope("nest-thread-test"))
                                                 {
-                                                    var innerTraceId = SampleHelpers.GetTraceId(innerScope);
-                                                    var innerSpanId = SampleHelpers.GetSpanId(innerScope);
+                                                    var innerTraceId = _sampleHelpers.GetTraceId(innerScope);
+                                                    var innerSpanId = _sampleHelpers.GetSpanId(innerScope);
 
                                                     if (outerTraceId != innerTraceId)
                                                     {

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Properties/launchSettings.json
@@ -13,7 +13,8 @@
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
 
-        "DD_LOGS_INJECTION": "true"
+        "DD_LOGS_INJECTION": "true",
+        "DD_TRACE_OTEL_ENABLED": "true"
       },
       "nativeDebugging": true
     }

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
@@ -9,4 +9,14 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\integrations\dependency-libs\ActivitySampleHelper\ActivitySampleHelper.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Program.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
+using ActivitySampleHelper;
 
 namespace DogStatsD.RaceCondition
 {
@@ -13,6 +14,7 @@ namespace DogStatsD.RaceCondition
         private static readonly string TraceMetrics = "DD_TRACE_METRICS_ENABLED";
         private static readonly string LogsInjection = "DD_LOGS_INJECTION";
         private static readonly string DebugEnabled = "DD_TRACE_DEBUG";
+        private static readonly ActivitySourceHelper _sampleHelpers = new(nameof(Program));
 
         static int Main(string[] args)
         {
@@ -29,7 +31,6 @@ namespace DogStatsD.RaceCondition
                     throw new Exception($"Make sure the following environment variables are set to \"true\": {TraceMetrics}, {LogsInjection}, {DebugEnabled}");
                 }
 
-                SampleHelpers.ConfigureTracer("DogStatsD.RaceCondition");
                 var totalIterations = 100;
                 var threadRepresentation = Enumerable.Range(0, 25).ToArray();
                 var threadCount = threadRepresentation.Length;
@@ -52,7 +53,7 @@ namespace DogStatsD.RaceCondition
 
                                         while (i++ < totalIterations)
                                         {
-                                            using (var outerScope = SampleHelpers.CreateScope("outer-span"))
+                                            using (var outerScope = _sampleHelpers.CreateScope("outer-span"))
                                             {
                                             }
                                         }
@@ -95,9 +96,6 @@ namespace DogStatsD.RaceCondition
                 {
                     throw new Exception("Got exception with 'System.IndexOutOfRangeException'");
                 }
-
-                Console.WriteLine("Press any key to exit");
-                Console.ReadKey();
             }
             catch (Exception ex)
             {

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/Properties/launchSettings.json
@@ -15,7 +15,8 @@
 
         "DD_TRACE_METRICS_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
-        "DD_TRACE_DEBUG": "true"
+        "DD_TRACE_DEBUG": "true",
+        "DD_TRACE_OTEL_ENABLED": "true"
       },
       "nativeDebugging": false
     }


### PR DESCRIPTION
## Summary of changes

Swaps a few other sample projects to use `Activity` instead of `SampleHelpers` -> specifically `SampleHelpers.CreateScope`.

## Reason for change

Want to move toward using `Activity` where possible in the tests.

## Implementation details

- I've added dependency on a `ActivitySampleHelper` project that mimics the `SampleHelper` API but for `Activity` for the samples here.
- Had to add a `<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>` to get the samples to play nice with .NET Core 2/3 because of the dependency within `ActivitySampleHelper`

## Test coverage

- Ran tests and updated snapshots where they seemed to be updated
- I ran `DataDogThreadTest` and it seems to be broken on both `master` and this branch, but we don't actually run that project in CI, so not really sure how valuable it is or whether I should spend time fixing it.

## Other details

Sorry the Owin one has a lot of changes in the snapshot, but they all looked the same so I opted to keep it in and not split it out.
