### PR TITLE
Avoid making excessive & unnecessary calls to TryGetGitTagsFromSouceLink

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Ci
             }
         }
 
-        protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings)
+        protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)
         {
             return new CIGitMetadataTagsProvider();
         }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -1,4 +1,4 @@
-// <copyright file="TracerManagerFactory.cs" company="Datadog">
+ // <copyright file="TracerManagerFactory.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -118,7 +118,7 @@ namespace Datadog.Trace
                 runtimeMetrics ??= new RuntimeMetricsWriter(statsd, TimeSpan.FromSeconds(10), settings.IsRunningInAzureAppService);
             }
 
-            var gitMetadataTagsProvider = GetGitMetadataTagsProvider(settings);
+            var gitMetadataTagsProvider = GetGitMetadataTagsProvider(settings, scopeManager);
             logSubmissionManager = DirectLogSubmissionManager.Create(
                 logSubmissionManager,
                 settings.LogSubmissionSettings,
@@ -179,9 +179,9 @@ namespace Datadog.Trace
                 remoteConfigurationManager);
         }
 
-        protected virtual IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings)
+        protected virtual IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)
         {
-            return new GitMetadataTagsProvider(settings);
+            return new GitMetadataTagsProvider(settings, scopeManager);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes
In `GitMetadataTagsProvider.TryGetGitTagsFromSourceLink`, there is a retry logic that is meant to allow callers to try again in case the method was originally called too early, such that the `entry assembly` cannot yet be retrieved, and therefore we cannot extract SourceLink information from it.

The current logic simply blindly allows up to 100 attempts. This fix changes the behavior such that if there is an active span, we assume the application has already loaded and we should be in a context that allows us to determine the entry assembly, we stop and prevent any further retries.

## Reason for change
Improve performance. Although the performance impact of `GetGitMetadataTagsProvider` should be quite negligible, this change should help reduce the performance cost we're currently paying each and every time we're loaded into a customer application (regardless of whether that customer is using Git Metadata / Source Code Integration or not).

## Test coverage
This is change is covered by the tests that were introduced in https://github.com/DataDog/dd-trace-dotnet/pull/3652