### PR TITLE
Move RCM state to the subscription manager

### DIFF
--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Numerics;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
 
@@ -26,4 +27,8 @@ internal interface IRcmSubscriptionManager
     void SetCapability(BigInteger index, bool available);
 
     byte[] GetCapabilities();
+
+    GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string? lastPollError);
+
+    void ProcessResponse(GetRcmResponse response);
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -180,9 +180,6 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 
         lock (_syncRoot)
         {
-            _targetsVersion = response.Targets.Signed.Version;
-            _backendClientState = response.Targets.Signed.Custom?.OpaqueBackendState;
-
             var configByProducts = new Dictionary<string, List<RemoteConfiguration>>();
             var receivedPaths = new List<string>();
 
@@ -278,6 +275,9 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
                         break;
                 }
             }
+
+            _targetsVersion = response.Targets.Signed.Version;
+            _backendClientState = response.Targets.Signed.Custom?.OpaqueBackendState;
         }
     }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -39,7 +39,6 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 
     public RcmSubscriptionManager()
     {
-        DatadogLogging.GetLoggerFor<RcmSubscriptionManager>().Debug("New RcmSubscriptionManager");
         _id = Guid.NewGuid().ToString();
     }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -3,22 +3,45 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using Datadog.Trace.Logging;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
 
 internal class RcmSubscriptionManager : IRcmSubscriptionManager
 {
+    private const int RootVersion = 1;
+
     public static readonly IRcmSubscriptionManager Instance = new RcmSubscriptionManager();
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RcmSubscriptionManager>();
 
     private readonly List<ISubscription> _subscriptions = new();
     private readonly object _syncRoot = new();
+
+    /// <summary>
+    /// Key is the path
+    /// </summary>
+    private readonly Dictionary<string, RemoteConfigurationCache> _appliedConfigurations = new();
+
+    private readonly string _id;
+
+    private string? _backendClientState;
+    private int _targetsVersion;
     private BigInteger _capabilities;
+
+    public RcmSubscriptionManager()
+    {
+        DatadogLogging.GetLoggerFor<RcmSubscriptionManager>().Debug("New RcmSubscriptionManager");
+        _id = Guid.NewGuid().ToString();
+    }
 
     public bool HasAnySubscription => _subscriptions.Count > 0;
 
@@ -121,6 +144,141 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 #endif
 
         return capabilitiesArray;
+    }
+
+    public GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string? lastPollError)
+    {
+        lock (_syncRoot)
+        {
+            var cachedTargetFiles = new List<RcmCachedTargetFile>();
+            var configStates = new List<RcmConfigState>();
+            var appliedConfigs = _appliedConfigurations.Values;
+
+            foreach (var cache in appliedConfigs)
+            {
+                cachedTargetFiles.Add(new RcmCachedTargetFile(cache.Path.Path, cache.Length, cache.Hashes.Select(kp => new RcmCachedTargetFileHash(kp.Key, kp.Value)).ToList()));
+                configStates.Add(new RcmConfigState(cache.Path.Id, cache.Version, cache.Path.Product, cache.ApplyState, cache.Error));
+            }
+
+            var rcmState = new RcmClientState(RootVersion, _targetsVersion, configStates, lastPollError != null, lastPollError, _backendClientState);
+            var rcmClient = new RcmClient(_id, ProductKeys, rcmTracer, rcmState, GetCapabilities());
+            var rcmRequest = new GetRcmRequest(rcmClient, cachedTargetFiles);
+
+            return rcmRequest;
+        }
+    }
+
+    public void ProcessResponse(GetRcmResponse response)
+    {
+        if (Log.IsEnabled(LogEventLevel.Debug))
+        {
+            var description = response.TargetFiles.Count > 0
+                                  ? "with the following paths: " + string.Join(",", response.TargetFiles.Select(t => t.Path))
+                                  : "that is empty.";
+            Log.Debug("Received Remote Configuration response {ResponseDescription}.", description);
+        }
+
+        lock (_syncRoot)
+        {
+            _targetsVersion = response.Targets.Signed.Version;
+            _backendClientState = response.Targets.Signed.Custom?.OpaqueBackendState;
+
+            var configByProducts = new Dictionary<string, List<RemoteConfiguration>>();
+            var receivedPaths = new List<string>();
+
+            // handle new configurations
+            foreach (var clientConfig in response.ClientConfigs)
+            {
+                var remoteConfigurationPath = RemoteConfigurationPath.FromPath(clientConfig);
+                receivedPaths.Add(remoteConfigurationPath.Path);
+                var signed = response.Targets.Signed.Targets;
+                var targetFiles =
+                    (response.TargetFiles ?? Enumerable.Empty<RcmFile>()).ToDictionary(f => f.Path, f => f);
+
+                if (!signed.TryGetValue(remoteConfigurationPath.Path, out var signedTarget))
+                {
+                    ThrowHelper.ThrowException($"Missing config {remoteConfigurationPath.Path} in targets");
+                }
+
+                if (!ProductKeys.Contains(remoteConfigurationPath.Product))
+                {
+                    Log.Warning("Received config {RemoteConfigurationPath} for a product that was not requested", remoteConfigurationPath);
+                    continue;
+                }
+
+                var isConfigApplied =
+                    _appliedConfigurations.TryGetValue(remoteConfigurationPath.Path, out var appliedConfig) &&
+                    appliedConfig.Hashes.SequenceEqual(signedTarget.Hashes);
+                if (isConfigApplied)
+                {
+                    continue;
+                }
+
+                if (!targetFiles.TryGetValue(remoteConfigurationPath.Path, out var targetFile))
+                {
+                    ThrowHelper.ThrowException($"Missing config {remoteConfigurationPath.Path} in target files");
+                }
+
+                var remoteConfigurationCache = new RemoteConfigurationCache(remoteConfigurationPath, signedTarget.Length, signedTarget.Hashes, signedTarget.Custom.V);
+                _appliedConfigurations[remoteConfigurationCache.Path.Path] = remoteConfigurationCache;
+
+                var remoteConfiguration = new RemoteConfiguration(remoteConfigurationPath, targetFile.Raw, signedTarget.Length, signedTarget.Hashes, signedTarget.Custom.V);
+                if (!configByProducts.ContainsKey(remoteConfigurationPath.Product))
+                {
+                    configByProducts[remoteConfigurationPath.Product] = new List<RemoteConfiguration>();
+                }
+
+                configByProducts[remoteConfigurationPath.Product].Add(remoteConfiguration);
+            }
+
+            Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct = new();
+            // handle removed configurations
+            foreach (var appliedConfiguration in _appliedConfigurations)
+            {
+                if (receivedPaths.Contains(appliedConfiguration.Key))
+                {
+                    continue;
+                }
+
+                if (!removedConfigsByProduct.ContainsKey(appliedConfiguration.Value.Path.Product))
+                {
+                    removedConfigsByProduct[appliedConfiguration.Value.Path.Product] =
+                        new List<RemoteConfigurationPath>();
+                }
+
+                removedConfigsByProduct[appliedConfiguration.Value.Path.Product].Add(appliedConfiguration.Value.Path);
+            }
+
+            // update applied configurations after removal
+            foreach (var removedConfig in removedConfigsByProduct.Values)
+            {
+                foreach (var value in removedConfig)
+                {
+                    _appliedConfigurations.Remove(value.Path);
+                }
+            }
+
+            var results = Update(configByProducts, removedConfigsByProduct);
+
+            foreach (var result in results)
+            {
+                switch (result.ApplyState)
+                {
+                    case ApplyStates.UNACKNOWLEDGED:
+                        // Do nothing
+                        break;
+                    case ApplyStates.ACKNOWLEDGED:
+                        _appliedConfigurations[result.Filename].Applied();
+                        break;
+                    case ApplyStates.ERROR:
+                        _appliedConfigurations[result.Filename].ErrorOccured(result.Error);
+                        break;
+                    default:
+                        Log.Warning("Unexpected ApplyState: {ApplyState}", result.ApplyState);
+                        break;
+                }
+            }
+        }
     }
 
     private void RefreshProductKeys() => ProductKeys = _subscriptions.SelectMany(s => s.ProductKeys).Distinct().ToList();

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -17,8 +17,6 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.Processors;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.RemoteConfigurationManagement.Transport;
-using Datadog.Trace.Util;
-using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
@@ -26,7 +24,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RemoteConfigurationManager));
 
