### PR TITLE
Fixes for telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
@@ -65,9 +65,8 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         public TimeSpan CircuitBreakPeriod { get; }
 
         /// <summary>
-        /// Gets maximum number of events to hold in the sink's internal queue, or <c>null</c>
-        /// for an unbounded queue.
+        /// Gets maximum number of events to hold in the sink's internal queue
         /// </summary>
-        public int? QueueLimit { get; }
+        public int QueueLimit { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace.Logging
                 TelemetryFactory.Metrics.RecordCountLogCreated(LevelToTag(level));
                 if (_rateLimiter.ShouldLog(sourceFile, sourceLine, out var skipCount))
                 {
-                    // RFC suggests we should always add the "messages skipped" line, but feels like necessary noise
+                    // RFC suggests we should always add the "messages skipped" line, but feels like unnecessary noise
                     if (skipCount > 0)
                     {
                         var newArgs = new object[args.Length + 1];

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -83,14 +83,17 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
                     value = int.MaxValue;
                 }
 
-                if (value > 0 && ((PublicApiUsage)i).ToStringFast() is { } metricName)
+                if (value > 0 && ((PublicApiUsage)i).ToStringFast() is { } tagName)
                 {
                     data.Add(
                         new MetricData(
-                            metricName,
+                            "public_api",
                             points: new MetricSeries { new(timestamp, value) },
                             common: false,
-                            type: TelemetryMetricType.Count));
+                            type: TelemetryMetricType.Count)
+                        {
+                            Tags = new[] { tagName }, // Annoying, should try to optimise this
+                        });
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -119,7 +119,11 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
                                 metricName,
                                 points: new MetricSeries { new(timestamp, value) },
                                 common: metric.IsCommon(),
-                                type: TelemetryMetricType.Count) { Tags = metricKey.Tags });
+                                type: TelemetryMetricType.Count)
+                            {
+                                Namespace = metric.GetNamespace(),
+                                Tags = metricKey.Tags,
+                            });
                     }
 
                     index--;
@@ -145,7 +149,11 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
                                 metricName,
                                 points: new MetricSeries { new(timestamp, value) },
                                 common: metric.IsCommon(),
-                                type: TelemetryMetricType.Gauge) { Tags = metricKey.Tags });
+                                type: TelemetryMetricType.Gauge)
+                            {
+                                Namespace = metric.GetNamespace(),
+                                Tags = metricKey.Tags
+                            });
                     }
 
                     index--;
@@ -188,7 +196,11 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
                         new DistributionMetricData(
                             metricName,
                             points: points,
-                            common: metric.IsCommon()) { Tags = metricKey.Tags, });
+                            common: metric.IsCommon())
+                        {
+                            Namespace = metric.GetNamespace(),
+                            Tags = metricKey.Tags,
+                        });
                 }
 
                 index--;

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -269,22 +269,22 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
 
         public void Clear()
         {
-            for (var i = 0; i < PublicApiUsageExtensions.Length; i++)
+            for (var i = 0; i < PublicApiCounts.Length; i++)
             {
                 PublicApiCounts[i] = 0;
             }
 
-            for (var i = 0; i < CountExtensions.Length; i++)
+            for (var i = 0; i < Counts.Length; i++)
             {
                 Counts[i].Value = 0;
             }
 
-            for (var i = 0; i < GaugeExtensions.Length; i++)
+            for (var i = 0; i < Gauges.Length; i++)
             {
                 Gauges[i].Value = 0;
             }
 
-            for (var i = 0; i < DistributionExtensions.Length; i++)
+            for (var i = 0; i < Distributions.Length; i++)
             {
                 while (Distributions[i].Values.TryDequeue(out _)) { }
             }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/TelemetryDataV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/TelemetryDataV2.cs
@@ -34,9 +34,9 @@ namespace Datadog.Trace.Telemetry
         public string ApiVersion => TelemetryConstants.ApiVersionV2;
 
         /// <summary>
-        /// Gets or sets integer denoting the naming schema version used by the tracer. 0 by default. Possible values are {0, 1}
+        /// Gets or sets integer denoting the naming schema version used by the tracer. Empty by default. Possible values are "0", "1"
         /// </summary>
-        public int? NamingSchemaVersion { get; set; }
+        public string? NamingSchemaVersion { get; set; }
 
         /// <summary>
         /// Gets or sets requested API function

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
@@ -38,7 +38,7 @@ internal class TelemetryControllerV2 : ITelemetryController
     private readonly TaskCompletionSource<bool> _processExit = new();
     private readonly Task _flushTask;
     private bool _fatalError;
-    private int? _namingVersion;
+    private string? _namingVersion;
     private bool _appStartedSent;
 
     internal TelemetryControllerV2(
@@ -90,7 +90,7 @@ internal class TelemetryControllerV2 : ITelemetryController
         // need to keep it around
         settings.Telemetry.CopyTo(_configuration);
         _application.RecordTracerSettings(settings, defaultServiceName);
-        _namingVersion = (int)settings.MetadataSchemaVersion;
+        _namingVersion = ((int)settings.MetadataSchemaVersion).ToString();
     }
 
     public void Start()

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
@@ -22,7 +22,7 @@ internal class TelemetryDataBuilderV2
         HostTelemetryDataV2 host,
         in TelemetryInput input,
         bool sendAppStarted,
-        int? namingSchemeVersion)
+        string? namingSchemeVersion)
     {
         List<MessageBatchData>? data = null;
 
@@ -117,10 +117,10 @@ internal class TelemetryDataBuilderV2
         return GetRequest(application, host, new MessageBatchPayload(data), namingSchemeVersion);
     }
 
