### PR TITLE
Revert removing IL2026 warning from customer trimming process.

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.props
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.props
@@ -9,8 +9,7 @@ Copyright 2017 Datadog, Inc.
   <PropertyGroup>
     <!-- IL2007: Could not resolve assembly specified in descriptor file -->
     <!-- IL2008: Could not resolve type specified in descriptor file -->
-    <!-- IL2026: Members attributed with RequiresUnreferencedCode may break when trimming -->
-    <NoWarn>IL2007;IL2008;IL2026</NoWarn>
+    <NoWarn>IL2007;IL2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

This PR reverts the removal of a warning in the customer trimming process.

## Reason for change

We shouldn't be removing that warning that may be useful for customers.