### PR TITLE
Extract OpenTelemetry exception attributes

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/DuckTypes/ActivityEvent.cs
+++ b/tracer/src/Datadog.Trace/Activity/DuckTypes/ActivityEvent.cs
@@ -1,0 +1,25 @@
+// <copyright file="ActivityEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.DuckTyping;
+
+// https://learn.microsoft.com/dotnet/api/system.diagnostics.activityevent
+
+namespace Datadog.Trace.Activity.DuckTypes
+{
+    [DuckCopy]
+    internal struct ActivityEvent
+    {
+        public string Name;
+
+        public IEnumerable<KeyValuePair<string, object?>> Tags;
+
+        public DateTimeOffset Timestamp;
+    }
+}

--- a/tracer/src/Datadog.Trace/Activity/DuckTypes/IActivity5.cs
+++ b/tracer/src/Datadog.Trace/Activity/DuckTypes/IActivity5.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.Activity.DuckTypes
@@ -20,6 +21,8 @@ namespace Datadog.Trace.Activity.DuckTypes
         IEnumerable<KeyValuePair<string, object>> TagObjects { get; }
 
         ActivitySource Source { get; }
+
+        IEnumerable Events { get; }
 
         object AddTag(string key, object value);
     }

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -371,7 +371,7 @@ namespace Datadog.Trace.Activity
             where TInner : IActivity
         {
             // OpenTelemetry stores the exception attributes in Activity.Events
-            // Activity.Events was only added in .NET 5+, which maps to out IActivity5 & IActivity6
+            // Activity.Events was only added in .NET 5+, which maps to our IActivity5 & IActivity6
             if (activity is not IActivity5 activity5)
             {
                 return;

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Text;
 using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -16,6 +17,12 @@ namespace Datadog.Trace.Activity
 {
     internal static class OtlpHelpers
     {
+        // see https://github.com/open-telemetry/opentelemetry-dotnet/blob/2916b2de80522d4b1cafe353b3fda3fd629ddb00/src/OpenTelemetry.Api/Internal/SemanticConventions.cs#LL109C25-L109C25
+        internal const string OpenTelemetryException = "exception";
+        internal const string OpenTelemetryErrorType = "exception.type";
+        internal const string OpenTelemetryErrorMsg = "exception.message";
+        internal const string OpenTelemetryErrorStack = "exception.stacktrace";
+
         internal static void UpdateSpanFromActivity<TInner>(TInner activity, Span span)
             where TInner : IActivity
         {
@@ -313,7 +320,10 @@ namespace Datadog.Trace.Activity
             if (activity is IActivity6 { Status: ActivityStatusCode.Error } activity6)
             {
                 span.Error = true;
+
                 // First iterate through Activity events first and set error.msg, error.type, and error.stack
+                ExtractExceptionAttributes(activity, span);
+
                 if (span.GetTag(Tags.ErrorMsg) is null)
                 {
                     span.SetTag(Tags.ErrorMsg, activity6.StatusDescription);
@@ -322,7 +332,10 @@ namespace Datadog.Trace.Activity
             else if (span.GetTag("otel.status_code") == "STATUS_CODE_ERROR")
             {
                 span.Error = true;
+
                 // First iterate through Activity events first and set error.msg, error.type, and error.stack
+                ExtractExceptionAttributes(activity, span);
+
                 if (span.GetTag(Tags.ErrorMsg) is null)
                 {
                     if (span.GetTag("otel.status_description") is string statusDescription)
@@ -341,6 +354,61 @@ namespace Datadog.Trace.Activity
                         }
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Iterates through <c>Activity.Events</c> looking for a <see cref="OpenTelemetryException"/> to copy over
+        /// to the <see cref="Span.Tags"/> of <paramref name="span"/>.
+        /// </summary>
+        /// <param name="activity">The <see cref="IActivity"/> to check for the exception event data.</param>
+        /// <param name="span">The <see cref="Span"/> to copy the exception event data to.</param>
+        /// <typeparam name="TInner">
+        /// The type of <c>Activity</c> - note that only <see cref="IActivity5"/> and up have support for events.
+        /// </typeparam>
+        /// <remarks>OpenTelemetry creates these attributes via it's <c>Activity.RecordException</c> function.</remarks>
+        private static void ExtractExceptionAttributes<TInner>(TInner activity, Span span)
+            where TInner : IActivity
+        {
+            // OpenTelemetry stores the exception attributes in Activity.Events
+            // Activity.Events was only added in .NET 5+, which maps to out IActivity5 & IActivity6
+            if (activity is not IActivity5 activity5)
+            {
+                return;
+            }
+
+            foreach (var activityEvent in activity5.Events)
+            {
+                if (!activityEvent.TryDuckCast<ActivityEvent>(out var duckEvent))
+                {
+                    continue;
+                }
+
+                if (duckEvent.Name != OpenTelemetryException)
+                {
+                    continue;
+                }
+
+                foreach (var tag in duckEvent.Tags)
+                {
+                    switch (tag.Key)
+                    {
+                        case OpenTelemetryErrorType:
+                            SetTagObject(span, Tags.ErrorType, tag.Value);
+                            break;
+
+                        case OpenTelemetryErrorMsg:
+                            SetTagObject(span, Tags.ErrorMsg, tag.Value);
+                            break;
+
+                        case OpenTelemetryErrorStack:
+                            SetTagObject(span, Tags.ErrorStack, tag.Value);
+                            break;
+                    }
+                }
+
+                // we've found the exception attribute so we should be done here
+                return;
             }
         }
 

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -151,11 +151,18 @@
     Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
+    Error: 1,
     Tags: {
       env: integration_tests,
+      error.msg: Example argument exception,
+      error.stack:
+System.ArgumentException: Example argument exception
+,
+      error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
+      otel.status_code: STATUS_CODE_ERROR,
+      otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -157,12 +157,12 @@
       error.msg: Example argument exception,
       error.stack:
 System.ArgumentException: Example argument exception
-,
+at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_ERROR,
-      otel.status_description: Something went wrong,
+      otel.status_description: Example argument exception,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -151,11 +151,18 @@
     Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
+    Error: 1,
     Tags: {
       env: integration_tests,
+      error.msg: Example argument exception,
+      error.stack:
+System.ArgumentException: Example argument exception
+,
+      error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
+      otel.status_code: STATUS_CODE_ERROR,
+      otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -157,12 +157,12 @@
       error.msg: Example argument exception,
       error.stack:
 System.ArgumentException: Example argument exception
-,
+at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_ERROR,
-      otel.status_description: Something went wrong,
+      otel.status_description: Example argument exception,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -151,11 +151,18 @@
     Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
+    Error: 1,
     Tags: {
       env: integration_tests,
+      error.msg: Example argument exception,
+      error.stack:
+System.ArgumentException: Example argument exception
+,
+      error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
+      otel.status_code: STATUS_CODE_ERROR,
+      otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource_1_0.verified.txt
@@ -157,12 +157,12 @@
       error.msg: Example argument exception,
       error.stack:
 System.ArgumentException: Example argument exception
-,
+at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_ERROR,
-      otel.status_description: Something went wrong,
+      otel.status_description: Example argument exception,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -151,11 +151,18 @@
     Service: MyServiceName,
     Type: custom,
     ParentId: Id_2,
+    Error: 1,
     Tags: {
       env: integration_tests,
+      error.msg: Example argument exception,
+      error.stack:
+System.ArgumentException: Example argument exception
+,
+      error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
-      otel.status_code: STATUS_CODE_UNSET,
+      otel.status_code: STATUS_CODE_ERROR,
+      otel.status_description: Something went wrong,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_1_0.verified.txt
@@ -157,12 +157,12 @@
       error.msg: Example argument exception,
       error.stack:
 System.ArgumentException: Example argument exception
-,
+at Samples.OpenTelemetrySdk.Program.RunSpanUpdateMethods(TelemetrySpan span),
       error.type: ArgumentException,
       language: dotnet,
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_ERROR,
-      otel.status_description: Something went wrong,
+      otel.status_description: Example argument exception,
       otel.trace_id: Guid_1,
       service.instance.id: Guid_3,
       service.name: MyServiceName,

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -167,9 +167,16 @@ public static class Program
         {
             // if we don't set the span as an error we won't check it for exception event
             // so if we only do RecordException, we wouldn't copy that info over as the span isn't marked as an Error
-            innerSpan.SetStatus(Status.Error.WithDescription("Something went wrong"));
-            innerSpan.RecordException(new ArgumentException("Example argument exception"));
-            innerSpan.UpdateName("InnerSpanUpdated");
+            try
+            {
+                throw new ArgumentException("Example argument exception");
+            }
+            catch (Exception ex)
+            {
+                innerSpan.SetStatus(Status.Error.WithDescription(ex.Message));
+                innerSpan.RecordException(ex);
+                innerSpan.UpdateName("InnerSpanUpdated");
+            }
         }
     }
 

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -167,6 +167,8 @@ public static class Program
         {
             // if we don't set the span as an error we won't check it for exception event
             // so if we only do RecordException, we wouldn't copy that info over as the span isn't marked as an Error
+            // see OpenTelemetry's example for .RecordException:
+            //  https://github.com/open-telemetry/opentelemetry-dotnet/tree/2916b2de80522d4b1cafe353b3fda3fd629ddb00/docs/trace/reporting-exceptions#option-4---use-activityrecordexception
             try
             {
                 throw new ArgumentException("Example argument exception");

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Program.cs
@@ -165,6 +165,9 @@ public static class Program
 
         using (var innerSpan = _tracer.StartActiveSpan("InnerSpan"))
         {
+            // if we don't set the span as an error we won't check it for exception event
+            // so if we only do RecordException, we wouldn't copy that info over as the span isn't marked as an Error
+            innerSpan.SetStatus(Status.Error.WithDescription("Something went wrong"));
             innerSpan.RecordException(new ArgumentException("Example argument exception"));
             innerSpan.UpdateName("InnerSpanUpdated");
         }


### PR DESCRIPTION
## Summary of changes

This fixes an issue when using `DD_TRACE_OTEL_ENABLED` where we wouldn't extract the OpenTelemetry exception information into the Datadog `Span`.

## Reason for change

We'd expect that OpenTelemetry's `Activity.RecordException` extension method would operate in a similar fashion to `ISpan.SetException`, but the exception data wasn't being transferred over to the Datadog `Span`.

## Implementation details

- Adds `ActivityEvent` DuckType struct as OpenTelemetry stores the exception data in `Activity.Events`
- Adds `IEnumerable Events` to `IActivity5` as the `Activity.Events` property was only added in .NET 5+
- When an OpenTelemetry span is marked as an error, will now search through its `Activity.Events` for an `"exception"` event and copy the attribute data over to `Span.Tags` so that the information is captured and displayed correctly.

## Test coverage

- Had to update the sample as just calling `.RecordException` doesn't mark the OpenTelemetry span as an error, so tacked on a call before that to mark it as an error.
- Snapshots updated
- Checked in the UI and the `error.type` and `error.stack` show up now.

## Other details
Fixes https://github.com/DataDog/dd-trace-dotnet/issues/4267