-    public TelemetryDataV2 BuildAppClosingTelemetryData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, int? namingSchemeVersion)
+    public TelemetryDataV2 BuildAppClosingTelemetryData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, string? namingSchemeVersion)
         => GetRequest(application, host, TelemetryRequestTypes.AppClosing, payload: null, namingSchemeVersion);
 
-    public TelemetryDataV2 BuildHeartbeatData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, int? namingSchemeVersion)
+    public TelemetryDataV2 BuildHeartbeatData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, string? namingSchemeVersion)
         => GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);
 
     public TelemetryDataV2 BuildExtendedHeartbeatData(
@@ -129,7 +129,7 @@ internal class TelemetryDataBuilderV2
         ICollection<ConfigurationKeyValue>? configuration,
         ICollection<DependencyTelemetryData>? dependencies,
         ICollection<IntegrationTelemetryData>? integrations,
-        int? namingSchemeVersion)
+        string? namingSchemeVersion)
         => GetRequest(
             application,
             host,
@@ -147,7 +147,7 @@ internal class TelemetryDataBuilderV2
         HostTelemetryDataV2 host,
         string requestType,
         IPayload? payload,
-        int? namingSchemeVersion)
+        string? namingSchemeVersion)
     {
         var sequence = Interlocked.Increment(ref _sequence);
 
@@ -168,7 +168,7 @@ internal class TelemetryDataBuilderV2
         ApplicationTelemetryDataV2 application,
         HostTelemetryDataV2 host,
         MessageBatchPayload? payload,
-        int? namingSchemeVersion)
+        string? namingSchemeVersion)
     {
         var sequence = Interlocked.Increment(ref _sequence);
 

--- a/tracer/src/Datadog.Trace/Util/BoundedConcurrentQueue.cs
+++ b/tracer/src/Datadog.Trace/Util/BoundedConcurrentQueue.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Util
         // Internal for testing
         internal ConcurrentQueue<T> InnerQueue => _queue;
 
-        public int Count => _queue.Count;
+        public int Count => _counter;
 
         public bool IsEmpty => _queue.IsEmpty;
 

--- a/tracer/src/Datadog.Trace/Util/BoundedConcurrentQueue.cs
+++ b/tracer/src/Datadog.Trace/Util/BoundedConcurrentQueue.cs
@@ -27,21 +27,19 @@ namespace Datadog.Trace.Util
 {
     internal class BoundedConcurrentQueue<T>
     {
-        private const int Unbounded = -1;
-
         private readonly ConcurrentQueue<T> _queue = new();
         private readonly int _queueLimit;
 
         private int _counter;
 
-        public BoundedConcurrentQueue(int? queueLimit = null)
+        public BoundedConcurrentQueue(int queueLimit)
         {
             if (queueLimit is <= 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
             }
 
-            _queueLimit = queueLimit ?? Unbounded;
+            _queueLimit = queueLimit;
         }
 
         // Internal for testing
@@ -53,11 +51,6 @@ namespace Datadog.Trace.Util
 
         public bool TryDequeue([NotNullWhen(returnValue: true)] out T? item)
         {
-            if (_queueLimit == Unbounded)
-            {
-                return _queue.TryDequeue(out item!);
-            }
-
             if (_queue.TryDequeue(out item!))
             {
                 Interlocked.Decrement(ref _counter);
@@ -69,12 +62,6 @@ namespace Datadog.Trace.Util
 
         public bool TryEnqueue(T item)
         {
-            if (_queueLimit == Unbounded)
-            {
-                _queue.Enqueue(item);
-                return true;
-            }
-
             if (Interlocked.Increment(ref _counter) <= _queueLimit)
             {
                 _queue.Enqueue(item);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -108,7 +108,7 @@ public class TelemetryHelperTests
         telemetryData.Add(BuildTelemetryDataV2(collector.GetData()));
 
         // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, 1)));
+        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
@@ -195,7 +195,7 @@ public class TelemetryHelperTests
         telemetryData.Add(BuildTelemetryDataV2(collector.GetData(), sendAppStarted: false));
 
         // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, 1)));
+        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
 
         var checkTelemetryFunc = () => TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
 
@@ -257,7 +257,7 @@ public class TelemetryHelperTests
         telemetryData.Add(BuildTelemetryDataV2(null, collector.GetData(), sendAppStarted: false));
 
         // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, 1)));
+        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled);
@@ -285,5 +285,5 @@ public class TelemetryHelperTests
                 _hostV2,
                 new TelemetryInput(configuration, null, integrations, null, null, null),
                 sendAppStarted,
-                namingSchemeVersion: 1));
+                namingSchemeVersion: "1"));
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Linq;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
@@ -52,10 +54,10 @@ public class MetricsTelemetryCollectorTests
             },
             new
             {
-                Metric = PublicApiUsage.Tracer_Ctor.ToStringFast(),
+                Metric = "public_api",
                 Points = new[] { new { Value = 1 } },
                 Type = TelemetryMetricType.Count,
-                Tags = (string[])null,
+                Tags = new[] { PublicApiUsage.Tracer_Ctor.ToStringFast() },
                 Common = false,
                 Namespace = (string)null,
             },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -43,10 +43,10 @@ public class MetricsTelemetryCollectorTests
         {
             new
             {
-                Metric = PublicApiUsage.Tracer_Configure.ToStringFast(),
+                Metric = "public_api",
                 Points = new[] { new { Value = 2 } },
                 Type = TelemetryMetricType.Count,
-                Tags = (string[])null,
+                Tags = new[] { PublicApiUsage.Tracer_Configure.ToStringFast() },
                 Common = false,
                 Namespace = (string)null,
             },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
+using NS = Datadog.Trace.Telemetry.MetricNamespaceConstants;
 
 namespace Datadog.Trace.Tests.Telemetry.Collectors;
 
@@ -24,6 +25,7 @@ public class MetricsTelemetryCollectorTests
         collector.RecordCountIntegrationsError(MetricTags.IntegrationName.Aerospike, MetricTags.InstrumentationError.Invoker);
         collector.RecordCountSpanCreated(MetricTags.IntegrationName.Aerospike);
         collector.RecordCountSpanDropped(MetricTags.DropReason.P0Drop, 23);
+        collector.RecordCountLogCreated(MetricTags.LogLevel.Debug, 3);
         collector.RecordGaugeStatsBuckets(234);
         collector.RecordDistributionInitTime(MetricTags.InitializationComponent.Total, 23);
         collector.RecordDistributionInitTime(MetricTags.InitializationComponent.Total, 46);
@@ -45,6 +47,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 2 } },
                 Type = TelemetryMetricType.Count,
                 Tags = (string[])null,
