### PR TITLE
Add CorProfilerInfo7::ApplyMetadata call

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1517,6 +1517,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         }
 
         Logger::Debug("JITCompilationStarted: Startup hook registered.");
+        hr = this->info_->ApplyMetaData(module_id);
+        if (FAILED(hr))
+        {
+            Logger::Warn("JITCompilationStarted: Error applying metadata to module_id: ", module_id);
+        }
     }
 
     return S_OK;

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -701,6 +701,13 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     Logger::Info("*** CallTarget_RewriterCallback() Finished: ", caller->type.name, ".", caller->name,
                  "() [IsVoid=", isVoid, ", IsStatic=", isStatic,
                  ", IntegrationType=", integration_definition->integration_type.name, ", Arguments=", numArgs, "]");
+
+    hr = this->m_corProfiler->info_->ApplyMetaData(module_id);
+    if (FAILED(hr))
+    {
+        Logger::Warn("*** CallTarget_RewriterCallback() Finished: Error applying metadata to module_id: ", module_id);
+    }
+
     return S_OK;
 }
 


### PR DESCRIPTION
## Summary of changes

This PR ensures to call CorProfilerInfo7::ApplyMetadata when we do module rewrites.

## Reason for change

Is recommended by the docs and can be the cause of potential issues.

https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/icorprofilerinfo7-applymetadata-method
