### PR TITLE
Fix build: Update Trimming.xml and add missing NuGets to IntegrationGroups

### DIFF
--- a/tracer/build/_build/Honeypot/IntegrationGroups.cs
+++ b/tracer/build/_build/Honeypot/IntegrationGroups.cs
@@ -84,6 +84,8 @@ namespace Honeypot
             NugetPackages.Add("Microsoft.AspNetCore.Mvc.Core", new [] { "Microsoft.AspNetCore.Mvc.Core" });
             NugetPackages.Add("OpenTelemetry.Api", new [] { "OpenTelemetry.Api" });
             NugetPackages.Add("OpenTelemetry", new [] { "OpenTelemetry" });
+            NugetPackages.Add("Microsoft.AspNetCore.Server.IIS", new[] { "Microsoft.AspNetCore.Server.IIS" });
+            NugetPackages.Add("Microsoft.AspNetCore.Server.Kestrel.Core", new string[] { "Microsoft.AspNetCore.Server.Kestrel.Core" });
         }
 
         private IntegrationMap()

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -55,6 +55,8 @@
       <type fullname="Microsoft.AspNetCore.Routing.RouteData" />
       <type fullname="Microsoft.AspNetCore.Routing.RouteValueDictionary" />
    </assembly>
+   <assembly fullname="Microsoft.AspNetCore.Server.IIS" />
+   <assembly fullname="Microsoft.AspNetCore.Server.Kestrel.Core" />
    <assembly fullname="Microsoft.Azure.Cosmos.Client" />
    <assembly fullname="Microsoft.Azure.Functions.Worker.Core" />
    <assembly fullname="Microsoft.Azure.WebJobs.Host" />


### PR DESCRIPTION
## Summary of changes

This updates the `Datadog.Trace.Trimming.xml` file and `IntegrationGroups` with the NuGets: `Microsoft.AspNetCore.Server.IIS` and `Microsoft.AspNetCore.Server.Kestrel.Core`

## Reason for change

Build wasn't working without these

## Implementation details

- Ran `build.ps1 BuildTracerHome CreateRootDescriptorsFile` to update the XML
- Saw that these two were causing issues in the `GeneratePackageVersion` step

## Test coverage

- If the respective Github actions pass

## Other details

Needed because these two NuGets were instrumented in https://github.com/DataDog/dd-trace-dotnet/pull/4209
