### PR TITLE
Include CreateRootDescriptorsFile as a dependency of BuildTracerHome

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -157,7 +157,8 @@ partial class Build : NukeBuild
         .DependsOn(PublishNativeTracer)
         .DependsOn(DownloadLibDdwaf)
         .DependsOn(CopyLibDdwaf)
-        .DependsOn(BuildNativeLoader);
+        .DependsOn(BuildNativeLoader)
+        .DependsOn(CreateRootDescriptorsFile);
 
     Target BuildProfilerHome => _ => _
         .Description("Builds the Profiler native and managed src, and publishes the profiler home directory")


### PR DESCRIPTION
## Summary of changes

Include `CreateRootDescriptorsFile` as a dependency of `BuildTracerHome` to avoid the friction and reduce CI failures.