### PR TITLE
[Release] Sign and upload our packages to the agent repository for libinjection (docker/bare metal)

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -54,11 +54,6 @@ jobs:
         env:
           Version: ${{steps.versions.outputs.full_version}}
 
-      - name: "Create and push git tag"
-        run: |
-          git tag "v${{steps.versions.outputs.full_version}}"
-          git push origin "v${{steps.versions.outputs.full_version}}"
-
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -77,11 +72,13 @@ jobs:
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
             ${{steps.assets.outputs.sha_path}}
 
-      - name: "Publish nuget packages to nuget.org"
-        working-directory: ${{steps.assets.outputs.artifacts_path}}
+      # Done after creating the release as some packaging ran on gitlab are triggered by the tag creation and rely
+      # on the assets present in the github release.
+      - name: "Create and push git tag"
         run: |
-          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-      
+          git tag "v${{steps.versions.outputs.full_version}}"
+          git push origin "v${{steps.versions.outputs.full_version}}"
+
       - name: "Trigger Docker Base Images Github Pipeline"
         run: |
           curl \
@@ -95,3 +92,8 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           targetBranch: ${{ github.event.ref }}
           commitSha: "${{ github.event.inputs.forced_commit_id }}"
+
+      - name: "Publish nuget packages to nuget.org"
+        working-directory: ${{steps.assets.outputs.artifacts_path}}
+        run: |
+          dotnet nuget push "*.${{steps.versions.outputs.full_version}}*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -199,4 +199,3 @@ package:
   stage: deploy
   variables:
     PRODUCT_NAME: auto_inject-dotnet
-    PACKAGE_FILTER: dotnet

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,13 @@
 
 stages:
   - build
+  - package
   - publish
   - deploy
-  
+
+include:
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
+
 variables:
   GIT_PROFILER_REF: master
   DEPLOY_TO_REL_ENV:
@@ -15,7 +19,9 @@ variables:
   DEPLOY_TO_DEBUGGER_BACKEND:
     value: "false"
     description: "Set to true to deploy to debugger backend demo application"
-    
+  DOTNET_PACKAGE_VERSION:
+    description: "Version to build for .deb and .rpm. Must be already published in NPM"
+
 build:
   only:
     - master
@@ -52,7 +58,7 @@ publish:
       - $DEPLOY_TO_REL_ENV == "true"
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  dependencies: 
+  dependencies:
     - build
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
@@ -178,3 +184,19 @@ deploy_to_debugger_backend:
     UPSTREAM_BRANCH: $CI_COMMIT_BRANCH
     UPSTREAM_TAG: $DEPLOY_TAG
 
+
+package:
+  extends: .package
+  rules:
+    - if: $DOTNET_PACKAGE_VERSION
+      when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      when: on_success
+  script:
+    - ../.gitlab/build-deb-rpm.sh
+
+.release-package:
+  stage: deploy
+  variables:
+    PRODUCT_NAME: auto_inject-dotnet
+    PACKAGE_FILTER: dotnet

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+source common_build_functions.sh
+
+if [ -n "$CI_COMMIT_TAG" ] && [ -z "$DOTNET_PACKAGE_VERSION" ]; then
+  $DOTNET_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
+fi
+
+curl --location --fail \
+  --output datadog-dotnet-apm.old \
+  "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm_${DOTNET_PACKAGE_VERSION}_amd64.deb"
+
+fpm --input-type deb \
+  --output-type dir \
+  --name datadog-dotnet-apm \
+  datadog-dotnet-apm.old
+
+echo -n $DOTNET_PACKAGE_VERSION > dotnet.version
+
+cp dotnet.version datadog-dotnet-apm.dir/opt/datadog/version
+
+# Build packages
+fpm_wrapper "datadog-apm-library-dotnet" "$DOTNET_PACKAGE_VERSION" \
+  --input-type dir \
+  --chdir=datadog-dotnet-apm.dir/opt/datadog \
+  --prefix "$LIBRARIES_INSTALL_BASE/dotnet" \
+  --after-install datadog-dotnet-apm.dir/opt/datadog/createLogPath.sh \
+  .=.

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -15,9 +15,9 @@ fpm --input-type deb \
   --name datadog-dotnet-apm \
   datadog-dotnet-apm.old
 
-echo -n $DOTNET_PACKAGE_VERSION > dotnet.version
+echo -n $DOTNET_PACKAGE_VERSION > auto_inject-dotnet.version
 
-cp dotnet.version datadog-dotnet-apm.dir/opt/datadog/version
+cp auto_inject-dotnet.version datadog-dotnet-apm.dir/opt/datadog/version
 
 # Build packages
 fpm_wrapper "datadog-apm-library-dotnet" "$DOTNET_PACKAGE_VERSION" \


### PR DESCRIPTION
## Summary of changes

Integrate in our release pipeline the packaging of our binaries for onboarding (docker/bare metal). To do so:
- Added a few scripts that will run on gitlab and depend on work done by @randomanderson (Thanks a lot Laplie) 
- Changed the release workflow to make sure we add the tags after we create the release as we rely on the artifacts of the release

Not related, I also moved the nuget push as the last step of the release creation. Indeed, when adding a new package, this step fails and so it is easier to have it last as we have one step less to trigger manually.

## Reason for change

Updating those dependencies should be part of our release process.

## Implementation details
Note that this makes a manual step in our release process but @randomanderson is already digging if we can change this.
![image](https://github.com/DataDog/dd-trace-dotnet/assets/22597395/6bf69c43-1150-42d6-837d-124864ec5cc2).

## After this is merged
The first prod release needs to be manually assisted by the agent-platform team (@bkabrda). You click release in the dot-net pipeline and they have to allow the release to go forward downstream. After the first release, no intervention by agent-platform is necessary.

## Test coverage
Ran a [pipeline](https://gitlab.ddbuild.io/DataDog/dd-trace-dotnet/-/pipelines/17120333).

## Other details
AIT-6084