+                Common = false,
+                Namespace = (string)null,
             },
             new
             {
@@ -52,6 +56,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 1 } },
                 Type = TelemetryMetricType.Count,
                 Tags = (string[])null,
+                Common = false,
+                Namespace = (string)null,
             },
             new
             {
@@ -59,6 +65,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 1 } },
                 Type = TelemetryMetricType.Count,
                 Tags = new[] { "integrations_name:aerospike", "error_type:invoker" },
+                Common = true,
+                Namespace = (string)null,
             },
             new
             {
@@ -66,6 +74,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 1 } },
                 Type = TelemetryMetricType.Count,
                 Tags = new[] { "integrations_name:aerospike" },
+                Common = true,
+                Namespace = (string)null,
             },
             new
             {
@@ -73,6 +83,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 15 } },
                 Type = TelemetryMetricType.Count,
                 Tags = (string[])null,
+                Common = true,
+                Namespace = (string)null,
             },
             new
             {
@@ -80,6 +92,17 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 23 } },
                 Type = TelemetryMetricType.Count,
                 Tags = new[] { "reason:p0_drop" },
+                Common = true,
+                Namespace = (string)null,
+            },
+            new
+            {
+                Metric = Count.LogCreated.GetName(),
+                Points = new[] { new { Value = 3 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "level:debug" },
+                Common = true,
+                Namespace = NS.General,
             },
             new
             {
@@ -87,6 +110,8 @@ public class MetricsTelemetryCollectorTests
                 Points = new[] { new { Value = 234 } },
                 Type = TelemetryMetricType.Gauge,
                 Tags = (string[])null,
+                Common = true,
+                Namespace = (string)null,
             },
         });
 
