### PR TITLE
Fix SNS Context Propagation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
@@ -48,7 +48,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 
             _createMessageAttributeValue = (Func<MemoryStream, object>)createMessageAttributeValueMethod.CreateDelegate(typeof(Func<MemoryStream, object>));
 
-
             // Initialize delegate for creating a Dictionary<string, MessageAttributeValue> object
             var genericDictType = typeof(Dictionary<,>);
             var constructedDictType = genericDictType.MakeGenericType(new Type[] { typeof(string), messageAttributeValueType });
@@ -73,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             return _createDict();
         }
 
-        public static object CreateMessageAttributeValue(string value)
+        public static object CreateMessageAttributeValue(MemoryStream value)
         {
             return _createMessageAttributeValue(value);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
     {
         private const string StringDataType = "Binary";
 
-		private static readonly Func<MemoryStream, object> _createMessageAttributeValue;
+        private static readonly Func<MemoryStream, object> _createMessageAttributeValue;
         private static readonly Func<IDictionary> _createDict;
 
         static CachedMessageHeadersHelper()

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 {
     internal static class CachedMessageHeadersHelper<TMarkerType>
     {
-        private const string StringDataType = "String";
+        private const string StringDataType = "Binary";
 
         private static readonly Func<string, object> _createMessageAttributeValue;
         private static readonly Func<IDictionary> _createDict;
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 
             messageAttributeIL.Emit(OpCodes.Dup);
             messageAttributeIL.Emit(OpCodes.Ldarg_0);
-            messageAttributeIL.Emit(OpCodes.Callvirt, messageAttributeValueType.GetProperty("StringValue").GetSetMethod());
+            messageAttributeIL.Emit(OpCodes.Callvirt, messageAttributeValueType.GetProperty("BinaryValue").GetSetMethod());
 
             messageAttributeIL.Emit(OpCodes.Ret);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.DuckTyping;
@@ -28,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             DynamicMethod createMessageAttributeValueMethod = new DynamicMethod(
                 $"SnsCachedMessageHeadersHelpers",
                 messageAttributeValueType,
-                parameterTypes: new Type[] { typeof(string) },
+                parameterTypes: new Type[] { typeof(MemoryStream) },
                 typeof(DuckType).Module,
                 true);
 
@@ -45,7 +46,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 
             messageAttributeIL.Emit(OpCodes.Ret);
 
-            _createMessageAttributeValue = (Func<string, object>)createMessageAttributeValueMethod.CreateDelegate(typeof(Func<string, object>));
+            _createMessageAttributeValue = (Func<MemoryStream, object>)createMessageAttributeValueMethod.CreateDelegate(typeof(Func<MemoryStream, object>));
+
 
             // Initialize delegate for creating a Dictionary<string, MessageAttributeValue> object
             var genericDictType = typeof(Dictionary<,>);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/CachedMessageHeadersHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
     {
         private const string StringDataType = "Binary";
 
-        private static readonly Func<string, object> _createMessageAttributeValue;
+		private static readonly Func<MemoryStream, object> _createMessageAttributeValue;
         private static readonly Func<IDictionary> _createDict;
 
         static CachedMessageHeadersHelper()

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Propagators;
@@ -26,7 +27,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             sb.Append('}');
 
             var resultString = Util.StringBuilderCache.GetStringAndRelease(sb);
-            messageAttributes[SnsKey] = CachedMessageHeadersHelper<TMessageRequest>.CreateMessageAttributeValue(resultString);
+            byte[] bytes = Encoding.UTF8.GetBytes(resultString);
+            MemoryStream stream = new MemoryStream(bytes);
+            messageAttributes[SnsKey] = CachedMessageHeadersHelper<TMessageRequest>.CreateMessageAttributeValue(stream);
         }
 
         public static void InjectHeadersIntoMessage<TMessageRequest>(IContainsMessageAttributes carrier, SpanContext spanContext)


### PR DESCRIPTION
## Summary of changes
Port https://github.com/DataDog/dd-trace-py/pull/3404/files over to dotnet sns integration
## Reason for change
trace propagation from sns to sqs breaks silently when using sns msg filters that are not in base64
trace context failing
SLS-3618

## Implementation details

## Test coverage
Manual test case
Dotnet lambda makes aws sdk publish async request to an sns topic, that topic has an sqs queue subscribed to said topic and that queue acts as a trigger to a downstream receiver lambda function:

[x] SNS message is sent when filtering on a different attribute hello: "world"
[x] SNS message is not sent when filter condition fails hello: "there"
[x] SNS message is sent when no filters are present
## Other details
<!-- Fixes #{issue} -->
