### PR TITLE
Disable nullable warnings in trimming app

### DIFF
--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -42,5 +42,5 @@
     </Otherwise>
   </Choose>
 
-  <Import Project=".\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
+  <Import Project=".\Samples.Shared\Samples.Shared.projitems" Label="Shared" Condition="'$(IncludeSharedSampleHelpers)' != 'false'" />
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.Trimming/Directory.Build.props
+++ b/tracer/test/test-applications/integrations/Samples.Trimming/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+    <PropertyGroup>
+        <IncludeSharedSampleHelpers>false</IncludeSharedSampleHelpers>
+    </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+</Project>


### PR DESCRIPTION
## Summary of changes

Removed the shared samples from the trimming app

## Reason for change

We don't actually use it, and it generates a ton of trim warnings

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/41b62c9f-480f-439f-b5eb-85726ba6d73c)

## Implementation details

Directory.Build.props voodoo

## Test coverage

N/A
