### PR TITLE
Fix TraceClock ctor()

### DIFF
--- a/tracer/src/Datadog.Trace/TraceClock.cs
+++ b/tracer/src/Datadog.Trace/TraceClock.cs
@@ -36,7 +36,7 @@ internal sealed class TraceClock
 
         // The following is to prevent the case of GC hitting between _utcStart and _timestamp set
         var retries = 3;
-        while ((DateTimeOffset.UtcNow - UtcNow).TotalMilliseconds > 16 || retries-- < 0)
+        while ((DateTimeOffset.UtcNow - UtcNow).TotalMilliseconds > 16 && retries-- > 0)
         {
             _utcStart = DateTimeOffset.UtcNow;
             _timestamp = Stopwatch.GetTimestamp();

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -28,7 +28,8 @@ namespace Datadog.Trace.Tests
             var now = traceContext.Clock.UtcNow;
             var expectedNow = DateTimeOffset.UtcNow;
 
-            Assert.True(expectedNow.Subtract(now) < TimeSpan.FromMilliseconds(30));
+            // We cannot assume that expectedNow > now due to the difference of accuracy of QPC and UtcNow.
+            Assert.True(Math.Abs(expectedNow.Subtract(now).TotalMilliseconds) <= 30);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

This PR fixes the comparison in the .ctor() of the TraceClock and reduces the flakiness of a test
