### PR TITLE
[ASM] Implement WAF metrics - part 1

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -11,6 +11,8 @@ using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Coordinator;

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -442,6 +442,13 @@ namespace Datadog.Trace.AppSec
                 {
                     _configurationStatus.FallbackEmbeddedRuleSet ??= RuleSet.From(_wafInitResult.EmbeddedRules);
                 }
+
+                if (!fromRemoteConfig)
+                {
+                    TelemetryFactory.Metrics.RecordCountWafInit();
+                }
+
+                TelemetryFactory.Metrics.RecordCountWafUpdates();
             }
             else
             {

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -443,10 +443,10 @@ namespace Datadog.Trace.AppSec
                     _configurationStatus.FallbackEmbeddedRuleSet ??= RuleSet.From(_wafInitResult.EmbeddedRules);
                 }
 
-                TelemetryFactory.Metrics.SetWafVersion(_waf!.Version);
-
                 if (!fromRemoteConfig)
                 {
+                    // occurs the first time we have initialize the WAF
+                    TelemetryFactory.Metrics.SetWafVersion(_waf!.Version);
                     TelemetryFactory.Metrics.RecordCountWafInit();
                 }
 

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -445,12 +445,10 @@ namespace Datadog.Trace.AppSec
 
                 if (!fromRemoteConfig)
                 {
-                    // occurs the first time we have initialize the WAF
+                    // occurs the first time we initialize the WAF
                     TelemetryFactory.Metrics.SetWafVersion(_waf!.Version);
                     TelemetryFactory.Metrics.RecordCountWafInit();
                 }
-
-                TelemetryFactory.Metrics.RecordCountWafUpdates();
             }
             else
             {

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -443,6 +443,8 @@ namespace Datadog.Trace.AppSec
                     _configurationStatus.FallbackEmbeddedRuleSet ??= RuleSet.From(_wafInitResult.EmbeddedRules);
                 }
 
+                TelemetryFactory.Metrics.SetWafVersion(_waf!.Version);
+
                 if (!fromRemoteConfig)
                 {
                     TelemetryFactory.Metrics.RecordCountWafInit();

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
@@ -26,5 +26,7 @@ namespace Datadog.Trace.AppSec.Waf
         ulong AggregatedTotalRuntime { get; }
 
         ulong AggregatedTotalRuntimeWithBindings { get; }
+
+        bool Timeout { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.AppSec.Waf
             AggregatedTotalRuntime = aggregatedTotalRuntime;
             AggregatedTotalRuntimeWithBindings = aggregatedTotalRuntimeWithBindings;
             Data = ShouldBeReported ? Marshal.PtrToStringAnsi(returnStruct.Data) : string.Empty;
+            Timeout = returnStruct.Timeout;
         }
 
         public ReturnCode ReturnCode => Encoder.DecodeReturnCode(returnCode);
@@ -45,6 +46,8 @@ namespace Datadog.Trace.AppSec.Waf
         public bool ShouldBlock { get; }
 
         public bool ShouldBeReported { get; }
+
+        public bool Timeout { get; }
 
         private void ReadActions(DdwafResultStruct returnStruct)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.AppSec.Waf.Initialization;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.AppSec.Waf
@@ -165,6 +166,7 @@ namespace Datadog.Trace.AppSec.Waf
                 // only if rules are provided will the waf give metrics
                 if (arguments.ContainsKey("rules"))
                 {
+                    TelemetryFactory.Metrics.RecordCountWafUpdates();
                     rulesetInfo = new DdwafRuleSetInfo();
                 }
 


### PR DESCRIPTION
## Summary of changes

Implement's telemetry about the usage of the WAF.

## Implementation details

Builds on the work in https://github.com/DataDog/dd-trace-dotnet/pull/4293. 

There are more telemetry values that should be sent, but these depend on:
- an upgrade to the WAF bindings
- work to be able to correctly collect telemetry distributions

## Test coverage

The collection of telemetry is already covered by unit tests. 
