### PR TITLE
[ASM] path params: Dont run waf if no data

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -110,6 +110,11 @@ internal static class SecurityCoordinatorHelpers
                         pathParams.Add(p.Name, routeValues[p.Name]);
                     }
 
+                    if (pathParams.Count == 0)
+                    {
+                        return;
+                    }
+
                     var args = new Dictionary<string, object> { { AddressesConstants.RequestPathParams, pathParams } };
                     var result = securityCoordinator.RunWaf(args);
                     securityCoordinator.CheckAndBlock(result);


### PR DESCRIPTION
## Summary of changes

In the case of  a post request with a  body, we get into this method, but as nothing is found in the route (there's a body but nothing bound to path params) we should not run the waf for nothing

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
