### PR TITLE
Small telemetry updates from feedback

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
@@ -671,8 +671,13 @@ internal partial class Sources
             return;
         }
 
+        var i = 0;
         foreach (var (_, metric) in names)
         {
+            sb.AppendLine(
+                $$"""
+                            // {{metric.MetricName}}, index = {{i}}
+                """);
             const string prefix =
                 """
                             new(
@@ -685,6 +690,7 @@ internal partial class Sources
                     {
                         foreach (var tag2Value in tag2Values)
                         {
+                            i++;
                             sb.Append(prefix)
                               .Append("new[] { \"")
                               .Append(tag1Value)
@@ -695,6 +701,7 @@ internal partial class Sources
                     }
                     else
                     {
+                        i++;
                         sb.Append(prefix)
                           .Append("new[] { \"")
                           .Append(tag1Value)
@@ -704,6 +711,7 @@ internal partial class Sources
             }
             else
             {
+                i++;
                 sb
                    .Append(prefix)
                    .AppendLine("null),");

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -173,10 +173,12 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetCountBuffer()
         => new MetricKey[]
         {
+            // log_created, index = 0
             new(new[] { "level:debug" }),
             new(new[] { "level:info" }),
             new(new[] { "level:warn" }),
             new(new[] { "level:error" }),
+            // integrations_error, index = 4
             new(new[] { "integrations_name:httpmessagehandler", "error_type:duck_typing" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:invoker" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:execution" }),
@@ -318,6 +320,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:aws_lambda", "error_type:duck_typing" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:invoker" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:execution" }),
+            // span_created, index = 145
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -365,24 +368,34 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // span_finished, index = 192
             new(null),
+            // span_sampled, index = 193
             new(null),
+            // span_dropped, index = 194
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_created, index = 199
             new(new[] { "new_continued:new" }),
             new(new[] { "new_continued:continued" }),
+            // trace_enqueued, index = 201
             new(null),
+            // trace_sampled, index = 202
             new(null),
+            // trace_dropped, index = 203
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_sent, index = 208
             new(null),
+            // trace_api.requests, index = 209
             new(null),
+            // trace_api.responses, index = 210
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -405,20 +418,26 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // trace_api.errors, index = 232
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // trace_partial_flush, index = 235
             new(new[] { "reason:large_trace" }),
             new(new[] { "reason:single_span_ingestion" }),
+            // context_header_style.injected, index = 237
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // context_header_style.extracted, index = 241
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // stats_api.requests, index = 245
             new(null),
+            // stats_api.responses, index = 246
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -441,11 +460,14 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // stats_api.errors, index = 268
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // telemetry_api.requests, index = 271
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
+            // telemetry_api.responses, index = 273
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -490,13 +512,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
+            // telemetry_api.errors, index = 317
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network_error" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network_error" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
+            // version_conflict_tracer_created, index = 323
             new(null),
+            // direct_log_logs, index = 324
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -544,7 +569,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // direct_log_api.requests, index = 371
             new(null),
+            // direct_log_api.responses, index = 372
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -567,6 +594,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // direct_log_api.errors.responses, index = 394
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -18,6 +18,7 @@ internal partial class MetricsTelemetryCollector
     private static DistributionKey[] GetDistributionBuffer()
         => new DistributionKey[]
         {
+            // init_time, index = 0
             new(new[] { "component:total" }),
             new(new[] { "component:byref_pinvoke" }),
             new(new[] { "component:calltarget_state_byref_pinvoke" }),

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -28,13 +28,16 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetGaugeBuffer()
         => new MetricKey[]
         {
+            // stats_buckets, index = 0
             new(null),
+            // instrumentations, index = 1
             new(new[] { "component_name:calltarget" }),
             new(new[] { "component_name:calltarget_derived" }),
             new(new[] { "component_name:calltarget_interfaces" }),
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
+            // direct_log_queue, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -173,10 +173,12 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetCountBuffer()
         => new MetricKey[]
         {
+            // log_created, index = 0
             new(new[] { "level:debug" }),
             new(new[] { "level:info" }),
             new(new[] { "level:warn" }),
             new(new[] { "level:error" }),
+            // integrations_error, index = 4
             new(new[] { "integrations_name:httpmessagehandler", "error_type:duck_typing" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:invoker" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:execution" }),
@@ -318,6 +320,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:aws_lambda", "error_type:duck_typing" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:invoker" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:execution" }),
+            // span_created, index = 145
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -365,24 +368,34 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // span_finished, index = 192
             new(null),
+            // span_sampled, index = 193
             new(null),
+            // span_dropped, index = 194
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_created, index = 199
             new(new[] { "new_continued:new" }),
             new(new[] { "new_continued:continued" }),
+            // trace_enqueued, index = 201
             new(null),
+            // trace_sampled, index = 202
             new(null),
+            // trace_dropped, index = 203
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_sent, index = 208
             new(null),
+            // trace_api.requests, index = 209
             new(null),
+            // trace_api.responses, index = 210
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -405,20 +418,26 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // trace_api.errors, index = 232
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // trace_partial_flush, index = 235
             new(new[] { "reason:large_trace" }),
             new(new[] { "reason:single_span_ingestion" }),
+            // context_header_style.injected, index = 237
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // context_header_style.extracted, index = 241
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // stats_api.requests, index = 245
             new(null),
+            // stats_api.responses, index = 246
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -441,11 +460,14 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // stats_api.errors, index = 268
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // telemetry_api.requests, index = 271
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
+            // telemetry_api.responses, index = 273
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -490,13 +512,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
+            // telemetry_api.errors, index = 317
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network_error" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network_error" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
+            // version_conflict_tracer_created, index = 323
             new(null),
+            // direct_log_logs, index = 324
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -544,7 +569,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // direct_log_api.requests, index = 371
             new(null),
+            // direct_log_api.responses, index = 372
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -567,6 +594,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // direct_log_api.errors.responses, index = 394
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -18,6 +18,7 @@ internal partial class MetricsTelemetryCollector
     private static DistributionKey[] GetDistributionBuffer()
         => new DistributionKey[]
         {
+            // init_time, index = 0
             new(new[] { "component:total" }),
             new(new[] { "component:byref_pinvoke" }),
             new(new[] { "component:calltarget_state_byref_pinvoke" }),

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -28,13 +28,16 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetGaugeBuffer()
         => new MetricKey[]
         {
+            // stats_buckets, index = 0
             new(null),
+            // instrumentations, index = 1
             new(new[] { "component_name:calltarget" }),
             new(new[] { "component_name:calltarget_derived" }),
             new(new[] { "component_name:calltarget_interfaces" }),
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
+            // direct_log_queue, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -173,10 +173,12 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetCountBuffer()
         => new MetricKey[]
         {
+            // log_created, index = 0
             new(new[] { "level:debug" }),
             new(new[] { "level:info" }),
             new(new[] { "level:warn" }),
             new(new[] { "level:error" }),
+            // integrations_error, index = 4
             new(new[] { "integrations_name:httpmessagehandler", "error_type:duck_typing" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:invoker" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:execution" }),
@@ -318,6 +320,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:aws_lambda", "error_type:duck_typing" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:invoker" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:execution" }),
+            // span_created, index = 145
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -365,24 +368,34 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // span_finished, index = 192
             new(null),
+            // span_sampled, index = 193
             new(null),
+            // span_dropped, index = 194
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_created, index = 199
             new(new[] { "new_continued:new" }),
             new(new[] { "new_continued:continued" }),
+            // trace_enqueued, index = 201
             new(null),
+            // trace_sampled, index = 202
             new(null),
+            // trace_dropped, index = 203
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_sent, index = 208
             new(null),
+            // trace_api.requests, index = 209
             new(null),
+            // trace_api.responses, index = 210
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -405,20 +418,26 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // trace_api.errors, index = 232
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // trace_partial_flush, index = 235
             new(new[] { "reason:large_trace" }),
             new(new[] { "reason:single_span_ingestion" }),
+            // context_header_style.injected, index = 237
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // context_header_style.extracted, index = 241
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // stats_api.requests, index = 245
             new(null),
+            // stats_api.responses, index = 246
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -441,11 +460,14 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // stats_api.errors, index = 268
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // telemetry_api.requests, index = 271
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
+            // telemetry_api.responses, index = 273
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -490,13 +512,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
+            // telemetry_api.errors, index = 317
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network_error" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network_error" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
+            // version_conflict_tracer_created, index = 323
             new(null),
+            // direct_log_logs, index = 324
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -544,7 +569,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // direct_log_api.requests, index = 371
             new(null),
+            // direct_log_api.responses, index = 372
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -567,6 +594,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // direct_log_api.errors.responses, index = 394
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -18,6 +18,7 @@ internal partial class MetricsTelemetryCollector
     private static DistributionKey[] GetDistributionBuffer()
         => new DistributionKey[]
         {
+            // init_time, index = 0
             new(new[] { "component:total" }),
             new(new[] { "component:byref_pinvoke" }),
             new(new[] { "component:calltarget_state_byref_pinvoke" }),

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -28,13 +28,16 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetGaugeBuffer()
         => new MetricKey[]
         {
+            // stats_buckets, index = 0
             new(null),
+            // instrumentations, index = 1
             new(new[] { "component_name:calltarget" }),
             new(new[] { "component_name:calltarget_derived" }),
             new(new[] { "component_name:calltarget_interfaces" }),
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
+            // direct_log_queue, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -173,10 +173,12 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetCountBuffer()
         => new MetricKey[]
         {
+            // log_created, index = 0
             new(new[] { "level:debug" }),
             new(new[] { "level:info" }),
             new(new[] { "level:warn" }),
             new(new[] { "level:error" }),
+            // integrations_error, index = 4
             new(new[] { "integrations_name:httpmessagehandler", "error_type:duck_typing" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:invoker" }),
             new(new[] { "integrations_name:httpmessagehandler", "error_type:execution" }),
@@ -318,6 +320,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:aws_lambda", "error_type:duck_typing" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:invoker" }),
             new(new[] { "integrations_name:aws_lambda", "error_type:execution" }),
+            // span_created, index = 145
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -365,24 +368,34 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // span_finished, index = 192
             new(null),
+            // span_sampled, index = 193
             new(null),
+            // span_dropped, index = 194
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_created, index = 199
             new(new[] { "new_continued:new" }),
             new(new[] { "new_continued:continued" }),
+            // trace_enqueued, index = 201
             new(null),
+            // trace_sampled, index = 202
             new(null),
+            // trace_dropped, index = 203
             new(new[] { "reason:sampling_decision" }),
             new(new[] { "reason:single_span_sampling" }),
             new(new[] { "reason:overfull_buffer" }),
             new(new[] { "reason:serialization_error" }),
             new(new[] { "reason:api_error" }),
+            // trace_sent, index = 208
             new(null),
+            // trace_api.requests, index = 209
             new(null),
+            // trace_api.responses, index = 210
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -405,20 +418,26 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // trace_api.errors, index = 232
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // trace_partial_flush, index = 235
             new(new[] { "reason:large_trace" }),
             new(new[] { "reason:single_span_ingestion" }),
+            // context_header_style.injected, index = 237
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // context_header_style.extracted, index = 241
             new(new[] { "header_style:tracecontext" }),
             new(new[] { "header_style:datadog" }),
             new(new[] { "header_style:b3multi" }),
             new(new[] { "header_style:b3single" }),
+            // stats_api.requests, index = 245
             new(null),
+            // stats_api.responses, index = 246
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -441,11 +460,14 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // stats_api.errors, index = 268
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),
+            // telemetry_api.requests, index = 271
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
+            // telemetry_api.responses, index = 273
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -490,13 +512,16 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
+            // telemetry_api.errors, index = 317
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network_error" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network_error" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
+            // version_conflict_tracer_created, index = 323
             new(null),
+            // direct_log_logs, index = 324
             new(new[] { "integrations_name:httpmessagehandler" }),
             new(new[] { "integrations_name:httpsocketshandler" }),
             new(new[] { "integrations_name:winhttphandler" }),
@@ -544,7 +569,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integrations_name:opentelemetry" }),
             new(new[] { "integrations_name:pathtraversal" }),
             new(new[] { "integrations_name:aws_lambda" }),
+            // direct_log_api.requests, index = 371
             new(null),
+            // direct_log_api.responses, index = 372
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -567,6 +594,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
+            // direct_log_api.errors.responses, index = 394
             new(new[] { "type:timeout" }),
             new(new[] { "type:network_error" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -18,6 +18,7 @@ internal partial class MetricsTelemetryCollector
     private static DistributionKey[] GetDistributionBuffer()
         => new DistributionKey[]
         {
+            // init_time, index = 0
             new(new[] { "component:total" }),
             new(new[] { "component:byref_pinvoke" }),
             new(new[] { "component:calltarget_state_byref_pinvoke" }),

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -28,13 +28,16 @@ internal partial class MetricsTelemetryCollector
     private static MetricKey[] GetGaugeBuffer()
         => new MetricKey[]
         {
+            // stats_buckets, index = 0
             new(null),
+            // instrumentations, index = 1
             new(new[] { "component_name:calltarget" }),
             new(new[] { "component_name:calltarget_derived" }),
             new(new[] { "component_name:calltarget_interfaces" }),
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
+            // direct_log_queue, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetry.Collector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetry.Collector.cs
@@ -1,4 +1,4 @@
-// <copyright file="ConfigurationTelemetryCollectorV2.cs" company="Datadog">
+// <copyright file="ConfigurationTelemetry.Collector.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -98,7 +98,7 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
         if (countsLength > 0)
         {
             var index = counts.Length - 1;
-            for (var i = CountExtensions.Length - 1; i >= 0; i--)
+            for (var i = CountEntryCounts.Length - 1; i >= 0; i--)
             {
                 var metric = (Count)i;
                 var entries = CountEntryCounts[i];
@@ -130,7 +130,7 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
         if (gaugesLength > 0)
         {
             var index = gauges.Length - 1;
-            for (var i = GaugeExtensions.Length - 1; i >= 0; i--)
+            for (var i = GaugeEntryCounts.Length - 1; i >= 0; i--)
             {
                 var metric = (Gauge)i;
                 var entries = GaugeEntryCounts[i];
@@ -168,7 +168,7 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
         var data = new List<DistributionMetricData>(distributionsLength);
 
         var index = distributions.Length - 1;
-        for (var i = DistributionExtensions.Length - 1; i >= 0; i--)
+        for (var i = DistributionEntryCounts.Length - 1; i >= 0; i--)
         {
             var metric = (Distribution)i;
             var entries = DistributionEntryCounts[i];

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
@@ -258,16 +258,20 @@ public class TelemetryMetricGeneratorTests
                 private static MetricKey[] GetTestMetricBuffer()
                     => new MetricKey[]
                     {
+                        // metric.zero, index = 0
                         new(null),
+                        // metric.one, index = 1
                         new(new[] { "debug" }),
                         new(new[] { "info" }),
                         new(new[] { "error" }),
+                        // metric.two, index = 4
                         new(new[] { "debug", "random" }),
                         new(new[] { "debug", "ducktyping" }),
                         new(new[] { "info", "random" }),
                         new(new[] { "info", "ducktyping" }),
                         new(new[] { "error", "random" }),
                         new(new[] { "error", "ducktyping" }),
+                        // metric.zeroagain, index = 10
                         new(null),
                     };
 
@@ -459,16 +463,20 @@ public class TelemetryMetricGeneratorTests
                 private static MetricKey[] GetTestMetricBuffer()
                     => new MetricKey[]
                     {
+                        // metric.zero, index = 0
                         new(null),
+                        // metric.one, index = 1
                         new(new[] { "debug" }),
                         new(new[] { "info" }),
                         new(new[] { "error" }),
+                        // metric.two, index = 4
                         new(new[] { "debug", "random" }),
                         new(new[] { "debug", "ducktyping" }),
                         new(new[] { "info", "random" }),
                         new(new[] { "info", "ducktyping" }),
                         new(new[] { "error", "random" }),
                         new(new[] { "error", "ducktyping" }),
+                        // metric.zeroagain, index = 10
                         new(null),
                     };
 
@@ -660,16 +668,20 @@ public class TelemetryMetricGeneratorTests
                 private static DistributionKey[] GetTestMetricBuffer()
                     => new DistributionKey[]
                     {
+                        // metric.zero, index = 0
                         new(null),
+                        // metric.one, index = 1
                         new(new[] { "debug" }),
                         new(new[] { "info" }),
                         new(new[] { "error" }),
+                        // metric.two, index = 4
                         new(new[] { "debug", "random" }),
                         new(new[] { "debug", "ducktyping" }),
                         new(new[] { "info", "random" }),
                         new(new[] { "info", "ducktyping" }),
                         new(new[] { "error", "random" }),
                         new(new[] { "error", "ducktyping" }),
+                        // metric.zeroagain, index = 10
                         new(null),
                     };
 


### PR DESCRIPTION
## Summary of changes

- Add comments to generated code to make it clearer how the metrics map in `GetMetricBuffer()`
- Rename file

## Reason for change

Addresses minor feedback points from #4251 and offline from @kevingosse 

## Implementation details

Biggest change was a tweak to the source generator

## Test coverage

Covered by existing tests
