### PR TITLE
[CIVisibility] Fix repository and branch extraction in ITR and GitUpload

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -740,7 +740,7 @@ internal class IntelligentTestRunnerClient
 
     private async Task<string> GetRepositoryUrlAsync()
     {
-        if (CIEnvironmentValues.Instance.Repository is { } repository)
+        if (CIEnvironmentValues.Instance.Repository is { Length: > 0 } repository)
         {
             return repository;
         }
@@ -757,7 +757,7 @@ internal class IntelligentTestRunnerClient
 
     private async Task<string> GetBranchNameAsync()
     {
-        if (CIEnvironmentValues.Instance.Branch is { } branch)
+        if (CIEnvironmentValues.Instance.Branch is { Length: > 0 } branch)
         {
             return branch;
         }

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -740,6 +740,11 @@ internal class IntelligentTestRunnerClient
 
     private async Task<string> GetRepositoryUrlAsync()
     {
+        if (CIEnvironmentValues.Instance.Repository is { } repository)
+        {
+            return repository;
+        }
+
         var gitOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "config --get remote.origin.url", _workingDirectory)).ConfigureAwait(false);
         if (gitOutput is null)
         {
@@ -752,6 +757,11 @@ internal class IntelligentTestRunnerClient
 
     private async Task<string> GetBranchNameAsync()
     {
+        if (CIEnvironmentValues.Instance.Branch is { } branch)
+        {
+            return branch;
+        }
+
         var gitOutput = await ProcessHelpers.RunCommandAsync(new ProcessHelpers.Command("git", "branch --show-current", _workingDirectory)).ConfigureAwait(false);
         if (gitOutput is null)
         {


### PR DESCRIPTION
## Summary of changes

This PR changes the repository url and branch name extraction when using ITR or GitUpload, trying to extract them first from the environment variables and as a fallback running the git command.

## Reason for change

We found an scenario where the git folder was copied with a different repository url (origin) but the CI provider is still exposing the correct url in the environment variables.

## Implementation details

Just trying to load them from the environment variables, and then if not found run the git command.
