### PR TITLE
[Tooling] Use pagination for code freeze

### DIFF
--- a/.github/actions/code-freeze/action.yml
+++ b/.github/actions/code-freeze/action.yml
@@ -1,0 +1,67 @@
+name: "Code Freeze PRs"
+description: 'Code Freeze PRs'
+
+inputs:
+  page_number:
+    description: "Page number"
+    required: true
+  github_token:
+    description: 'Github token'
+    required: true
+  end_freeze:
+    description: "Start or stop code freeze"
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: octokit/request-action@v2.x
+      name: 'Get open PRs'
+      id: prs
+      with:
+        route: GET /repos/{owner}/{repo}/pulls
+        owner: DataDog
+        repo: dd-trace-dotnet
+        state: open
+        base: master
+        per_page: 25
+        page: ${{inputs.page_number}}
+      env:
+        GITHUB_TOKEN: "${{ inputs.github_token }}"
+
+    - name: 'Update all PRs with Code Freeze status'
+      shell: bash
+      env:
+        github_token: "${{ inputs.github_token }}"
+      run: |
+        set -o pipefail
+        
+        targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_start.yml"
+        state="failure"
+        description="A code freeze is in place"
+        
+        if ${{ inputs.end_freeze }} ; then
+          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_end.yml"
+          state="success"
+          description="No code freeze is in place"
+        fi
+        
+        json=$(cat << 'ENDOFMESSAGE'
+          ${{ steps.prs.outputs.data }}
+        ENDOFMESSAGE
+        )
+        arrayLength=$(echo $json | jq -r 'length')
+        echo "Updating code freeze  status for $arrayLength PRs" 
+      
+        arrayLength=$((arrayLength-1))
+        for i in $(seq 0 $arrayLength); do
+          title=$(echo $json | jq -r ".[$i].title")
+          echo "Setting code freeze for '$title'" 
+          sha=$(echo $json | jq -r ".[$i].head.sha")
+      
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ env.github_token }}" \
+              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+              -d '{"state":"'"$state"'","context":"code_freeze","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
+        done

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -9,12 +9,15 @@ jobs:
   end_code_freeze:
     if: | 
       github.event_name == 'workflow_dispatch' 
-      || (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'closed') 
+      || (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'closed')
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
+    - name: Clone dd-trace-dotnet repository
+      uses: actions/checkout@v3
+
     - uses: octokit/request-action@v2.x
       name: 'Close Code Freeze Milestone'
       id: milestones
@@ -27,42 +30,30 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-    - uses: octokit/request-action@v2.x
-      name: 'Get open PRs'
-      id: prs
+    - uses: ./.github/actions/code-freeze
+      name: 'Unfreeze 25 PRs'
       with:
-        route: GET /repos/{owner}/{repo}/pulls
-        owner: DataDog
-        repo: dd-trace-dotnet
-        state: open
-        base: master
-        per_page: 100 # max value, for simplicity. If we have more than 100 pull requests open, then we need to revisit!
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        page_number: 1
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        end_freeze: "true"
 
-    - run: |
-        set -o pipefail
-        json=$(cat << 'ENDOFMESSAGE'
-          ${{ steps.prs.outputs.data }}
-        ENDOFMESSAGE
-        )
-        arrayLength=$(echo $json | jq -r 'length')
-        echo "Updating code freeze status for $arrayLength PRs" 
+    - uses: ./.github/actions/code-freeze
+      name: 'Unfreeze 25 PRs'
+      with:
+        page_number: 2
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        end_freeze: "true"
 
-        arrayLength=$((arrayLength-1))
-        for i in $(seq 0 $arrayLength); do
-          title=$(echo $json | jq -r ".[$i].title")
-          echo "Removing code freeze for '$title'" 
-          sha=$(echo $json | jq -r ".[$i].head.sha")
-          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_end.yml"
-        
-          curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
-              -d '{"state":"success","context":"code_freeze","description":"No code freeze is in place","target_url":"'"$targetUrl"'"}'
-        done
-      name: 'Update all PRs with Code Freeze status'
+    - uses: ./.github/actions/code-freeze
+      name: 'Unfreeze 25 PRs'
+      with:
+        page_number: 3
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        end_freeze: "true"
 
-        
-        
+    - uses: ./.github/actions/code-freeze
+      name: 'Unfreeze 25 PRs'
+      with:
+        page_number: 4
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        end_freeze: "true"

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -9,65 +9,43 @@ jobs:
   start_code_freeze:
     if: | 
       github.event_name == 'workflow_dispatch' || 
-      (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open') 
+      (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open')
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
-    - uses: octokit/request-action@v2.x
-      name: 'Open Code Freeze Milestone'
-      id: milestones
-      if: github.event_name == 'workflow_dispatch'
-      with:
-        route: PATCH /repos/{owner}/{repo}/milestones/115
-        owner: DataDog
-        repo: dd-trace-dotnet
-        state: open
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Clone dd-trace-dotnet repository
+        uses: actions/checkout@v3
 
-    - uses: octokit/request-action@v2.x
-      name: 'Get open PRs'
-      id: prs
-      with:
-        route: GET /repos/{owner}/{repo}/pulls
-        owner: DataDog
-        repo: dd-trace-dotnet
-        state: open
-        base: master
-        per_page: 100 # max value, for simplicity. If we have more than 100 pull requests open, then we need to revisit!
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: ./.github/actions/code-freeze
+        name: 'Freeze 25 PRs'
+        with:
+          page_number: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-    - run: |
-        set -o pipefail
-        json=$(cat << 'ENDOFMESSAGE'
-          ${{ steps.prs.outputs.data }}
-        ENDOFMESSAGE
-        )
-        arrayLength=$(echo $json | jq -r 'length')
-        echo "Updating code freeze  status for $arrayLength PRs" 
+      - uses: ./.github/actions/code-freeze
+        name: 'Freeze 25 PRs'
+        with:
+          page_number: 2
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-        arrayLength=$((arrayLength-1))
-        for i in $(seq 0 $arrayLength); do
-          title=$(echo $json | jq -r ".[$i].title")
-          echo "Setting code freeze for '$title'" 
-          sha=$(echo $json | jq -r ".[$i].head.sha")
-          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/code_freeze_start.yml"
+      - uses: ./.github/actions/code-freeze
+        name: 'Freeze 25 PRs'
+        with:
+          page_number: 3
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: ./.github/actions/code-freeze
+        name: 'Freeze 25 PRs'
+        with:
+          page_number: 4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger AAS deploy
+        run: |
           curl -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
-              -d '{"state":"failure","context":"code_freeze","description":"A code freeze is in place","target_url":"'"$targetUrl"'"}'
-        done
-      name: 'Update all PRs with Code Freeze status'
-
-    - name: Trigger AAS deploy
-      run: |
-        curl -X POST \
-        -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
-        https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
-        -d '{"event_type": "dd-trace-code-freeze", "client_payload": {"sha":"'"$GITHUB_SHA"'" } }'
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+          https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
+          -d '{"event_type": "dd-trace-code-freeze", "client_payload": {"sha":"'"$GITHUB_SHA"'" } }'


### PR DESCRIPTION
## Summary of changes

Start and end freeze actions now handle PRs by group of 25.

## Reason for change
It was often failing and needed retries

## Implementation details
Added a new shared action used by both start and end code freeze workflows.
The action handles 25 PRs and is called page by page

## Test coverage
Tested both starting and ending the freeze from the branch. It works

## Other details
<!-- Fixes #{issue} -->
