### PR TITLE
[Profiler] Try fixing code hotspots tests

### DIFF
--- a/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Controllers/ProductsController.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using BuggyBits.Models;
 using Microsoft.AspNetCore.Http;
@@ -160,6 +161,29 @@ namespace BuggyBits.Controllers
             ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
             ViewData["ProductsTable"] = productsTable;
             return View();
+        }
+
+        // GET: Products/IndexSlow
+        public IActionResult IndexSlow()
+        {
+            SpinWait.SpinUntil(() => false, TimeSpan.FromSeconds(1));
+
+            var sw = new Stopwatch();
+            sw.Start();
+            var products = dataLayer.GetAllProducts();
+            var productsTable = "<table><tr><th>Product Name</th><th>Description</th><th>Price</th></tr>";
+            foreach (var product in products)
+            {
+                productsTable += $"<tr><td>{product.ProductName}</td><td>{product.Description}</td><td>${product.Price}</td></tr>";
+            }
+
+            productsTable += "</table>";
+            sw.Stop();
+
+            ViewData["ElapsedTimeInMs"] = sw.ElapsedMilliseconds;
+            ViewData["ProductsTable"] = productsTable;
+
+            return View("Index");
         }
 
         // GET: Products/Details/BugSpray

--- a/profiler/src/Demos/Samples.BuggyBits/Program.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/Program.cs
@@ -24,7 +24,8 @@ namespace BuggyBits
         FormatExceptions = 16, // generating FormatExceptions for prices
         ParallelLock = 32,     // using parallel code with lock
         MemoryLeak = 64, // keep a controller in memory due to instance callback passed to a cache
-        EndpointsCount = 128 // Specific test with '.' in endpoint name
+        EndpointsCount = 128, // Specific test with '.' in endpoint name
+        Spin = 256 // Requests that take a long time
     }
 
     public class Program

--- a/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
+++ b/profiler/src/Demos/Samples.BuggyBits/SelfInvoker.cs
@@ -138,6 +138,11 @@ namespace BuggyBits
                 {
                     urls.Add($"{rootUrl}/End.Point.With.Dots");
                 }
+
+                if ((_scenario & Scenario.Spin) == Scenario.Spin)
+                {
+                    urls.Add($"{rootUrl}/Products/IndexSlow");
+                }
             }
 
             return urls;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -206,7 +206,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 
             var endpoints = GetEndpointsFromPprofFiles(runner.Environment.PprofDir);
 
-            endpoints.Distinct().Should().BeEquivalentTo("GET /products/builder");
+            endpoints.Distinct().Should().BeEquivalentTo("GET /products/indexslow");
         }
 
         [TestAppFact("Samples.BuggyBits")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -22,7 +22,7 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
 {
     public class CodeHotspotTest
     {
-        private const string ScenarioCodeHotspot = "--scenario 2";
+        private const string ScenarioCodeHotspot = "--scenario 256";
         //private const string ScenarioExceptions = "--scenario 16";
         private static readonly Regex RuntimeIdPattern = new("runtime-id:(?<runtimeId>[A-Z0-9-]+)", RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
         private readonly ITestOutputHelper _output;


### PR DESCRIPTION
## Summary of changes

Code hotspots tests are currently flaky. I suspect it's because they rely on very short requests (~3 ms per request on my machine, with 100 ms of pause between each request), so the probability that the profiler captures a CPU profile with an active span is actually quite low.

## Reason for change

Reduce the wear on the "Retry" button in the CI.

## Implementation details

Added a lengthy spin wait to make the CPU busy and increase global warming.
