### PR TITLE
Fix explicit interface methods instrumentation

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -89,7 +89,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
         iterate_explicit_interface_methods ?
             enumExplicitInterfaceMethods.begin() : enumMethods.begin();
     auto iteratorEnd = enumMethods.end();
-    auto explicitMode = true;
+    auto explicitMode = iterate_explicit_interface_methods;
 
     for (; enumIterator != iteratorEnd; enumIterator = ++enumIterator)
     {

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -117,8 +117,6 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             continue;
         }
 
-        Logger::Debug("    * Enumerating => method: ", caller.type.name, ".", caller.name);
-
         // We create a new function info into the heap from the caller functionInfo in the stack, to
         // be used later in the ReJIT process
         auto functionInfo = FunctionInfo(caller);

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -92,8 +92,8 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
 
     for (; enumIterator != iteratorEnd; enumIterator = ++enumIterator)
     {
-        // When interface methods are being iterated and we reach the end of the regular method search,
-        // switch over to the explicit interface method search
+        // When interface methods are being iterated first we go over the explicit interface method search and then
+        // switch to the regular method search, just like the runtime behaves.
         if (iterate_explicit_interface_methods && !(enumIterator != enumExplicitInterfaceMethods.end()))
         {
             enumIterator = enumMethods.begin();

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -85,18 +85,21 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
     auto enable_by_ref_instrumentation = m_rejit_handler->GetEnableByRefInstrumentation();
     auto enable_calltarget_state_by_ref = m_rejit_handler->GetEnableCallTargetStateByRef();
 
-    auto enumIterator = enumMethods.begin();
-    auto combinedEnd = iterate_explicit_interface_methods ? enumExplicitInterfaceMethods.end() : enumMethods.end();
-    for (; enumIterator != combinedEnd; enumIterator = ++enumIterator)
+    auto enumIterator =
+        iterate_explicit_interface_methods && enumExplicitInterfaceMethods.begin() != enumExplicitInterfaceMethods.end() ?
+            enumExplicitInterfaceMethods.begin() : enumMethods.begin();
+    auto iteratorEnd = enumMethods.end();
+
+    for (; enumIterator != iteratorEnd; enumIterator = ++enumIterator)
     {
         // When interface methods are being iterated and we reach the end of the regular method search,
         // switch over to the explicit interface method search
-        if (iterate_explicit_interface_methods && !(enumIterator != enumMethods.end()))
+        if (iterate_explicit_interface_methods && !(enumIterator != enumExplicitInterfaceMethods.end()))
         {
-            enumIterator = enumExplicitInterfaceMethods.begin();
+            enumIterator = enumMethods.begin();
 
             // Immediately exit if the second enumerator has 0 entries
-            if (!(enumIterator != combinedEnd))
+            if (!(enumIterator != iteratorEnd))
             {
                 break;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -191,8 +191,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     ".VoidMethod",
                 };
 
-                Assert.Equal(2, begin1MethodCount);
-                Assert.Equal(2, endMethodCount);
+                Assert.Equal(3, begin1MethodCount);
+                Assert.Equal(3, endMethodCount);
 
                 foreach (var typeName in typeNames)
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -23,9 +23,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static IEnumerable<object[]> MethodArgumentsData()
         {
-            for (int i = 0; i < 10; i++)
+            for (var i = 0; i < 10; i++)
             {
-                bool fastPath = i < 9;
+                var fastPath = i < 9;
                 yield return new object[] { i, fastPath };
             }
         }
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
                 int exceptionCount = Regex.Matches(processResult.StandardOutput, "Exception thrown.").Count;
 
-                string[] typeNames = new string[]
+                string[] typeNames =
                 {
                     ".VoidMethod",
                     ".ReturnValueMethod",
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
-                string[] typeNames = new string[]
+                string[] typeNames =
                 {
                     ".VoidMethod",
                     ".VoidRefMethod",
@@ -126,7 +126,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
-                string[] typeNames = new string[]
+                string[] typeNames =
                 {
                     ".VoidMethod",
                 };
@@ -156,7 +156,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
-                string[] typeNames = new string[]
+                string[] typeNames =
                 {
                     ".VoidMethod",
                     ".OtherMethod",
@@ -183,12 +183,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (var processResult = RunSampleAndWaitForExit(agent, arguments: "interface"))
             {
-                int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
+                int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\(").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
-                string[] typeNames = new string[]
+                string[] typeNames =
                 {
                     ".VoidMethod",
+                    ".ReturnValueMethod",
                 };
 
                 Assert.Equal(3, begin1MethodCount);

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
@@ -23,7 +23,7 @@ partial class Program
         
         // Check we always select the explicit implementation over a normal implementation.
         IExplicitOverNormal explicitOverNormalImpl = new ExplicitOverNormalImpl();
-        Console.WriteLine($"{typeof(ExplicitOverNormalImpl).FullName}.ReturnString");
+        Console.WriteLine($"{typeof(ExplicitOverNormalImpl).FullName}.ReturnValueMethod");
         RunMethod(() =>
         {
             var value = explicitOverNormalImpl.ReturnValueMethod();

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Interface.cs
@@ -1,4 +1,5 @@
 using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace CallTargetNativeTest;
 
@@ -19,6 +20,18 @@ partial class Program
         InterfaceType derivedImplicit = new DerivedImplicit();
         Console.WriteLine($"{typeof(DerivedImplicit).FullName}.VoidMethod");
         RunMethod(() => derivedImplicit.VoidMethod("Hello World"), checkInstrumented: false);
+        
+        // Check we always select the explicit implementation over a normal implementation.
+        IExplicitOverNormal explicitOverNormalImpl = new ExplicitOverNormalImpl();
+        Console.WriteLine($"{typeof(ExplicitOverNormalImpl).FullName}.ReturnString");
+        RunMethod(() =>
+        {
+            var value = explicitOverNormalImpl.ReturnValueMethod();
+            if (value != "Hello World")
+            {
+                throw new Exception("Error! Incorrect instrumentation.");
+            }
+        });
     }
 }
 
@@ -45,5 +58,43 @@ internal class DerivedImplicit : ImplicitImplInterface
 {
     public override void VoidMethod(string name)
     {
+    }
+}
+
+internal interface IExplicitOverNormal
+{
+    string ReturnValueMethod();
+}
+
+internal class ExplicitOverNormalImpl : IExplicitOverNormal
+{
+    string IExplicitOverNormal.ReturnValueMethod()
+    {
+        return "Hello";
+    }
+
+    public string ReturnValueMethod()
+    {
+        return null;
+    }
+}
+
+public static class ExplicitOverNormalIntegration
+{
+    public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+    {
+        Console.WriteLine($"ProfilerOK: BeginMethod(0)<{typeof(ExplicitOverNormalIntegration)}, {typeof(TTarget)}>({instance})");
+        return CallTargetState.GetDefault();
+    }
+
+    public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+    {
+        if (returnValue is "Hello")
+        {
+            Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(ExplicitOverNormalIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            return new CallTargetReturn<TReturn>((TReturn)(object)"Hello World");
+        }
+
+        return new CallTargetReturn<TReturn>(returnValue);
     }
 }

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -133,6 +133,7 @@ namespace CallTargetNativeTest
             NativeMethods.AddInterfaceInstrumentations(Guid.NewGuid().ToString("N"), new NativeCallTargetDefinition[]
             {
                 new(TargetAssembly, typeof(InterfaceType).FullName, "VoidMethod", new[] { "_", "_" }, 0,0,0,1,1,1, integrationAssembly, typeof(Noop1ArgumentsVoidIntegration).FullName),
+                new(TargetAssembly, typeof(IExplicitOverNormal).FullName, "ReturnValueMethod", new[] { "_" }, 0,0,0,1,1,1, integrationAssembly, typeof(ExplicitOverNormalIntegration).FullName),
             });
         }
 


### PR DESCRIPTION
## Summary of changes

This PR fixes an issue detected when instrumenting an application using the [`MassTransit.RabbitMQ` ](https://www.nuget.org/packages/MassTransit.RabbitMQ/7.3.0)nuget package.

## Reason for change


MassTransit has implemented the RabbitMQ interface [using explicit implementation](https://github.com/MassTransit/MassTransit/blob/v7.3.0/src/Transports/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs#L98-L104): 

```csharp
        Task IAsyncBasicConsumer.HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
            IBasicProperties properties, ReadOnlyMemory<byte> body)
        {
            HandleBasicDeliver(consumerTag, deliveryTag, redelivered, exchange, routingKey, properties, body);

            return TaskUtil.Completed;
        }
```

But they also have a [public method with the same name and arguments but with a different Return type](https://github.com/MassTransit/MassTransit/blob/v7.3.0/src/Transports/MassTransit.RabbitMqTransport/Pipeline/RabbitMqBasicConsumer.cs#L183-L222):

```csharp
        public void HandleBasicDeliver(string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey,
            IBasicProperties properties, ReadOnlyMemory<byte> body)
        {
            var bodyBytes = body.ToArray();

            Task.Run(async () =>
            {
                LogContext.Current = _context.LogContext;

                var context = new RabbitMqReceiveContext(exchange, routingKey, _consumerTag, deliveryTag, bodyBytes, redelivered, properties,
                    _context, _receiveSettings, _model, _model.ConnectionContext);
...
```

Because the CallTarget machinery doesn't include the return type in the signature checker and the method selector first search for regular methods and then for explicit interface implementation methods, we are picking the wrong method in our [Interface integration](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverAsyncIntegration.cs#L15-L24).

## Implementation details

There are two ways to fix the issue:

1) Changing the signature checker: this will fix this particular issue but doesn't fix the scenario where we have both, explicit interface implementation and a normal method with the exact return type, name and parameters. Because our integration is for interface we must always pick the explicit implementation.

2) Fix the method selector code to make sure we first check for explicit implementation and then for regular methods.

This PR solves the issue modifying the method selector code.

## Test coverage

There's a new `CallTargetNativeTests` test case to check we always select the explicit implementation over the normal implementation.