### PR TITLE
Ensure dependency collector persists across telemetry controllers

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -117,6 +117,47 @@ public class TelemetryFactoryTests
     }
 
     [Fact]
+    public void TelemetryFactory_V1Telemetry_CollectorsPersistWhenNewController()
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: true,
+            v2Enabled: false,
+            metricsEnabled: false);
+
+        var controller1 = factory.CreateTelemetryController(tracerSettings, settings);
+        var metrics1 = TelemetryFactory.Metrics;
+        var config1 = TelemetryFactory.Metrics;
+
+        var controller2 = factory.CreateTelemetryController(tracerSettings, settings);
+        var metrics2 = TelemetryFactory.Metrics;
+        var config2 = TelemetryFactory.Metrics;
+
+        var v1Controller1 = controller1.Should().BeOfType<TelemetryController>().Subject;
+        var v1Controller2 = controller2.Should().BeOfType<TelemetryController>().Subject;
+        v1Controller1.Should().NotBe(v1Controller2);
+
+        metrics1.Should().Be(metrics2);
+        config1.Should().Be(config2);
+
+        var dependencies = GetField<TelemetryController>("_dependencies");
+        dependencies.GetValue(controller1).Should().BeSameAs(dependencies.GetValue(controller2));
+
+        var integrations = GetField<TelemetryController>("_integrations");
+        integrations.GetValue(controller1).Should().BeSameAs(integrations.GetValue(controller2));
+    }
+
+    [Fact]
     public void TelemetryFactory_V2Telemetry_DisablesMetricsIfMetricsDisabled()
     {
         // set the defaults (module initializer resets everything by default
@@ -162,5 +203,59 @@ public class TelemetryFactoryTests
         var controller = factory.CreateTelemetryController(tracerSettings, settings);
 
         TelemetryFactory.Metrics.Should().BeOfType<MetricsTelemetryCollector>();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TelemetryFactory_V2Telemetry_CollectorsPersistWhenNewController(bool dependencyCollectionEnabled)
+    {
+        // set the defaults (module initializer resets everything by default
+        TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
+        TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
+
+        var factory = TelemetryFactory.CreateFactory();
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var settings = new TelemetrySettings(
+            telemetryEnabled: true,
+            configurationError: null,
+            agentlessSettings: null,
+            agentProxyEnabled: true,
+            heartbeatInterval: TimeSpan.FromSeconds(1),
+            dependencyCollectionEnabled: dependencyCollectionEnabled,
+            v2Enabled: true,
+            metricsEnabled: true);
+
+        var controller1 = factory.CreateTelemetryController(tracerSettings, settings);
+        var metrics1 = TelemetryFactory.Metrics;
+        var config1 = TelemetryFactory.Metrics;
+
+        var controller2 = factory.CreateTelemetryController(tracerSettings, settings);
+        var metrics2 = TelemetryFactory.Metrics;
+        var config2 = TelemetryFactory.Metrics;
+
+        var v1Controller1 = controller1.Should().BeOfType<TelemetryControllerV2>().Subject;
+        var v1Controller2 = controller2.Should().BeOfType<TelemetryControllerV2>().Subject;
+        v1Controller1.Should().NotBe(v1Controller2);
+
+        metrics1.Should().Be(metrics2);
+        config1.Should().Be(config2);
+
+        var dependencies = GetField<TelemetryControllerV2>("_dependencies");
+        dependencies.GetValue(controller1).Should().BeSameAs(dependencies.GetValue(controller2));
+
+        var integrations = GetField<TelemetryControllerV2>("_integrations");
+        integrations.GetValue(controller1).Should().BeSameAs(integrations.GetValue(controller2));
+
+        var products = GetField<TelemetryControllerV2>("_products");
+        products.GetValue(controller1).Should().BeSameAs(products.GetValue(controller2));
+
+        var application = GetField<TelemetryControllerV2>("_application");
+        application.GetValue(controller1).Should().BeSameAs(application.GetValue(controller2));
+    }
+
+    private static FieldInfo GetField<T>(string name)
+    {
+        return typeof(T).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
     }
 }


### PR DESCRIPTION
## Summary of changes

Ensure we only initialize dependency collector once

## Reason for change

Collectors should persist across multiple `TelemetryController`s, so that we don't lose values.

## Implementation details

Ensure we only initialize the collector once.

## Test coverage

Added some hacky unit tests to confirm the behaviour

## Other details

Introduced in #4180 