@@ -97,12 +122,16 @@ public class MetricsTelemetryCollectorTests
                 Metric = Distribution.InitTime.GetName(),
                 Tags = new[] { "component:total" },
                 Points = new[] { 23, 46 },
+                Common = true,
+                Namespace = NS.General,
             },
             new
             {
                 Metric = Distribution.InitTime.GetName(),
                 Tags = new[] { "component:managed" },
                 Points = new[] {  52 },
+                Common = true,
+                Namespace = NS.General,
             },
         });
     }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Processors;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
@@ -19,9 +20,7 @@ namespace Datadog.Trace.Tests.Telemetry.Metrics;
 public class TelemetryMetricExtensionsTests
 {
     public static IEnumerable<object[]> AllEnums
-        => GetEnums<PublicApiUsage>()
-          .Select(x => new object[] { x, x.ToStringFast() })
-          .Concat(GetEnums<Count>().Select(x => new object[] { x, x.GetName() }))
+        => GetEnums<Count>().Select(x => new object[] { x, x.GetName() })
           .Concat(GetEnums<Gauge>().Select(x => new object[] { x, x.GetName() }))
           .Concat(GetEnums<Distribution>().Select(x => new object[] { x, x.GetName() }))
           .ToList();
@@ -43,6 +42,14 @@ public class TelemetryMetricExtensionsTests
     {
         _ = api;
         metricName.Should().Be(metricName.ToLowerInvariant());
+    }
+
+    [Theory]
+    [MemberData(nameof(AllEnums))]
+    public void MustHaveNormalizedMetricNames(int api, string metricName)
+    {
+        _ = api;
+        metricName.Should().Be(TraceUtil.NormalizeMetricName(metricName, limit: 100));
     }
 
     [Fact]
@@ -70,6 +77,15 @@ public class TelemetryMetricExtensionsTests
            .Select(x => ((IntegrationId)x[0]).GetMetricTag())
            .Should()
            .OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public void MustHaveValidTagsForEveryPublicApi()
+    {
+        foreach (var tag in GetEnums<PublicApiUsage>().Select(x => x.ToStringFast()))
+        {
+            AssertValidTags(new[] { tag });
+        }
     }
 
     [Fact]
@@ -105,11 +121,15 @@ public class TelemetryMetricExtensionsTests
                 continue;
             }
 
-            tags.Should()
-                .OnlyContain(x => x.ToLowerInvariant() == x, "should all be lowercase")
-                .And.OnlyContain(x => x.Trim() == x, "should not have any whitespace");
+            AssertValidTags(tags);
         }
     }
