### PR TITLE
Handle new StyleCop errors

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 #nullable enable
 
 namespace Datadog.Trace.AppSec.Waf;
+
 internal interface IContext : IDisposable
 {
     IResult? Run(IDictionary<string, object> addresses, ulong timeoutMicroSeconds);

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
+
 namespace Datadog.Trace.Debugger.Configurations.Models;
 
 internal record Decoration
@@ -25,3 +27,5 @@ internal record TagValue
 
     public SnapshotSegment[] Segments { get; set; }
 }
+
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -461,3 +463,5 @@ internal record BoundLineProbeLocation
 
     public int LineNumber { get; set; }
 }
+
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Debugger/Models/SnapshotProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Models/SnapshotProbe.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -205,3 +207,5 @@ namespace Datadog.Trace.Debugger.Models
         }
     }
 }
+
+#pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.Iast;
+
 internal static class Ranges
 {
     public static void CopyShift(Range[] src, Range[] dst, int dstPos, int shift)


### PR DESCRIPTION
## Summary of changes

A new beta version of StyleCop just released, which is pulled in automatically by the project, that has a lot of changes/improvements. Some of those were fixes to some analyzers that didn't work on file-scoped namespaces and `record` types.

See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/tag/1.2.0-beta.507

- SA1516 (blank lines) now works for file-scoped namespaces
- SA1402 (single type per file) now works for `record` types

I fixed the two instances of SA1516 and suppressed in source the few instances of SA1402

## Reason for change

New version of StyleCop.Analyzers was causing the local builds to fail.

## Implementation details

- Fix new instances of SA1516
- Suppress instances of SA1402 - figure they are fine

## Test coverage

It builds now locally

## Other details
<!-- Fixes #{issue} -->