-        private readonly string _id;
         private readonly RcmClientTracer _rcmTracer;
         private readonly IDiscoveryService _discoveryService;
         private readonly IRemoteConfigurationApi _remoteConfigurationApi;
@@ -36,23 +33,14 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         private readonly CancellationTokenSource _cancellationSource;
 
-        /// <summary>
-        /// Key is the path
-        /// </summary>
-        private readonly Dictionary<string, RemoteConfigurationCache> _appliedConfigurations = new();
-
-        private readonly int _rootVersion;
-        private int _targetsVersion;
         private string? _lastPollError;
         private int _isPollingStarted;
         private bool _isRcmEnabled;
-        private string? _backendClientState;
         private bool _gitMetadataAddedToRequestTags;
 
         private RemoteConfigurationManager(
             IDiscoveryService discoveryService,
             IRemoteConfigurationApi remoteConfigurationApi,
-            string id,
             RcmClientTracer rcmTracer,
             TimeSpan pollInterval,
             IGitMetadataTagsProvider gitMetadataTagsProvider,
@@ -63,10 +51,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             _rcmTracer = rcmTracer;
             _pollInterval = pollInterval;
             _gitMetadataTagsProvider = gitMetadataTagsProvider;
-            _id = id;
 
-            _rootVersion = 1;
-            _targetsVersion = 0;
             _lastPollError = null;
             _subscriptionManager = subscriptionManager;
             _cancellationSource = new CancellationTokenSource();
@@ -80,7 +65,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             return new RemoteConfigurationManager(
                     discoveryService,
                     remoteConfigurationApi,
-                    id: settings.Id,
                     rcmTracer: new RcmClientTracer(settings.RuntimeId, settings.TracerVersion, serviceName, TraceUtil.NormalizeTag(tracerSettings.EnvironmentInternal), tracerSettings.ServiceVersionInternal, tags),
                     pollInterval: settings.PollInterval,
                     gitMetadataTagsProvider,
@@ -163,38 +147,21 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         {
             try
             {
-                var request = BuildRequest();
+                var request = _subscriptionManager.BuildRequest(_rcmTracer, _lastPollError);
+
+                EnrichTagsWithGitMetadata(request.Client.ClientTracer.Tags);
+
                 var response = await _remoteConfigurationApi.GetConfigs(request).ConfigureAwait(false);
 
                 if (response?.Targets?.Signed != null)
                 {
-                    ProcessResponse(response);
-                    _targetsVersion = response.Targets.Signed.Version;
-                    _backendClientState = response.Targets.Signed.Custom?.OpaqueBackendState;
+                    _subscriptionManager.ProcessResponse(response);
                 }
             }
             catch (Exception e)
             {
                 _lastPollError = e.Message;
             }
-        }
-
-        private GetRcmRequest BuildRequest()
-        {
-            var cachedTargetFiles = new List<RcmCachedTargetFile>();
-            var configStates = new List<RcmConfigState>();
-            var appliedConfigs = _appliedConfigurations.Values;
-            foreach (var cache in appliedConfigs)
-            {
-                cachedTargetFiles.Add(new RcmCachedTargetFile(cache.Path.Path, cache.Length, cache.Hashes.Select(kp => new RcmCachedTargetFileHash(kp.Key, kp.Value)).ToList()));
-                configStates.Add(new RcmConfigState(cache.Path.Id, cache.Version, cache.Path.Product, cache.ApplyState, cache.Error));
-            }
-
-            var rcmState = new RcmClientState(_rootVersion, _targetsVersion, configStates, _lastPollError != null, _lastPollError, _backendClientState);
-            var rcmClient = new RcmClient(_id, _subscriptionManager.ProductKeys, _rcmTracer, rcmState, _subscriptionManager.GetCapabilities());
-            EnrichTagsWithGitMetadata(rcmClient.ClientTracer.Tags);
-            var rcmRequest = new GetRcmRequest(rcmClient, cachedTargetFiles);
-            return rcmRequest;
         }
 
         private void EnrichTagsWithGitMetadata(List<string> tags)
@@ -217,116 +184,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             }
 
             _gitMetadataAddedToRequestTags = true;
-        }
-
-        private void ProcessResponse(GetRcmResponse response)
-        {
-            if (Log.IsEnabled(LogEventLevel.Debug))
-            {
-                var description = response.TargetFiles.Count > 0
-                                      ? "with the following paths: " + string.Join(",", response.TargetFiles.Select(t => t.Path))
-                                      : "that is empty.";
-                Log.Debug("Received Remote Configuration response {ResponseDescription}.", description);
-            }
-
-            var configByProducts = new Dictionary<string, List<RemoteConfiguration>>();
-            var receivedPaths = new List<string>();
-
-            // handle new configurations
-            foreach (var clientConfig in response.ClientConfigs)
-            {
-                var remoteConfigurationPath = RemoteConfigurationPath.FromPath(clientConfig);
-                receivedPaths.Add(remoteConfigurationPath.Path);
-                var signed = response.Targets.Signed.Targets;
-                var targetFiles =
-                    (response.TargetFiles ?? Enumerable.Empty<RcmFile>()).ToDictionary(f => f.Path, f => f);
-
-                if (!signed.TryGetValue(remoteConfigurationPath.Path, out var signedTarget))
-                {
-                    ThrowHelper.ThrowException($"Missing config {remoteConfigurationPath.Path} in targets");
-                }
-
-                if (!_subscriptionManager.ProductKeys.Contains(remoteConfigurationPath.Product))
-                {
-                    Log.Warning("Received config {RemoteConfigurationPath} for a product that was not requested", remoteConfigurationPath);
-                    continue;
-                }
-
-                var isConfigApplied =
-                    _appliedConfigurations.TryGetValue(remoteConfigurationPath.Path, out var appliedConfig) &&
-                    appliedConfig.Hashes.SequenceEqual(signedTarget.Hashes);
-                if (isConfigApplied)
-                {
-                    continue;
-                }
-
-                if (!targetFiles.TryGetValue(remoteConfigurationPath.Path, out var targetFile))
-                {
-                    ThrowHelper.ThrowException($"Missing config {remoteConfigurationPath.Path} in target files");
-                }
-
-                var remoteConfigurationCache = new RemoteConfigurationCache(remoteConfigurationPath, signedTarget.Length, signedTarget.Hashes, signedTarget.Custom.V);
-                _appliedConfigurations[remoteConfigurationCache.Path.Path] = remoteConfigurationCache;
-
-                var remoteConfiguration = new RemoteConfiguration(remoteConfigurationPath, targetFile.Raw, signedTarget.Length, signedTarget.Hashes, signedTarget.Custom.V);
-                if (!configByProducts.ContainsKey(remoteConfigurationPath.Product))
-                {
-                    configByProducts[remoteConfigurationPath.Product] = new List<RemoteConfiguration>();
-                }
-
-                configByProducts[remoteConfigurationPath.Product].Add(remoteConfiguration);
-            }
-
-            Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct = new();
-            // handle removed configurations
-            foreach (var appliedConfiguration in _appliedConfigurations)
-            {
-                if (receivedPaths.Contains(appliedConfiguration.Key))
-                {
-                    continue;
-                }
-
-                if (!removedConfigsByProduct.ContainsKey(appliedConfiguration.Value.Path.Product))
-                {
-                    removedConfigsByProduct[appliedConfiguration.Value.Path.Product] =
-                        new List<RemoteConfigurationPath>();
-                }
-
-                removedConfigsByProduct[appliedConfiguration.Value.Path.Product].Add(appliedConfiguration.Value.Path);
-            }
-
-            // update applied configurations after removal
-            foreach (var removedConfig in removedConfigsByProduct.Values)
-            {
-                foreach (var value in removedConfig)
-                {
-                    _appliedConfigurations.Remove(value.Path);
-                }
-            }
-
-            var results = _subscriptionManager.Update(configByProducts, removedConfigsByProduct);
-
-            if (results != null)
-            {
-                foreach (var result in results)
-                {
-                    switch (result.ApplyState)
-                    {
-                        case ApplyStates.UNACKNOWLEDGED:
-                            // Do nothing
-                            break;
-                        case ApplyStates.ACKNOWLEDGED:
-                            _appliedConfigurations[result.Filename].Applied();
-                            break;
-                        case ApplyStates.ERROR:
-                            _appliedConfigurations[result.Filename].ErrorOccured(result.Error);
-                            break;
-                        default:
-                            Log.Warning("Unexpected ApplyState: {ApplyState}", result.ApplyState);
-                            break;
-                    }
-                }
-            }
         }
 
         private void SetRcmEnabled(AgentConfiguration c)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationSettings.cs
