### PR TITLE
Fix more trim warnings

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Trimming/Samples.Trimming.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Trimming/Samples.Trimming.csproj
@@ -11,7 +11,7 @@
     <PublishTrimmed>true</PublishTrimmed>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
-    <NoWarn>IL2007;IL2008;IL2026</NoWarn>
+    <NoWarn>IL2007;IL2008;IL2026;IL2104</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <TrimmerRootDescriptor Include="../../../../src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml"/>


### PR DESCRIPTION
## Summary of changes

Ignore trim warnings in the trimming app

## Reason for change

The .NET 7 libraries aren't completely valid for trimming, so we get trim warnings like this, which are annoying in the CI

```
C:\Users\AzDevOps\.nuget\packages\microsoft.aspnetcore.app.runtime.win-x64\7.0.1\runtimes\win-x64\lib et7.0\Microsoft.AspNetCore.Components.dll
 : warning IL2104: Assembly 'Microsoft.AspNetCore.Components' produced trim warnings.
 For more information see https://aka.ms/dotnet-illink/libraries
 [D:\a\1\s\tracer\test\test-applications\integrations\Samples.Trimming\Samples.Trimming.csproj::TargetFramework=net7.0]
```

## Implementation details

Ignore IL2104 in the trimming test app