+
+    private static void AssertValidTags(string[] tags)
+        => tags.Should()
+               .OnlyContain(x => x.ToLowerInvariant() == x, "should all be lowercase")
+               .And.OnlyContain(x => x.Trim() == x, "should not have any whitespace")
+               .And.OnlyContain(x => TraceUtil.NormalizeTag(x) == x, "should match normalized version");
 
     private static IEnumerable<T> GetEnums<T>()
         => Enum.GetValues(typeof(T)).Cast<T>();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/TelemetryMetricExtensionsTests.cs
@@ -6,7 +6,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
@@ -70,6 +72,52 @@ public class TelemetryMetricExtensionsTests
            .OnlyHaveUniqueItems();
     }
 
+    [Fact]
+    public void MustHaveValidTagsForEveryCount()
+    {
+        var keys = typeof(MetricsTelemetryCollector).GetMethod("GetCountBuffer", BindingFlags.Static | BindingFlags.NonPublic);
+        CheckTagsAreValid(keys);
+    }
+
+    [Fact]
+    public void MustHaveValidTagsForEveryGauge()
+    {
+        var keys = typeof(MetricsTelemetryCollector).GetMethod("GetGaugeBuffer", BindingFlags.Static | BindingFlags.NonPublic);
+        CheckTagsAreValid(keys);
+    }
+
+    [Fact]
+    public void MustHaveValidTagsForEveryDistribution()
+    {
+        var keys = typeof(MetricsTelemetryCollector).GetMethod("GetDistributionBuffer", BindingFlags.Static | BindingFlags.NonPublic);
+        CheckTagsAreValid(keys);
+    }
+
+    private static void CheckTagsAreValid(MethodInfo getMetricKeys)
+    {
+        var values = (Array)getMetricKeys.Invoke(null, Array.Empty<object>());
+        for (var i = 0; i < values.Length; i++)
+        {
+            var duckTyped = values.GetValue(i).DuckCast<MetricKeyDuckType>();
+            var tags = duckTyped.Tags;
+            if (tags is null)
+            {
+                continue;
+            }
+
+            tags.Should()
+                .OnlyContain(x => x.ToLowerInvariant() == x, "should all be lowercase")
+                .And.OnlyContain(x => x.Trim() == x, "should not have any whitespace");
+        }
+    }
+
     private static IEnumerable<T> GetEnums<T>()
         => Enum.GetValues(typeof(T)).Cast<T>();
+
+    [DuckCopy]
+    public struct MetricKeyDuckType
+    {
+        [DuckField]
+        public string[] Tags;
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
@@ -18,7 +18,7 @@ public class TelemetryDataBuilderV2Tests
 {
     private readonly ApplicationTelemetryDataV2 _application;
     private readonly HostTelemetryDataV2 _host;
-    private readonly int? _namingSchemaVersion = 1;
+    private readonly string _namingSchemaVersion = "1";
 
     public TelemetryDataBuilderV2Tests()
     {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     }
                 })
             {
-                NamingSchemaVersion = 1
+                NamingSchemaVersion = "1"
             };
 
             var serialized = JsonTelemetryTransport.SerializeTelemetry(data);
@@ -316,7 +316,7 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                             })),
                     }))
             {
-                NamingSchemaVersion = 1
+                NamingSchemaVersion = "1"
             };
 
             var serialized = JsonTelemetryTransport.SerializeTelemetry(data);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started-v2.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started-v2.json
@@ -1,6 +1,6 @@
 ﻿{
   "api_version": "v2",
-  "naming_schema_version": 1,
+  "naming_schema_version": "1",
   "request_type": "app-started",
   "tracer_time": 1628099086,
   "runtime_id": "20338dfd-f700-4e5c-b3f6-0d470f054ae8",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_message-batch-v2.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_message-batch-v2.json
@@ -1,6 +1,6 @@
 ﻿{
   "api_version": "v2",
-  "naming_schema_version": 1,
+  "naming_schema_version": "1",
   "request_type": "message-batch",
   "tracer_time": 1628099086,
   "runtime_id": "20338dfd-f700-4e5c-b3f6-0d470f054ae8",


### PR DESCRIPTION
## Summary of changes

- Fix v2 telemetry naming schema version
- Add missing namespace to metrics
- minor fixes

## Reason for change

Fixes broken telemetry requests

## Implementation details

mostly `int` -> `string`

## Test coverage

Covered by existing

## Other details
Stacked on https://github.com/DataDog/dd-trace-dotnet/pull/4269
