### PR TITLE
Add Windows support for -TestAllPackageVersions

### DIFF
--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -23,6 +23,10 @@
     <NoWarn>SYSLIB0014</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
   <!-- OS Detection Properties -->
   <PropertyGroup>
     <IsWindows Condition="'$(OS)' == 'Windows_NT'">true</IsWindows>

--- a/tracer/test/test-applications/integrations/Samples.Couchbase/Samples.Couchbase.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase/Samples.Couchbase.csproj
@@ -4,6 +4,7 @@
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.4.8</ApiVersion>
     <OutputType>Exe</OutputType>
     <RequiresDockerDependency>true</RequiresDockerDependency>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Couchbase3/Samples.Couchbase3.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Couchbase3/Samples.Couchbase3.csproj
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <RequiresDockerDependency>true</RequiresDockerDependency>
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Samples.OpenTelemetrySdk.csproj
+++ b/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/Samples.OpenTelemetrySdk.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
     <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
     <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <ApiVersion Condition="'$(ApiVersion)' == ''">1.3.1</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'>='1.2.0'">$(DefineConstants);OTEL_1_2</DefineConstants>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

This adds support for `-TestAllPackageVersions` on Windows. Mainly to aid in running integration tests in one go for a project that targets multiple NuGet versions. So, instead of doing an edit/rebuild/run/update snapshots for each version just adding `-TestAllPackageVersions` at the end of the command will do it.

To use: add `-TestAllPackageVersions` onto the end of current nuke commands

## Reason for change

Mainly to help with local development

## Implementation details

- Already had MSBuild targets for the samples that had multiple versions, so I have basically copied those over from their Linux steps into the Windows step.
- One hacky thing I did was make it so that all of the projects that have multiple package versions have their `bin` and `obj` directories deleted before each run. This was due to an issue where a few projects would duplicate their builds `e.g. Samples.GraphQL4\bin\4.1.0\Debug\net7.0\bin\4.3.0` and create thousands of directories/files after a handful of runs. I don't know why that happens
- Note that when using this instead of a `bin\Debug` you get various `bin\X.Y.Z\Debug` for each NuGet version for the built project, which is expected.
- To get everything to build, I had to add `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` to the props for the samples and `<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>` to a few others

## Test coverage

- I ran various tests with different samples and they all seemed to work fine

## Other details

- I didn't add support for `IncludeMinorPackageVersions` as I didn't think that was necessary, but should be easy to add in if needed

<!-- Fixes #{issue} -->
