### PR TITLE
Update RCM and Telemetry poll settings

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Rcm.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Rcm.cs
@@ -13,9 +13,9 @@ namespace Datadog.Trace.Configuration
         internal static class Rcm
         {
             /// <summary>
-            /// Configuration key for RCM poll interval (in milliseconds).
-            /// Default value is 5000 ms
-            /// Maximum value is 5000 ms
+            /// Configuration key for RCM poll interval (in seconds).
+            /// Default value is 5 s
+            /// Maximum value is 5 s
             /// </summary>
             /// <seealso cref="RemoteConfigurationSettings.PollInterval"/>
             public const string PollInterval = "DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS";

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 {
     internal class RemoteConfigurationSettings
     {
-        internal const int DefaultPollIntervalMilliseconds = 5000;
+        internal const double DefaultPollIntervalSeconds = 5;
 
         public RemoteConfigurationSettings(IConfigurationSource? configurationSource, IConfigurationTelemetry telemetry)
         {
@@ -28,9 +28,9 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 #pragma warning disable CS0618
                               .WithKeys(ConfigurationKeys.Rcm.PollInterval, ConfigurationKeys.Rcm.PollIntervalInternal)
 #pragma warning restore CS0618
-                              .AsInt32(DefaultPollIntervalMilliseconds, pollInterval => pollInterval is > 0 and <= 5000);
+                              .AsDouble(DefaultPollIntervalSeconds, pollInterval => pollInterval is > 0 and <= 5);
 
-            PollInterval = TimeSpan.FromMilliseconds(pollInterval.Value);
+            PollInterval = TimeSpan.FromSeconds(pollInterval.Value);
         }
 
         public string Id { get; }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Telemetry
 
             var heartbeatInterval = config
                                    .WithKeys(ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds)
-                                   .AsInt32(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
+                                   .AsDouble(defaultValue: 60, rawInterval => rawInterval is > 0 and <= 3600)
                                    .Value;
 
             var dependencyCollectionEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DependencyCollectionEnabled).AsBool(true);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -3,10 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.IO;
 using System.Linq;
-using System.Numerics;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
@@ -28,7 +26,7 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     {
         Fixture = fixture;
         EnableSecurity = enableSecurity;
-        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
+        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "0.5");
 
         // the directory would be created anyway, but in certain case a delay can lead to an exception from the LogEntryWatcher
         Directory.CreateDirectory(LogDirectory);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RcmBaseFramework.cs" company="Datadog">
+// <copyright file="RcmBaseFramework.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -18,7 +18,7 @@ public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
     public RcmBaseFramework(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null, string testName = null)
         : base(sampleName, outputHelper,  shutdownPath, samplesDir, testName)
     {
-        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "500");
+        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "0.5");
 
         // even if not using the log entry watcher , it's nice to have different logs directories to read artifacts
         Directory.CreateDirectory(LogDirectory);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/RemoteConfigurationSettingsTests.cs
@@ -38,17 +38,17 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData(null, null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        [InlineData("", null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        [InlineData("invalid", null, RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        [InlineData("50", "100", 50)]
-        [InlineData(null, "100", 100)]
-        [InlineData("invalid", "100", 100)]
-        [InlineData("0", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        [InlineData("-1", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        [InlineData("5000", "100", 5000)]
-        [InlineData("5001", "100", RemoteConfigurationSettings.DefaultPollIntervalMilliseconds)]
-        public void PollInterval(string value, string fallbackValue, int expected)
+        [InlineData(null, null, RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        [InlineData("", null, RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        [InlineData("invalid", null, RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        [InlineData("0.5", "100", 0.5)]
+        [InlineData(null, "2", 2)]
+        [InlineData("invalid", "0.5", 0.5)]
+        [InlineData("0", "1", RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        [InlineData("-1", "1", RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        [InlineData("5", "1", 5)]
+        [InlineData("5.1", "1", RemoteConfigurationSettings.DefaultPollIntervalSeconds)]
+        public void PollInterval(string value, string fallbackValue, double expected)
         {
 #pragma warning disable CS0618
             var source = CreateConfigurationSource(
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             var settings = new RemoteConfigurationSettings(source, NullConfigurationTelemetry.Instance);
 
-            settings.PollInterval.Should().Be(TimeSpan.FromMilliseconds(expected));
+            settings.PollInterval.Should().Be(TimeSpan.FromSeconds(expected));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -283,10 +283,10 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData(null, 60)]
         [InlineData("", 60)]
         [InlineData("invalid", 60)]
-        [InlineData("523", 523)]
+        [InlineData("523.5", 523.5)]
         [InlineData("3600", 3600)]
         [InlineData("3601", 60)]
-        public void HeartbeatInterval(string value, int expected)
+        public void HeartbeatInterval(string value, double expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds, value));
             var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);


### PR DESCRIPTION
## Summary of changes

 - Changed the RCM poll interval to be in seconds, like the name of the setting indicates
 - Changed telemetry and RCM poll interval to double to allow for values smaller than 1

## Reason for change

Inconsistent behavior between tracers for system tests.