### PR TITLE
[Release] Deploy AAS test apps twice a week to monitor memory leaks

### DIFF
--- a/.github/actions/deploy-aas-dev-apps/action.yml
+++ b/.github/actions/deploy-aas-dev-apps/action.yml
@@ -1,0 +1,18 @@
+name: 'Deploy AAS dev app'
+description: 'Deploy AAS dev app'
+
+inputs:
+  aas_github_token:
+    description: 'aas_github_token'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Trigger AAS deploy
+      run: |
+        curl -X POST \
+        -H "Accept: application/vnd.github.v3+json" \
+        -H "Authorization: Bearer ${{ inputs.aas_github_token }}" \
+        https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
+        -d '{"event_type": "dd-trace-dotnet-nightly", "client_payload": {"sha":"'"$GITHUB_SHA"'" } }'

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -1,0 +1,45 @@
+name: Deploy AAS test apps
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * TUE'
+    - cron: '0 0 * * FRI'
+
+jobs:
+  deploy_aas_test_apps:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+      - uses: octokit/request-action@v2.x
+        name: 'Open Code Freeze Milestone'
+        id: milestones
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          route: GET /repos/{owner}/{repo}/milestones
+          owner: DataDog
+          repo: dd-trace-dotnet
+          state: open
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: 'Check if code freeze is in place'
+        if: github.event_name != 'workflow_dispatch' # don't check if triggered manually
+        run: |
+          json=$(cat << 'ENDOFMESSAGE'
+            ${{ steps.milestones.outputs.data }}
+          ENDOFMESSAGE
+          )
+          
+          if addr=$(echo $json | jq -er '.[] | select(.title == "Code Freeze")'); then
+            echo "A code freeze is in place, we should not trigger a deployment."
+            echo "stop=true" >> "$GITHUB_ENV"
+          fi
+
+      - uses: ./.github/actions/deploy-aas-dev-apps
+        name: 'Trigger AAS deploy'
+        if: env.stop != 'true'
+        with:
+          aas_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -9,7 +9,7 @@ jobs:
   start_code_freeze:
     if: | 
       github.event_name == 'workflow_dispatch' || 
-      (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open') 
+      (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open')
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -64,10 +64,7 @@ jobs:
         done
       name: 'Update all PRs with Code Freeze status'
 
-    - name: Trigger AAS deploy
-      run: |
-        curl -X POST \
-        -H "Accept: application/vnd.github.v3+json" \
-        -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
-        https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
-        -d '{"event_type": "dd-trace-code-freeze", "client_payload": {"sha":"'"$GITHUB_SHA"'" } }'
+    - uses: ./.github/actions/deploy-aas-dev-apps
+      name: 'Trigger AAS deploy'
+      with:
+        aas_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of changes
Deploy AAS test apps twice a week to monitor memory leaks

## Reason for change
AAS seems to be way more stable than Rel Env memory wise. So it should be easier to catch some memory leaks there.

## Implementation details
- Adds a composite action to avoid duplication
- Adds a workflow on schedule to trigger the AAS deployment. This one checks whether the code freeze is in place before updating to not interfere with releases.

## Test coverage
None so far. I need to merge this first version in master to be able to run it from a branch (I could do it from a fork but looks like an unnecessary hassle)

## Other details
<!-- Fixes #{issue} -->