@@ -20,7 +20,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
         {
             configurationSource ??= NullConfigurationSource.Instance;
 
-            Id = Guid.NewGuid().ToString();
             RuntimeId = Util.RuntimeId.Get();
             TracerVersion = TracerConstants.ThreePartVersion;
 
@@ -32,8 +31,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
             PollInterval = TimeSpan.FromSeconds(pollInterval.Value);
         }
-
-        public string Id { get; }
 
         public string RuntimeId { get; }
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.Debugger.ProbeStatuses;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using FluentAssertions;
 using Xunit;
 
@@ -141,6 +142,16 @@ public class LiveDebuggerTests
         }
 
         public byte[] GetCapabilities()
+        {
+            throw new NotImplementedException();
+        }
+
+        public GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string lastPollError)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ProcessResponse(GetRcmResponse response)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
## Summary of changes

Move the RCM state from the RemoteConfigurationManager to the RCMSubscriptionManager.

## Reason for change

The RemoteConfigurationManager is recreated when the tracer is reconfigured (because the agent URI can change, among other things). If we don't carry over the state then we lose the acknowledgement status of the products, possibly before they are communicated back to the agent.

The RCMSubscriptionManager is a singleton that is never recreated, so it's a good candidate to carry the state.

## Implementation details

Move the BuildRequest/ProcessResponse methods from the RemoteConfigurationManager to the RCMSubscriptionManager.

## Test coverage

The existing RCM tests should be enough.